### PR TITLE
Element hiding: new ad labels, generic rules, and site specific rules

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -22,6 +22,18 @@
                 "type": "closest-empty"
             },
             {
+                "selector": "[id*='dfp_']",
+                "type": "closest-empty"
+            },
+            {
+                "selector": "#google_ads",
+                "type": "hide-empty"
+            },
+            {
+                "selector": ".adsbygoogle",
+                "type": "hide-empty"
+            },
+            {
                 "selector": "[id*='taboola-']",
                 "type": "closest-empty"
             },
@@ -36,6 +48,10 @@
             {
                 "selector": ".ad",
                 "type": "closest-empty"
+            },
+            {
+                "selector": "[class*='ad-content']",
+                "type": "hide-empty"
             },
             {
                 "selector": ".ad-leaderboard",
@@ -54,6 +70,14 @@
                 "type": "hide-empty"
             },
             {
+                "selector": "#credential_picker_container",
+                "type": "hide"
+            },
+            {
+                "selector": ".ad_container",
+                "type": "closest-empty"
+            },
+            {
                 "selector": ".ad-container",
                 "type": "closest-empty"
             },
@@ -62,11 +86,19 @@
                 "type": "closest-empty"
             },
             {
+                "selector": ".advertisement",
+                "type": "closest-empty"
+            },
+            {
                 "selector": ".ad-slot",
                 "type": "closest-empty"
             },
             {
                 "selector": ".ad-wrapper",
+                "type": "closest-empty"
+            },
+            {
+                "selector": ".ads-wrapper",
                 "type": "closest-empty"
             },
             {
@@ -90,8 +122,16 @@
                 "type": "closest-empty"
             },
             {
+                "selector": "[data-ad]",
+                "type": "hide-empty"
+            },
+            {
                 "selector": ".bordeaux-slot",
                 "type": "closest-empty"
+            },
+            {
+                "selector": "#spotim-specific",
+                "type": "hide"
             }
         ],
         "adLabelStrings": [
@@ -102,16 +142,42 @@
             "advertisement - scroll to continue",
             "advertising",
             "ad feedback",
+            "anzeige",
             "sponsored",
+            "sponsorisé",
+            "publicité",
+            "publicidade",
             "reklama",
             "continue reading the main story"
         ],
         "domains": [
             {
+                "domain": "abc.es",
+                "rules": [
+                    {
+                        "selector": ".voc-advertising",
+                        "type": "hide-empty"
+                    }
+                ]
+            },
+            {
+                "domain": "apnews.com",
+                "rules": [
+                    {
+                        "selector": ".proper-dynamic-insertion",
+                        "type": "closest-empty"
+                    }
+                ]
+            },
+            {
                 "domain": "bbc.com",
                 "rules": [
                     {
                         "selector": ".dotcom-ad",
+                        "type": "closest-empty"
+                    },
+                    {
+                        "selector": ".leaderboard-ad-placeholder",
                         "type": "closest-empty"
                     }
                 ]
@@ -126,11 +192,38 @@
                 ]
             },
             {
+                "domain": "bloomberg.com",
+                "rules": [
+                    {
+                        "selector": ".unsupported-browser-notification-container",
+                        "type": "hide"
+                    }
+                ]
+            },
+            {
+                "domain": "coingecko.com",
+                "rules": [
+                    {
+                        "selector": "[data-target='ads.banner']",
+                        "type": "hide-empty"
+                    }
+                ]
+            },
+            {
                 "domain": "cyclingtips.com",
                 "rules": [
                     {
                         "selector": "[data-block-name='ads']",
                         "type": "closest-empty"
+                    }
+                ]
+            },
+            {
+                "domain": "ebay-kleinanzeigen.de",
+                "rules": [
+                    {
+                        "selector": "[data-liberty-position-name]",
+                        "type": "hide-empty"
                     }
                 ]
             },
@@ -179,10 +272,54 @@
                 ]
             },
             {
+                "domain": "huffpost.com",
+                "rules": [
+                    {
+                        "selector": ".connatix-player",
+                        "type": "closest-empty"
+                    }
+                ]
+            },
+            {
+                "domain": "indiatimes.com",
+                "rules": [
+                    {
+                        "selector": ".ad-cls",
+                        "type": "hide-empty"
+                    }
+                ]
+            },
+            {
                 "domain": "indy100.com",
                 "rules": [
                     {
                         "selector": "[id*='thirdparty']",
+                        "type": "hide-empty"
+                    }
+                ]
+            },
+            {
+                "domain": "leboncoin.fr",
+                "rules": [
+                    {
+                        "selector": "#lht-space-ad",
+                        "type": "hide-empty"
+                    },
+                    {
+                        "selector": "[class*='styles__ad']",
+                        "type": "hide-empty"
+                    }
+                ]
+            },
+            {
+                "domain": "macrumors.com",
+                "rules": [
+                    {
+                        "selector": ".tertiary",
+                        "type": "hide-empty"
+                    },
+                    {
+                        "selector": "[class*='sidebarblock']",
                         "type": "hide-empty"
                     }
                 ]
@@ -193,6 +330,15 @@
                     {
                         "selector": ".j-ad",
                         "type": "closest-empty"
+                    }
+                ]
+            },
+            {
+                "domain": "orange.fr",
+                "rules": [
+                    {
+                        "selector": ".tag-rm",
+                        "type": "hide-empty"
                     }
                 ]
             },
@@ -219,11 +365,29 @@
                 ]
             },
             {
+                "domain": "skysports.com",
+                "rules": [
+                    {
+                        "selector": "[data-format='leaderboard']",
+                        "type": "hide-empty"
+                    }
+                ]
+            },
+            {
                 "domain": "snopes.com",
                 "rules": [
                     {
                         "selector": ".proper-dynamic-insertion",
                         "type": "closest-empty"
+                    }
+                ]
+            },
+            {
+                "domain": "uol.com.br",
+                "rules": [
+                    {
+                        "selector": ".model-base-bnr",
+                        "type": "hide"
                     }
                 ]
             },
@@ -244,11 +408,7 @@
                 "domain": "wsj.com",
                 "rules": [
                     {
-                        "selector": "[class*='adWrapper']",
-                        "type": "closest-empty"
-                    },
-                    {
-                        "selector": "[id*='cx-']",
+                        "selector": "#cx-what-to-read-next",
                         "type": "closest-empty"
                     }
                 ]
@@ -267,6 +427,14 @@
                 "rules": [
                     {
                         "selector": "[class*='DFP-']",
+                        "type": "closest-empty"
+                    },
+                    {
+                        "selector": "[id*='banC']",
+                        "type": "hide-empty"
+                    },
+                    {
+                        "selector": ".indexPremium__adv",
                         "type": "hide-empty"
                     }
                 ]
@@ -307,6 +475,48 @@
                     {
                         "selector": "[id*='cxense-']",
                         "type": "closest-empty"
+                    }
+                ]
+            },
+            {
+                "domain": "first-party.site",
+                "rules": [
+                    {
+                        "selector": ".hide-test",
+                        "type": "hide"
+                    },
+                    {
+                        "selector": ".hide-empty-test",
+                        "type": "hide-empty"
+                    },
+                    {
+                        "selector": ".closest-empty-test",
+                        "type": "closest-empty"
+                    },
+                    {
+                        "selector": ".ad-container",
+                        "type": "override"
+                    }
+                ]
+            },
+            {
+                "domain": "privacy-test-pages.glitch.me",
+                "rules": [
+                    {
+                        "selector": ".hide-test",
+                        "type": "hide"
+                    },
+                    {
+                        "selector": ".hide-empty-test",
+                        "type": "hide-empty"
+                    },
+                    {
+                        "selector": ".closest-empty-test",
+                        "type": "closest-empty"
+                    },
+                    {
+                        "selector": ".ad-container",
+                        "type": "override"
                     }
                 ]
             }


### PR DESCRIPTION
**Asana URL**
https://app.asana.com/0/0/1203511103063545/f
**Description**
This PR adds a handful of new selectors for the element hiding feature to target, as well as ad labels. These were derived from analyzing popular sites in several regions. Also included are rules to be used by the privacy test page for this feature, which will be ready shortly.