### PR TITLE
Mitigate canvas breakage on online-stopwatch.com & online-calculator.com

### DIFF
--- a/features/fingerprinting-canvas.json
+++ b/features/fingerprinting-canvas.json
@@ -62,6 +62,14 @@
             "reason": "https://github.com/duckduckgo/privacy-configuration/issues/350"
         },
         {
+            "domain": "online-calculator.com",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/issues/875"
+        },
+        {
+            "domain": "online-stopwatch.com",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/issues/875"
+        },
+        {
             "domain": "spirit.com",
             "reason": "When attempting to sign in, a semi-transparent overlay appears over the page which prevents further interaction with the site."
         },


### PR DESCRIPTION
**Asana Task:** https://app.asana.com/0/0/1204470763496915/f

**Description**
Reported in https://github.com/duckduckgo/duckduckgo-privacy-extension/issues/1927, anti canvas fingerprinting is causing issues on these sites. The recent uptick in this type of breakage is concerning, we should conduct a root cause analysis to figure out what changed.