### PR TITLE
Add "clickToLoad" feature configuration and deprecate "clickToPlay"

### DIFF
--- a/features/click-to-load.json
+++ b/features/click-to-load.json
@@ -1,6 +1,6 @@
 {
     "_meta": {
-        "description": "DEPRECATED - See clickToLoad.",
+        "description": "Click to Load feature for blocking embedded third-party social/video content.",
         "sampleExcludeRecords": {
             "domain": "example.com",
             "reason": "site breakage"
@@ -8,9 +8,11 @@
     },
     "exceptions": [],
     "settings": {
-        "Facebook": {
-            "clicksBeforeSimpleVersion": 3,
+        "Facebook, Inc.": {
             "ruleActions": ["block-ctl-fb"]
+        },
+        "Youtube": {
+            "ruleActions": ["block-ctl-yt"]
         }
     }
 }

--- a/index.js
+++ b/index.js
@@ -166,7 +166,7 @@ async function buildPlatforms () {
                             settings[settingsKey] = overrideSettings[settingsKey]
                         }
                         platformConfig.features[key][platformKey] = settings
-                    } else if (key === 'clickToPlay' && platformKey === 'settings') {
+                    } else if ((key === 'clickToLoad' || key === 'clickToPlay') && platformKey === 'settings') {
                         // Handle Click to Load settings override later, so that individual entities
                         // are disabled/enabled correctly (and disabled by default).
                         continue
@@ -184,12 +184,14 @@ async function buildPlatforms () {
             }
 
             // Ensure the correct enabled state for Click to Load entities.
-            const clickToLoadSettings = platformConfig?.features?.clickToPlay?.settings
-            if (clickToLoadSettings) {
-                const clickToLoadSettingsOverride = platformOverride?.features?.clickToPlay?.settings
-                for (const entity of Object.keys(clickToLoadSettings)) {
-                    clickToLoadSettings[entity].state =
-                        clickToLoadSettingsOverride?.[entity]?.state || clickToLoadSettings[entity].state || 'disabled'
+            if (key === 'clickToLoad' || key === 'clickToPlay') {
+                const clickToLoadSettings = platformConfig?.features?.[key]?.settings
+                if (clickToLoadSettings) {
+                    const clickToLoadSettingsOverride = platformOverride?.features?.[key]?.settings
+                    for (const entity of Object.keys(clickToLoadSettings)) {
+                        clickToLoadSettings[entity].state =
+                            clickToLoadSettingsOverride?.[entity]?.state || clickToLoadSettings[entity].state || 'disabled'
+                    }
                 }
             }
 

--- a/overrides/extension-override.json
+++ b/overrides/extension-override.json
@@ -46,6 +46,14 @@
         "referrer": {
             "state": "enabled"
         },
+        "clickToLoad": {
+            "state": "enabled",
+            "settings": {
+                "Facebook, Inc.": {
+                    "state": "enabled"
+                }
+            }
+        },
         "clickToPlay": {
             "state": "enabled",
             "settings": {


### PR DESCRIPTION
The Click to Load feature was misnamed "clickToPlay" in the extension
configuration, which had a knock-on effect with the naming of files in
the content-scope-scripts and other repositories. Let's fix that now,
or at least start the towards fixing that.

We can't remove the old "clickToPlay" feature configuration yet, but
we can deprecate it and add the new "clickToLoad" feature
configuration ready for use. Also, let's take care to remove the old
"clicksBeforeSimpleVersion" setting from the new configuration and
correct the Facebook entity name ("Facebook, Inc." instead of
"Facebook") to match our block list.