### PR TITLE
Add "Click to Load" exception for khanacademy.org

### DIFF
--- a/features/click-to-load.json
+++ b/features/click-to-load.json
@@ -10,6 +10,9 @@
         "domain": "duckduckgo.com",
         "reason": "Warnings are already displayed before embedded YouTube videos are loaded."
     }, {
+        "domain": "khanacademy.org",
+        "reason": "https://github.com/duckduckgo/privacy-configuration/issues/945"
+    }, {
         "domain": "www.google.ad",
         "reason": "https://github.com/duckduckgo/privacy-configuration/issues/911"
     }, {


### PR DESCRIPTION
Some lessons on Khan Academy contain embedded YouTube videos. The
website detects when they are blocked, and either displays an
alternative video or takes the student to an error
page.

See https://github.com/duckduckgo/privacy-configuration/issues/945
