### PR TITLE
Follow up cigna.com login fix

### DIFF
--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -197,6 +197,19 @@
                     }
                 ]
             },
+            "amazonaws.com": {
+                "rules": [
+                    {
+                        "rule": "elb.amazonaws.com/public/digital-experience/js/common.js",
+                        "domains": [
+                            "cigna.com"
+                        ],
+                        "reason": [
+                            "https://github.com/duckduckgo/privacy-configuration/issues/820"
+                        ]
+                    }
+                ]
+            },
             "azure.net": {
                 "rules": [
                     {


### PR DESCRIPTION
**Asana Task:** https://app.asana.com/0/0/1204350617665350/f

**Description**
It appears the fix in https://github.com/duckduckgo/privacy-configuration/pull/821 didn't fully resolve the problem, as common.js can also be served from an aws endpoint.