### PR TITLE
Disable CPM on corporatefinanceinstitute.com

### DIFF
--- a/features/autoconsent.json
+++ b/features/autoconsent.json
@@ -48,6 +48,9 @@
     }, {
         "domain": "tfl.gov.uk",
         "reason": "https://github.com/duckduckgo/autoconsent/issues/68"
+    }, {
+        "domain": "corporatefinanceinstitute.com",
+        "reason": "CMP gets incorrectly handled / repeatedly opens tabs"
     }],
     "settings": {
         "disabledCMPs": [


### PR DESCRIPTION
**Asana Task:** https://app.asana.com/0/1201279386299865/1203715681457282/f

**Description**
The above issue is caused by Cookie Prompt Management automatically clicking the 'Learn More' button which open's a new tab, which displays the same cookie prompt, which causes 'Learn More' to be clicked.... and so on.