### PR TITLE
Expand bing image mitigation

### DIFF
--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -331,14 +331,12 @@
                         ]
                     },
                     {
-                        "rule": "th.bing.com/th",
+                        "rule": "bing.com/th",
                         "domains": [
                             "drudgereport.com"
                         ],
                         "reason": [
-                            "On the homepage (drudgereport.com), some images are fetched from bing.com.",
-                            "When we block these requests, the images do not render, and the page appears to have blank boxes.",
-                            "Note that requests can be of the form th.bing.com/th?id=... or th.bing.com/th/id/..., hence we unblock the common path here."
+                            "https://github.com/duckduckgo/privacy-configuration/issues/765",
                         ]
                     },
                     {

--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -333,10 +333,10 @@
                     {
                         "rule": "bing.com/th",
                         "domains": [
-                            "drudgereport.com"
+                            "<all>"
                         ],
                         "reason": [
-                            "https://github.com/duckduckgo/privacy-configuration/issues/765",
+                            "https://github.com/duckduckgo/privacy-configuration/issues/765"
                         ]
                     },
                     {


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:** https://app.asana.com/0/569473074191537/1205244745350683/f

## Description
Expands the mitigation for bing images fetched from 3p sites to resolve broken images on start.gg and other sites that fetch images from bing's image proxy.

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

