### PR TITLE
Disable ServiceWorker initiated request blocking for more platforms

### DIFF
--- a/overrides/browsers/bravemv3-override.json
+++ b/overrides/browsers/bravemv3-override.json
@@ -2,6 +2,9 @@
     "features": {
         "fingerprintingCanvas": {
             "state": "disabled"
+        },
+        "serviceworkerInitiatedRequests": {
+            "state": "disabled"
         }
     }
 }

--- a/overrides/browsers/chromemv3-override.json
+++ b/overrides/browsers/chromemv3-override.json
@@ -11,6 +11,9 @@
                     "reason": "Adwall appears which reappears when dismissed. The adwall prevents interaction with the page."
                 }
             ]
+        },
+        "serviceworkerInitiatedRequests": {
+            "state": "disabled"
         }
     }
 }


### PR DESCRIPTION
We already disabled ServiceWorker initiated request blocking for
MV3 builds of the Edge extension, since due to this Chromium
bug[1] it caused us to also block requests initiated by other browser
extensions.

Until that is resolved, we should disable ServiceWorker initiated
request blocking for all MV3 builds targetting Chromium-based
browsers.

1 - https://crbug.com/1421697

**Asana Task:** https://app.asana.com/0/892838074342800/1204020304422664/f
