### PR TITLE
Automatically add CNAME mitigation entries for CNAME-target exceptions

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,21 +19,18 @@ const platforms = require('./platforms')
 
 const tdsPath = 'live'
 
-let tdsCached
 async function getTds () {
-    if (tdsCached) {
-        return tdsCached
-    }
+    let tds
     if (tdsPath === 'live') {
         console.log('Fetching remote TDS')
         const response = await fetch('https://staticcdn.duckduckgo.com/trackerblocking/v3/tds.json')
-        tdsCached = await response.json()
+        tds = await response.json()
         console.log('Fetched remote TDS')
     } else {
         console.log('Using local TDS')
-        tdsCached = JSON.parse(fs.readFileSync(tdsPath))
+        tds = JSON.parse(fs.readFileSync(tdsPath))
     }
-    return tdsCached
+    return tds
 }
 
 /**
@@ -126,6 +123,7 @@ function isFeatureMissingState (feature) {
 // Handle platform specific overrides and write configs to disk
 async function buildPlatforms () {
     const platformConfigs = {}
+    const tds = await getTds()
 
     for (const platform of platforms) {
         let platformConfig = JSON.parse(JSON.stringify(defaultConfig))
@@ -198,7 +196,6 @@ async function buildPlatforms () {
             platformConfig.unprotectedTemporary = platformConfig.unprotectedTemporary.concat(platformOverride.unprotectedTemporary)
         }
 
-        const tds = await getTds()
         addCnameEntriesToAllowlist(tds, platformConfig.features.trackerAllowlist.settings.allowlistedTrackers)
         platformConfig = inlineReasonArrays(platformConfig)
         platformConfigs[platform] = platformConfig

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,10 @@
       "name": "config-builder",
       "version": "1.0.0",
       "license": "Apache 2.0",
+      "dependencies": {
+        "node-fetch": "^3.2.10",
+        "tldts": "^5.7.91"
+      },
       "devDependencies": {
         "ajv": "^8.6.3",
         "chai": "^4.3.4",
@@ -529,6 +533,14 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.0.tgz",
+      "integrity": "sha512-Vr3mLBA8qWmcuschSLAOogKgQ/Jwxulv3RNE4FXnYWRGujzrRWQI4m12fQqRkwX06C0KanhLr4hK+GydchZsaA==",
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/debug": {
@@ -1197,6 +1209,28 @@
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
     "node_modules/file-entry-cache": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -1264,6 +1298,17 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.2.tgz",
       "integrity": "sha512-JaTY/wtrcSyvXJl4IMFHPKyFur1sE9AUqc0QnhOaJ0CxHtAoIV8pYDzeEfAaNEtGkOfq4gr3LBFmdXW5mOQFnA==",
       "dev": true
+    },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
     },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
@@ -2038,6 +2083,41 @@
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
+    },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "3.2.10",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.2.10.tgz",
+      "integrity": "sha512-MhuzNwdURnZ1Cp4XTazr69K0BTizsBroX7Zx3UgDSVcZYKF/6p0CBe4EUb/hLqmzVhl0UpYfgRljQ4yxE+iCxA==",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
     },
     "node_modules/normalize-package-data": {
       "version": "2.5.0",
@@ -2902,6 +2982,22 @@
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
       "dev": true
     },
+    "node_modules/tldts": {
+      "version": "5.7.91",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-5.7.91.tgz",
+      "integrity": "sha512-Z/oS4ptsj46Ak/HAK3XCezDAilfu5wqyqmyteinzXI1fRuBVC+HI87vWb82k6kRPuQjq/0/qU3zCix4HO5y/9g==",
+      "dependencies": {
+        "tldts-core": "^5.7.91"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "5.7.91",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-5.7.91.tgz",
+      "integrity": "sha512-j/x+MqakUhsWBOy9j1mmUgoErwaS4tgfwTP8j4tSeRG8UTrAWLDPhn3vjNx6mwgWl2cIgzHSBmnTS8bH3NndVQ=="
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -2997,6 +3093,14 @@
       "dependencies": {
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
+      }
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz",
+      "integrity": "sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q==",
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/which": {
@@ -3625,6 +3729,11 @@
         "which": "^2.0.1"
       }
     },
+    "data-uri-to-buffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.0.tgz",
+      "integrity": "sha512-Vr3mLBA8qWmcuschSLAOogKgQ/Jwxulv3RNE4FXnYWRGujzrRWQI4m12fQqRkwX06C0KanhLr4hK+GydchZsaA=="
+    },
     "debug": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
@@ -4128,6 +4237,15 @@
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
+    "fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "requires": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      }
+    },
     "file-entry-cache": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -4177,6 +4295,14 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.2.tgz",
       "integrity": "sha512-JaTY/wtrcSyvXJl4IMFHPKyFur1sE9AUqc0QnhOaJ0CxHtAoIV8pYDzeEfAaNEtGkOfq4gr3LBFmdXW5mOQFnA==",
       "dev": true
+    },
+    "formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "requires": {
+        "fetch-blob": "^3.1.2"
+      }
     },
     "fs.realpath": {
       "version": "1.0.0",
@@ -4737,6 +4863,21 @@
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
+    },
+    "node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ=="
+    },
+    "node-fetch": {
+      "version": "3.2.10",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.2.10.tgz",
+      "integrity": "sha512-MhuzNwdURnZ1Cp4XTazr69K0BTizsBroX7Zx3UgDSVcZYKF/6p0CBe4EUb/hLqmzVhl0UpYfgRljQ4yxE+iCxA==",
+      "requires": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      }
     },
     "normalize-package-data": {
       "version": "2.5.0",
@@ -5375,6 +5516,19 @@
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
       "dev": true
     },
+    "tldts": {
+      "version": "5.7.91",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-5.7.91.tgz",
+      "integrity": "sha512-Z/oS4ptsj46Ak/HAK3XCezDAilfu5wqyqmyteinzXI1fRuBVC+HI87vWb82k6kRPuQjq/0/qU3zCix4HO5y/9g==",
+      "requires": {
+        "tldts-core": "^5.7.91"
+      }
+    },
+    "tldts-core": {
+      "version": "5.7.91",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-5.7.91.tgz",
+      "integrity": "sha512-j/x+MqakUhsWBOy9j1mmUgoErwaS4tgfwTP8j4tSeRG8UTrAWLDPhn3vjNx6mwgWl2cIgzHSBmnTS8bH3NndVQ=="
+    },
     "to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -5453,6 +5607,11 @@
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
       }
+    },
+    "web-streams-polyfill": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz",
+      "integrity": "sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q=="
     },
     "which": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -19,5 +19,9 @@
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-promise": "^5.1.0",
     "mocha": "^9.1.1"
+  },
+  "dependencies": {
+    "node-fetch": "^3.2.10",
+    "tldts": "^5.7.91"
   }
 }

--- a/tests/build-tests.js
+++ b/tests/build-tests.js
@@ -178,6 +178,10 @@ describe('mergeAllowlistedTrackers', () => {
             f1: { rules: [] }, f3: { rules: [] }
         }))).to.deep.equal(['f1', 'f2', 'f3', 'f4'])
     })
+    it('is idempotent', () => {
+        const gen = () => ({ 'simple.com': { rules: [{ rule: 'really.simple.com/foo', domains: ['domain1.com'], reason: 'Simple reason' }] } })
+        expect(mergeAllowlistedTrackers(gen(), gen())).to.deep.equal(gen())
+    })
 })
 
 describe('inlineReasonArrays', () => {

--- a/tests/build-tests.js
+++ b/tests/build-tests.js
@@ -1,6 +1,6 @@
 const expect = require('chai').expect
 
-const { inlineReasonArrays, mergeAllowlistedTrackers } = require('../util')
+const { addAllowlistRule, addCnameEntriesToAllowlist, inlineReasonArrays, mergeAllowlistedTrackers } = require('../util')
 
 const ta1 = {
     'f1.com': {
@@ -181,6 +181,73 @@ describe('mergeAllowlistedTrackers', () => {
     it('is idempotent', () => {
         const gen = () => ({ 'simple.com': { rules: [{ rule: 'really.simple.com/foo', domains: ['domain1.com'], reason: 'Simple reason' }] } })
         expect(mergeAllowlistedTrackers(gen(), gen())).to.deep.equal(gen())
+    })
+})
+
+describe('addAllowlistRule', () => {
+    let allowlist
+    beforeEach(() => {
+        allowlist = {}
+    })
+    it('should add single entry', () => {
+        addAllowlistRule(allowlist, { rule: 'really.simple.com/foo', domains: ['domain1.com'], reason: 'Simple reason' })
+        expect(allowlist).to.deep.equal({ 'simple.com': { rules: [{ rule: 'really.simple.com/foo', domains: ['domain1.com'], reason: 'Simple reason' }] } })
+    })
+    it('identifies true base domain', () => {
+        addAllowlistRule(allowlist, { rule: 'really.simple.co.uk/foo', domains: ['domain1.com'], reason: 'Simple reason' })
+        expect(Object.keys(allowlist)).to.deep.equal(['simple.co.uk'])
+    })
+    it('should be idempotent', () => {
+        addAllowlistRule(allowlist, { rule: 'really.simple.com/foo', domains: ['domain1.com'], reason: 'Simple reason' })
+        addAllowlistRule(allowlist, { rule: 'really.simple.com/foo', domains: ['domain1.com'], reason: 'Simple reason' })
+        expect(allowlist).to.deep.equal({ 'simple.com': { rules: [{ rule: 'really.simple.com/foo', domains: ['domain1.com'], reason: 'Simple reason' }] } })
+    })
+    it('does not add duplicate reason', () => {
+        addAllowlistRule(allowlist, { rule: 'really.simple.com/foo', domains: ['domain1.com'], reason: 'Simple reason 1' })
+        addAllowlistRule(allowlist, { rule: 'really.simple.com/foo', domains: ['domain1.com'], reason: 'Simple reason 2' })
+        addAllowlistRule(allowlist, { rule: 'really.simple.com/foo', domains: ['domain1.com'], reason: 'Simple reason 2' })
+        expect(allowlist).to.deep.equal({ 'simple.com': { rules: [{ rule: 'really.simple.com/foo', domains: ['domain1.com'], reason: 'Simple reason 1; Simple reason 2' }] } })
+    })
+    it('should merge domains and reasons', () => {
+        addAllowlistRule(allowlist, { rule: 'really.simple.com/foo', domains: ['domain1.com'], reason: 'Simple reason 1' })
+        addAllowlistRule(allowlist, { rule: 'really.simple.com/foo', domains: ['domain2.com'], reason: 'Simple reason 2' })
+        expect(allowlist).to.deep.equal({ 'simple.com': { rules: [{ rule: 'really.simple.com/foo', domains: ['domain1.com', 'domain2.com'], reason: 'Simple reason 1; Simple reason 2' }] } })
+    })
+})
+
+describe('addCnameEntriesToAllowlist', () => {
+    const mkRule = (rulePath, domains, reason) => {
+        return {
+            rule: rulePath,
+            domains: domains || ['<all>'],
+            reason: reason || ''
+        }
+    }
+    const tds = { cnames: { 'tracker.simple.com': 'simple.tracker.com', 'tracker.simple2.com': 'simple2.tracker.com' } }
+    it('adds only specific domains when full CNAME domain specified', () => {
+        const allowlist = {}
+        addAllowlistRule(allowlist, mkRule('simple.tracker.com/request'))
+        addCnameEntriesToAllowlist(tds, allowlist)
+        expect(Object.keys(allowlist)).to.deep.equal(['tracker.com', 'simple.com'])
+    })
+    it('if domains are specified, exempts only on specified domains', () => {
+        const allowlist = {}
+        addAllowlistRule(allowlist, mkRule('simple.tracker.com/request', ['domain.com']))
+        addCnameEntriesToAllowlist(tds, allowlist)
+        expect(allowlist['simple.com'].rules[0].domains).to.deep.equal(['domain.com'])
+    })
+    it('merges with existing entry', () => {
+        const allowlist = {}
+        addAllowlistRule(allowlist, mkRule('tracker.simple.com/request', ['domain1.com']))
+        addAllowlistRule(allowlist, mkRule('simple.tracker.com/request', ['domain2.com']))
+        addCnameEntriesToAllowlist(tds, allowlist)
+        expect(allowlist['simple.com'].rules[0].domains).to.deep.equal(['domain1.com', 'domain2.com'])
+    })
+    it('adds all domains when partial CNAME domain specified', () => {
+        const allowlist = {}
+        addAllowlistRule(allowlist, mkRule('tracker.com/request'))
+        addCnameEntriesToAllowlist(tds, allowlist)
+        expect(Object.keys(allowlist)).to.deep.equal(['tracker.com', 'simple.com', 'simple2.com'])
     })
 })
 

--- a/util.js
+++ b/util.js
@@ -24,7 +24,11 @@ function addPathRule (rules, rule) {
         rules.push(existing)
     }
     existing.domains = Array.from(new Set(existing.domains.concat(rule.domains).sort()))
-    existing.reason = [existing.reason, rule.reason].filter(function (x) { return x !== '' }).join('; ')
+    const reasons = existing.reason.split('; ')
+    const newReason = rule.reason
+    if (!reasons.includes(rule.reason)) {
+        existing.reason = reasons.concat([newReason]).filter(function (x) { return x !== '' }).join('; ')
+    }
 }
 
 function mergeAllowlistedTrackers (t1, t2) {

--- a/util.js
+++ b/util.js
@@ -31,6 +31,9 @@ function addPathRule (rules, rule) {
         rules.push(existing)
     }
     existing.domains = Array.from(new Set(existing.domains.concat(rule.domains).sort()))
+    if (existing.domains.includes('<all>')) {
+        existing.domains = ['<all>']
+    }
     const reasons = existing.reason.split('; ')
     const newReason = rule.reason
     if (!reasons.includes(rule.reason)) {

--- a/util.js
+++ b/util.js
@@ -1,8 +1,10 @@
+const tldts = require('tldts')
+
 function getAllowlistedRule (rules, rulePath) {
     return rules.find(function (x) { return x.rule === rulePath })
 }
 
-function addDomainRule (allowlist, domain, rule) {
+function addDomainRules (allowlist, domain, rule) {
     const found = allowlist[domain]
     const existing = found || { rules: [] }
     if (!found) {
@@ -15,6 +17,11 @@ function addDomainRule (allowlist, domain, rule) {
     existing.rules.sort(function (a, b) {
         return a.rule.includes(b.rule) ? -1 : b.rule.includes(a.rule) ? 1 : 0
     })
+}
+
+function addAllowlistRule (allowlist, rule) {
+    const dom = tldts.getDomain(rule.rule)
+    addDomainRules(allowlist, dom, { rules: [rule] })
 }
 
 function addPathRule (rules, rule) {
@@ -34,10 +41,10 @@ function addPathRule (rules, rule) {
 function mergeAllowlistedTrackers (t1, t2) {
     const res = {}
     for (const dom in t1) {
-        addDomainRule(res, dom, t1[dom])
+        addDomainRules(res, dom, t1[dom])
     }
     for (const dom in t2) {
-        addDomainRule(res, dom, t2[dom])
+        addDomainRules(res, dom, t2[dom])
     }
     // Sort the resulting generated object by domain keys.
     // This makes working with the generated config easier and more human-navigable.
@@ -69,7 +76,42 @@ function inlineReasonArrays (data) {
     }
 }
 
+/**
+ * All domains that may map to the given cnameTarget.
+ */
+function getCnameSources (tds, cnameTarget) {
+    return Object.entries(tds.cnames).filter(([k, v]) => v.endsWith(cnameTarget)).map(kv => kv[0])
+}
+
+/**
+ * Generate rules which CNAME to the CNAMEd rule.
+ */
+function generateCnameRules (tds, cnamedRule) {
+    const dom = cnamedRule.rule.split('/')[0]
+    const sources = getCnameSources(tds, dom)
+    const resultRules = []
+    for (const source of sources) {
+        resultRules.push({
+            ...cnamedRule,
+            rule: cnamedRule.rule.replace(dom, source),
+            reason: 'CNAME ENTRY GENERATED FROM: ' + dom
+        })
+    }
+    return resultRules
+}
+
+/**
+ * Add CNAME entries to the allowlist to support platforms with incorrect CNAME resolution.
+ */
+function addCnameEntriesToAllowlist (tds, allowlist) {
+    Object.values(allowlist).forEach(ruleSet => ruleSet.rules.forEach(rule => {
+        generateCnameRules(tds, rule).forEach(rule => addAllowlistRule(allowlist, rule))
+    }))
+}
+
 module.exports = {
+    addAllowlistRule: addAllowlistRule,
+    addCnameEntriesToAllowlist: addCnameEntriesToAllowlist,
     inlineReasonArrays: inlineReasonArrays,
     mergeAllowlistedTrackers: mergeAllowlistedTrackers
 }


### PR DESCRIPTION
https://app.asana.com/0/0/1203041061869327/f

To alleviate differences with how CNAMEs may be resolved when reading the config, this does the following:

- when the config is built (`index.js`), for every rule `R` that exists for a CNAME-target domain `C`, for every `S` that has a CNAME mapping `S -> [X.]C`, we generate a rule `[S/C]R` that is rule `R` on domain `S` instead of `C`. The presence of `[X.]` means that we can specify e.g., an exact CNAME target, or we can specify a more general CNAME target, which will generate exceptions for any matching CNAME source.
- the current live tds is used to determine CNAMEs
  - note that this means that a client on an older TDS may have different CNAME expectations, but using the live TDS should be a good approximation without needing any platform changes

- note that most of the changes to `index.js` are just indentation to accommodate the async fetch
  - helps to view the diff without spacing changes -> https://github.com/duckduckgo/privacy-configuration/pull/481/files?diff=unified&w=1

### Testing

1. Look up a CNAME entry (`S -> T`) in https://staticcdn.duckduckgo.com/trackerblocking/v3/tds.json
2. Add a `trackerAllowlist` exception for the target (`T`) of the CNAME entry
3. Run `node index.js`
4. Check the `generated/v2/*-config.json` files, you should see a generated entry for `S`
5. Look up a CNAME entry `S1 -> X1.T` and entry `S2 -> X2.T`
6. Add a `trackerAllowlist` exception for the subdomain target `T`
7. Run `node index.js`
8. Check the `generated/v2/*-config.json` files, you should see a generated entry for `S1` and for `S2`