### PR TITLE
Temporarily disable trackingParameters stripping feature in extensions

### DIFF
--- a/overrides/extension-override.json
+++ b/overrides/extension-override.json
@@ -595,7 +595,7 @@
             "state": "enabled"
         },
         "trackingParameters": {
-            "state": "enabled"
+            "state": "disabled"
         },
         "ampLinks": {
             "state": "enabled"


### PR DESCRIPTION
**Asana Task:** https://app.asana.com/0/0/1204622926998046/1204613227024570/f

**Description**
We've identified an extension implementation issue with how we strip tracking parameters from urls that can lead to broken redirects. Temporarily disabling the feature for extensions only while we fix the underlying issue.