### PR TITLE
Disable interceptDnsRequests

### DIFF
--- a/features/app-tracker-protection.json
+++ b/features/app-tracker-protection.json
@@ -3,6 +3,9 @@
         "description": "App Tracking Protection"
     },
     "settings": {
+        "interceptDnsRequests": {
+            "state": "disabled"
+        },
         "openBeta": {
             "state": "enabled"
         },


### PR DESCRIPTION
**Asana Task/Github Issue:**https://app.asana.com/0/0/1205145153997748/f

## Description
The `interceptDnsRequests` is a remote feature flag, or rather a kill-switch, ie. enabled by default in the client. Can be disabled using remote config

The client that contains that feature enabled is the Android app v5.164.2. We've been monitoring the breakage and it is stable, but I want to be ready in case something doesn't go well over the weekend and I need to disable that feature.

I may also merge this, even if things don't go wrong, but once we have enough data to see whether is worth continuing with this approach or not.



#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

