### PR TITLE
adding `navigatorDDG` configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -121,3 +121,6 @@ dist
 
 # exclude built configs
 generated
+
+# JetBrains IDEs
+.idea

--- a/features/navigator-interface.json
+++ b/features/navigator-interface.json
@@ -1,0 +1,10 @@
+{
+    "_meta": {
+        "description": "Navigator interface to provide various signals about the presence of DDG",
+        "sampleExcludeRecords": {
+            "domain": "example.com",
+            "reason": "site breakage"
+        }
+    },
+    "exceptions": []
+}

--- a/overrides/extension-override.json
+++ b/overrides/extension-override.json
@@ -35,6 +35,9 @@
         },
         "floc": {
             "state": "enabled"
+        },
+        "navigatorInterface": {
+            "state": "enabled"
         }
     },
     "unprotectedTemporary": [

--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -32,6 +32,9 @@
         },
         "trackingParameters": {
             "state": "enabled"
+        },
+        "navigatorInterface": {
+            "state": "enabled"
         }
     },
     "unprotectedTemporary": [

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -15,6 +15,9 @@
                     "privacy-test-pages.glitch.me"
                 ]
             }
+        },
+        "navigatorInterface": {
+            "state": "enabled"
         }
     },
     "unprotectedTemporary": [


### PR DESCRIPTION
This PR is here to open the discussion about the proposed naming of the new DOM API that we're adding

Please see the following task: https://app.asana.com/0/72649045549333/1201487308673313/f
Tech Design: https://app.asana.com/0/0/1201508656742121/f

In the tech design, I suggested 2 names

```
navigatorNamespace
navigatorDDG
```

I don't have a strong preference, and I'm open to hearing other idea too?