### PR TITLE
Element hiding: Address credentials variant

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -216,6 +216,10 @@
                 "type": "hide"
             },
             {
+                "selector": "#google-one-tap-popup-container",
+                "type": "hide"
+            },
+            {
                 "selector": ".google-one-tap-modal-div",
                 "type": "hide"
             },


### PR DESCRIPTION
**Asana Task:** https://app.asana.com/0/0/1204350617665344/f

**Description**
Handles yet another variant of the 'sign in with Google' pop-up. Encountered on seekingalpha.com, but making the rule global since this selector is likely used elsewhere as well.