### PR TITLE
unblock cmp-quantcast from all domains

### DIFF
--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -542,17 +542,6 @@
                     }
                 ]
             },
-            "quantcast.com": {
-                "rules": [
-                    {
-                        "rule": "cmp.quantcast.com",
-                        "domains": [
-                            "express.co.uk"
-                        ],
-                        "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1068"
-                    }
-                ]
-            },
             "crisp.chat": {
                 "rules": [
                     {
@@ -1972,6 +1961,17 @@
                             "aternos.org"
                         ],
                         "reason": "https://github.com/duckduckgo/privacy-configuration/issues/328"
+                    }
+                ]
+            },
+            "quantcast.com": {
+                "rules": [
+                    {
+                        "rule": "cmp.quantcast.com",
+                        "domains": [
+                            "<all>"
+                        ],
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1125"
                     }
                 ]
             },


### PR DESCRIPTION
**Asana Task/Github Issue:**

https://app.asana.com/0/0/1205086363392384/f
https://github.com/duckduckgo/privacy-configuration/issues/1125

## Description

On a few local newspapers videos don't play because of blocking cmp.quantcast.com
Since we handle quantcast with CPM, we can unblock it from our tracker list and let CPM handle quantcast.

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

