### PR TITLE
Revert "Add cookie exception for shutterfly.com"

### DIFF
--- a/overrides/extension-override.json
+++ b/overrides/extension-override.json
@@ -21,10 +21,6 @@
                     {
                         "domain": "payments.google.com",
                         "reason": "After sign-in for Google Pay flows (after flickering is resolved), blocking this causes the loading spinner to spin indefinitely, and the payment flow cannot proceed."
-                    },
-                    {
-                        "domain": "shutterfly.com",
-                        "reason": "https://github.com/duckduckgo/privacy-configuration/issues/544"
                     }
                 ],
                 "firstPartyTrackerCookiePolicy": {


### PR DESCRIPTION
Reverts duckduckgo/privacy-configuration#545

This issue was fixed in the latest extension release.
Fixes #544 