### PR TITLE
Element hiding: add more specificity to reddit sign in with google rule

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -861,7 +861,7 @@
                         "type": "hide"
                     },
                     {
-                        "selector": "[data*='\"isNsfw\":false'] ~ shreddit-experience-tree",
+                        "selector": "[devicetype=\"desktop\"] [data*='\"isNsfw\":false'] ~ shreddit-experience-tree",
                         "type": "hide"
                     }
                 ]


### PR DESCRIPTION
**Asana Task:** https://app.asana.com/0/1200277586140538/1204493204880138/f

**Description**
Turns out reddit is using the same `shreddit-experience-tree` element to load a nag to use the app on mobile browsers and adding `overflow: hidden` to the body element until the user dismisses this nag. By hiding this nag, users have no way to dismiss it and remove `overflow: hidden` from the body element (outside of refreshing the page - this only happens on first page load when not logged in). This PR adds specificity to the rule to only target the element on desktop, which mitigates this issue.