### PR TITLE
AppTP: Remove stale scoped exclusions

### DIFF
--- a/features/app-tracker-protection.json
+++ b/features/app-tracker-protection.json
@@ -38,99 +38,10 @@
         "exceptionLists": {
             "appTrackerAllowList": [
                 {
-                    "domain": "acdn.adnxs.com",
-                    "packageNames": [
-                        {
-                            "packageName": "se.prisjakt.pricespy"
-                        }
-                    ]
-                },
-                {
-                    "domain": "ad.doubleclick.net",
-                    "packageNames": [
-                        {
-                            "packageName": "com.subway.mobile.subwayapp03"
-                        },
-                        {
-                            "packageName": "com.subway.subway"
-                        }
-                    ]
-                },
-                {
-                    "domain": "adservice.google.com",
-                    "packageNames": [
-                        {
-                            "packageName": "com.subway.mobile.subwayapp03"
-                        },
-                        {
-                            "packageName": "com.subway.subway"
-                        }
-                    ]
-                },
-                {
                     "domain": "api2.branch.io",
                     "packageNames": [
-                        {
-                            "packageName": "com.airbnb.android"
-                        },
-                        {
-                            "packageName": "com.amazon.mp3"
-                        },
-                        {
-                            "packageName": "com.cvs.launchers.cvs"
-                        },
-                        {
-                            "packageName": "com.deliveroo.orderapp"
-                        },
-                        {
-                            "packageName": "com.esharesinc.android"
-                        },
-                        {
-                            "packageName": "com.glovo"
-                        },
-                        {
-                            "packageName": "com.imdb.mobile"
-                        },
-                        {
-                            "packageName": "com.marriott.mrt"
-                        },
                         {   
                             "packageName": "com.toyota.oneapp"
-                        }
-                    ]
-                },
-                {
-                    "domain": "cm.everesttech.net",
-                    "packageNames": [
-                        {
-                            "packageName": "com.excentus.frn.android"
-                        }
-                    ]
-                },
-                {
-                    "domain": "connect.facebook.net",
-                    "packageNames": [
-                        {
-                            "packageName": "com.subway.mobile.subwayapp03"
-                        },
-                        {
-                            "packageName": "com.subway.subway"
-                        }
-                    ]
-                },
-                {
-                    "domain": "data.flurry.com",
-                    "packageNames": [
-                        {
-                            "packageName": "ru.afisha.android"
-                        }
-                    ]
-                },
-                {
-                    "domain": "device-api.urbanairship.com",
-                    "packageNames": [
-                        {
-                            "packageName": "com.thehomedepot"
                         }
                     ]
                 },
@@ -139,23 +50,6 @@
                     "packageNames": [
                         {
                             "packageName": "com.discoverfinancial.mobile"
-                        },
-                        {
-                            "packageName": "com.excentus.frn.android"
-                        },
-                        {
-                            "packageName": "com.marriott.mrt"
-                        },
-                        {
-                            "packageName": "com.sap.mdc.loblaw.nativ"
-                        }
-                    ]
-                },
-                {
-                    "domain": "events.appsflyer.com",
-                    "packageNames": [
-                        {
-                            "packageName": "com.mapswithme.maps.pro"
                         }
                     ]
                 },
@@ -171,59 +65,13 @@
                     "domain": "g.doubleclick.net",
                     "packageNames": [
                         {
-                            "packageName": "com.bloomberg.android.plus"
-                        },
-                        {
-                            "packageName": "com.cbs.app"
-                        },
-                        {
-                            "packageName": "com.ftt.boxingstar.gl.aos"
-                        },
-                        {
-                            "packageName": "com.goldtouch.ynet"
-                        },
-                        {
-                            "packageName": "com.subway.mobile.subwayapp03"
-                        },
-                        {
-                            "packageName": "com.subway.subway"
-                        },
-                        {
-                            "packageName": "com.thoptv.livetvstream"
-                        },
-                        {
-                            "packageName": "com.tour.pgatour"
-                        },
-                        {
-                            "packageName": "com.treemolabs.apps.cbsnews"
-                        },
-                        {
-                            "packageName": "pl.promate.bilkom"
+                            "packageName": "com.udonistemple.magicalmixing"
                         },
                         {
                             "packageName": "ro.rcsrds.mydigi"
-                        },
-                        {
-                            "packageName": "com.udonistemple.magicalmixing"
                         }
                     ]
-                },
-                {
-                    "domain": "graph.instagram.com",
-                    "packageNames": [
-                        {
-                            "packageName": "com.okcupid.okcupid"
-                        }
-                    ]
-                },
-                {
-                    "domain": "ib.adnxs.com",
-                    "packageNames": [
-                        {
-                            "packageName": "se.prisjakt.pricespy"
-                        }
-                    ]
-                },
+                },       
                 {
                     "domain": "insight.adsrvr.org",
                     "packageNames": [
@@ -249,28 +97,6 @@
                     ]
                 },
                 {
-                    "domain": "sc.omtrdc.net",
-                    "packageNames": [
-                        {
-                            "packageName": "com.audible.application"
-                        },
-                        {
-                            "packageName": "com.subway.mobile.subwayapp03"
-                        },
-                        {
-                            "packageName": "com.subway.subway"
-                        }
-                    ]
-                },
-                {
-                    "domain": "sentry.io",
-                    "packageNames": [
-                        {
-                            "packageName": "com.fastmail.app"
-                        }
-                    ]
-                },
-                {
                     "domain": "sessions.bugsnag.com",
                     "packageNames": [
                         {
@@ -279,19 +105,8 @@
                     ]
                 },
                 {
-                    "domain": "t.co",
-                    "packageNames": [
-                        {
-                            "packageName": "com.zecwalletmobile"
-                        }
-                    ]
-                },
-                {
                     "domain": "tt.omtrdc.net",
                     "packageNames": [
-                        {
-                            "packageName": "com.coppi.bestbuy"
-                        },
                         {
                             "packageName": "com.discoverfinancial.mobile"
                         },
@@ -300,12 +115,6 @@
                         },
                         {
                             "packageName": "com.macys.android"
-                        },
-                        {
-                            "packageName": "com.subway.mobile.subwayapp03"
-                        },
-                        {
-                            "packageName": "com.subway.subway"
                         }
                     ]
                 },
@@ -335,47 +144,10 @@
                     ]
                 },
                 {
-                    "domain": "v.fwmrm.net",
-                    "packageNames": [
-                        {
-                            "packageName": "com.cnn.mobile.android.phone"
-                        },
-                        {
-                            "packageName": "com.crunchyroll.crunchyroid"
-                        }
-                    ]
-                },
-                {
                     "domain": "www.facebook.com",
                     "packageNames": [
                         {
-                            "packageName": "com.chefsteps.circulator"
-                        },
-                        {
-                            "packageName": "com.subway.mobile.subwayapp03"
-                        },
-                        {
-                            "packageName": "com.subway.subway"
-                        },
-                        {
                             "packageName": "org.thoughtcrime.securesms"
-                        }
-                    ]
-                },
-                {
-                    "domain": "www.google-analytics.com",
-                    "packageNames": [
-                        {
-                            "packageName": "com.bladock.perkopolis"
-                        },
-                        {
-                            "packageName": "com.fitbit.FitbitMobile"
-                        },
-                        {
-                            "packageName": "jp.naver.line.android"
-                        },
-                        {
-                            "packageName": "pl.promate.bilkom"
                         }
                     ]
                 },

--- a/features/app-tracker-protection.json
+++ b/features/app-tracker-protection.json
@@ -66,9 +66,6 @@
                     "packageNames": [
                         {
                             "packageName": "com.udonistemple.magicalmixing"
-                        },
-                        {
-                            "packageName": "ro.rcsrds.mydigi"
                         }
                     ]
                 },       


### PR DESCRIPTION
**Asana Task:** https://app.asana.com/0/1202279501986195/1203633396255861/f

**Description**
We have many potentially stale tracker exceptions for various apps, none of which were being honored anyway until late November due to a bug in how we processed the list. I've removed all the exceptions older than November for which there is no obvious or compelling evidence (e.g., unblocking `www.instagram.com` to allow linking to Instagram within another app, particularly an app for which managing IG is its main function, would be considered a good reason).

Adding reasons for the exceptions that remain will be done in a subsequent PR.
