### PR TITLE
Ensure merged allowlistedTrackers are sorted

### DIFF
--- a/tests/build-tests.js
+++ b/tests/build-tests.js
@@ -171,4 +171,11 @@ describe('mergeAllowlistedTrackers', () => {
     it('should be able to perform a basic merge', () => {
         expect(mergeAllowlistedTrackers(ta1, ta2)).to.deep.equal(ta1plus2)
     })
+    it('should sort merged domain keys', () => {
+        expect(Object.keys(mergeAllowlistedTrackers({
+            f2: { rules: [] }, f4: { rules: [] }
+        }, {
+            f1: { rules: [] }, f3: { rules: [] }
+        }))).to.deep.equal(['f1', 'f2', 'f3', 'f4'])
+    })
 })

--- a/util.js
+++ b/util.js
@@ -35,7 +35,9 @@ function mergeAllowlistedTrackers (t1, t2) {
     for (const dom in t2) {
         addDomainRule(res, dom, t2[dom])
     }
-    return res
+    // Sort the resulting generated object by domain keys.
+    // This makes working with the generated config easier and more human-navigable.
+    return Object.keys(res).sort().reduce(function (acc, k) { acc[k] = res[k]; return acc }, {})
 }
 
 module.exports = {


### PR DESCRIPTION
https://app.asana.com/0/0/1202583040260414/f

This ensures `allowlistedTrackers` resulting from a merge are sorted in the output - this makes it easier to work with the generated files when performing manual changes (e.g., during testing for breakage).