### PR TITLE
Enable AMP Link processing on Android

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -26,7 +26,7 @@
             ]
         },
         "ampLinks": {
-            "state": "disabled"
+            "state": "enabled"
         },
         "trackingParameters": {
             "state": "enabled"


### PR DESCRIPTION
We are confident that this was not the cause of the `WebView` crashes in the previous Android release, so we are re-enabling the feature.
I will continue to monitor once the feature is enabled.

Task: https://app.asana.com/0/414730916066338/1201850932614952/f