### PR TITLE
Fix too-general ad rules (breaking manga sites)

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -151,7 +151,7 @@
                 "type": "hide-empty"
             },
             {
-                "selector": "[class*='adunit']",
+                "selector": "[class^='adunit']",
                 "type": "hide-empty"
             },
             {
@@ -219,7 +219,11 @@
                 "type": "closest-empty"
             },
             {
-                "selector": "[class*='ad-container']",
+                "selector": "[class^='ad-container']",
+                "type": "hide-empty"
+            },
+            {
+                "selector": "[class*='-ad-container']",
                 "type": "hide-empty"
             },
             {


### PR DESCRIPTION
These were matching e.g., "read-container".

Asana: https://app.asana.com/0/0/1204105180432086/f