### PR TITLE
Update ampproject regex

### DIFF
--- a/features/amp-links.json
+++ b/features/amp-links.json
@@ -10,7 +10,7 @@
     "settings": {
         "linkFormats": [
             "^https?:\\/\\/(?:w{3}\\.)?google\\.\\S{2,}\\/amp\\/s\\/(\\S+)$",
-            "^https?:\\/\\/\\S+ampproject\\.org\\/v\\/s\\/(\\S+)$"
+            "^https?:\\/\\/\\S+ampproject\\.org\\/\\S\\/s\\/(\\S+)$"
         ],
         "keywords": [
             "=amp",


### PR DESCRIPTION
AMP url not previously matched by this regex: https://www-usatoday-com.cdn.ampproject.org/c/s/www.usatoday.com/amp-stories/beyonce-rule-the-world/