### PR TITLE
disable element hiding on bizjournals.com

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -50,6 +50,10 @@
         {
             "domain": "thechive.com",
             "reason": "https://github.com/duckduckgo/privacy-configuration/issues/592"
+        },
+        {
+            "domain": "bizjournals.com",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/issues/592"
         }
     ],
     "settings": {


### PR DESCRIPTION
**Asana Task:** https://app.asana.com/0/0/1204461066916740/f

**Description**
Element hiding triggers an adblock wall on mobile.