### PR TITLE
Temporarily add earth.google.com to unprotected list due to loading issues

### DIFF
--- a/features/unprotected-temporary.json
+++ b/features/unprotected-temporary.json
@@ -16,6 +16,10 @@
             "reason": "https://github.com/duckduckgo/privacy-configuration/issues/794"
         },
         {
+            "domain": "earth.google.com",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1099"
+        },
+        {
             "domain": "ticketmaster.com",
             "reason": "https://github.com/duckduckgo/privacy-configuration/issues/794"
         },


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:** https://app.asana.com/0/1200277586140538/1205010492882704/f

## Description
Will remove this mitigation once we've completed a root cause analysis.

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

