### PR TITLE
Temporarily allow qualtrics requests to resolve embedded content breakage

### DIFF
--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -2125,6 +2125,17 @@
                     }
                 ]
             },
+            "qualtrics.com": {
+                "rules": [
+                    {
+                        "rule": "qualtrics.com",
+                        "domains": [
+                            "<all>"
+                        ],
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1196"
+                    }
+                ]
+            },
             "quantcast.com": {
                 "rules": [
                     {


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:** https://app.asana.com/0/1200277586140538/1205199506779759/f

## Description
Temporarily allow requests to qualtrics.com to resolve breakage issues with embedded content. This rule will be removed once we update our blocklist next week to only block certain qualtrics paths instead of all.

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

