### PR TITLE
add referrer exception for vimeo player

### DIFF
--- a/features/referrer.json
+++ b/features/referrer.json
@@ -10,6 +10,10 @@
         {
             "domain": "canadapost-postescanada.ca",
             "reason": "https://github.com/duckduckgo/privacy-configuration/issues/647"
+        },
+        {
+            "domain": "player.vimeo.com",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/issues/931"
         }
     ]
 }


### PR DESCRIPTION
**Asana Task:** https://app.asana.com/0/1200277586140538/1204588886627260/f

**Description**
Vimeo offers a way for users to limit where videos can be embedded that relies on the referrer.