### PR TITLE
Disable serviceworkerInitiatedRequests for Edge MV3

### DIFF
--- a/overrides/browsers/edgmv3-override.json
+++ b/overrides/browsers/edgmv3-override.json
@@ -1,3 +1,7 @@
 {
-    "features": {}
+    "features": {
+        "serviceworkerInitiatedRequests": {
+            "state": "disabled"
+        }
+    }
 }


### PR DESCRIPTION
**Asana Task:**
https://app.asana.com/0/892838074342800/1204020304422664/f

**Description**
Disable SW-initiated blocking on Edge MV3 due to blocking of other extensions' requests. See https://github.com/duckduckgo/duckduckgo-privacy-extension/issues/1732
