### PR TITLE
Fix FoxNews videos with scoped exceptions

### DIFF
--- a/features/app-tracker-protection.json
+++ b/features/app-tracker-protection.json
@@ -71,10 +71,21 @@
                     "domain": "g.doubleclick.net",
                     "packageNames": [
                         {
+                            "packageName": "com.foxnews.android"
+                        },
+                        {
                             "packageName": "com.udonistemple.magicalmixing"
                         }
                     ]
-                },       
+                },
+                {
+                    "domain": "hb.omtrdc.net",
+                    "packageNames": [
+                        {
+                            "packageName": "com.foxnews.android"
+                        }
+                    ]
+                },   
                 {
                     "domain": "insight.adsrvr.org",
                     "packageNames": [


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/0/1202279501986195/1204734173934276/f

## Description
Some videos lag and others time out without loading unless we allow two trackers (1 Google, 1 Adobe) in the FoxNews app.

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

