### PR TITLE
Fix key being in wrong section

### DIFF
--- a/overrides/extension-override.json
+++ b/overrides/extension-override.json
@@ -176,50 +176,50 @@
         },
         "ampLinks": {
             "state": "enabled"
-        }
-    },
-    "trackerAllowlist": {
-        "settings": {
-            "allowlistedTrackers": {
-                "criteo.net": {
-                    "rules": [
-                        {
-                            "rule": "static.criteo.net/js/ld/publishertag.js",
-                            "domains": [
-                                "wp.pl"
-                            ],
-                            "reason": "Adwall appears which reappears when dismissed. The adwall prevents interaction with the page."
-                        },
-                        {
-                            "rule": "static.criteo.net/js/ld/publishertag.prebid.js",
-                            "domains": [
-                                "wp.pl"
-                            ],
-                            "reason": "Adwall appears which reappears when dismissed. The adwall prevents interaction with the page."
-                        }
-                    ]
-                },
-                "facebook.net": {
-                    "rules": [
-                        {
-                            "rule": "connect.facebook.net/en_US/fbevents.js",
-                            "domains": [
-                                "wp.pl"
-                            ],
-                            "reason": "Adwall appears which reappears when dismissed. The adwall prevents interaction with the page."
-                        }
-                    ]
-                },
-                "gemius.pl": {
-                    "rules": [
-                        {
-                            "rule": "wp.hit.gemius.pl/xgemius.js",
-                            "domains": [
-                                "wp.pl"
-                            ],
-                            "reason": "Adwall appears which reappears when dismissed. The adwall prevents interaction with the page."
-                        }
-                    ]
+        },
+        "trackerAllowlist": {
+            "settings": {
+                "allowlistedTrackers": {
+                    "criteo.net": {
+                        "rules": [
+                            {
+                                "rule": "static.criteo.net/js/ld/publishertag.js",
+                                "domains": [
+                                    "wp.pl"
+                                ],
+                                "reason": "Adwall appears which reappears when dismissed. The adwall prevents interaction with the page."
+                            },
+                            {
+                                "rule": "static.criteo.net/js/ld/publishertag.prebid.js",
+                                "domains": [
+                                    "wp.pl"
+                                ],
+                                "reason": "Adwall appears which reappears when dismissed. The adwall prevents interaction with the page."
+                            }
+                        ]
+                    },
+                    "facebook.net": {
+                        "rules": [
+                            {
+                                "rule": "connect.facebook.net/en_US/fbevents.js",
+                                "domains": [
+                                    "wp.pl"
+                                ],
+                                "reason": "Adwall appears which reappears when dismissed. The adwall prevents interaction with the page."
+                            }
+                        ]
+                    },
+                    "gemius.pl": {
+                        "rules": [
+                            {
+                                "rule": "wp.hit.gemius.pl/xgemius.js",
+                                "domains": [
+                                    "wp.pl"
+                                ],
+                                "reason": "Adwall appears which reappears when dismissed. The adwall prevents interaction with the page."
+                            }
+                        ]
+                    }
                 }
             }
         }


### PR DESCRIPTION
Followup on #282, fixes the `trackerAllowlist` key being in the wrong section.