### PR TITLE
Add canvas fp mitigation for citi.com

### DIFF
--- a/features/fingerprinting-canvas.json
+++ b/features/fingerprinting-canvas.json
@@ -39,6 +39,10 @@
             "reason": "https://github.com/duckduckgo/privacy-configuration/issues/499"
         },
         {
+            "domain": "citi.com",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/issues/499"
+        },
+        {
             "domain": "emirates.com",
             "reason": "After filling out flight information and clicking 'Search flights', a blank page is shown for several seconds before the page redirects."
         },


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:** https://github.com/duckduckgo/privacy-configuration/issues/499

## Description
We've seen some reports for citi.com, and it appears they are using canvas fp during their login flow. This should mitigate the issues.

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

