### PR TITLE
Element hiding: add override rule to fix overly broad hiding on carandclassic.com

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -346,6 +346,15 @@
                 ]
             },
             {
+                "domain": "carandclassic.com",
+                "rules": [
+                    {
+                        "selector": "[id*='advert-']",
+                        "type": "override"
+                    }
+                ]
+            },
+            {
                 "domain": "cbc.ca",
                 "rules": [
                     {


### PR DESCRIPTION
**Description**
This site has a slideshow within a common ad selector which is being hidden. This is a temp override fix - I will tweak the logic in the content script that checks if elements are empty to catch cases like this.