### PR TITLE
Enable YouTube "Click to Load" feature for MV2 extension builds

### DIFF
--- a/overrides/browsers/bravemv3-override.json
+++ b/overrides/browsers/bravemv3-override.json
@@ -5,6 +5,13 @@
         },
         "serviceworkerInitiatedRequests": {
             "state": "disabled"
+        },
+        "clickToLoad": {
+            "settings": {
+                "Youtube": {
+                    "state": "disabled"
+                }
+            }
         }
     }
 }

--- a/overrides/browsers/chromemv3-override.json
+++ b/overrides/browsers/chromemv3-override.json
@@ -11,6 +11,13 @@
         },
         "serviceworkerInitiatedRequests": {
             "state": "disabled"
+        },
+        "clickToLoad": {
+            "settings": {
+                "Youtube": {
+                    "state": "disabled"
+                }
+            }
         }
     }
 }

--- a/overrides/browsers/edgmv3-override.json
+++ b/overrides/browsers/edgmv3-override.json
@@ -2,6 +2,13 @@
     "features": {
         "serviceworkerInitiatedRequests": {
             "state": "disabled"
+        },
+        "clickToLoad": {
+            "settings": {
+                "Youtube": {
+                    "state": "disabled"
+                }
+            }
         }
     }
 }

--- a/overrides/extension-override.json
+++ b/overrides/extension-override.json
@@ -540,8 +540,12 @@
         },
         "clickToLoad": {
             "state": "enabled",
+            "minSupportedVersion": "2023.4.27",
             "settings": {
                 "Facebook, Inc.": {
+                    "state": "enabled"
+                },
+                "Youtube": {
                     "state": "enabled"
                 }
             }


### PR DESCRIPTION
Now that it's ready, let's enable the YouTube "Click to Load"
extension feature.

Notes:
 - The latest code was only included with extension release 2023.4.27,
   so set that as the minimum version for the feature.
 - The feature is not yet working correctly on MV3 builds, due to
   https://crbug.com/1428971. For now, disable the feature for MV3
   builds targetting Chromium-based browsers.
