### PR TITLE
Broaden klaviyo exception on kmail-lists.com

### DIFF
--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -933,7 +933,7 @@
                         "reason": "https://github.com/duckduckgo/privacy-configuration/issues/362"
                     },
                     {
-                        "rule": "static-app.klaviyo.com/",
+                        "rule": "klaviyo.com/",
                         "domains": [
                             "kmail-lists.com"
                         ],


### PR DESCRIPTION
https://github.com/duckduckgo/privacy-configuration/issues/362#issuecomment-1325339347

**Asana Task:** https://app.asana.com/0/1200277586140538/1203424780734379/f

**Description**
Allow all klaviyo subdomains on kmail-lists (same owner).