### PR TITLE
Expand yotpo mitigation to cover more images

### DIFF
--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -2209,7 +2209,7 @@
                         "reason": "https://github.com/duckduckgo/privacy-configuration/issues/348"
                     },
                     {
-                        "rule": "cdn-yotpo-images-production.yotpo.com/Product/.*/.*/square.jpg",
+                        "rule": "cdn-yotpo-images-production.yotpo.com",
                         "domains": [
                             "<all>"
                         ],


### PR DESCRIPTION
Catches more cases of image breakage from #348.
