### PR TITLE
add derstandard.at to the exception list

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -12,6 +12,10 @@
             "reason": "https://github.com/duckduckgo/privacy-configuration/issues/589"
         },
         {
+            "domain": "derstandard.at",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1101"
+        },
+        {
             "domain": "foxnews.com",
             "reason": "https://github.com/duckduckgo/privacy-configuration/issues/965"
         },


### PR DESCRIPTION

**Asana Task/Github Issue:**
https://app.asana.com/0/0/1205014205767863/f
https://github.com/duckduckgo/privacy-configuration/issues/1101

## Description
Adblock wall triggered by element hiding.

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

