### PR TITLE
Add mitigation for missing comic images on manhwatop

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -40,6 +40,10 @@
             "reason": "https://github.com/duckduckgo/privacy-configuration/issues/592"
         },
         {
+            "domain": "manhwatop.com",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/issues/592"
+        },
+        {
             "domain": "wiwo.de",
             "reason": "https://github.com/duckduckgo/privacy-configuration/issues/592"
         },


### PR DESCRIPTION
Mitigates manhwatop.com for #592.

Asana: https://app.asana.com/0/1200223097357040/1204104265556443/f