### PR TITLE
Use :has pseudoselector for chrome popup rules

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -20,10 +20,6 @@
             "reason": "Adblocker wall"
         },
         {
-            "domain": "google.com",
-            "reason": "https://github.com/duckduckgo/privacy-configuration/issues/592"
-        },
-        {
             "domain": "wiwo.de",
             "reason": "https://github.com/duckduckgo/privacy-configuration/issues/592"
         },
@@ -659,100 +655,52 @@
                 "domain": "google.com",
                 "rules": [
                     {
-                        "selector": "iframe[src*='prid=19026802']",
+                        "selector": ":is(div:has(> iframe[src*='prid=19026802']))",
                         "type": "hide"
                     },
                     {
-                        "selector": "iframe[src*='prid=19026802']",
-                        "type": "closest-empty"
-                    },
-                    {
-                        "selector": "iframe[src*='prid=19015398']",
+                        "selector": ":is(div:has(> iframe[src*='prid=19015398']))",
                         "type": "hide"
                     },
                     {
-                        "selector": "iframe[src*='prid=19015398']",
-                        "type": "closest-empty"
-                    },
-                    {
-                        "selector": "iframe[src*='prid=19026796']",
+                        "selector": ":is(div:has(> iframe[src*='prid=19026796']))",
                         "type": "hide"
                     },
                     {
-                        "selector": "iframe[src*='prid=19026796']",
-                        "type": "closest-empty"
-                    },
-                    {
-                        "selector": "iframe[src*='prid=19018053']",
+                        "selector": ":is(div:has(> iframe[src*='prid=19018053']))",
                         "type": "hide"
                     },
                     {
-                        "selector": "iframe[src*='prid=19018053']",
-                        "type": "closest-empty"
-                    },
-                    {
-                        "selector": "iframe[src*='prid=19018054']",
+                        "selector": ":is(div:has(> iframe[src*='prid=19018054']))",
                         "type": "hide"
                     },
                     {
-                        "selector": "iframe[src*='prid=19018054']",
-                        "type": "closest-empty"
-                    },
-                    {
-                        "selector": "iframe[src*='prid=19016403']",
+                        "selector": ":is(div:has(> iframe[src*='prid=19016403']))",
                         "type": "hide"
                     },
                     {
-                        "selector": "iframe[src*='prid=19016403']",
-                        "type": "closest-empty"
-                    },
-                    {
-                        "selector": "iframe[src*='prid=19015972']",
+                        "selector": ":is(div:has(> iframe[src*='prid=19015972']))",
                         "type": "hide"
                     },
                     {
-                        "selector": "iframe[src*='prid=19015972']",
-                        "type": "closest-empty"
-                    },
-                    {
-                        "selector": "iframe[src*='prid=19016223']",
+                        "selector": ":is(div:has(> iframe[src*='prid=19016223']))",
                         "type": "hide"
                     },
                     {
-                        "selector": "iframe[src*='prid=19016223']",
-                        "type": "closest-empty"
-                    },
-                    {
-                        "selector": "iframe[src*='prid=19015952']",
+                        "selector": ":is(div:has(> iframe[src*='prid=19015952']))",
                         "type": "hide"
                     },
                     {
-                        "selector": "iframe[src*='prid=19015952']",
-                        "type": "closest-empty"
-                    },
-                    {
-                        "selector": "iframe[src*='prid=19030391']",
+                        "selector": ":is(div:has(> iframe[src*='prid=19030391']))",
                         "type": "hide"
                     },
                     {
-                        "selector": "iframe[src*='prid=19030391']",
-                        "type": "closest-empty"
-                    },
-                    {
-                        "selector": "iframe[src*='prid=19030389']",
+                        "selector": ":is(div:has(> iframe[src*='prid=19030389']))",
                         "type": "hide"
                     },
                     {
-                        "selector": "iframe[src*='prid=19030389']",
-                        "type": "closest-empty"
-                    },
-                    {
-                        "selector": "iframe[src*='prid=19030167']",
+                        "selector": ":is(div:has(> iframe[src*='prid=19030167']))",
                         "type": "hide"
-                    },
-                    {
-                        "selector": "iframe[src*='prid=19030167']",
-                        "type": "closest-empty"
                     }
                 ]
             },


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:** https://app.asana.com/0/1203557590179903/1204908558710325/f

## Description
We temporarily turned off hiding of 'switch to chrome' popups on Google properties as we received some reports that in certain situations we are hiding the popup but not the parent div, which left an unusable space where the popup was.

This PR removes google.com from the exception list and modifies the selectors used to explicitly target the wrapper div of these popups. These rules look a little funny because `:has` isn't fully supported in Firefox yet, so we wrap it in `:is` to make it a forgiving selector list (which will silently fail in Firefox instead of throwing an error). It's okay that this doesn't work in Firefox - the popups we're targeting aren't present in Firefox anyway.

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

