### PR TITLE
Add scoped exception for Sephora breakage

### DIFF
--- a/features/app-tracker-protection.json
+++ b/features/app-tracker-protection.json
@@ -118,6 +118,9 @@
                         },
                         {
                             "packageName": "com.macys.android"
+                        },
+                        {
+                            "packageName": "com.sephora"
                         }
                     ]
                 },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/0/1202279501986195/1204725493949533/f

## Description
Sephora app will not load with AppTP enabled, but allowing Adobe's `tt.omtrdc.net` domain fixes this.

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

