### PR TITLE
Disable generic-cosmetic rule (multiple breakages)

### DIFF
--- a/features/autoconsent.json
+++ b/features/autoconsent.json
@@ -114,7 +114,8 @@
     ],
     "settings": {
         "disabledCMPs": [
-            "Sourcepoint-top"
+            "Sourcepoint-top",
+            "generic-cosmetic"
         ]
     }
 }


### PR DESCRIPTION
**Asana Task:**

https://app.asana.com/0/1201844467387842/1204331553986287/f

**Description**

Disable the `generic-cosmetic` autoconsent rule due to multiple breakages, e.g. on https://www.webhallen.com/