### PR TITLE
Re-enable URL parameter stripping in the extension

### DIFF
--- a/overrides/extension-override.json
+++ b/overrides/extension-override.json
@@ -595,7 +595,7 @@
             "state": "enabled"
         },
         "trackingParameters": {
-            "state": "disabled"
+            "state": "enabled"
         },
         "ampLinks": {
             "state": "enabled"

--- a/overrides/extension-override.json
+++ b/overrides/extension-override.json
@@ -595,7 +595,8 @@
             "state": "enabled"
         },
         "trackingParameters": {
-            "state": "enabled"
+            "state": "enabled",
+            "minSupportedVersion": "2023.5.23"
         },
         "ampLinks": {
             "state": "enabled"


### PR DESCRIPTION
**Asana Task:** Fix stripping tracking parameters encoding leading to breakage in extensions

**Description**
This has been fixed in https://github.com/duckduckgo/duckduckgo-privacy-extension/pull/1988