### PR TITLE
unbreak norton chat by unblocking a tracker

### DIFF
--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -234,6 +234,17 @@
                     }
                 ]
             },
+            "analytics.analytics-egain.com": {
+                "rules": [
+                    {
+                        "rule": "https://analytics.analytics-egain.com/onetag/EG94020756",
+                        "domains": [
+                            "support.norton.com"
+                        ],
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1156"
+                    }
+                ]
+            },
             "aticdn.net": {
                 "rules": [
                     {

--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -234,10 +234,10 @@
                     }
                 ]
             },
-            "analytics.analytics-egain.com": {
+            "analytics-egain.com": {
                 "rules": [
                     {
-                        "rule": "https://analytics.analytics-egain.com/onetag/EG94020756",
+                        "rule": "analytics.analytics-egain.com/onetag/",
                         "domains": [
                             "support.norton.com"
                         ],


### PR DESCRIPTION
**Asana Task/Github Issue:**

Github: https://github.com/duckduckgo/privacy-configuration/issues/1156
Asana: https://app.asana.com/0/0/1205160643673966/f

## Description

By blocking the following tracker: https://analytics.analytics-egain.com/onetag/EG94020756 (which appears asap a user hit the "chat now" button) we prevent the chat feature's window to open.
No need of creating an account when entering [support.norton.com](https://support.norton.com/) . Choose "continue as a guest".

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

