### PR TITLE
Temporary rules to hide Chrome popups

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -614,6 +614,107 @@
                 ]
             },
             {
+                "domain": "google.com",
+                "rules": [
+                    {
+                        "selector": "iframe[src*='prid=19026802']",
+                        "type": "hide"
+                    },
+                    {
+                        "selector": "iframe[src*='prid=19026802']",
+                        "type": "closest-empty"
+                    },
+                    {
+                        "selector": "iframe[src*='prid=19015398']",
+                        "type": "hide"
+                    },
+                    {
+                        "selector": "iframe[src*='prid=19015398']",
+                        "type": "closest-empty"
+                    },
+                    {
+                        "selector": "iframe[src*='prid=19026796']",
+                        "type": "hide"
+                    },
+                    {
+                        "selector": "iframe[src*='prid=19026796']",
+                        "type": "closest-empty"
+                    },
+                    {
+                        "selector": "iframe[src*='prid=19018053']",
+                        "type": "hide"
+                    },
+                    {
+                        "selector": "iframe[src*='prid=19018053']",
+                        "type": "closest-empty"
+                    },
+                    {
+                        "selector": "iframe[src*='prid=19018054']",
+                        "type": "hide"
+                    },
+                    {
+                        "selector": "iframe[src*='prid=19018054']",
+                        "type": "closest-empty"
+                    },
+                    {
+                        "selector": "iframe[src*='prid=19016403']",
+                        "type": "hide"
+                    },
+                    {
+                        "selector": "iframe[src*='prid=19016403']",
+                        "type": "closest-empty"
+                    },
+                    {
+                        "selector": "iframe[src*='prid=19015972']",
+                        "type": "hide"
+                    },
+                    {
+                        "selector": "iframe[src*='prid=19015972']",
+                        "type": "closest-empty"
+                    },
+                    {
+                        "selector": "iframe[src*='prid=19016223']",
+                        "type": "hide"
+                    },
+                    {
+                        "selector": "iframe[src*='prid=19016223']",
+                        "type": "closest-empty"
+                    },
+                    {
+                        "selector": "iframe[src*='prid=19015952']",
+                        "type": "hide"
+                    },
+                    {
+                        "selector": "iframe[src*='prid=19015952']",
+                        "type": "closest-empty"
+                    },
+                    {
+                        "selector": "iframe[src*='prid=19030391']",
+                        "type": "hide"
+                    },
+                    {
+                        "selector": "iframe[src*='prid=19030391']",
+                        "type": "closest-empty"
+                    },
+                    {
+                        "selector": "iframe[src*='prid=19030389']",
+                        "type": "hide"
+                    },
+                    {
+                        "selector": "iframe[src*='prid=19030389']",
+                        "type": "closest-empty"
+                    },
+                    {
+                        "selector": "iframe[src*='prid=19030167']",
+                        "type": "hide"
+                    },
+                    {
+                        "selector": "iframe[src*='prid=19030167']",
+                        "type": "closest-empty"
+                    }
+                ]
+            },
+            {
                 "domain": "harpygee.com",
                 "rules": [
                     {


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:** https://app.asana.com/0/1177771139624306/1203893444717855/f

## Description
We've received many complaints from users that they're being bombarded with 'Switch to Chrome' popups when accessing Google properties using our desktop browsers. Unfortunately Google doesn't make it easy to hide only these Chrome popups without also hiding their other various popups (sign into google, password checkup, etc), and the url of the iframe containing these popups is different when signed in vs signed out. So we're forced to target these popups using a bit of their iframe src attribute that has been found to only be present on Chrome popups. This leaves us with a bit of a brittle solution for the time being, but we plan to follow up on this to address the issue via other means.

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

