### PR TITLE
Add Android hardware fingerprinting exception: crocs.com

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -76,7 +76,13 @@
                 "keyboard": {"type": "undefined"},
                 "hardwareConcurrency": {"type": "number", "value": 8},
                 "deviceMemory": {"type": "number", "value": 4}
-            }
+            },
+            "exceptions": [
+                {
+                    "domain": "crocs.com",
+                    "reason": "https://github.com/duckduckgo/privacy-configuration/issues/567"
+                }
+            ]
         },
         "fingerprintingScreenSize": {
             "state": "enabled",


### PR DESCRIPTION
**Asana Task:**
https://app.asana.com/0/1202552961248957/1203491772909082/f

**Description**
Issue: https://github.com/duckduckgo/privacy-configuration/issues/567
Adds an exception for crocs.com to `fingerprintingHardware`.

**Before**
![without exception](https://user-images.githubusercontent.com/3471025/205910339-a1fbf971-2ad1-4eb5-950d-58dbdb65c200.png)

**After**
![with exception](https://user-images.githubusercontent.com/3471025/205910370-e7a86993-76af-4199-923f-e2ca9e89b56f.png)