### PR TITLE
Expand CSE mitigation to cover more cases

### DIFF
--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -781,14 +781,14 @@
                         "reason": "https://github.com/duckduckgo/privacy-configuration/issues/475"
                     },
                     {
-                        "rule": "cse.google.com/cse/cse.js",
+                        "rule": "cse.google.com/cse/element/",
                         "domains": [
                             "<all>"
                         ],
                         "reason": "https://github.com/duckduckgo/privacy-configuration/issues/475"
                     },
                     {
-                        "rule": "cse.google.com/cse/element/",
+                        "rule": "google.com/cse/cse.js",
                         "domains": [
                             "<all>"
                         ],


### PR DESCRIPTION
Covers more cases (e.g., w3schools) where embedded search wasn't working - https://github.com/duckduckgo/privacy-configuration/issues/475