### PR TITLE
Disable Click to Load for the video vertical

### DIFF
--- a/features/click-to-load.json
+++ b/features/click-to-load.json
@@ -6,7 +6,10 @@
             "reason": "site breakage"
         }
     },
-    "exceptions": [],
+    "exceptions": [{
+        "domain": "duckduckgo.com",
+        "reason": "Warnings are already displayed before embedded YouTube videos are loaded."
+    }],
     "settings": {
         "Facebook, Inc.": {
             "ruleActions": ["block-ctl-fb"]


### PR DESCRIPTION
When searching for videos on duckduckgo.com, a warning is already
displayed before embedded YouTube videos are loaded. Let's avoid Click
to Load displaying a second warning, since it will be annoying for the
user to have to click to proceed twice.

**Asana Task:** https://app.asana.com/0/45878998844068/1203640054901774/f
