### PR TITLE
Disable runtimeChecks on cnn.com

### DIFF
--- a/features/runtime-checks.json
+++ b/features/runtime-checks.json
@@ -8,6 +8,10 @@
     },
     "state": "disabled",
     "exceptions": [
+        {
+            "domain": "cnn.com",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/issues/837"
+        }
     ],
     "settings": {
         "taintCheck": "disabled",


### PR DESCRIPTION
**Asana Task:**
https://app.asana.com/0/0/1204400253974526/f

**Description**

Disabling for now as per https://github.com/duckduckgo/privacy-configuration/issues/837

I'll scope down the mitigation later to the script that's breaking.