### PR TITLE
Remove useStrictHideStyleTag everywhere else

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -49,6 +49,7 @@
         }
     ],
     "settings": {
+        "useStrictHideStyleTag": false,
         "rules": [
             {
                 "selector": "[id*='gpt-']",

--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -45,8 +45,7 @@
             }
         },
         "elementHiding": {
-            "state": "enabled",
-            "useStrictHideStyleTag": false
+            "state": "enabled"
         },
         "customUserAgent": {
             "state": "enabled",

--- a/overrides/browsers/firefox-override.json
+++ b/overrides/browsers/firefox-override.json
@@ -1,8 +1,5 @@
 {
     "features": {
-        "elementHiding": {
-            "useStrictHideStyleTag": true
-        },
         "runtimeChecks": {
             "minSupportedVersion": "2023.3.15"
         },

--- a/overrides/extension-override.json
+++ b/overrides/extension-override.json
@@ -72,8 +72,7 @@
             "state": "enabled"
         },
         "elementHiding": {
-            "state": "enabled",
-            "useStrictHideStyleTag": false
+            "state": "enabled"
         },
         "fingerprintingCanvas": {
             "state": "enabled"

--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -34,8 +34,7 @@
             "state": "enabled"
         },
         "elementHiding": {
-            "state": "enabled",
-            "useStrictHideStyleTag": false
+            "state": "enabled"
         },
         "autoconsent": {
             "state": "enabled"

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -10,7 +10,6 @@
         },
         "elementHiding": {
             "state": "enabled",
-            "useStrictHideStyleTag": false,
             "exceptions": [
                 {
                     "domain": "wunderground.com",

--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -10,8 +10,7 @@
             "state": "enabled"
         },
         "elementHiding": {
-            "state": "enabled",
-            "useStrictHideStyleTag": false
+            "state": "enabled"
         },
         "cookie": {
             "exceptions": [],


### PR DESCRIPTION
**Asana Task:** https://app.asana.com/0/1200890834746050/1204208396328571/f covers the prevention of this happening again and https://app.asana.com/0/1200890834746050/1202348774384704/f covers settings being merged in unexpected ways.

**Description**
CSP issue as per: https://github.com/duckduckgo/duckduckgo-privacy-extension/issues/367#issuecomment-1471912354

Fixes up https://github.com/duckduckgo/privacy-configuration/pull/742 which removed the key rendering the feature disabled everywhere anyway due to the lack of "settings" nesting.