### PR TITLE
Disabling the cookie feature for Windows

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -14,7 +14,7 @@
         },
         "cookie": {
             "exceptions": [],
-            "state": "enabled",
+            "state": "disabled",
             "minSupportedVersion": "0.36.0",
             "settings": {
                 "trackerCookie": "enabled",


### PR DESCRIPTION
**Description**

- Disabling the cookie feature as it turns out Content Scope Scripts do not support the minSupportedVersion value and only look at the state enabled/disabled.
