### PR TITLE
unblock two requests to display scheels content

### DIFF
--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -624,6 +624,13 @@
                             "<all>"
                         ],
                         "reason": "https://github.com/duckduckgo/privacy-configuration/issues/486"
+                    },
+                    {
+                        "rule": "p.cquotient.com/pebble",
+                        "domains": [
+                            "scheels.com"
+                        ],
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/issues/486"
                     }
                 ]
             },
@@ -2448,6 +2455,13 @@
                             "<all>"
                         ],
                         "reason": "https://github.com/duckduckgo/privacy-configuration/issues/830"
+                    },
+                    {
+                        "rule": "rapid-cdn.yottaa.com/rapid/lib/ows8CdAyrC5lTw.js",
+                        "domains": [
+                            "scheels.com"
+                        ],
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/issues/492"
                     }
                 ]
             },


### PR DESCRIPTION

**Asana Task/Github Issue:**
https://app.asana.com/0/0/1205073410073537/f
https://github.com/duckduckgo/privacy-configuration/issues/486
https://github.com/duckduckgo/privacy-configuration/issues/492

## Description
[p.cquotient.com/pebble](https://p.cquotient.com/pebble) for "You may also like" & [rapid-cdn.yottaa.com/rapid/lib/ows8CdAyrC5lTw.js](https://rapid-cdn.yottaa.com/rapid/lib/ows8CdAyrC5lTw.js) for "Q&A + Reviews + What everyone's saying" need to be allowed to display those sections' content

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

