### PR TITLE
Remove Chrome mitigations for breakage fixes in runtimeChecks

### DIFF
--- a/features/runtime-checks.json
+++ b/features/runtime-checks.json
@@ -8,58 +8,6 @@
     },
     "state": "disabled",
     "exceptions": [
-        {
-            "domain": "ally.com",
-            "reason": "https://github.com/duckduckgo/privacy-configuration/issues/780"
-        },
-        {
-            "domain": "att.com",
-            "reason": "https://github.com/duckduckgo/privacy-configuration/issues/794"
-        },
-        {
-            "domain": "capitalone.com",
-            "reason": "https://github.com/duckduckgo/privacy-configuration/issues/794"
-        },
-        {
-            "domain": "navyfederal.org",
-            "reason": "https://github.com/duckduckgo/privacy-configuration/issues/794"
-        },
-        {
-            "domain": "stackoverflow.com",
-            "reason": "https://github.com/duckduckgo/duckduckgo-privacy-extension/issues/1819"
-        },
-        {
-            "domain": "stackexchange.com",
-            "reason": "https://github.com/duckduckgo/duckduckgo-privacy-extension/issues/1819"
-        },
-        {
-            "domain": "mathoverflow.net",
-            "reason": "https://github.com/duckduckgo/duckduckgo-privacy-extension/issues/1819"
-        },
-        {
-            "domain": "askubuntu.com",
-            "reason": "https://github.com/duckduckgo/duckduckgo-privacy-extension/issues/1819"
-        },
-        {
-            "domain": "superuser.com",
-            "reason": "https://github.com/duckduckgo/duckduckgo-privacy-extension/issues/1819"
-        },
-        {
-            "domain": "serverfault.com",
-            "reason": "https://github.com/duckduckgo/duckduckgo-privacy-extension/issues/1819"
-        },
-        {
-            "domain": "stackapps.com",
-            "reason": "https://github.com/duckduckgo/duckduckgo-privacy-extension/issues/1819"
-        },
-        {
-            "domain": "wellsfargo.com",
-            "reason": "https://github.com/duckduckgo/privacy-configuration/issues/794"
-        },
-        {
-            "domain": "substack.com",
-            "reason": "https://github.com/duckduckgo/duckduckgo-privacy-extension/issues/1841"
-        }
     ],
     "settings": {
         "taintCheck": "disabled",

--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -48,7 +48,45 @@
             "state": "enabled"
         },
         "runtimeChecks": {
-            "state": "enabled"
+            "state": "enabled",
+            "exceptions": [
+                {
+                    "domain": "ally.com",
+                    "reason": "https://github.com/duckduckgo/privacy-configuration/issues/780"
+                },
+                {
+                    "domain": "stackoverflow.com",
+                    "reason": "https://github.com/duckduckgo/duckduckgo-privacy-extension/issues/1819"
+                },
+                {
+                    "domain": "stackexchange.com",
+                    "reason": "https://github.com/duckduckgo/duckduckgo-privacy-extension/issues/1819"
+                },
+                {
+                    "domain": "mathoverflow.net",
+                    "reason": "https://github.com/duckduckgo/duckduckgo-privacy-extension/issues/1819"
+                },
+                {
+                    "domain": "askubuntu.com",
+                    "reason": "https://github.com/duckduckgo/duckduckgo-privacy-extension/issues/1819"
+                },
+                {
+                    "domain": "superuser.com",
+                    "reason": "https://github.com/duckduckgo/duckduckgo-privacy-extension/issues/1819"
+                },
+                {
+                    "domain": "serverfault.com",
+                    "reason": "https://github.com/duckduckgo/duckduckgo-privacy-extension/issues/1819"
+                },
+                {
+                    "domain": "stackapps.com",
+                    "reason": "https://github.com/duckduckgo/duckduckgo-privacy-extension/issues/1819"
+                },
+                {
+                    "domain": "substack.com",
+                    "reason": "https://github.com/duckduckgo/duckduckgo-privacy-extension/issues/1841"
+                }
+            ]
         },
         "customUserAgent": {
             "state": "enabled",

--- a/overrides/browsers/chrome-override.json
+++ b/overrides/browsers/chrome-override.json
@@ -10,7 +10,7 @@
             ]
         },
         "runtimeChecks": {
-            "minSupportedVersion": "2023.3.15",
+            "minSupportedVersion": "2023.4.11",
             "settings": {
                 "taintCheck": "enabled",
                 "matchAllDomains": "enabled",
@@ -18,6 +18,8 @@
                 "overloadInstanceOf": "enabled",
                 "elementRemovalTimeout": 1000,
                 "domains": [
+                ],
+                "scripts": [
                 ],
                 "stackDomains": [
                     {
@@ -42,7 +44,7 @@
                         "domain": "indeed.com"
                     },
                     {
-                        "disabled_domain": "stackexchange.com"
+                        "domain": "stackexchange.com"
                     },
                     {
                         "domain": "bangassets.com"
@@ -252,7 +254,7 @@
                         "domain": "iperceptions.com"
                     },
                     {
-                        "disabled_domain": "cookielaw.org"
+                        "domain": "cookielaw.org"
                     },
                     {
                         "domain": "vscdns.com"
@@ -447,7 +449,7 @@
                         "domain": "d9sq4cz0q8up0.cloudfront.net"
                     },
                     {
-                        "disabled_domain": "adobedtm.com"
+                        "domain": "adobedtm.com"
                     },
                     {
                         "domain": "tealiumiq.com"

--- a/overrides/browsers/chromemv3-override.json
+++ b/overrides/browsers/chromemv3-override.json
@@ -1,7 +1,9 @@
 {
     "features": {
         "runtimeChecks": {
-            "state": "enabled"
+            "state": "enabled",
+            "exceptions": [
+            ]
         },
         "fingerprintingScreenSize": {
             "state": "enabled",

--- a/overrides/browsers/firefox-override.json
+++ b/overrides/browsers/firefox-override.json
@@ -1,6 +1,44 @@
 {
     "features": {
         "runtimeChecks": {
+            "exceptions": [
+                {
+                    "domain": "ally.com",
+                    "reason": "https://github.com/duckduckgo/privacy-configuration/issues/780"
+                },
+                {
+                    "domain": "stackoverflow.com",
+                    "reason": "https://github.com/duckduckgo/duckduckgo-privacy-extension/issues/1819"
+                },
+                {
+                    "domain": "stackexchange.com",
+                    "reason": "https://github.com/duckduckgo/duckduckgo-privacy-extension/issues/1819"
+                },
+                {
+                    "domain": "mathoverflow.net",
+                    "reason": "https://github.com/duckduckgo/duckduckgo-privacy-extension/issues/1819"
+                },
+                {
+                    "domain": "askubuntu.com",
+                    "reason": "https://github.com/duckduckgo/duckduckgo-privacy-extension/issues/1819"
+                },
+                {
+                    "domain": "superuser.com",
+                    "reason": "https://github.com/duckduckgo/duckduckgo-privacy-extension/issues/1819"
+                },
+                {
+                    "domain": "serverfault.com",
+                    "reason": "https://github.com/duckduckgo/duckduckgo-privacy-extension/issues/1819"
+                },
+                {
+                    "domain": "stackapps.com",
+                    "reason": "https://github.com/duckduckgo/duckduckgo-privacy-extension/issues/1819"
+                },
+                {
+                    "domain": "substack.com",
+                    "reason": "https://github.com/duckduckgo/duckduckgo-privacy-extension/issues/1841"
+                }
+            ],
             "minSupportedVersion": "2023.3.15"
         },
         "ampLinks": {

--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -25,7 +25,45 @@
             }
         },
         "runtimeChecks": {
-            "state": "enabled"
+            "state": "enabled",
+            "exceptions": [
+                {
+                    "domain": "ally.com",
+                    "reason": "https://github.com/duckduckgo/privacy-configuration/issues/780"
+                },
+                {
+                    "domain": "stackoverflow.com",
+                    "reason": "https://github.com/duckduckgo/duckduckgo-privacy-extension/issues/1819"
+                },
+                {
+                    "domain": "stackexchange.com",
+                    "reason": "https://github.com/duckduckgo/duckduckgo-privacy-extension/issues/1819"
+                },
+                {
+                    "domain": "mathoverflow.net",
+                    "reason": "https://github.com/duckduckgo/duckduckgo-privacy-extension/issues/1819"
+                },
+                {
+                    "domain": "askubuntu.com",
+                    "reason": "https://github.com/duckduckgo/duckduckgo-privacy-extension/issues/1819"
+                },
+                {
+                    "domain": "superuser.com",
+                    "reason": "https://github.com/duckduckgo/duckduckgo-privacy-extension/issues/1819"
+                },
+                {
+                    "domain": "serverfault.com",
+                    "reason": "https://github.com/duckduckgo/duckduckgo-privacy-extension/issues/1819"
+                },
+                {
+                    "domain": "stackapps.com",
+                    "reason": "https://github.com/duckduckgo/duckduckgo-privacy-extension/issues/1819"
+                },
+                {
+                    "domain": "substack.com",
+                    "reason": "https://github.com/duckduckgo/duckduckgo-privacy-extension/issues/1841"
+                }
+            ]
         },
         "ampLinks": {
             "state": "enabled"

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -2,6 +2,44 @@
     "features": {
         "runtimeChecks": {
             "state": "enabled",
+            "exceptions": [
+                {
+                    "domain": "ally.com",
+                    "reason": "https://github.com/duckduckgo/privacy-configuration/issues/780"
+                },
+                {
+                    "domain": "stackoverflow.com",
+                    "reason": "https://github.com/duckduckgo/duckduckgo-privacy-extension/issues/1819"
+                },
+                {
+                    "domain": "stackexchange.com",
+                    "reason": "https://github.com/duckduckgo/duckduckgo-privacy-extension/issues/1819"
+                },
+                {
+                    "domain": "mathoverflow.net",
+                    "reason": "https://github.com/duckduckgo/duckduckgo-privacy-extension/issues/1819"
+                },
+                {
+                    "domain": "askubuntu.com",
+                    "reason": "https://github.com/duckduckgo/duckduckgo-privacy-extension/issues/1819"
+                },
+                {
+                    "domain": "superuser.com",
+                    "reason": "https://github.com/duckduckgo/duckduckgo-privacy-extension/issues/1819"
+                },
+                {
+                    "domain": "serverfault.com",
+                    "reason": "https://github.com/duckduckgo/duckduckgo-privacy-extension/issues/1819"
+                },
+                {
+                    "domain": "stackapps.com",
+                    "reason": "https://github.com/duckduckgo/duckduckgo-privacy-extension/issues/1819"
+                },
+                {
+                    "domain": "substack.com",
+                    "reason": "https://github.com/duckduckgo/duckduckgo-privacy-extension/issues/1841"
+                }
+            ],
             "settings": {
                 "taintCheck": "enabled",
                 "matchAllDomains": "disabled",


### PR DESCRIPTION
**Asana Task:**

https://app.asana.com/0/0/1204208106954755/f

**Description**

- Moves exceptions to platforms to allow Chrome to be scoped to having these fixes tested
  - Updates the min version to 2023.4.11 to have the fixes.
- Removes https://github.com/duckduckgo/privacy-configuration/issues/794 testing changes