### PR TITLE
Exempt prime.amazon.dev on all domains until entity data fixed

### DIFF
--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -228,27 +228,7 @@
                     {
                         "rule": "prime.amazon.dev",
                         "domains": [
-                            "amazon.eg",
-                            "amazon.com.br",
-                            "amazon.ca",
-                            "amazon.com.mx",
-                            "amazon.com",
-                            "amazon.cn",
-                            "amazon.in",
-                            "amazon.co.jp",
-                            "amazon.sa",
-                            "amazon.sg",
-                            "amazon.com.tr",
-                            "amazon.ae",
-                            "amazon.com.be",
-                            "amazon.fr",
-                            "amazon.it",
-                            "amazon.nl",
-                            "amazon.pl",
-                            "amazon.es",
-                            "amazon.se",
-                            "amazon.co.uk",
-                            "amazon.com.au"
+                            "<all>"
                         ],
                         "reason": "https://github.com/duckduckgo/privacy-configuration/issues/943"
                     }


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:** https://app.asana.com/0/1200223097357040/1205132730961921/f

## Description
We can remove this once the next blocklist update goes out. Only need the exception until entity data for amazon.dev is updated. (https://github.com/duckduckgo/privacy-configuration/issues/943)

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

