### PR TITLE
Enable AMP protections on extensions

### DIFF
--- a/features/amp-links.json
+++ b/features/amp-links.json
@@ -8,6 +8,8 @@
     },
     "exceptions": [],
     "settings": {
+        "deepExtractionEnabled": true,
+        "deepExtractionTimeout": 1500,
         "linkFormats": [
             "^https?:\\/\\/(?:w{3}\\.)?google\\.\\S{2,}\\/amp\\/s\\/(\\S+)$",
             "^https?:\\/\\/\\S+ampproject\\.org\\/v\\/s\\/(\\S+)$"

--- a/overrides/extension-override.json
+++ b/overrides/extension-override.json
@@ -41,6 +41,9 @@
         },
         "trackingParameters": {
             "state": "enabled"
+        },
+        "ampLinks": {
+            "state": "enabled"
         }
     },
     "unprotectedTemporary": [


### PR DESCRIPTION
See https://github.com/duckduckgo/duckduckgo-privacy-extension/pull/1092 for implementation