### PR TITLE
Disable cookielaw

### DIFF
--- a/overrides/browsers/chrome-override.json
+++ b/overrides/browsers/chrome-override.json
@@ -276,7 +276,7 @@
                         "domain": "iperceptions.com"
                     },
                     {
-                        "domain": "cookielaw.org"
+                        "disabled_domain": "cookielaw.org"
                     },
                     {
                         "domain": "vscdns.com"


### PR DESCRIPTION
**Description**
As part of: https://github.com/duckduckgo/privacy-configuration/pull/853


Cookielaw again is the cause of overloading our code; it's clear it needs to be off for now until we fix.