### PR TITLE
Add mitigation for aliexpress.us

### DIFF
--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -126,9 +126,9 @@
                     {
                         "rule": "alicdn.com",
                         "domains": [
-                            "aliexpress.com"
+                            "aliexpress.us"
                         ],
-                        "reason": "Page content renders as text without images."
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/issues/460"
                     }
                 ]
             },


### PR DESCRIPTION
- adds mitigation for entity data on aliexpress.us (see #460)
- removes old aliexpress.com mitigation too
