### PR TITLE
Disable cookie prompt management for voici.fr

### DIFF
--- a/features/autoconsent.json
+++ b/features/autoconsent.json
@@ -42,6 +42,9 @@
     }, {
         "domain": "heise.de",
         "reason": "infinite reload"
+    }, {
+        "domain": "voici.fr",
+        "reason": "https://github.com/duckduckgo/autoconsent/issues/66"
     }],
     "settings": {
         "disabledCMPs": [


### PR DESCRIPTION
**Asana Task:**
https://app.asana.com/0/1201844467387842/1203548906751304/f


**Description**
Redirects to a login page after opt-out. https://github.com/duckduckgo/autoconsent/issues/66