### PR TITLE
Add exceptions for canvas fp and runtime checks on several sites with reported login breakage

### DIFF
--- a/features/fingerprinting-canvas.json
+++ b/features/fingerprinting-canvas.json
@@ -23,12 +23,20 @@
             "reason": "https://github.com/duckduckgo/privacy-configuration/issues/499"
         },
         {
+            "domain": "att.com",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/issues/794"
+        },
+        {
+            "domain": "capitalone.com",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/issues/794"
+        },
+        {
             "domain": "chase.com",
             "reason": "https://github.com/duckduckgo/privacy-configuration/issues/499"
         },
         {
-            "domain": "xfinity.com",
-            "reason": "https://github.com/duckduckgo/privacy-configuration/issues/788"
+            "domain": "cigna.com",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/issues/794"
         },
         {
             "domain": "emirates.com",
@@ -50,6 +58,10 @@
             "reason": "https://github.com/duckduckgo/privacy-configuration/issues/499"
         },
         {
+            "domain": "navyfederal.org",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/issues/794"
+        },
+        {
             "domain": "northernrailway.co.uk",
             "reason": "https://github.com/duckduckgo/privacy-configuration/issues/350"
         },
@@ -64,6 +76,14 @@
         {
             "domain": "walgreens.com",
             "reason": "https://github.com/duckduckgo/privacy-configuration/issues/499"
+        },
+        {
+            "domain": "wellsfargo.com",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/issues/794"
+        },
+        {
+            "domain": "xfinity.com",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/issues/788"
         },
         {
             "domain": "godaddy.com",

--- a/features/runtime-checks.json
+++ b/features/runtime-checks.json
@@ -13,12 +13,32 @@
             "reason": "https://github.com/duckduckgo/privacy-configuration/issues/780"
         },
         {
+            "domain": "att.com",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/issues/794"
+        },
+        {
+            "domain": "capitalone.com",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/issues/794"
+        },
+        {
+            "domain": "cigna.com",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/issues/794"
+        },
+        {
+            "domain": "navyfederal.org",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/issues/794"
+        },
+        {
             "domain": "stackoverflow.com",
             "reason": "https://github.com/duckduckgo/duckduckgo-privacy-extension/issues/1819"
         },
         {
             "domain": "stackexchange.com",
             "reason": "https://github.com/duckduckgo/duckduckgo-privacy-extension/issues/1819"
+        },
+        {
+            "domain": "wellsfargo.com",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/issues/794"
         }
     ],
     "settings": {


### PR DESCRIPTION
**Asana Task:** https://app.asana.com/0/0/1204285623263283/f

Mitigations for https://github.com/duckduckgo/privacy-configuration/issues/794

**Description**
We've seen an uptick in reported login breakage on several popular domains over the past week. We've been able to repro the issue on a few sites where we have accounts and traced it back to anti canvas fingerprinting, so we are disabling it on these sites until we understand what's going on. Out of an abundance of caution, we are also disabling runtime checks on these same sites.

cc @jonathanKingston 