### PR TITLE
Expand google element hiding mitigation to domain

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -20,7 +20,7 @@
             "reason": "Adblocker wall"
         },
         {
-            "domain": "mail.google.com",
+            "domain": "google.com",
             "reason": "https://github.com/duckduckgo/privacy-configuration/issues/592"
         },
         {


### PR DESCRIPTION
Expands mitigation for mail.google.com to cover more domains (#592).

https://app.asana.com/0/1203557590179903/1204916213990978/f