### PR TITLE
Disable runtime checks on truist.com as it appears to be breaking login flow

### DIFF
--- a/features/runtime-checks.json
+++ b/features/runtime-checks.json
@@ -47,6 +47,10 @@
         {
             "domain": "login.xfinity.com",
             "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1018"
+        },
+        {
+            "domain": "truist.com",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1020"
         }
     ],
     "settings": {


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:** https://app.asana.com/0/0/1204845051135938/f https://github.com/duckduckgo/privacy-configuration/issues/1020

## Description
Attempting to login on https://dias.bank.truist.com/ui/login with runtime checks enabled redirects you to a 'Service Unavailable' page. Adding an exception here to resolve the issue while we investigate.

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

