### PR TITLE
Add GPC header sites to iOS config

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -8,6 +8,16 @@
                 }
             ]
         },
+        "gpc": {
+            "settings": {
+                "gpcHeaderEnabledSites": [
+                    "global-privacy-control.glitch.me",
+                    "washingtonpost.com",
+                    "nytimes.com",
+                    "privacy-test-pages.glitch.me"
+                ]
+            }
+        },
         "ampLinks": {
             "state": "enabled",
             "exceptions": [],


### PR DESCRIPTION
This is step 1 to bringing iOS to parity in its GPC implementation