### PR TITLE
Don't use custom UA on instagram.com

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -55,6 +55,10 @@
                         "reason": "When going to the main login page, there is a banner at the top which warns of an 'Unsupported browser'."
                     },
                     {
+                        "domain": "instagram.com",
+                        "reason": "A banner at the bottom which warns of an 'Unsupported browser' and interferes with rest of the UI."
+                    },
+                    {
                         "domain": "xfinity.com",
                         "reason": "Stream page shows an incompatibility warning and does not load further."
                     },


### PR DESCRIPTION
**Asana Task:**
https://app.asana.com/0/414709148257752/1203702692306726/f

**Description**
instagram.com shows an "unsupported browser" banner due to custom UA that our iOS browser presents

