### PR TITLE
Enable browsingTopics on extension config

### DIFF
--- a/features/browsing-topics.json
+++ b/features/browsing-topics.json
@@ -1,6 +1,6 @@
 {
     "_meta": {
-        "description": "Removal of floc [legacy protection]",
+        "description": "Removal of browsingTopics",
         "sampleExcludeRecords": {
             "domain": "example.com",
             "reason": "site breakage"

--- a/features/floc.json
+++ b/features/floc.json
@@ -6,5 +6,6 @@
             "reason": "site breakage"
         }
     },
+    "eol": "v1",
     "exceptions": []
 }

--- a/features/google-rejected.json
+++ b/features/google-rejected.json
@@ -1,6 +1,6 @@
 {
     "_meta": {
-        "description": "Removal of browsingTopics",
+        "description": "Removal of browsingTopics and FLEDGE",
         "sampleExcludeRecords": {
             "domain": "example.com",
             "reason": "site breakage"

--- a/index.js
+++ b/index.js
@@ -45,6 +45,12 @@ function generateV1Config (platformConfig) {
             delete v1Config.features[feature].minSupportedVersion
             v1Config.features[feature].state = 'disabled'
         }
+
+        if (v1Config.features[feature].eol === 'v1') {
+            // This feature's support ends in v1 so remove it from platformConfig
+            delete v1Config.features[feature].eol
+            delete platformConfig.features[feature]
+        }
     }
 
     return v1Config

--- a/index.js
+++ b/index.js
@@ -130,7 +130,7 @@ const legacyNaming = {
     fingerprintingBattery: 'battery',
     fingerprintingScreenSize: 'screen-size',
     fingerprintingHardware: 'hardware',
-    floc: 'floc',
+    browsingTopics: 'floc',
     gpc: 'gpc',
     autofill: 'autofill'
 }

--- a/index.js
+++ b/index.js
@@ -162,7 +162,7 @@ const legacyNaming = {
     fingerprintingBattery: 'battery',
     fingerprintingScreenSize: 'screen-size',
     fingerprintingHardware: 'hardware',
-    browsingTopics: 'floc',
+    googleRejected: 'floc',
     gpc: 'gpc',
     autofill: 'autofill'
 }

--- a/overrides/extension-override.json
+++ b/overrides/extension-override.json
@@ -33,6 +33,9 @@
         "fingerprintingBattery": {
             "state": "enabled"
         },
+        "browsingTopics": {
+            "state": "enabled"
+        },
         "floc": {
             "state": "enabled"
         },

--- a/overrides/extension-override.json
+++ b/overrides/extension-override.json
@@ -33,7 +33,7 @@
         "fingerprintingBattery": {
             "state": "enabled"
         },
-        "browsingTopics": {
+        "googleRejected": {
             "state": "enabled"
         },
         "floc": {


### PR DESCRIPTION
https://app.asana.com/0/1163321984198618/1201719300245228/f

`browsingTopics` is effectively replacing `floc`. This PR enables the browsingTopics protection for the extension.

**Note:** I've kept floc enabled in the config for previous extension versions.