### PR TITLE
Disable spiegel.de and derstandard.at

### DIFF
--- a/features/autoconsent.json
+++ b/features/autoconsent.json
@@ -24,6 +24,12 @@
     }, {
         "domain": "n-tv.de",
         "reason": "Page renders but one cannot scroll (and no CMP is shown) for a few seconds."
+    },{
+        "domain": "spiegel.de",
+        "reason": "CMP gets incorrectly handled, gets stuck in preferences dialogue."
+    },{
+        "domain": "derstandard.at",
+        "reason": "CMP gets incorrectly handled / detected."
     }, {
         "domain": "concursolutions.com",
         "reason": "Page renders blank for several seconds before cookie management can complete."


### PR DESCRIPTION
**Asana Task:** https://app.asana.com/0/1201844467387842/1203191122685034/f & https://app.asana.com/0/1199230911884351/1203144940444659/f

**Description**

As we're still having issues correctly handling cookie consent on these sites (and as we can't do an opt-out there anyway) let's disable them for now until we have a fix.
