### PR TITLE
Adapt Reddit 'sign in with Google' rule to handle site changes

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -873,7 +873,7 @@
                 "domain": "reddit.com",
                 "rules": [
                     {
-                        "selector": "iframe[src^='https://www.reddit.com/account/sso/one_tap/']",
+                        "selector": "._233XfOVq91N_ugGQDBb_OT",
                         "type": "hide"
                     }
                 ]


### PR DESCRIPTION
**Asana Task:** https://app.asana.com/0/1177771139624306/1204414348989297/f

**Description**
Reddit has begun using the same iframe for both the 'Sign in with Google' popup and the general login form, which is causing the rule we use to hide the Google popup to hide the general login form as well. This PR changes that rule so that only the Google popup is hidden.