### PR TITLE
Element hiding: make media and form selectors configurable

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -313,6 +313,7 @@
         ],
         "useStrictHideStyleTag": true,
         "styleTagExceptions": [],
+        "mediaAndFormSelectors": "video,canvas,embed,object,audio,map,form,input,textarea,select,option,button",
         "adLabelStrings": [
             "advertisement",
             "advertisment",


### PR DESCRIPTION
**Asana Task:** https://app.asana.com/0/1203557590179903/1204090946699947/f
**Corresponding C-S-S PR**: https://github.com/duckduckgo/content-scope-scripts/pull/319

**Description**
This PR makes the tags we look for in element hiding remotely configurable.