### PR TITLE
Hide google pop up on indeed.com

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -794,6 +794,15 @@
                 ]
             },
             {
+                "domain": "indeed.com",
+                "rules": [
+                    {
+                        "selector": ".google-Only-Modal",
+                        "type": "hide"
+                    }
+                ]
+            },
+            {
                 "domain": "indiatimes.com",
                 "rules": [
                     {


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:** https://app.asana.com/0/1203557590179903/1205174622371345/f

## Description
Hides the 'Sign in with Google' nag on indeed.com.

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

