### PR TITLE
Add mitigation for bing maps on dhl.de

### DIFF
--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -256,6 +256,15 @@
                         ]
                     },
                     {
+                        "rule": "www.bing.com/maps/sdk/mapcontrol",
+                        "domains": [
+                            "<all>"
+                        ],
+                        "reason": [
+                            "https://github.com/duckduckgo/privacy-configuration/issues/321"
+                        ]
+                    },
+                    {
                         "rule": "www.bing.com/maps/sdkrelease/mapcontrol",
                         "domains": [
                             "<all>"
@@ -409,6 +418,7 @@
                     {
                         "rule": "dpm.demdex.net/id",
                         "domains": [
+                            "dhl.de",
                             "homedepot.com"
                         ],
                         "reason": "https://github.com/duckduckgo/privacy-configuration/issues/393"


### PR DESCRIPTION
Adds mitigation for dhl.de bing maps - see #321  and #393.