### PR TITLE
Collision conf breakage

### DIFF
--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -385,6 +385,17 @@
                     }
                 ]
             },
+            "civiccomputing.com": {
+                "rules": [
+                    {
+                        "rule": "civiccomputing\\.com\\/9\\/cookieControl-9\\.x\\.min\\.js",
+                        "domains": [
+                            "collisionconf.com"
+                        ],
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/issues/979"
+                    }
+                ]
+            },
             "cloudflare.com": {
                 "rules": [
                     {


### PR DESCRIPTION
**Asana Task/Github Issue:** https://github.com/duckduckgo/privacy-configuration/issues/979

## Description

Visiting https://collisionconf.com/ shows a cookie consent dialog that you cannot interact with / dismiss (cookie prompt management off). Works if you turn off protections entirely.

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

