### PR TITLE
Add mitigation for Strava login on Safari

### DIFF
--- a/features/content-blocking.json
+++ b/features/content-blocking.json
@@ -9,6 +9,10 @@
     "state": "enabled",
     "exceptions": [
         {
+            "domain": "strava.com",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/issues/748"
+        },
+        {
             "domain": "welt.de",
             "reason": "Video pauses at about 13-15 seconds in. Playing the video again results in a single frame rendering without progressing to the next frame."
         }


### PR DESCRIPTION
Mitigates #748 for Safari.

Note: as Safari does not have support for many remote configuration features, we have to disable contentBlocking entirely to get Safari to recognise the mitigation.

Asana: https://app.asana.com/0/1200277586140538/1204305938177479/f