### PR TITLE
Switch politico exception to elementHiding

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -6,7 +6,12 @@
             "reason": "site breakage"
         }
     },
-    "exceptions": [],
+    "exceptions": [
+        {
+            "domain": "politico.com",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/issues/592"
+        }
+    ],
     "settings": {
         "rules": [
             {

--- a/features/unprotected-temporary.json
+++ b/features/unprotected-temporary.json
@@ -7,9 +7,5 @@
         }
     },
     "exceptions": [
-        {
-            "domain": "politico.com",
-            "reason": "Site breakage"
-        }
     ]
 }


### PR DESCRIPTION
Scopes down the politico exception. See #592 for the breakage.