### PR TITLE
Migrate UA exceptions on macOS to `webViewDefault`

### DIFF
--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -68,40 +68,43 @@
             "state": "enabled"
         },
         "customUserAgent": {
-            "exceptions": [
-                {
-                    "domain": "blinkist.com",
-                    "reason": "https://github.com/duckduckgo/privacy-configuration/issues/693"
-                },
-                {
-                    "domain": "help.ryanair.com",
-                    "reason": "https://github.com/duckduckgo/privacy-configuration/issues/693"
-                },
-                {
-                    "domain": "nordaccount.com",
-                    "reason": "https://github.com/duckduckgo/privacy-configuration/issues/693"
-                },
-                {
-                    "domain": "openai.com",
-                    "reason": "https://github.com/duckduckgo/privacy-configuration/issues/693"
-                },
-                {
-                    "domain": "cloudflare.com",
-                    "reason": "https://github.com/duckduckgo/privacy-configuration/issues/693"
-                },
-                {
-                    "domain": "ancestry.com",
-                    "reason": "https://github.com/duckduckgo/privacy-configuration/issues/693"
-                },
-                {
-                    "domain": "bookshop.org",
-                    "reason": "https://github.com/duckduckgo/privacy-configuration/issues/693"
-                },
-                {
-                    "domain": "easyjet.com",
-                    "reason": "https://github.com/duckduckgo/privacy-configuration/issues/693"
-                }
-            ]
+            "state": "enabled",
+            "settings": {
+                "webViewDefault": [
+                    {
+                        "domain": "blinkist.com",
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/issues/693"
+                    },
+                    {
+                        "domain": "help.ryanair.com",
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/issues/693"
+                    },
+                    {
+                        "domain": "nordaccount.com",
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/issues/693"
+                    },
+                    {
+                        "domain": "openai.com",
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/issues/693"
+                    },
+                    {
+                        "domain": "cloudflare.com",
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/issues/693"
+                    },
+                    {
+                        "domain": "ancestry.com",
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/issues/693"
+                    },
+                    {
+                        "domain": "bookshop.org",
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/issues/693"
+                    },
+                    {
+                        "domain": "easyjet.com",
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/issues/693"
+                    }
+                ]
+            }
         },
         "trackerAllowlist": {
             "settings": {


### PR DESCRIPTION
**Asana Task:** https://app.asana.com/0/0/1204006097893477/f

**Description**
Move the UA exceptions in macOS-override to `webViewDefault` inside the `settings` dict to follow config design better.