### PR TITLE
Disable YouTube "Click to Load" again

### DIFF
--- a/overrides/extension-override.json
+++ b/overrides/extension-override.json
@@ -546,7 +546,7 @@
                     "state": "enabled"
                 },
                 "Youtube": {
-                    "state": "enabled"
+                    "state": "disabled"
                 }
             }
         },


### PR DESCRIPTION
While not as bad as last time, we still are receiving quite a few
breakage reports relating to the YouTube "Click to Load" feature. Some
seem to be breakage, but some seem to be that the user didn't like the
feature. In any case, let's disable the feature again now while we
investigate further.
