### PR TITLE
Element hiding: add styletag global and domain specific flags

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -183,6 +183,8 @@
                 "type": "closest-empty"
             }
         ],
+        "useStrictHideStyleTag": true,
+        "styleTagExceptions": [],
         "adLabelStrings": [
             "advertisement",
             "advertisment",


### PR DESCRIPTION
**Asana Task:** https://app.asana.com/0/1203557590179903/1203556051691984/f
**Corresponding C-S-S PR:** https://github.com/duckduckgo/content-scope-scripts/pull/229

**Description**
This PR adds a global flag and a for injecting strict hide rules as a style tag, as well as an exception list to disable this on specific domains if it causes breakage.