### PR TITLE
Add URLs to breakage form

### DIFF
--- a/.github/ISSUE_TEMPLATE/breakage-form.yml
+++ b/.github/ISSUE_TEMPLATE/breakage-form.yml
@@ -9,6 +9,14 @@ body:
         Each exception should be documented. Please create an issue using this form before creating a new exception. The exception should then link back to the created issue.
         Set the title to the domain of the broken site.
   - type: textarea
+    id: urls
+    attributes:
+      label: URLs affected
+      description: Which URLs are affected by this breakage?
+      placeholder: https://example.com/page.html?product=shoes
+    validations:
+      required: true
+  - type: textarea
     id: description
     attributes:
       label: Description of Breakage


### PR DESCRIPTION
@SlayterDev I saw some breakage forms come in without providing example URLs, so I've added it here.
