### PR TITLE
Disable AMP Link processing on Android

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -26,7 +26,7 @@
             ]
         },
         "ampLinks": {
-            "state": "enabled"
+            "state": "disabled"
         },
         "trackingParameters": {
             "state": "enabled"


### PR DESCRIPTION
We're seeing an increase in `WebView` crashes, so we're going to temporarily disable this feature to see if it is the cause.

Task: https://app.asana.com/0/414730916066338/1201814461914604/f