### PR TITLE
Adds autofill password generation feature flag enabled internally

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -98,6 +98,9 @@
                 "accessCredentialManagement": {
                     "state": "enabled",
                     "minSupportedVersion": "7.74.0"
+                },
+                "autofillPasswordGeneration": {
+                    "state": "internal"
                 }
             }
         },


### PR DESCRIPTION
**Asana Task:**
https://app.asana.com/0/0/1204613855344696/f

**Description**
Updated `ios-config.json` to add `autofillPasswordGeneration` with state `internal`

We want to enable password generation on iOS for internal testing 