### PR TITLE
Exempt login.xfinity.com from runtime checks due to login breakage

### DIFF
--- a/features/runtime-checks.json
+++ b/features/runtime-checks.json
@@ -43,6 +43,10 @@
         {
             "domain": "wikimedia.org",
             "reason": "https://github.com/duckduckgo/content-scope-scripts/issues/540"
+        },
+        {
+            "domain": "login.xfinity.com",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1018"
         }
     ],
     "settings": {


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:** https://app.asana.com/0/569473074191537/1204844629773408/f / https://github.com/duckduckgo/privacy-configuration/issues/1018

## Description
![image](https://github.com/duckduckgo/privacy-configuration/assets/4481594/5fac6514-6566-42af-b5f1-81f99f0fc330)


#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

