### PR TITLE
Add exceptions to fix reported breakage

### DIFF
--- a/features/app-tracker-protection.json
+++ b/features/app-tracker-protection.json
@@ -93,6 +93,9 @@
                         },
                         {
                             "packageName": "com.marriott.mrt"
+                        },
+                        {   
+                            "packageName": "com.toyota.oneapp"
                         }
                     ]
                 },
@@ -142,6 +145,9 @@
                         },
                         {
                             "packageName": "com.marriott.mrt"
+                        },
+                        {
+                            "packageName": "com.sap.mdc.loblaw.nativ"
                         }
                     ]
                 },
@@ -219,6 +225,22 @@
                     ]
                 },
                 {
+                    "domain": "insight.adsrvr.org",
+                    "packageNames": [
+                        {
+                            "packageName": "com.safeway.client.android.safeway"
+                        }
+                    ]
+                },
+                {
+                    "domain": "js.adsrvr.org",
+                    "packageNames": [
+                        {
+                            "packageName": "com.safeway.client.android.safeway"
+                        }
+                    ]
+                },
+                {
                     "domain": "sc.omtrdc.net",
                     "packageNames": [
                         {
@@ -253,6 +275,15 @@
                     "packageNames": [
                         {
                             "packageName": "com.coppi.bestbuy"
+                        },
+                        {
+                            "packageName": "com.discoverfinancial.mobile"
+                        },
+                        {
+                            "packageName": "com.fedex.ida.android"
+                        },
+                        {
+                            "packageName": "com.macys.android"
                         },
                         {
                             "packageName": "com.subway.mobile.subwayapp03"
@@ -309,6 +340,9 @@
                         },
                         {
                             "packageName": "com.subway.subway"
+                        },
+                        {
+                            "packageName": "org.thoughtcrime.securesms"
                         }
                     ]
                 },
@@ -343,6 +377,9 @@
                         },
                         {
                             "packageName": "get.instagram.followers.unfollowers"
+                        },
+                        {
+                            "packageName": "org.thoughtcrime.securesms"
                         }
                     ]
                 }
@@ -521,6 +558,10 @@
                     "reason": "App loads websites"
                 },
                 {
+                    "packageName": "com.google.android.apps.chromecast.app",
+                    "reason": "Users report app issues with AppTP enabled"
+                },
+                {
                     "packageName": "com.google.android.apps.searchlite",
                     "reason": "App loads websites"
                 },
@@ -673,10 +714,6 @@
                     "reason": "App loads websites"
                 },
                 {
-                    "packageName": "com.vanced.android.youtube",
-                    "reason": "Users report app issues with AppTP enabled"
-                },
-                {
                     "packageName": "com.vivaldi.browser",
                     "reason": "App loads websites"
                 },
@@ -702,6 +739,10 @@
                 },
                 {
                     "packageName": "fast.private.secure.browser",
+                    "reason": "App loads websites"
+                },
+                {
+                    "packageName": "io.github.forkmaintainers.iceraven",
                     "reason": "App loads websites"
                 },
                 {


### PR DESCRIPTION
**Asana Task:**
https://app.asana.com/0/1202279501986195/1203472773665611/f

**Description**
Allow:
* 1 Branch domain to fix Toyota loading
* 1 Adobe domain to fix some functions in Macy's & PC Optimum + FedEx app loading
* 2 Adobe domains to fix Discover login
* 2 Trade Desk domains to fix some Safeway functions
* Main Facebook & Instagram domains to fix link previews in Signal

Exclude from protection:
* Google Home to allow device setup
* Iceraven because it's a browser