### PR TITLE
Only run jobs when code files are changed

### DIFF
--- a/.github/workflows/auto-respond-pr.yml
+++ b/.github/workflows/auto-respond-pr.yml
@@ -5,6 +5,10 @@ on:
     types:
       - opened
       - synchronize
+    paths:
+      - '**.json'
+      - '**.js'
+      - '**.yml'
 
 jobs:
   auto_respond:

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -3,7 +3,11 @@ name: Build and Publish
 on:
   push:
     branches:
-    - main
+      - main
+    paths:
+      - '**.json'
+      - '**.js'
+      - '**.yml'
 
 jobs:
   publish:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,16 @@
 name: Test
 
-on: [push, pull_request]
+on: 
+  push:
+    paths:
+      - '**.json'
+      - '**.js'
+      - '**.yml'
+  pull_request:
+    paths:
+      - '**.json'
+      - '**.js'
+      - '**.yml'
 
 jobs:
   unit:


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:** https://app.asana.com/0/1200890834746050/1203192416044482/f

## Description
This PR adds filters to most of the github jobs to only run when changes are made to code files. This will prevent running config releases, or output change comments, when only things like READMEs changes.

Example PR not triggering jobs: https://github.com/duckduckgo/privacy-configuration/pull/1007
Example PR triggering jobs: https://github.com/duckduckgo/privacy-configuration/pull/1008

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

