### PR TITLE
Disable tracking parameters feature

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -29,7 +29,7 @@
             "state": "enabled"
         },
         "trackingParameters": {
-            "state": "enabled"
+            "state": "disabled"
         },
         "autofill": {
             "state": "enabled"


### PR DESCRIPTION
There is a crash when opening a parameter link from a mail in gmail.com (At least that's the only way I could reproduce it), so I'm disabling this feature until the issue is fixed.

Task: https://app.asana.com/0/414730916066338/1202011815553692/f