### PR TITLE
Disable amp protection on www.audiosciencereview.com due to redirect looping

### DIFF
--- a/features/amp-links.json
+++ b/features/amp-links.json
@@ -10,6 +10,10 @@
         {
             "domain": "freecodecamp.org",
             "reason": "Clicking 'get started' reloads the page and does not progress to the login page."
+        },
+        {
+            "domain": "www.audiosciencereview.com",
+            "reason": "Pages on the site end up in redirect loops in Firefox."
         }
     ],
     "settings": {


### PR DESCRIPTION
**Asana Task:**

https://app.asana.com/0/892838074342800/1202861196126465/f

**Description**

Disables amp protections due to confirmed reports of infinite redirect looping.