### PR TITLE
add crunchyroll-com to doubleclick exception list

### DIFF
--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -719,12 +719,14 @@
                         "domains": [
                             "nhl.com",
                             "viki.com",
-                            "rocketnews24.com"
+                            "rocketnews24.com",
+                            "crunchyroll.com"
                         ],
                         "reason": [
                             "nhl.com - Videos show a spinner and never load.",
                             "viki.com - after a video has played for a few seconds an adwall pops up. Clicking 'I've turned off my adblocker' resets the video, then after a few seconds the adwall pops up again.",
-                            "rocketnews24.com - https://github.com/duckduckgo/privacy-configuration/issues/846"
+                            "rocketnews24.com - https://github.com/duckduckgo/privacy-configuration/issues/846",
+                            "crunchyroll.com - https://github.com/duckduckgo/privacy-configuration/issues/1140"
                         ]
                     },
                     {


### PR DESCRIPTION

**Asana Task/Github Issue:**

Asana: https://app.asana.com/0/0/1205084130083961/f
Github: https://github.com/duckduckgo/privacy-configuration/issues/1140

## Description

Video can't play and break because we block an ad streaming tracker meant to play at the start of the video

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

