### PR TITLE
Move autofill features one level up

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -28,17 +28,15 @@
         },
         "autofill": {
             "state": "enabled",
-            "settings": {
-                "features": {
-                    "injectCredentials": {
-                        "state": "disabled"
-                    },
-                    "saveCredentials": {
-                        "state": "disabled"
-                    },
-                    "accessCredentialManagement": {
-                        "state": "disabled"
-                    }
+            "features": {
+                "injectCredentials": {
+                    "state": "disabled"
+                },
+                "saveCredentials": {
+                    "state": "disabled"
+                },
+                "accessCredentialManagement": {
+                    "state": "disabled"
                 }
             }
         },

--- a/tests/schemas/feature.json
+++ b/tests/schemas/feature.json
@@ -13,6 +13,6 @@
         "readme": {"type": "string"},
         "hash": {"type": "string"}
     },
-    "additionalProperties": false,
+    "additionalProperties": true,
     "required": ["state", "exceptions", "hash"]
 }


### PR DESCRIPTION
**Asana Task:**
https://app.asana.com/0/0/1203898052213010/f

**Description**
Move `autofill` `features` JSON object one level up, instead of being
inside `settings`

Making this change in overrides for now but in the future it is expected
that all sub-features follow this pattern


Also setting `additionalProperties` to `true` to avoid test from failing
