### PR TITLE
Disable autoconsent on swm.de to prevent infinite reload

### DIFF
--- a/features/autoconsent.json
+++ b/features/autoconsent.json
@@ -33,6 +33,9 @@
     }, {
         "domain": "concursolutions.com",
         "reason": "Page renders blank for several seconds before cookie management can complete."
+    }, {
+        "domain": "swm.de",
+        "reason": "infinite reload"
     }],
     "settings": {
         "disabledCMPs": []


### PR DESCRIPTION
**Asana Task:** https://app.asana.com/0/1201844467387842/1203197597853180/f

**Description**
False positive in popup open detection, and a page reload triggered by opt-out are causing an infinite reload on swm.de in the mac browser.