### PR TITLE
Add pch.com to broken sites

### DIFF
--- a/generated/android-config.json
+++ b/generated/android-config.json
@@ -23,6 +23,10 @@
                 {
                     "domain": "id.me",
                     "reason": "Broken logins"
+                },
+                {
+                    "domain": "pch.com",
+                    "reason": "Broken site reports"
                 }
             ]
         },
@@ -268,7 +272,7 @@
             ]
         }
     },
-    "version": 1630934361237,
+    "version": 1630954986681,
     "unprotectedTemporary": [
         {
             "domain": "inlandbank.com",

--- a/generated/extension-config.json
+++ b/generated/extension-config.json
@@ -281,7 +281,7 @@
             ]
         }
     },
-    "version": 1630934361237,
+    "version": 1630954986681,
     "unprotectedTemporary": [
         {
             "domain": "inlandbank.com",

--- a/generated/ios-config.json
+++ b/generated/ios-config.json
@@ -268,7 +268,7 @@
             ]
         }
     },
-    "version": 1630934361237,
+    "version": 1630954986681,
     "unprotectedTemporary": [
         {
             "domain": "inlandbank.com",

--- a/generated/macos-config.json
+++ b/generated/macos-config.json
@@ -268,7 +268,7 @@
             ]
         }
     },
-    "version": 1630934361237,
+    "version": 1630954986681,
     "unprotectedTemporary": [
         {
             "domain": "inlandbank.com",

--- a/generated/trackers-unprotected-temporary.txt
+++ b/generated/trackers-unprotected-temporary.txt
@@ -18,3 +18,5 @@ www.livenewsnow.com
 rp5.ru
 easyjet.com
 id.me
+www.sportskeeda.com
+pch.com

--- a/generated/trackers-whitelist-temporary.txt
+++ b/generated/trackers-whitelist-temporary.txt
@@ -18,3 +18,5 @@ www.livenewsnow.com
 rp5.ru
 easyjet.com
 id.me
+www.sportskeeda.com
+pch.com

--- a/generated/windows-config.json
+++ b/generated/windows-config.json
@@ -268,7 +268,7 @@
             ]
         }
     },
-    "version": 1630934361237,
+    "version": 1630954986681,
     "unprotectedTemporary": [
         {
             "domain": "inlandbank.com",

--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -1,8 +1,15 @@
 {
     "features": {
-        
+        "contentBlocking": {
+            "exceptions": [
+                {
+                    "domain": "pch.com",
+                    "reason": "Broken site reports"
+                }
+            ]
+        }
     },
     "unprotectedTemporary": [
-        
+
     ]
 }


### PR DESCRIPTION
I'm adding this back due to the breakage numbers ongoing: https://app.asana.com/0/1200223097357040/1200913004760528/f

1. This is a contentBlocking change specifically for android which doesn't disable all other protections.
2. It merges all the platforms together for the various lists we consider to be part of the old global list.
3. I had to move the legacy list code to the bottom of the file, but is unchanged.
4. `www.sportskeeda.com` is also now in the legacy list  as it's in the `unprotectedTemporary` for iOS