### PR TITLE
Fixes for AMP Regexes

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -13,8 +13,8 @@
             "exceptions": [],
             "settings": {
                 "linkFormats": [
-                    "https?:\\/\\/(?:w{3}\\.)?google\\.\\w{2,}\\/amp\\/s\\/(\\S+)",
-                    "https?:\\/\\/\\S+ampproject\\.org\\/v\\/s\\/(\\S+)"
+                    "^https?:\\/\\/(?:w{3}\\.)?google\\.\\S{2,}\\/amp\\/s\\/(\\S+)$",
+                    "^https?:\\/\\/\\S+ampproject\\.org\\/v\\/s\\/(\\S+)$"
                 ],
                 "keywords": [
                     "=amp",


### PR DESCRIPTION
Anchors the string to beginning and end and supports TLDs like `.co.uk`