### PR TITLE
Re-enabled customUserAgent feature on Windows

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -136,7 +136,7 @@
                 "omitClientHintMutations": []
             },
             "exceptions": [],
-            "state": "disabled"
+            "state": "enabled"
         },
         "requestFilterer": {
             "state": "enabled",


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:**

https://app.asana.com/0/1201048563534612/1204827898220965/f

## Description

- I had previously disabled `customUserAgent` feature for windows as there were no custom UA rules present
- However, the `customUserAgent` feature on windows is also responsible for modifying the `SEC-CH-UA` header, to remove the webview2 string from it. So disabling the feature in remote config had disabled this behaviour. 
- This re-enables the feature. I've also added a network-level test to the browser - https://github.com/duckduckgo/windows-browser/pull/705 - to verify the behaviour is as expected.
