### PR TITLE
Reduce number of days since install for in-context signup

### DIFF
--- a/overrides/extension-override.json
+++ b/overrides/extension-override.json
@@ -7,7 +7,7 @@
             "state": "enabled",
             "minSupportedVersion": "2023.3.28.1",
             "settings": {
-                "installedDays": 30
+                "installedDays": 21
             }
         },
         "cookie": {


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/0/0/1204748576474055/f

## Description
Reduce the installed days setting for in-context signup from 30 to 21

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

