### PR TITLE
Add EME exception for Amazon Prime Video

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -11,6 +11,10 @@
             "state": "enabled",
             "exceptions": [
                 {
+                    "domain": "amazon.com",
+                    "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1162"
+                },
+                {
                     "domain": "foxnews.com",
                     "reason": "https://github.com/duckduckgo/privacy-configuration/issues/984"
                 },


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:** https://app.asana.com/0/1200223097357040/1205132730961921/f

## Description
Follows up on https://github.com/duckduckgo/privacy-configuration/pull/1163 to expand the Amazon Prime Video mitigation to US Amazon Prime, which is hosted on the amazon.com domain.

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

