### PR TITLE
Add CPM exceptions for several sites

### DIFF
--- a/features/autoconsent.json
+++ b/features/autoconsent.json
@@ -162,6 +162,22 @@
         {
             "domain": "kia.com",
             "reason": "https://github.com/duckduckgo/autoconsent/issues/210"
+        },
+        {
+            "domain": "pcworld.com",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/issues/326"
+        },
+        {
+            "domain": "windowscentral.com",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/issues/326"
+        },
+        {
+            "domain": "driving.co.uk",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/issues/326"
+        },
+        {
+            "domain": "news.sky.com",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/issues/326"
         }
     ],
     "settings": {


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:** https://app.asana.com/0/1200277586140538/1204522885984854/f / https://github.com/duckduckgo/privacy-configuration/issues/326

## Description
Adding cookie pop up management exceptions for several sites

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

