### PR TITLE
enable CTL for macos

### DIFF
--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -8,6 +8,9 @@
         },
         "navigatorInterface": {
             "state": "enabled"
+        },        
+        "clickToPlay": {
+            "state": "enabled"
         }
     },
     "unprotectedTemporary": [


### PR DESCRIPTION
https://app.asana.com/0/0/1201694797383792/f

Enables Click to Load on mac.

Corresponding PR: more-duckduckgo-org/macos-browser#329