### PR TITLE
allow tracker tiqcdn on mcafee-com

### DIFF
--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -2027,6 +2027,13 @@
                             "virginmedia.com"
                         ],
                         "reason": "Chat button appears faded and cannot be interacted with."
+                    },
+                    {
+                        "rule": "https://tags.tiqcdn.com/utag/tiqapp/utag.currency.js",
+                        "domains": [
+                            "mcafee.com"
+                        ],
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1104"
                     }
                 ]
             },


### PR DESCRIPTION
**Asana Task/Github Issue:**

https://app.asana.com/0/0/1205014205767868/f
https://github.com/duckduckgo/privacy-configuration/issues/1104

## Description

When our protection is ON the feedback tab disappears. This is caused by some tag that we block aka https://tags.tiqcdn.com/utag/tiqapp/utag.currency.js 

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

