### PR TITLE
Disable usercentrics-api autoconsent rule

### DIFF
--- a/features/autoconsent.json
+++ b/features/autoconsent.json
@@ -167,7 +167,8 @@
     "settings": {
         "disabledCMPs": [
             "Sourcepoint-top",
-            "generic-cosmetic"
+            "generic-cosmetic",
+            "usercentrics-api"
         ]
     }
 }


### PR DESCRIPTION

<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:**
https://app.asana.com/0/1203983824454590/1205120565999862/f
https://github.com/duckduckgo/autoconsent/issues/210

## Description
Usercentrics API started using Promises, so the rule needs to be updated

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

