### PR TITLE
enable the navigator interface and element hiding on windows

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -5,6 +5,12 @@
         },
         "autofill": {
             "state": "enabled"
+        },
+        "navigatorInterface": {
+            "state": "enabled"
+        },
+        "elementHiding": {
+            "state": "enabled"
         }
     },
     "unprotectedTemporary": [


### PR DESCRIPTION
**Asana Task:**
- https://app.asana.com/0/1201048563534612/1203664999661733/f
- https://app.asana.com/0/1201048563534612/1203086567720768/f

CC: @RendijsSmukulis @q71114 @moollaza @shakyShane 

**Description**
- Enable the navigator interface aka duckduckgo DOM signal on Windows
- Enable the element hiding feature on Windows
- Tested both features using a local modified versionof the config and all worked well
