### PR TITLE
Add new ad label without newlines for nyt ad spaces

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -267,6 +267,7 @@
             "advertisement",
             "advertisment",
             "advertisementclose",
+            "advertisementcontinue reading the main story",
             "advertisement\ncontinue reading the main story",
             "advertisement\n\ncontinue reading the main story",
             "advertisement - scroll to continue",


### PR DESCRIPTION
**Description**
Follow up to https://github.com/duckduckgo/privacy-configuration/pull/624 . For whatever reason [this line](https://github.com/duckduckgo/content-scope-scripts/blob/main/src/features/element-hiding.js#L136) is returning "advertisement\n\ncontinue reading the main story" for several ad spaces on nytimes.com when run in our mac browser, but the newline chars are being stripped out when run in our firefox extension. Unclear exactly why this is happening--I'm going to investigate and see if it's just a one-off case, or if we should update the content script logic to strip all newline characters from ad labels for consistency.