### PR TITLE
Add EME exception for primevideo.com

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -23,6 +23,10 @@
                     "reason": "https://github.com/duckduckgo/privacy-configuration/issues/684"
                 },
                 {
+                    "domain": "primevideo.com",
+                    "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1162"
+                },
+                {
                     "domain": "showtime.com",
                     "reason": "https://github.com/duckduckgo/privacy-configuration/issues/867"
                 }


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:** https://app.asana.com/0/1200223097357040/1205132730961921/f

## Description
Amazon Prime Video playback is broken on Android due to DRM, this should fix it.

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

