### PR TITLE
Element hiding: address empty ad spaces on nytimes.com, mail.com, financialpost.com

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -348,7 +348,8 @@
             "publicidade",
             "reklama",
             "skip ad",
-            "continue reading the main story"
+            "continue reading the main story",
+            "this advertisement has not loaded yet, but your article continues below."
         ],
         "domains": [
             {
@@ -694,6 +695,15 @@
                 ]
             },
             {
+                "domain": "mail.com",
+                "rules": [
+                    {
+                        "selector": ".primis",
+                        "type": "closest-empty"
+                    }
+                ]
+            },
+            {
                 "domain": "marketwatch.com",
                 "rules": [
                     {
@@ -780,6 +790,10 @@
                     {
                         "selector": "[id*='story-ad']",
                         "type": "hide-empty"
+                    },
+                    {
+                        "selector": "[data-testid='StandardAd']",
+                        "type": "closest-empty"
                     }
                 ]
             },

--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -352,6 +352,7 @@
             "publicidade",
             "reklama",
             "skip ad",
+            "sponsored news",
             "continue reading the main story",
             "this advertisement has not loaded yet, but your article continues below.",
             "story continues below\nthis advertisement has not loaded yet, but your article continues below."

--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -228,6 +228,10 @@
                 "type": "closest-empty"
             },
             {
+                "selector": ".ad__container",
+                "type": "closest-empty"
+            },
+            {
                 "selector": "[class^='ad-container']",
                 "type": "hide-empty"
             },
@@ -349,7 +353,8 @@
             "reklama",
             "skip ad",
             "continue reading the main story",
-            "this advertisement has not loaded yet, but your article continues below."
+            "this advertisement has not loaded yet, but your article continues below.",
+            "story continues below\nthis advertisement has not loaded yet, but your article continues below."
         ],
         "domains": [
             {


### PR DESCRIPTION
**Asana Task:** https://app.asana.com/0/0/1204105180583031/f

**Description**
![image](https://user-images.githubusercontent.com/4481594/228973323-fa1a708f-cc9c-4bf0-93f0-4b2002a9e5e4.png)
![image](https://user-images.githubusercontent.com/4481594/228973485-0ba8c57f-5640-4881-8774-afdc2b0abba2.png)
![image](https://user-images.githubusercontent.com/4481594/228973546-2c80e5fd-f86b-4cc1-92eb-0517808eba6e.png)

