### PR TITLE
Set checkBlockingFunction state to internal

### DIFF
--- a/features/app-tracker-protection.json
+++ b/features/app-tracker-protection.json
@@ -4,7 +4,7 @@
     },
     "settings": {
         "checkBlockingFunction": {
-            "state": "enabled"
+            "state": "internal"
         },
         "openBeta": {
             "state": "enabled"


### PR DESCRIPTION
**Asana Task:**https://app.asana.com/0/0/1203486119137072/f

**Description**
Set "checkBlockingFunction" back to "internal" as it may be contributing to the increase of known crashes in Android release 5.144.0
