### PR TITLE
Add exclusions & un-hide 2 pre-installed apps

### DIFF
--- a/features/app-tracker-protection.json
+++ b/features/app-tracker-protection.json
@@ -241,6 +241,15 @@
                     ]
                 },
                 {
+                    "domain": "logx.optimizely.com",
+                    "packageNames": [
+                        {
+                            "packageName": "com.stopandshop.mobile.droid"
+                        }
+                    ]
+                },
+
+                {
                     "domain": "sc.omtrdc.net",
                     "packageNames": [
                         {
@@ -259,6 +268,14 @@
                     "packageNames": [
                         {
                             "packageName": "com.fastmail.app"
+                        }
+                    ]
+                },
+                {
+                    "domain": "sessions.bugsnag.com",
+                    "packageNames": [
+                        {
+                            "packageName": "com.stopandshop.mobile.droid"
                         }
                     ]
                 },
@@ -360,6 +377,17 @@
                         },
                         {
                             "packageName": "pl.promate.bilkom"
+                        }
+                    ]
+                },
+                {
+                    "domain": "www.googletagmanager.com",
+                    "packageNames": [
+                        {
+                            "packageName": "com.stopandshop.mobile.droid"
+                        },
+                        {
+                            "packageName": "nl.rabomobiel"
                         }
                     ]
                 },
@@ -694,6 +722,9 @@
                     "reason": "App loads websites"
                 },
                 {
+                    "packageName": "com.samsung.android.oneconnect",
+                    "reason": "App doesn't run over any VPN connection"
+                {
                     "packageName": "com.sec.android.app.sbrowser",
                     "reason": "App loads websites"
                 },
@@ -832,8 +863,10 @@
                 "com.chrome.beta",
                 "com.chrome.canary",
                 "com.chrome.dev",
+                "com.facebook.katana",
                 "com.google.android.apps.chromecast.app",
                 "com.google.android.apps.docs",
+                "com.google.android.apps.googleassistant",
                 "com.google.android.apps.magazines",
                 "com.google.android.apps.maps",
                 "com.google.android.apps.mapslite",

--- a/features/app-tracker-protection.json
+++ b/features/app-tracker-protection.json
@@ -248,7 +248,6 @@
                         }
                     ]
                 },
-
                 {
                     "domain": "sc.omtrdc.net",
                     "packageNames": [
@@ -724,6 +723,7 @@
                 {
                     "packageName": "com.samsung.android.oneconnect",
                     "reason": "App doesn't run over any VPN connection"
+                },
                 {
                     "packageName": "com.sec.android.app.sbrowser",
                     "reason": "App loads websites"


### PR DESCRIPTION
**Asana Task:** https://app.asana.com/0/1202279501986195/1203533735848903/f

**Description**
Allow:
* 1 Google domain to fix Rabobank login lag
* 1 Google domain, 1 Optimizely domain & 1 Bugsnag domain to fix login + offer functions in Stop & Shop
* 2 Adobe domains to fix Discover login
* 2 Trade Desk domains to fix some Safeway functions
* Main Facebook & Instagram domains to fix link previews in Signal

Exclude from protection:
* SmartThings because app won't work properly over a VPN connection

Manually expose to protection:
* Facebook & Google Assistant, which are pre-installed & treated as system apps on some devices