### PR TITLE
add https exception to act-alt-org

### DIFF
--- a/features/https.json
+++ b/features/https.json
@@ -7,5 +7,10 @@
         }
     },
     "state": "enabled",
-    "exceptions": []
+    "exceptions": [
+        {
+            "domain": "act.alz.org",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1158"
+        }
+    ]
 }


### PR DESCRIPTION
**Asana Task/Github Issue:**

Asana: https://app.asana.com/0/1201534009035032/1205121865293389/f
Github: https://github.com/duckduckgo/privacy-configuration/issues/1158

## Description

add act.alt.org to the exception list of https since it causes too many requests and prevents the site to load.

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

