### PR TITLE
add cnn-com tracker and eme exceptions

### DIFF
--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -198,6 +198,7 @@
                         "rule": "c.amazon-adsystem.com/aax2/apstag.js",
                         "domains": [
                             "corriere.it",
+                            "cnn.com",
                             "eurogamer.net",
                             "seattletimes.com",
                             "wcvb.com"
@@ -207,6 +208,7 @@
                             "Example URL: https://www.corriere.it/video-articoli/2022/07/13/missione-wwf-liberare-mare-plastica/9abb64de-029d-11ed-a0cc-ad3c68cacbae.shtml;",
                             "Clicking on the video to play causes a still frame to show and the video does not continue.",
                             "eurogamer.net, seattletimes.com - An unskippable adwall appears which prevents interaction with the page.",
+                            "cnn.com - https://github.com/duckduckgo/privacy-configuration/issues/1220",
                             "wcvb.com - https://github.com/duckduckgo/privacy-configuration/issues/1088"
                         ]
                     }

--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -15,6 +15,10 @@
                     "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1162"
                 },
                 {
+                    "domain": "cnn.com",
+                    "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1220"
+                },
+                {
                     "domain": "foxnews.com",
                     "reason": "https://github.com/duckduckgo/privacy-configuration/issues/984"
                 },


### PR DESCRIPTION
**Asana Task/Github Issue:**

Asana: https://app.asana.com/0/0/1205294031693443/f
Github: https://github.com/duckduckgo/privacy-configuration/issues/1220

## Description

Two mitigations:
- On Android, an article's video does not load protection ON/OFF → add cnn.com to the eme/DRM exception list
- On MacOS, there's a delay between audio and video where audio starts couple of seconds before the audio privacy protection ON/OFF → unblock amazon-adsystem.com/aax2/apstag.js onto cnn.com

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

