### PR TITLE
Generalize glean.com exception

### DIFF
--- a/overrides/extension-override.json
+++ b/overrides/extension-override.json
@@ -95,7 +95,7 @@
                         "reason": "broken videos"
                     },
                     {
-                        "domain": "app.glean.com",
+                        "domain": "glean.com",
                         "reason": "Broken login: https://github.com/duckduckgo/duckduckgo-privacy-extension/issues/1220"
                     },
                     {


### PR DESCRIPTION
**Task:** https://github.com/duckduckgo/duckduckgo-privacy-extension/issues/1220

**Description**
glean.com uses customer specific domains for cookies. Generalize the exception to catch them all.