### PR TITLE
Mitigate lastpass MacOS breakage

### DIFF
--- a/features/web-compat.json
+++ b/features/web-compat.json
@@ -8,6 +8,10 @@
     },
     "exceptions": [
         {
+            "domain": "lastpass.com",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/issues/533"
+        },
+        {
             "domain": "forums.swift.org",
             "reason": "https://github.com/duckduckgo/privacy-configuration/issues/519"
         },


### PR DESCRIPTION
**Asana Task:** https://app.asana.com/0/1177771139624306/1203280562787367/f


**Description**
https://github.com/duckduckgo/privacy-configuration/issues/533

Lastpass.com (last verified 2022-11-03)
    Missing Safari API similar to 

Discourse breakage #519 breaking login