### PR TITLE
Windows browser now supports remote-config for the User Agent service…

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -87,6 +87,23 @@
             }
         }
     },
+    "customUserAgent": {
+        "settings": {
+            "omitApplicationSites": [],
+            "omitVersionSites": [],
+            "userAgentOverrides": [
+                {
+                    "domain": "accounts.google.com",
+                    "userAgent": "chrome",
+                    "pathRegex": "^/ServiceLogin$",
+                    "reason": "Auth flow broken when Google detects a webview. Using a 'chrome' UA works around the issue."
+                }
+            ],
+            "omitClientHintMutations": []
+        },
+        "exceptions": [],
+        "state": "enabled"            
+    },
     "unprotectedTemporary": [
         
     ]


### PR DESCRIPTION
**Asana Task:**

Task: https://app.asana.com/0/1200890834746050/1201692074409346/f
Tech design: https://app.asana.com/0/481882893211075/1204012480705920/f
Associated PR on the Windows side, enabling remote-config for the UserAgent service: https://github.com/more-duckduckgo-org/windows-browser/pull/557


**Description**

Windows browser now supports remote-config for the User Agent service. This is enabling the service, and setting up the existing rules (the Google rule was previously hard-coded in the browser, this enables it to be loaded from the remote config).
