### PR TITLE
add two domains to element-hiding exception list

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -42,6 +42,14 @@
         {
             "domain": "bizjournals.com",
             "reason": "https://github.com/duckduckgo/privacy-configuration/issues/592"
+        },
+        {
+            "domain": "slate.com",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/issues/592"
+        },
+        {
+            "domain": "dailycaller.com",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/issues/592"
         }
     ],
     "settings": {


### PR DESCRIPTION
**Asana Task/Github Issue:**

Github: https://github.com/duckduckgo/privacy-configuration/issues/592
Asana:
- slate.com: https://app.asana.com/0/1201534009035032/1205084127366554/f
- dailycaller.com: https://app.asana.com/0/1201534009035032/1205084127366549/f

## Description
Add slate.com and dailycaller.com to element-hiding exception due to an ad blocker wall

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

