### PR TITLE
Duplicate nintendo.com allowlist entry to nintendo.com.edgekey.net

### DIFF
--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -527,6 +527,13 @@
                             "aliexpress.us"
                         ],
                         "reason": "https://github.com/duckduckgo/privacy-configuration/issues/570"
+                    },
+                    {
+                        "rule": "nintendo.com.edgekey.net/account/js/common.js",
+                        "domains": [
+                            "nintendo.com"
+                        ],
+                        "reason": "CNAME version of nintendo.com exception"
                     }
                 ]
             },
@@ -1038,17 +1045,6 @@
                             "nintendo.com"
                         ],
                         "reason": "Accounts page renders blank. Download buttons show loading stars and never finish loading. Pricing information doesn't load. Note that cdn.accounts.nintendo.com CNAMEs to star.accounts.nintendo.com.edgekey.net at the time of mitigation."
-                    }
-                ]
-            },
-            "nintendo.com.edgekey.net": {
-                "rules": [
-                    {
-                        "rule": "nintendo.com.edgekey.net/account/js/common.js",
-                        "domains": [
-                            "nintendo.com"
-                        ],
-                        "reason": "CNAME version of nintendo.com exception"
                     }
                 ]
             },

--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -1030,6 +1030,17 @@
                     }
                 ]
             },
+            "nintendo.com.edgekey.net": {
+                "rules": [
+                    {
+                        "rule": "nintendo.com.edgekey.net/account/js/common.js",
+                        "domains": [
+                            "nintendo.com"
+                        ],
+                        "reason": "CNAME version of nintendo.com exception"
+                    }
+                ]
+            },
             "nuance.com": {
                 "rules": [
                     {


### PR DESCRIPTION
Due to a bug in android exception matching

**Asana Task:**
https://app.asana.com/0/1200295047952574/1203770718751292/f

**Description**
The original allowlist entry does not work on android as the domain is first party.