### PR TITLE
Mitigate input false positives caused by data-unit rule

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -231,10 +231,6 @@
                 "type": "closest-empty"
             },
             {
-                "selector": "[data-unit]",
-                "type": "closest-empty"
-            },
-            {
                 "selector": "[data-targeting]",
                 "type": "closest-empty"
             },


### PR DESCRIPTION
**Asana Task:** https://app.asana.com/0/1203557590179903/1203879775591693/f

**Description**
Temporarily remove `data-unit` selector rule to mitigate unintentional hiding of non-ad elements flagged in https://github.com/duckduckgo/duckduckgo-privacy-extension/issues/1679. Will add rule back once underlying issue that's causing us to see input fields as 'empty' has been patched.