### PR TITLE
Disable runtime checks stylesheet injection on github.com

### DIFF
--- a/overrides/extension-override.json
+++ b/overrides/extension-override.json
@@ -105,6 +105,16 @@
                                 }
                             }
                         ]
+                    },
+                    {
+                        "domain": "github.com",
+                        "patchSettings": [
+                            {
+                                "op": "replace",
+                                "path": "/injectGlobalStyles",
+                                "value": "disabled"
+                            }
+                        ]
                     }
                 ],
                 "scripts": [


### PR DESCRIPTION
**Asana Task:** https://app.asana.com/0/0/1204524928580696/f

**Description**
Injecting a stylesheet on github.com is causing a CSP violation in Firefox, which is leading to a ~1s slowdown on page navigation. Not entirely clear why this is happening, but this PR disables the stylesheet injection and mitigates the issue.