### PR TITLE
Remove fingerprintingScreenSize on MacOS due to breakage

### DIFF
--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -98,7 +98,7 @@
             }
         },
         "fingerprintingScreenSize": {
-            "state": "enabled"
+            "state": "disabled"
         },
         "fingerprintingCanvas": {
             "state": "disabled"


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:** https://github.com/duckduckgo/privacy-configuration/issues/1072

## Description

Disables fingerprinting screen size as we're running before the webCompat feature thus breaking sites like Google sheets.

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

