### PR TITLE
rollout not rollouts

### DIFF
--- a/compatibility.js
+++ b/compatibility.js
@@ -53,15 +53,15 @@ const compatFunctions = {
         return v1Config
     },
     v2: (config) => {
-        // Breaking changes: rollouts key in sub-features
+        // Breaking changes: rollout key in sub-features
 
         const v2Config = JSON.parse(JSON.stringify(config))
         for (const feature of Object.keys(v2Config.features)) {
             const subFeatures = v2Config.features[feature].features
             if (subFeatures) {
                 for (const subFeature of Object.keys(subFeatures)) {
-                    if (subFeatures[subFeature].rollouts) {
-                        delete subFeatures[subFeature].rollouts
+                    if (subFeatures[subFeature].rollout) {
+                        delete subFeatures[subFeature].rollout
                         v2Config.features[feature].features[subFeature].state = 'disabled'
                     }
                 }


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:** https://app.asana.com/0/0/1205278669759807/f

## Description
Fixes v2 compat function to delete `rollout` keys. **Not** `rollouts`.

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

