### PR TITLE
Disable URL parameter removal as part of breakage reduction work

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -146,7 +146,7 @@
             "exceptions": [ ]
         },
         "trackingParameters": {
-            "state": "enabled"
+            "state": "disabled"
         }
     },
     "unprotectedTemporary": []


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:**
https://app.asana.com/0/72649045549333/1204926383388878/f


## Description

During O-E meeting yesterday it was decided not to enable URL Parameter removal in the v0.45 release as part of the ongoing work to reduce breakages.

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

