### PR TITLE
Add scoped exception for Adobe demdex in MyCigna app

### DIFF
--- a/features/app-tracker-protection.json
+++ b/features/app-tracker-protection.json
@@ -48,6 +48,9 @@
                         {
                             "packageName": "com.bestbuy.android"
                         },
+                        {   
+                            "packageName": "com.cigna.mobile.mycigna"
+                        },
                         {
                             "packageName": "com.discoverfinancial.mobile"
                         },


### PR DESCRIPTION
**Asana Task:**
https://app.asana.com/0/1202279501986195/1204540432951506

**Description**
MyCigna app freezes on launch -- fixed by allowing `dpm.demdex.net`
