### PR TITLE
Limit Chrome runtime checks to 2023.3.15 and onwards

### DIFF
--- a/overrides/browsers/chrome-override.json
+++ b/overrides/browsers/chrome-override.json
@@ -10,6 +10,7 @@
             ]
         },
         "runtimeChecks": {
+            "minSupportedVersion": "2023.3.15",
             "settings": {
                 "taintCheck": "enabled",
                 "matchAllDomains": "enabled",


### PR DESCRIPTION
**Asana Task:** https://app.asana.com/0/0/1204276364449692/f

**Description**
We're seeing JSE's of the taintCheck that should have been fixed in "2023.3.15" and onwards.

Let's validate if they go away before disabling the feature.