### PR TITLE
Add qubushotel site to custom-user-agent list

### DIFF
--- a/features/custom-user-agent.json
+++ b/features/custom-user-agent.json
@@ -27,6 +27,10 @@
             {
                 "domain": "facebook.com",
                 "reason": "Site reports browser not supported"
+            },
+            {
+                "domain": "qubushotel.com",
+                "reason": "Site UI elements are not interactable"
             }
         ],
         "omitVersionSites": []


### PR DESCRIPTION
**Asana Task:**
https://app.asana.com/0/414709148257752/1202315203368304/f

**Description**
qubushotel website UI elements don't work correctly with our user agent. 
This PR adds the site to the `omitApplicationSites` settings