### PR TITLE
Turn on the macOS incremental feature flag test

### DIFF
--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -1,5 +1,20 @@
 {
     "features": {
+        "incrementalRolloutTest": {
+            "state": "enabled",
+            "features": {
+                "rollout": {
+                    "state": "enabled",
+                    "rollout": {
+                        "steps": [
+                            {
+                                "percent": 1.0
+                            }
+                        ]
+                    }
+                }
+            }
+        },
         "contentBlocking": {
             "state": "enabled",
             "exceptions": [


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:** https://app.asana.com/0/0/1205273260468954/f

## Description

This PR turns on the `incrementalRolloutTest` flag, support for which was added in the latest macOS build and sends a pixel the first time that the client detects that this flag is enabled. This is so that we can verify that the incremental rollout support recently added to feature flags is working as intended.

Once the test has proven that the incremental rollout feature is working correctly, support for this feature flag will be removed.

Android equivalent PR is here: https://github.com/duckduckgo/privacy-configuration/pull/1227

The macOS feature flag is defined in BSK here: [PrivacyFeature.swift#L43](https://github.com/duckduckgo/BrowserServicesKit/blob/0c4f894f1d41508c3a545798dc1eaaf49487b863/Sources/BrowserServicesKit/PrivacyConfig/Features/PrivacyFeature.swift#L43)

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

