### PR TITLE
Enable protectGames AppTP config

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -4,6 +4,9 @@
             "state": "enabled",
             "exceptions": [],
             "settings": {
+                "protectGames": {
+                    "state": "enabled"
+                },
                 "connectivityChecks": {
                     "state": "enabled"
                 },


### PR DESCRIPTION
**Asana Task:**
https://app.asana.com/0/0/1203179573627817/f

**Description**
We're updating the AppTP exclusion list where we have removed a lot of exceptions (see [this task](https://app.asana.com/0/0/1203013400411200/f)).

Games exceptions are not part of the exception list because they're detected at runtime, but are guarded by a remote config, ie. `protectGames`.

This PR enables `protectGames` so that Game apps are also protected by default as part of the effort to reduce the AppTP exclusion list to offer more out of the box protection to our users.
