### PR TITLE
Disable content blocking on xfinity.com

### DIFF
--- a/features/content-blocking.json
+++ b/features/content-blocking.json
@@ -15,6 +15,10 @@
         {
             "domain": "welt.de",
             "reason": "Video pauses at about 13-15 seconds in. Playing the video again results in a single frame rendering without progressing to the next frame."
+        },
+        {
+            "domain": "xfinity.com",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/issues/788"
         }
     ]
 }


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:** https://app.asana.com/0/1200223097357040/1201063880803483/f

## Description
We're seeing elevated breakage reports, primarily on Android, related to xfinity login. We're disabling content blocking to verify if it addresses the issue. 

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

