### PR TITLE
Adjust element hiding generic rules to fix comments on foxnews

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -51,7 +51,7 @@
             },
             {
                 "selector": ".ad",
-                "type": "closest-empty"
+                "type": "hide-empty"
             },
             {
                 "selector": "[class*='ad-content']",
@@ -91,7 +91,7 @@
             },
             {
                 "selector": ".ad-container",
-                "type": "closest-empty"
+                "type": "hide-empty"
             },
             {
                 "selector": ".adcontainer",
@@ -144,10 +144,6 @@
             {
                 "selector": ".bordeaux-slot",
                 "type": "closest-empty"
-            },
-            {
-                "selector": "#spotim-specific",
-                "type": "hide"
             }
         ],
         "adLabelStrings": [
@@ -336,6 +332,15 @@
                     {
                         "selector": "[id*='InStream']",
                         "type": "closest-empty"
+                    }
+                ]
+            },
+            {
+                "domain": "foxnews.com",
+                "rules": [
+                    {
+                        "selector": ".vendor-unit",
+                        "type": "hide-empty"
                     }
                 ]
             },


### PR DESCRIPTION
**Asana Task:** https://app.asana.com/0/1203557590179903/1203571611285301/f

**Description**
This fixes the issue on foxnews.com where the comment section was being hidden. Our check for visible content was getting tripped up by the comment section loading via shadow DOM, which led to us hiding that section along with the neighboring empty ad units.