### PR TITLE
Hide broken GPC banner on xfinity.com

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -629,6 +629,19 @@
                 ]
             },
             {
+                "domain": "xfinity.com",
+                "rules": [
+                    {
+                        "selector": ".f-gpc-flyout",
+                        "type": "hide"
+                    },
+                    {
+                        "selector": ".f-gpc-banner",
+                        "type": "hide"
+                    }
+                ]
+            },
+            {
                 "domain": "first-party.site",
                 "rules": [
                     {


### PR DESCRIPTION
**Asana Task:** https://app.asana.com/0/1200289808319188/1203671220084980/f

**Description**
xfinity.com is showing a broken banner when GPC is set on Apple platforms. This will hide it.