### PR TITLE
Add mitigation for bing maps

### DIFF
--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -106,6 +106,16 @@
             "bing.com": {
                 "rules": [
                     {
+                        "rule": "r.bing.com/rp/",
+                        "domains": [
+                            "<all>"
+                        ],
+                        "reason": [
+                            "See https://github.com/duckduckgo/privacy-configuration/issues/321.",
+                            "These requests are associated with map/location functionality on websites."
+                        ]
+                    },
+                    {
                         "rule": "th.bing.com/th",
                         "domains": [
                             "drudgereport.com"
@@ -114,6 +124,46 @@
                             "On the homepage (drudgereport.com), some images are fetched from bing.com.",
                             "When we block these requests, the images do not render, and the page appears to have blank boxes.",
                             "Note that requests can be of the form th.bing.com/th?id=... or th.bing.com/th/id/..., hence we unblock the common path here."
+                        ]
+                    },
+                    {
+                        "rule": "www.bing.com/api/maps/mapcontrol",
+                        "domains": [
+                            "<all>"
+                        ],
+                        "reason": [
+                            "See https://github.com/duckduckgo/privacy-configuration/issues/321.",
+                            "This request is associated with map/location functionality on websites."
+                        ]
+                    },
+                    {
+                        "rule": "www.bing.com/api/v6/Places/AutoSuggest",
+                        "domains": [
+                            "<all>"
+                        ],
+                        "reason": [
+                            "See https://github.com/duckduckgo/privacy-configuration/issues/321.",
+                            "This request is associated with map/location auto-suggest functionality on websites."
+                        ]
+                    },
+                    {
+                        "rule": "www.bing.com/maps/sdkrelease/mapcontrol",
+                        "domains": [
+                            "<all>"
+                        ],
+                        "reason": [
+                            "See https://github.com/duckduckgo/privacy-configuration/issues/321.",
+                            "This request is associated with map/location functionality on websites."
+                        ]
+                    },
+                    {
+                        "rule": "www.bing.com/rp/",
+                        "domains": [
+                            "<all>"
+                        ],
+                        "reason": [
+                            "See https://github.com/duckduckgo/privacy-configuration/issues/321.",
+                            "These requests are associated with map/location functionality on websites."
                         ]
                     }
                 ]


### PR DESCRIPTION
https://app.asana.com/0/0/1202546809440417/f

This mitigates #321, where we found that blocking certain bing requests was causing widespread map/location breakage.