### PR TITLE
Restore scoped exception for demdex in pc optimum

### DIFF
--- a/features/app-tracker-protection.json
+++ b/features/app-tracker-protection.json
@@ -50,6 +50,9 @@
                         },
                         {
                             "packageName": "com.discoverfinancial.mobile"
+                        },
+                        {
+                            "packageName": "com.sap.mdc.loblaw.nativ"
                         }
                     ]
                 },


### PR DESCRIPTION
**Asana Task:** https://app.asana.com/0/1202279501986195/1204230083792498/f

**Description**
Accidentally removed this during the exclusion cleanup due to the obscure package name, restoring the Adobe `demdex` exception to speed up the PC Optimum app