### PR TITLE
Add mitigation for bloomingdales breakage

### DIFF
--- a/features/fingerprinting-canvas.json
+++ b/features/fingerprinting-canvas.json
@@ -27,6 +27,10 @@
             "reason": "https://github.com/duckduckgo/privacy-configuration/issues/794"
         },
         {
+            "domain": "bloomingdales.com",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/issues/379"
+        },
+        {
             "domain": "capitalone.com",
             "reason": "https://github.com/duckduckgo/privacy-configuration/issues/794"
         },


### PR DESCRIPTION
Mitigates bloomingdales.com login breakage in #379.

Note: the tiqcdn component will be handled in the blocklist.

Asana: https://app.asana.com/0/0/1204670471114497/f