### PR TITLE
Match feature state to feature table

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -3,5 +3,5 @@ description: 'Build generated privacy configs'
 author: DuckDuckGo
 
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'index.js'

--- a/features/amp-links.json
+++ b/features/amp-links.json
@@ -1,0 +1,31 @@
+{
+    "_meta": {
+        "description": "Rewrite AMP links to safer alternatives.",
+        "sampleExcludeRecords": {
+            "domain": "example.com",
+            "reason": "site breakage"
+        }
+    },
+    "exceptions": [],
+    "settings": {
+        "ampLinkFormats": [
+            "^https?:\\/\\/(?:w{3}\\.)?google\\.\\S{2,}\\/amp\\/s\\/(\\S+)$",
+            "^https?:\\/\\/\\S+ampproject\\.org\\/v\\/s\\/(\\S+)$"
+        ],
+        "ampKeywords": [
+            "=amp",
+            "amp=",
+            "&amp",
+            "amp&",
+            "/amp",
+            "amp/",
+            ".amp",
+            "amp.",
+            "%amp",
+            "amp%",
+            "_amp",
+            "amp_",
+            "?amp"
+        ]
+    }
+}

--- a/features/autoconsent.json
+++ b/features/autoconsent.json
@@ -6,7 +6,6 @@
             "reason": "site breakage"
         }
     },
-    "state": "enabled",
     "exceptions": [{
         "domain": "spiegel.de",
         "reason": "Opt-out not possible"

--- a/features/autofill.json
+++ b/features/autofill.json
@@ -6,7 +6,6 @@
             "reason": "site breakage"
         }
     },
-    "state": "disabled",
     "exceptions": [
         {
             "domain": "asana.com",

--- a/features/autofill.json
+++ b/features/autofill.json
@@ -6,6 +6,7 @@
             "reason": "site breakage"
         }
     },
+    "state": "disabled",
     "exceptions": [
         {
             "domain": "asana.com",

--- a/features/click-to-play.json
+++ b/features/click-to-play.json
@@ -6,6 +6,6 @@
             "reason": "site breakage"
         }
     },
-    "state": "enabled",
+    "state": "disabled",
     "exceptions": []
 }

--- a/features/click-to-play.json
+++ b/features/click-to-play.json
@@ -6,6 +6,5 @@
             "reason": "site breakage"
         }
     },
-    "state": "disabled",
     "exceptions": []
 }

--- a/features/fingerprinting-battery.json
+++ b/features/fingerprinting-battery.json
@@ -6,6 +6,5 @@
             "reason": "site breakage"
         }
     },
-    "state": "enabled",
     "exceptions": []
 }

--- a/features/fingerprinting-canvas.json
+++ b/features/fingerprinting-canvas.json
@@ -6,7 +6,6 @@
             "reason": "site breakage"
         }
     },
-    "state": "disabled",
     "exceptions": [
         {
             "domain": "krunker.io",

--- a/features/fingerprinting-canvas.json
+++ b/features/fingerprinting-canvas.json
@@ -6,7 +6,7 @@
             "reason": "site breakage"
         }
     },
-    "state": "enabled",
+    "state": "disabled",
     "exceptions": [
         {
             "domain": "krunker.io",

--- a/features/fingerprinting-hardware.json
+++ b/features/fingerprinting-hardware.json
@@ -6,7 +6,6 @@
             "reason": "site breakage"
         }
     },
-    "state": "enabled",
     "exceptions": [
         {
             "domain": "play.geforcenow.com",

--- a/features/fingerprinting-screen-size.json
+++ b/features/fingerprinting-screen-size.json
@@ -6,6 +6,5 @@
             "reason": "site breakage"
         }
     },
-    "state": "enabled",
     "exceptions": []
 }

--- a/features/fingerprinting-temporary-storage.json
+++ b/features/fingerprinting-temporary-storage.json
@@ -6,6 +6,5 @@
             "reason": "site breakage"
         }
     },
-    "state": "enabled",
     "exceptions": []
 }

--- a/features/floc.json
+++ b/features/floc.json
@@ -6,6 +6,5 @@
             "reason": "site breakage"
         }
     },
-    "state": "enabled",
     "exceptions": []
 }

--- a/features/navigator-credentials.json
+++ b/features/navigator-credentials.json
@@ -1,11 +1,10 @@
 {
     "_meta": {
-        "description": "Domains which should have referrer trimming protections disabled due to site breakage issues.",
+        "description": "Disable the credentials API on the navigator",
         "sampleExcludeRecords": {
             "domain": "example.com",
             "reason": "site breakage"
         }
     },
-    "state": "disabled",
     "exceptions": []
 }

--- a/features/referrer.json
+++ b/features/referrer.json
@@ -6,6 +6,5 @@
             "reason": "site breakage"
         }
     },
-    "state": "disabled",
     "exceptions": []
 }

--- a/features/tracking-cookies-1p.json
+++ b/features/tracking-cookies-1p.json
@@ -6,7 +6,7 @@
             "reason": "site breakage"
         }
     },
-    "state": "enabled",
+    "state": "disabled",
     "settings": {
         "firstPartyTrackerCookiePolicy": {
             "threshold": 86400,

--- a/features/tracking-cookies-1p.json
+++ b/features/tracking-cookies-1p.json
@@ -6,7 +6,6 @@
             "reason": "site breakage"
         }
     },
-    "state": "disabled",
     "settings": {
         "firstPartyTrackerCookiePolicy": {
             "threshold": 86400,

--- a/features/tracking-cookies-3p.json
+++ b/features/tracking-cookies-3p.json
@@ -6,7 +6,6 @@
             "reason": "site breakage"
         }
     },
-    "state": "disabled",
     "settings": {
         "excludedCookieDomains": [
             {

--- a/features/tracking-cookies-3p.json
+++ b/features/tracking-cookies-3p.json
@@ -6,7 +6,7 @@
             "reason": "site breakage"
         }
     },
-    "state": "enabled",
+    "state": "disabled",
     "settings": {
         "excludedCookieDomains": [
             {

--- a/features/tracking-links.json
+++ b/features/tracking-links.json
@@ -1,0 +1,54 @@
+{
+    "_meta": {
+        "description": "Rewrite AMP links and links with tracking parameters to safer alternatives.",
+        "sampleExcludeRecords": {
+            "domain": "example.com",
+            "reason": "site breakage"
+        }
+    },
+    "exceptions": [],
+    "settings": {
+        "ampLinkFormats": [
+            "https?:\\/\\/(?:w{3}\\.)?google\\.\\w{2,}\\/amp\\/s\\/(\\S+)",
+            "https?:\\/\\/\\S+ampproject\\.org\\/v\\/s\\/(\\S+)"
+        ],
+        "ampKeywords": [
+            "=amp",
+            "amp=",
+            "&amp",
+            "amp&",
+            "/amp",
+            "amp/",
+            ".amp",
+            "amp.",
+            "%amp",
+            "amp%",
+            "_amp",
+            "amp_",
+            "?amp"
+        ],
+        "trackingParameters": [
+            "utm_[a-zA-Z]*",
+            "gclid",
+            "fbclid",
+            "fb_action_ids",
+            "fb_action_types",
+            "fb_source",
+            "fb_ref",
+            "ga_source",
+            "ga_medium",
+            "ga_term",
+            "ga_content",
+            "ga_campaign",
+            "ga_place",
+            "action_object_map",
+            "action_type_map",
+            "action_ref_map",
+            "gs_l",
+            "mkt_tok",
+            "hmb_campaign",
+            "hmb_source",
+            "hmb_medium"
+        ]
+    }
+}

--- a/features/tracking-parameters.json
+++ b/features/tracking-parameters.json
@@ -1,6 +1,6 @@
 {
     "_meta": {
-        "description": "Rewrite AMP links and links with tracking parameters to safer alternatives.",
+        "description": "Rewrite links with tracking parameters to safer alternatives.",
         "sampleExcludeRecords": {
             "domain": "example.com",
             "reason": "site breakage"
@@ -8,25 +8,6 @@
     },
     "exceptions": [],
     "settings": {
-        "ampLinkFormats": [
-            "https?:\\/\\/(?:w{3}\\.)?google\\.\\w{2,}\\/amp\\/s\\/(\\S+)",
-            "https?:\\/\\/\\S+ampproject\\.org\\/v\\/s\\/(\\S+)"
-        ],
-        "ampKeywords": [
-            "=amp",
-            "amp=",
-            "&amp",
-            "amp&",
-            "/amp",
-            "amp/",
-            ".amp",
-            "amp.",
-            "%amp",
-            "amp%",
-            "_amp",
-            "amp_",
-            "?amp"
-        ],
         "trackingParameters": [
             "utm_[a-zA-Z]*",
             "gclid",

--- a/features/user-agent-rotation.json
+++ b/features/user-agent-rotation.json
@@ -6,7 +6,6 @@
             "reason": "Two factor auth that verifies device pathes using user agent"
         }
     },
-    "state": "disabled",
     "settings": {
         "agentExcludePatterns": [
             {

--- a/index.js
+++ b/index.js
@@ -137,15 +137,17 @@ const legacyNaming = {
 const protections = {}
 for (const key in legacyNaming) {
     let newConfig
+    const override = JSON.parse(fs.readFileSync(`${OVERRIDE_DIR}/extension-override.json`))
     if (!defaultConfig.features[key] || defaultConfig.features[key].state !== 'enabled') {
-        const override = JSON.parse(fs.readFileSync(`${OVERRIDE_DIR}/extension-override.json`))
         if (!override.features[key]) {
             continue
         }
 
         newConfig = override.features[key]
         if (!newConfig.exceptions) {
-            newConfig.exceptions = []
+            // feature may be disabled in default config but enabled in override
+            // add exceptions from default config
+            newConfig.exceptions = defaultConfig.features[key]?.exceptions || []
         }
 
         // TODO: convert camel key to hyphen
@@ -155,6 +157,7 @@ for (const key in legacyNaming) {
         }
     } else {
         newConfig = defaultConfig.features[key]
+        newConfig.exceptions = newConfig.exceptions.concat(override.features[key]?.exceptions || [])
     }
     const legacyConfig = {
         enabled: newConfig.state === 'enabled',

--- a/index.js
+++ b/index.js
@@ -91,6 +91,7 @@ for (const platform of platforms) {
         if (isFeatureDisabled(platformConfig.features[key])) {
             // If feature isn't enabled for platform remove.
             // delete platformConfig.features[key]
+            platformConfig.features[key].state = 'disabled'
         }
     }
 
@@ -142,6 +143,9 @@ for (const key in legacyNaming) {
         }
 
         newConfig = override.features[key]
+        if (!newConfig.exceptions) {
+            newConfig.exceptions = []
+        }
 
         // TODO: convert camel key to hyphen
         if (fs.existsSync(`${LISTS_DIR}/${key}.json`)) {

--- a/overrides/extension-override.json
+++ b/overrides/extension-override.json
@@ -1,8 +1,40 @@
 {
     "features": {
         "autofill": {
-            "state": "enabled",
-            "exceptions": []
+            "state": "enabled"
+        },
+        "referrer": {
+            "state": "enabled"
+        },
+        "clickToPlay": {
+            "state": "enabled"
+        },
+        "trackingCookies3p": {
+            "state": "enabled"
+        },
+        "trackingCookies1p": {
+            "state": "enabled"
+        },
+        "fingerprintingCanvas": {
+            "state": "enabled"
+        },
+        "fingerprintingAudio": {
+            "state": "disabled"
+        },
+        "fingerprintingTemporaryStorage": {
+            "state": "enabled"
+        },
+        "fingerprintingScreenSize": {
+            "state": "enabled"
+        },
+        "fingerprintingHardware": {
+            "state": "enabled"
+        },
+        "fingerprintingBattery": {
+            "state": "enabled"
+        },
+        "floc": {
+            "state": "enabled"
         }
     },
     "unprotectedTemporary": [

--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -8,7 +8,7 @@
                 }
             ]
         },
-        "fingerprintingTemporarayStorage": {
+        "fingerprintingTemporaryStorage": {
             "state": "enabled"
         },
         "fingerprintingScreenSize": {
@@ -28,58 +28,10 @@
             }
         },
         "ampLinks": {
-            "state": "enabled",
-            "exceptions": [],
-            "settings": {
-                "linkFormats": [
-                    "^https?:\\/\\/(?:w{3}\\.)?google\\.\\S{2,}\\/amp\\/s\\/(\\S+)$",
-                    "^https?:\\/\\/\\S+ampproject\\.org\\/v\\/s\\/(\\S+)$"
-                ],
-                "keywords": [
-                    "=amp",
-                    "amp=",
-                    "&amp",
-                    "amp&",
-                    "/amp",
-                    "amp/",
-                    ".amp",
-                    "amp.",
-                    "%amp",
-                    "amp%",
-                    "_amp",
-                    "amp_",
-                    "?amp"
-                ]
-            }
+            "state": "enabled"
         },
         "trackingParameters": {
-            "state": "enabled",
-            "exceptions": [],
-            "settings": {
-                "parameters": [
-                    "utm_[a-zA-Z]*",
-                    "gclid",
-                    "fbclid",
-                    "fb_action_ids",
-                    "fb_action_types",
-                    "fb_source",
-                    "fb_ref",
-                    "ga_source",
-                    "ga_medium",
-                    "ga_term",
-                    "ga_content",
-                    "ga_campaign",
-                    "ga_place",
-                    "action_object_map",
-                    "action_type_map",
-                    "action_ref_map",
-                    "gs_l",
-                    "mkt_tok",
-                    "hmb_campaign",
-                    "hmb_source",
-                    "hmb_medium"
-                ]
-            }
+            "state": "enabled"
         }
     },
     "unprotectedTemporary": [

--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -8,53 +8,17 @@
                 }
             ]
         },
+        "fingerprintingTemporarayStorage": {
+            "state": "enabled"
+        },
+        "fingerprintingScreenSize": {
+            "state": "enabled"
+        },
+        "fingerprintingBattery": {
+            "state": "enabled"
+        },
         "trackingLinks": {
-            "state": "enabled",
-            "exceptions": [],
-            "settings": {
-                "ampLinkFormats": [
-                    "https?:\\/\\/(?:w{3}\\.)?google\\.\\w{2,}\\/amp\\/s\\/(\\S+)",
-                    "https?:\\/\\/\\S+ampproject\\.org\\/v\\/s\\/(\\S+)"
-                ],
-                "ampKeywords": [
-                    "=amp",
-                    "amp=",
-                    "&amp",
-                    "amp&",
-                    "/amp",
-                    "amp/",
-                    ".amp",
-                    "amp.",
-                    "%amp",
-                    "amp%",
-                    "_amp",
-                    "amp_",
-                    "?amp"
-                ],
-                "trackingParameters": [
-                    "utm_[a-zA-Z]*",
-                    "gclid",
-                    "fbclid",
-                    "fb_action_ids",
-                    "fb_action_types",
-                    "fb_source",
-                    "fb_ref",
-                    "ga_source",
-                    "ga_medium",
-                    "ga_term",
-                    "ga_content",
-                    "ga_campaign",
-                    "ga_place",
-                    "action_object_map",
-                    "action_type_map",
-                    "action_ref_map",
-                    "gs_l",
-                    "mkt_tok",
-                    "hmb_campaign",
-                    "hmb_source",
-                    "hmb_medium"
-                ]
-            }
+            "state": "enabled"
         }
     },
     "unprotectedTemporary": [

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -3,6 +3,9 @@
         "navigatorCredentials": {
             "state": "enabled"
         },
+        "autoconsent": {
+            "enabled": true
+        },
         "gpc": {
             "settings": {
                 "gpcHeaderEnabledSites": [

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -4,7 +4,7 @@
             "state": "enabled"
         },
         "autoconsent": {
-            "enabled": true
+            "state": "enabled"
         },
         "gpc": {
             "settings": {

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -1,8 +1,7 @@
 {
     "features": {
         "navigatorCredentials": {
-            "state": "enabled",
-            "exceptions": []
+            "state": "enabled"
         },
         "gpc": {
             "settings": {


### PR DESCRIPTION
https://app.asana.com/0/1200890834746050/1201349025761436/f

I used https://app.asana.com/0/1200890834746050/1201287926785314/f as a guide to match which features are only on certain platforms. The generated configs should properly reflect the supported feature set. Some of our newer features (trackingLinks, navigatorCredentials) were moved into the `features` dir.

Also I think doing this broke something slightly with generating legacy configs. Namely the `protections.json` file. Please check it works as expected.