### PR TITLE
Add GPC header sites to config

### DIFF
--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -1,6 +1,15 @@
 {
     "features": {
-        
+        "gpc": {
+            "settings": {
+                "gpcHeaderEnabledSites": [
+                    "http://global-privacy-control.glitch.me",
+                    "https://washingtonpost.com",
+                    "https://nytimes.com",
+                    "https://privacy-test-pages.glitch.me"
+                ]
+            }
+        }
     },
     "unprotectedTemporary": [
         


### PR DESCRIPTION
This adds sites we WILL be sending GPC headers to to the macOS config. A future PR will add this feature to the iOS config when that support is added there.