### PR TITLE
Add autoconsent exceptions for derstandard

### DIFF
--- a/features/autoconsent.json
+++ b/features/autoconsent.json
@@ -9,6 +9,12 @@
     "exceptions": [{
         "domain": "spiegel.de",
         "reason": "Opt-out not possible"
+    }, {
+        "domain": "www.derstandard.de",
+        "reason": "Opt-out not possible"
+    }, {
+        "domain": "www.derstandard.at",
+        "reason": "Opt-out not possible"
     }],
     "settings": {
         "disabledCMPs": []


### PR DESCRIPTION
These sites do not offer an opt-out -- just 'allow all' or 'subscribe', so we automatic opt-out will fail.