### PR TITLE
Add mitigation for rocketnews24

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -124,3 +124,6 @@ generated
 
 # JetBrains IDEs
 .idea
+
+# Build files
+/tds.json

--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -527,58 +527,84 @@
                     {
                         "rule": "securepubads.g.doubleclick.net/gampad/ads",
                         "domains": [
-                            "ah.nl"
+                            "ah.nl",
+                            "rocketnews24.com"
                         ],
-                        "reason": "'Bonus offer' elements do not render and are not clickable."
+                        "reason": [
+                            "ah.nl - 'Bonus offer' elements do not render and are not clickable.",
+                            "rocketnews24.com - https://github.com/duckduckgo/privacy-configuration/issues/846"
+                        ]
                     },
                     {
                         "rule": "pubads.g.doubleclick.net/gampad/ads",
                         "domains": [
                             "nhl.com",
-                            "viki.com"
+                            "viki.com",
+                            "rocketnews24.com"
                         ],
                         "reason": [
                             "nhl.com - Videos show a spinner and never load.",
-                            "viki.com - after a video has played for a few seconds an adwall pops up. Clicking 'I've turned off my adblocker' resets the video, then after a few seconds the adwall pops up again."
+                            "viki.com - after a video has played for a few seconds an adwall pops up. Clicking 'I've turned off my adblocker' resets the video, then after a few seconds the adwall pops up again.",
+                            "rocketnews24.com - https://github.com/duckduckgo/privacy-configuration/issues/846"
                         ]
                     },
                     {
                         "rule": "pubads.g.doubleclick.net/ssai/event/",
                         "domains": [
-                            "cbssports.com"
+                            "cbssports.com",
+                            "rocketnews24.com"
                         ],
-                        "reason": "Live videos do not load or render."
+                        "reason": [
+                            "cbssports.com - Live videos do not load or render.",
+                            "rocketnews24.com - https://github.com/duckduckgo/privacy-configuration/issues/846"
+                        ]
                     },
                     {
                         "rule": "securepubads.g.doubleclick.net/tag/js/gpt.js",
                         "domains": [
                             "ah.nl",
                             "wunderground.com",
-                            "youmath.it"
+                            "youmath.it",
+                            "rocketnews24.com"
                         ],
                         "reason": [
                             "ah.nl - 'Bonus offer' elements do not render and are not clickable.",
                             "wunderground.com - Video element does not display.",
-                            "youmath.it - Adwall displays which prevents page interaction and resets the page view when clicked."
+                            "youmath.it - Adwall displays which prevents page interaction and resets the page view when clicked.",
+                            "rocketnews24.com - https://github.com/duckduckgo/privacy-configuration/issues/846"
                         ]
                     },
                     {
                         "rule": "securepubads.g.doubleclick.net/gpt/pubads_impl_",
                         "domains": [
                             "ah.nl",
-                            "wunderground.com"
+                            "wunderground.com",
+                            "rocketnews24.com"
                         ],
                         "reason": [
                             "ah.nl - 'Bonus offer' elements do not render and are not clickable.",
-                            "wunderground.com - Video element does not display."
+                            "wunderground.com - Video element does not display.",
+                            "rocketnews24.com - https://github.com/duckduckgo/privacy-configuration/issues/846"
                         ]
                     },
                     {
                         "rule": "securepubads.g.doubleclick.net/pagead/ppub_config",
                         "domains": [
+                            "rocketnews24.com",
                             "weather.com"
                         ],
-                        "reason": "https://github.com/duckduckgo/privacy-configuration/issues/415"
+                        "reason": [
+                            "https://github.com/duckduckgo/privacy-configuration/issues/415",
+                            "rocketnews24.com - https://github.com/duckduckgo/privacy-configuration/issues/846"
+                        ]
+
+                    },
+                    {
+                        "rule": "doubleclick.net",
+                        "domains": [
+                            "rocketnews24.com"
+                        ],
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/issues/846"
                     }
                 ]
             },
@@ -946,17 +972,32 @@
                         "domains": [
                             "magicgameworld.com",
                             "youmath.it",
-                            "duden.de"
+                            "duden.de",
+                            "rocketnews24.com"
                         ],
-                        "reason": "https://github.com/duckduckgo/privacy-configuration/issues/388"
+                        "reason": [
+                            "https://github.com/duckduckgo/privacy-configuration/issues/388",
+                            "rocketnews24.com - https://github.com/duckduckgo/privacy-configuration/issues/846"
+                        ]
                     },
                     {
                         "rule": "tpc.googlesyndication.com/pagead/js/loader21.html",
                         "domains": [
                             "laprensa.hn",
-                            "rumble.com"
+                            "rumble.com",
+                            "rocketnews24.com"
                         ],
-                        "reason": "https://github.com/duckduckgo/privacy-configuration/issues/388"
+                        "reason": [
+                            "https://github.com/duckduckgo/privacy-configuration/issues/388",
+                            "rocketnews24.com - https://github.com/duckduckgo/privacy-configuration/issues/846"
+                        ]
+                    },
+                    {
+                        "rule": "googlesyndication.com",
+                        "domains": [
+                            "rocketnews24.com"
+                        ],
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/issues/846"
                     }
                 ]
             },


### PR DESCRIPTION
Mitigates #846.

Note, we're aiming to mitigate `doubleclick.net` and `googlesyndication.com` here, but the rule structuring means we have to add the entry to multiple existing rules.

https://app.asana.com/0/1200277586140538/1204378805271407/f

Aside: added the `tds.json` to `.gitignore`, this gets pulled down when we run the build, so we shouldn't VC this.