### PR TITLE
re-enable autoconsent on Windows using the "enableIfMainWorldIsSuppoted" setting

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -13,7 +13,10 @@
                 "disabledCMPs": [
                     "generic-cosmetic"
                 ],
-                "enableIfMainWorldIsSupported": "enabled"
+                "enableIfMainWorldIsSupported": {
+                    "state": "enabled",
+                    "minSupportedVersion": "0.50.0"
+                }
             }
         },
         "navigatorInterface": {

--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -7,7 +7,14 @@
             "state": "enabled"
         },
         "autoconsent": {
-            "state": "disabled"
+            "state": "disabled",
+            "minSupportedVersion": "0.50.0",
+            "settings": {
+                "disabledCMPs": [
+                    "generic-cosmetic"
+                ],
+                "enableIfMainWorldIsSupported": "enabled"
+            }
         },
         "navigatorInterface": {
             "state": "enabled"


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:** https://app.asana.com/0/0/1205319036091446/f

cc: @muodov @SlayterDev 

## Description

In https://github.com/duckduckgo/privacy-configuration/pull/1212 we temporarily disabled autoconsent. 

Now we would like to enable it again, but:
- old clients (< 0.50) should still have autoconsent disabled
- new clients (>= 0.50) should have the feature immediately enabled

We wanted to use `minSupportedVersion` to achieve our goals, but the native service handler don't take `minSupportedVersion` into account at all and only listen to the global state enabled/disabled flag.

As a workaround and/or improvement:
- added `minSupportedVersion` and implemented the proper client side handling of that property
- added a new setting called `enableIfMainWorldIsSuppoted` which will temporarily act as a enabled/disabled flag and we'll keep top level global state flag disabled, until almost everyone is updated to v0.50 or higher. Then we will remove the `enableIfMainWorldIsSuppoted` and flip the global disabled to enabled.

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

