### PR TITLE
Add exception to speed up BestBuy + new browser

### DIFF
--- a/features/app-tracker-protection.json
+++ b/features/app-tracker-protection.json
@@ -49,7 +49,9 @@
                     "domain": "dpm.demdex.net",
                     "packageNames": [
                         {
-                            "packageName": "com.bestbuy.android",
+                            "packageName": "com.bestbuy.android"
+                        },
+                        {
                             "packageName": "com.discoverfinancial.mobile"
                         }
                     ]

--- a/features/app-tracker-protection.json
+++ b/features/app-tracker-protection.json
@@ -49,6 +49,7 @@
                     "domain": "dpm.demdex.net",
                     "packageNames": [
                         {
+                            "packageName": "com.bestbuy.android",
                             "packageName": "com.discoverfinancial.mobile"
                         }
                     ]
@@ -555,6 +556,10 @@
                 },
                 {
                     "packageName": "net.fast.web.browser",
+                    "reason": "App loads websites"
+                },
+                {
+                    "packageName": "org.adblockplus.adblockplussbrowser",
                     "reason": "App loads websites"
                 },
                 {


### PR DESCRIPTION
**Asana Task:** https://app.asana.com/0/1202279501986195/1203688042689730/f

**Description**

- Add exception for `demdex` in BestBuy app to prevent long hang on launch & new screen loads
- Exclude Samsung-specific AdBlock browser from protection