### PR TITLE
Enabled windowsDownloadLink.

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -208,7 +208,7 @@
             "state": "enabled"
         },
         "windowsDownloadLink": {
-            "state": "disabled"
+            "state": "enabled"
         }
     },
     "unprotectedTemporary": [


### PR DESCRIPTION
**Asana Task:** https://app.asana.com/0/0/1204569901701347/f

**Description**
Updated `android-override.json` to enable `windowsDownloadLink`.

As part of `Windows Browser: Launch into Open Beta`, we need to replace the Windows waitlist flow with one that matches the current Open Beta Mac implementation in the iOS and Android, pointing to the Windows download page. We want to enable the feature. The `windowsWaitlist` will stay as `enabled` for users with old versions of the DDG Android.