### PR TITLE
Omit application component for UA on nypost

### DIFF
--- a/features/custom-user-agent.json
+++ b/features/custom-user-agent.json
@@ -31,6 +31,10 @@
             {
                 "domain": "wykop.pl",
                 "reason": "https://github.com/duckduckgo/privacy-configuration/issues/667"
+            },
+            {
+                "domain": "nypost.com",
+                "reason": "https://github.com/duckduckgo/privacy-configuration/issues/667"
             }
         ],
         "omitVersionSites": []


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:**
https://app.asana.com/0/414709148257752/1205093291144988/f

## Description

Videos broken on nypost.com

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

