### PR TITLE
Add localhost to unprotectedTempoary

### DIFF
--- a/overrides/extension-override.json
+++ b/overrides/extension-override.json
@@ -669,6 +669,17 @@
         }
     },
     "unprotectedTemporary": [
-
+        {
+            "domain": "localhost",
+            "reason": "Protections are disabled on localhost pages"
+        },
+        {
+            "domain": "127.0.0.1",
+            "reason": "Protections are disabled on localhost pages"
+        },
+        {
+            "domain": "::1",
+            "reason": "Protections are disabled on localhost pages"
+        }
     ]
 }


### PR DESCRIPTION
**Asana Task:**
https://app.asana.com/0/569473074191537/1202888606171820/f

**Description**
In some cases protections aren't being properly disabled for localhost pages, which contradicts our dashboard UI. This ensures that these domains always get excluded from protections.