### PR TITLE
add fingerprintingHardware exception to airbnb

### DIFF
--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -383,7 +383,13 @@
                     {"type": "number", "value": 8, "criteria": {"arch": "AppleSilicon"}}
                  ],
                 "deviceMemory": {"type": "undefined"}
-            }
+            },
+            "exceptions": [
+                {
+                    "domain": "airbnb.com",
+                    "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1224"
+                }
+            ]
         },
         "fingerprintingScreenSize": {
             "state": "disabled"


### PR DESCRIPTION
**Asana Task/Github Issue:**

Asana: https://app.asana.com/0/0/1205301853420978/f
Github: https://github.com/duckduckgo/privacy-configuration/issues/1224

## Description

map on airbnb does not load properly on MacOS when protection is ON because of fingerprinting-hardware. An exception to be added to the macos-override file

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

