### PR TITLE
Remotely set the socket read alert threshold

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -22,7 +22,14 @@
                 },
                 "badHealthMitigation": {
                     "state": "enabled",
-                    "settings": {}
+                    "settings": {
+                        "triggers": {
+                            "socketReadExceptionAlerts": {
+                                "state": "enabled",
+                                "threshold": 20
+                            }
+                        }
+                    }
                 }
             }
         },


### PR DESCRIPTION
**Asana Task:** https://app.asana.com/0/1202279501986195/1202810419472818/f

**Description**
Move the threshold configuraiton for the socketRead exceptions to the remote config. See asana task for more info if necessary.

The resulting privacy config JSON has already been tested in the debug app and works as expected
