### PR TITLE
element hiding: anchor adWrapper rule

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -219,7 +219,7 @@
                 "type": "closest-empty"
             },
             {
-                "selector": "[class*='adWrapper']",
+                "selector": "[class^='adWrapper']",
                 "type": "closest-empty"
             },
             {


### PR DESCRIPTION
Fixes https://github.com/duckduckgo/duckduckgo-privacy-extension/issues/1670

**Description**
This PR fixes an issue on https://beastacademy.com/demo/school where the `[class*='adWrapper']` rule was matching an element with class `quadWrapper`.

@sammacbeth we should probably update other similar rules to avoid potential collisions yeah? This is the first case I've seen like this so I doubt it's that common, but couldn't hurt to be safe.