### PR TITLE
Disable Sourcepoint-top CMP

### DIFF
--- a/features/autoconsent.json
+++ b/features/autoconsent.json
@@ -44,6 +44,8 @@
         "reason": "infinite reload"
     }],
     "settings": {
-        "disabledCMPs": []
+        "disabledCMPs": [
+            "Sourcepoint-top"
+        ]
     }
 }


### PR DESCRIPTION
**Asana Task:**
https://app.asana.com/0/0/1203288491490638/f

**Description**
This prevents the consent management feature from triggering on some sites which do not offer an opt-out (only opt-in and subscription).


