### PR TITLE
Revert "Enable autofill ios subfeatures for 7.73.0"

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -84,20 +84,16 @@
             "state": "enabled",
             "features": {
                 "credentialsSaving": {
-                    "state":"enabled",
-                    "minSupportedVersion":"7.73.0"
+                    "state":"internal"
                 },
                 "credentialsAutofill": {
-                    "state":"enabled",
-                    "minSupportedVersion": "7.73.0"
+                    "state":"internal"
                 },
                 "inlineIconCredentials": {
-                    "state":"enabled",
-                    "minSupportedVersion": "7.73.0"
+                    "state":"internal"
                 },
                 "accessCredentialManagement": {
-                    "state":"enabled",
-                    "minSupportedVersion": "7.73.0"
+                    "state":"internal"
                 }
             }
         },


### PR DESCRIPTION
Reverts duckduckgo/privacy-configuration#905

We found a blocker so need to switch this back off. This is somewhat time sensitive so excuse the lack of Asana task. I will add more context as soon as I can.