### PR TITLE
Reenable content blocking on video.ibm.com

### DIFF
--- a/features/content-blocking.json
+++ b/features/content-blocking.json
@@ -69,10 +69,6 @@
             "reason": "Missing site content"
         },
         {
-            "domain": "video.ibm.com",
-            "reason": "Broken videos"
-        },
-        {
             "domain": "virginmedia.com",
             "reason": "Chat widget blocked"
         }


### PR DESCRIPTION
Fixed by the latest blocklist update.