### PR TITLE
Add referrer trimming exception for atlassian.com

### DIFF
--- a/features/referrer.json
+++ b/features/referrer.json
@@ -8,6 +8,10 @@
     },
     "exceptions": [
         {
+            "domain": "atlassian.com",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1092"
+        },
+        {
             "domain": "learning.edx.org",
             "reason": "https://github.com/duckduckgo/privacy-configuration/issues/934"
         },


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:** https://app.asana.com/0/0/1205011524066951/f

## Description
Users are reporting issues with logging into bitbucket.com due to referrer trimming.

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

