### PR TITLE
Remove cookielaw checking whilst investigating breakage

### DIFF
--- a/features/runtime-checks.json
+++ b/features/runtime-checks.json
@@ -8,10 +8,6 @@
     },
     "state": "disabled",
     "exceptions": [
-        {
-            "domain": "www.pandora.com",
-            "reason": "reported breakage"
-        }
     ],
     "settings": {
         "taintCheck": "disabled",
@@ -302,7 +298,7 @@
                 "domain": "iperceptions.com"
             },
             {
-                "domain": "cookielaw.org"
+                "disabled_domain": "cookielaw.org"
             },
             {
                 "domain": "vscdns.com"


### PR DESCRIPTION
**Asana Task:** https://app.asana.com/0/0/1204243453023943/f

**Description**

Verified that cookielaw.org is causing issues on pandora.com; I'm still investigating but let's disable whilst I understand why there's an issue.