### PR TITLE
Disable element hiding on wiwo.de

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -30,6 +30,10 @@
         {
             "domain": "manhwascan.net",
             "reason": "https://github.com/duckduckgo/privacy-configuration/issues/592"
+        },
+        {
+            "domain": "wiwo.de",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/issues/592"
         }
     ],
     "settings": {


### PR DESCRIPTION
**Asana Task:** https://app.asana.com/0/1200277586140538/1203628862739405

**Description**
Element hiding triggers an adblocker wall.
https://github.com/duckduckgo/privacy-configuration/issues/592