### PR TITLE
Add runtime checks exception for wikimedia.org

### DIFF
--- a/features/runtime-checks.json
+++ b/features/runtime-checks.json
@@ -27,6 +27,10 @@
         {
             "domain": "panomax.com",
             "reason": "https://github.com/duckduckgo/duckduckgo-privacy-extension/issues/2007"
+        },
+        {
+            "domain": "wikimedia.org",
+            "reason": "https://github.com/duckduckgo/content-scope-scripts/issues/540"
         }
     ],
     "settings": {


### PR DESCRIPTION
**Asana Task:** https://app.asana.com/0/0/1204687909074988/f

**Description**
Temporarily disabling runtime checks on wikimedia.org while we work out a proper fix for the issue raised in https://github.com/duckduckgo/content-scope-scripts/issues/540.