### PR TITLE
Fix alicdn CNAME exception

### DIFF
--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -512,7 +512,8 @@
                     {
                         "rule": "alicdn.com.edgekey.net/",
                         "domains": [
-                            "aliexpress.com"
+                            "aliexpress.com",
+                            "aliexpress.us"
                         ],
                         "reason": "https://github.com/duckduckgo/privacy-configuration/issues/570"
                     }


### PR DESCRIPTION
**Asana Task:**
https://app.asana.com/0/1200223097357040/1203559615126606/f

**Description**
Automatic generation of CNAME rules when building the config created some rules that invalidated the previous aliexpress.us rule.
