### PR TITLE
Change bannerAd hiding rule from closest-empty to hide-empty

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -39,7 +39,7 @@
             },
             {
                 "selector": "[class*='bannerAd']",
-                "type": "closest-empty"
+                "type": "hide-empty"
             },
             {
                 "selector": ".ad-container",


### PR DESCRIPTION
**Asana Task:** https://app.asana.com/0/1177771139624306/1203464830721025/f

**Description**
This is a temporary fix to address element hiding related breakage found on https://www.msn.com/en-us/news/technology/elon-musk-may-be-luring-apple-into-a-fight-with-republicans/ar-AA14I7oj. What's happening there is the heuristic we use to determine if an element contains visible content doesn't see shadow DOM content, so we end up hiding the article title and byline.

I'll follow up with a fix to the heuristic we use to address all potential cases like this.