### PR TITLE
Generalise daumcdn mitigation

### DIFF
--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -289,7 +289,7 @@
                     {
                         "rule": "daumcdn.net",
                         "domains": [
-                            "tistory.com"
+                            "<all>"
                         ],
                         "reason": "https://github.com/duckduckgo/privacy-configuration/issues/444"
                     }


### PR DESCRIPTION
Expands mitigation for #444 to support more domains.