### PR TITLE
Improved targeting of google creds popup on reddit post pages

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -881,7 +881,7 @@
                         "type": "hide"
                     },
                     {
-                        "selector": "shreddit-experience-tree",
+                        "selector": "[data*='\"isNsfw\":false'] ~ shreddit-experience-tree",
                         "type": "hide"
                     }
                 ]


### PR DESCRIPTION
**Asana Task:** https://app.asana.com/0/1203557590179903/1204466309385459/f

**Description**
Turns out Reddit uses the same `shreddit-experience-tree` element to show mature content warnings on nsfw post pages ([example](https://www.reddit.com/r/oddlyterrifying/comments/12y93l4/ai_generated_pizza_commercial/)), so we need to explicitly target this selector only on sfw pages.