### PR TITLE
Disable YouTube "Click to Load"

### DIFF
--- a/overrides/extension-override.json
+++ b/overrides/extension-override.json
@@ -546,7 +546,7 @@
                     "state": "enabled"
                 },
                 "Youtube": {
-                    "state": "enabled"
+                    "state": "disabled"
                 }
             }
         },


### PR DESCRIPTION
Unfortunately, we had some breakage reports come in after enabling the
feature. Let's disable it for now, while we investigate and fix those
issues.