### PR TITLE
Disable web-compat fixes for discourse sites as causing breakage

### DIFF
--- a/features/web-compat.json
+++ b/features/web-compat.json
@@ -6,5 +6,26 @@
             "reason": "site breakage"
         }
     },
-    "exceptions": []
+    "exceptions": [
+        {
+            "domain": "forums.swift.org",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/issues/519"
+        },
+        {
+            "domain": "twittercommunity.com",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/issues/519"
+        },
+        {
+            "domain": "forum.asana.com",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/issues/519"
+        },
+        {
+            "domain": "community.developer.atlassian.com",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/issues/519"
+        },
+        {
+            "domain": "meta.discourse.org",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/issues/519"
+        }
+    ]
 }


### PR DESCRIPTION
**Asana Task:** https://app.asana.com/0/1200277586140538/1203187378723611/f

**Description**

Discourse fails to load as we're shimming window.safari for other website breakage. Fix is here: https://github.com/duckduckgo/content-scope-scripts/pull/172

Reported: https://github.com/duckduckgo/privacy-configuration/issues/519