### PR TITLE
AppTP: Add scoped exception for doubleclick in Paramount+

### DIFF
--- a/features/app-tracker-protection.json
+++ b/features/app-tracker-protection.json
@@ -71,6 +71,9 @@
                     "domain": "g.doubleclick.net",
                     "packageNames": [
                         {
+                            "packageName": "com.cbs.app"
+                        },
+                        {
                             "packageName": "com.foxnews.android"
                         },
                         {


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:** https://app.asana.com/0/1202279501986195/1204896203561856/f

## Description
Video playback hangs and a poor connection is reported when we block the initial call to `g.doubleclick.net`. Allowing that one tracker appears to fix the issue.

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

