### PR TITLE
Domain specific rules for washpo, cbc, psypost; generic rule additions

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -26,6 +26,10 @@
                 "type": "closest-empty"
             },
             {
+                "selector": "[id*='google_ads_iframe']",
+                "type": "hide"
+            },
+            {
                 "selector": "#google_ads",
                 "type": "hide-empty"
             },
@@ -102,6 +106,10 @@
                 "type": "closest-empty"
             },
             {
+                "selector": ".ad-wrap",
+                "type": "closest-empty"
+            },
+            {
                 "selector": ".ad-wrapper",
                 "type": "closest-empty"
             },
@@ -155,6 +163,7 @@
             "anzeige",
             "sponsored",
             "sponsorisé",
+            "story continues below advertisement",
             "publicité",
             "publicidade",
             "reklama",
@@ -217,6 +226,23 @@
                     {
                         "selector": ".arc_ad",
                         "type": "closest-empty"
+                    }
+                ]
+            },
+            {
+                "domain": "cbc.ca",
+                "rules": [
+                    {
+                        "selector": ".ad-risingstar-container",
+                        "type": "hide-empty"
+                    },
+                    {
+                        "selector": ".bigBoxContainer",
+                        "type": "hide-empty"
+                    },
+                    {
+                        "selector": ".stickyRailAd",
+                        "type": "hide-empty"
                     }
                 ]
             },
@@ -398,6 +424,15 @@
                 ]
             },
             {
+                "domain": "psypost.com",
+                "rules": [
+                    {
+                        "selector": ".jeg_midbar",
+                        "type": "hide-empty"
+                    }
+                ]
+            },
+            {
                 "domain": "qz.com",
                 "rules": [
                     {
@@ -473,6 +508,10 @@
                     },
                     {
                         "selector": "#leaderboard-wrapper",
+                        "type": "hide-empty"
+                    },
+                    {
+                        "selector": ".outbrain-wrapper",
                         "type": "hide-empty"
                     }
                 ]


### PR DESCRIPTION
**Asana Task:** https://app.asana.com/0/1203557590179903/1203565217641648/f

**Description**
Addresses:
- top banner & right rail space on cbc.ca
- mid article spaces on washingtonpost.com mobile site
- top banner space on psypost.com
