### PR TITLE
Fix invalid selector in Firefox only

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -416,7 +416,7 @@
                 "type": "hide-empty"
             },
             {
-                "selector": "[#amp_floatingAdDiv]",
+                "selector": "#amp_floatingAdDiv",
                 "type": "hide"
             },
             {


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->

## Description
Firefox is throwing an error on this selector. This type of error will go away with https://github.com/duckduckgo/content-scope-scripts/pull/683, but for the time being we should just change it to something that won't throw in Firefox.

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

