### PR TITLE
Enable Ad Click Attribution feature on macOS

### DIFF
--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -51,7 +51,7 @@
             "state": "enabled"
         },
         "adClickAttribution": {
-            "state": "disabled"
+            "state": "enabled"
         },
         "trackerAllowlist": {
             "settings": {


### PR DESCRIPTION
**Asana Task:**

https://app.asana.com/0/856498667320406/1202887636115165

**Description**

This has been initially disabled, but as this flag is not actively checked in current codebase, enabling that won't have any effect on macOS.