### PR TITLE
Expand element hiding rules to address ad spaces on more sites

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -75,8 +75,20 @@
                 "type": "closest-empty"
             },
             {
+                "selector": ".taboolaHeight",
+                "type": "hide"
+            },
+            {
                 "selector": ".adHolder",
                 "type": "closest-empty"
+            },
+            {
+                "selector": ".adplaceholder",
+                "type": "hide-empty"
+            },
+            {
+                "selector": ".ad-placeholder",
+                "type": "hide-empty"
             },
             {
                 "selector": "[class*='ad_unit']",
@@ -88,6 +100,26 @@
             },
             {
                 "selector": "[class*='ad-content']",
+                "type": "hide-empty"
+            },
+            {
+                "selector": "[class*='ad-slot_']",
+                "type": "hide-empty"
+            },
+            {
+                "selector": ".ad-block",
+                "type": "hide-empty"
+            },
+            {
+                "selector": ".adBox",
+                "type": "hide-empty"
+            },
+            {
+                "selector": ".adunitContainer",
+                "type": "hide-empty"
+            },
+            {
+                "selector": ".apexAd",
                 "type": "hide-empty"
             },
             {
@@ -103,7 +135,23 @@
                 "type": "closest-empty"
             },
             {
+                "selector": ".leaderboard_wrapper",
+                "type": "hide-empty"
+            },
+            {
+                "selector": ".ad-banner-container",
+                "type": "hide-empty"
+            },
+            {
                 "selector": "[class*='bannerAd']",
+                "type": "hide-empty"
+            },
+            {
+                "selector": ".banner-placeholder",
+                "type": "hide-empty"
+            },
+            {
+                "selector": ".header-ad-slot",
                 "type": "hide-empty"
             },
             {
@@ -135,8 +183,20 @@
                 "type": "closest-empty"
             },
             {
+                "selector": ".ad-current",
+                "type": "hide-empty"
+            },
+            {
                 "selector": ".advertisement",
                 "type": "closest-empty"
+            },
+            {
+                "selector": "[class*='advert-']",
+                "type": "hide-empty"
+            },
+            {
+                "selector": "[id*='advert-']",
+                "type": "hide-empty"
             },
             {
                 "selector": ".ad-slot",
@@ -159,6 +219,10 @@
                 "type": "closest-empty"
             },
             {
+                "selector": "[class*='ad-zone']",
+                "type": "hide-empty"
+            },
+            {
                 "selector": "[data-adunitpath]",
                 "type": "closest-empty"
             },
@@ -179,8 +243,20 @@
                 "type": "hide-empty"
             },
             {
+                "selector": ".arc-ad-wrapper",
+                "type": "hide-empty"
+            },
+            {
                 "selector": ".bordeaux-slot",
                 "type": "closest-empty"
+            },
+            {
+                "selector": ".rightAd",
+                "type": "hide-empty"
+            },
+            {
+                "selector": ".sponsored-slot",
+                "type": "hide-empty"
             }
         ],
         "adLabelStrings": [
@@ -189,6 +265,7 @@
             "advertisementclose",
             "advertisement\ncontinue reading the main story",
             "advertisement - scroll to continue",
+            "advertisement · scroll to continue",
             "advertising",
             "advertising\nskip ad",
             "advertising\nskip ad\nskip ad\nskip ad",
@@ -338,6 +415,15 @@
                 ]
             },
             {
+                "domain": "essentiallysports.com",
+                "rules": [
+                    {
+                        "selector": ".es-ad-space-container",
+                        "type": "hide-empty"
+                    }
+                ]
+            },
+            {
                 "domain": "fandom.com",
                 "rules": [
                     {
@@ -396,6 +482,14 @@
                     {
                         "selector": ".ad-cls",
                         "type": "hide-empty"
+                    },
+                    {
+                        "selector": "._3JJMX",
+                        "type": "hide-empty"
+                    },
+                    {
+                        "selector": ".paisa-wrapper",
+                        "type": "hide-empty"
                     }
                 ]
             },
@@ -422,6 +516,19 @@
                 ]
             },
             {
+                "domain": "livemint.com",
+                "rules": [
+                    {
+                        "selector": "#adfreeDeskSpace",
+                        "type": "hide-empty"
+                    },
+                    {
+                        "selector": "#dekBudgetAd",
+                        "type": "hide-empty"
+                    }
+                ]
+            },
+            {
                 "domain": "macrumors.com",
                 "rules": [
                     {
@@ -440,6 +547,15 @@
                     {
                         "selector": ".j-ad",
                         "type": "closest-empty"
+                    }
+                ]
+            },
+            {
+                "domain": "mirror.co.uk",
+                "rules": [
+                    {
+                        "selector": "#comments-standalone-mpu",
+                        "type": "hide-empty"
                     }
                 ]
             },
@@ -493,6 +609,15 @@
                 ]
             },
             {
+                "domain": "scmp.com",
+                "rules": [
+                    {
+                        "selector": "[class*='ad-slot-container']",
+                        "type": "hide-empty"
+                    }
+                ]
+            },
+            {
                 "domain": "si.com",
                 "rules": [
                     {
@@ -524,6 +649,15 @@
                 ]
             },
             {
+                "domain": "thingiverse.com",
+                "rules": [
+                    {
+                        "selector": "[class*='AdCard__leaderboard']",
+                        "type": "hide-empty"
+                    }
+                ]
+            },
+            {
                 "domain": "tripadvisor.com",
                 "rules": [
                     {
@@ -537,6 +671,23 @@
                 "rules": [
                     {
                         "selector": ".model-base-bnr",
+                        "type": "hide"
+                    }
+                ]
+            },
+            {
+                "domain": "vice.com",
+                "rules": [
+                    {
+                        "selector": ".adph",
+                        "type": "hide-empty"
+                    },
+                     {
+                        "selector": ".vice-ad__container",
+                        "type": "hide-empty"
+                    },
+                     {
+                        "selector": ".fixed-slot",
                         "type": "hide"
                     }
                 ]

--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -264,7 +264,7 @@
             "advertisment",
             "advertisementclose",
             "advertisement\ncontinue reading the main story",
-            "advertisement\n\ncontinue reading the main story"
+            "advertisement\n\ncontinue reading the main story",
             "advertisement - scroll to continue",
             "advertisement · scroll to continue",
             "advertising",

--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -601,7 +601,7 @@
                         "type": "hide-empty"
                     },
                     {
-                        "selector": ".e1xxpj0j1.css-4vtjtj",
+                        "selector": ".e1xxpj0j1",
                         "type": "hide-empty"
                     },
                     {

--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -264,6 +264,7 @@
             "advertisment",
             "advertisementclose",
             "advertisement\ncontinue reading the main story",
+            "advertisement\n\ncontinue reading the main story"
             "advertisement - scroll to continue",
             "advertisement · scroll to continue",
             "advertising",
@@ -568,6 +569,15 @@
                     },
                     {
                         "selector": "#nbcsports-leaderboard",
+                        "type": "hide-empty"
+                    }
+                ]
+            },
+            {
+                "domain": "nytimes.com",
+                "rules": [
+                    {
+                        "selector": "#top-wrapper",
                         "type": "hide-empty"
                     }
                 ]

--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -579,6 +579,34 @@
                     {
                         "selector": "#top-wrapper",
                         "type": "hide-empty"
+                    },
+                    {
+                        "selector": "#bottom-wrapper",
+                        "type": "hide-empty"
+                    },
+                    {
+                        "selector": "#mid1-wrapper",
+                        "type": "hide-empty"
+                    },
+                    {
+                        "selector": "#mid2-wrapper",
+                        "type": "hide-empty"
+                    },
+                    {
+                        "selector": "#mid3-wrapper",
+                        "type": "hide-empty"
+                    },
+                    {
+                        "selector": "#mktg-wrapper",
+                        "type": "hide-empty"
+                    },
+                    {
+                        "selector": ".e1xxpj0j1.css-4vtjtj",
+                        "type": "hide-empty"
+                    },
+                    {
+                        "selector": "[id*='story-ad']",
+                        "type": "hide-empty"
                     }
                 ]
             },


### PR DESCRIPTION
**Asana Task:** https://app.asana.com/0/1203557590179903/1203618492999951/f

**Description**
This PR addresses empty ad spaces on the following reported websites:
- https://timesofindia.indiatimes.com/gadgets-news/how-to-download-and-install-ios-16-2-update/articleshow/96214536.cms
- https://www.reuters.com/business/autos-transportation/tesla-suspends-production-shanghai-plant-internal-notice-2022-12-24/
- https://www.thegamer.com/high-on-life-references-easter-eggs-hidden-details/
- https://www.axios.com/2022/12/23/elon-musk-tesla-stock
- https://www.thesun.co.uk/news/20708220/meghan-markle-monster-jeremy-clarkson/
- https://www.essentiallysports.com/nfl-news-aaron-rodgers-narrates-his-spine-chilling-encounter-with-a-mysterious-hat-man-during-his-trip-to-peru-veiled-by-darkness-holding-the-corpse-of-a-dead/
- https://www.timesofisrael.com/liveblog_entry/jared-kushner-elon-musk-spotted-together-at-world-cup-final-in-qatar/
- https://www.mirror.co.uk/3am/celebrity-news/jeremy-clarkson-dreams-meghan-markle-28757874
- https://www.rottentomatoes.com/m/pig_2021
- https://www.vice.com/en/article/pkg49n/were-robbing-fcking-idiots-twitter-influencers-bragged-and-laughed-while-pumping-and-dumping-stocks-sec-says
- https://www.livemint.com/
- https://www.thingiverse.com/thing:4872630 
- https://www.fox8live.com/2023/01/17/tulane-football-be-recognized-cotton-bowl-win-wed-pels-vs-heat-game/
- https://www.bikeradar.com/
- https://www.scmp.com/news/china/politics/article/3206839/china-records-more-60000-covid-related-deaths-after-abrupt-shift-policy
- https://www.nytimes.com/2023/01/20/technology/google-chatgpt-artificial-intelligence.html
- https://www.nytimes.com/
- https://www.nytimes.com/section/technology