### PR TITLE
Add mitigation for boston comments

### DIFF
--- a/features/gpc.json
+++ b/features/gpc.json
@@ -16,6 +16,10 @@
             ]
         },
         {
+            "domain": "boston.com",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/issues/700"
+        },
+        {
             "domain": "costco.com",
             "reason": "https://github.com/duckduckgo/privacy-configuration/issues/644"
         },


### PR DESCRIPTION
Mitigates boston comments in https://github.com/duckduckgo/privacy-configuration/issues/700

Asana: https://app.asana.com/0/1200277586140538/1205121797630365/f

