### PR TITLE
Remove deprecation notice from firstPartyTrackerCookiePolicy

### DIFF
--- a/overrides/extension-override.json
+++ b/overrides/extension-override.json
@@ -28,7 +28,6 @@
                     }
                 ],
                 "firstPartyTrackerCookiePolicy": {
-                    "readme": "This policy is deprecated. We are expanding this protection to all first party cookies set by scripts and using firstPartyCookiePolicy policy instead.",
                     "threshold": 86400,
                     "maxAge": 86400
                 },


### PR DESCRIPTION
**Asana Task:**

https://app.asana.com/0/0/1204257980027287/f

**Description**

As per https://github.com/duckduckgo/content-scope-scripts/pull/349 we're adding this back in some cases.