### PR TITLE
add rte-ie to android eme exception list

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -31,6 +31,10 @@
                     "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1162"
                 },
                 {
+                    "domain": "rte.ie",
+                    "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1217"
+                },
+                {
                     "domain": "showtime.com",
                     "reason": "https://github.com/duckduckgo/privacy-configuration/issues/867"
                 }


### PR DESCRIPTION
**Asana Task/Github Issue:**

https://github.com/duckduckgo/privacy-configuration/issues/1217
https://app.asana.com/0/1200277586140538/1205283779424185/f

## Description

requires user's drm permission to play the live news video. This site needs to be added to android eme exception list.

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

