### PR TITLE
add allocine-fr to autoconsent exception list

### DIFF
--- a/features/autoconsent.json
+++ b/features/autoconsent.json
@@ -8,6 +8,10 @@
     },
     "exceptions": [
         {
+            "domain": "allocine.fr",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1241"
+        },
+        {
             "domain": "bild.de",
             "reason": "https://github.com/duckduckgo/privacy-configuration/issues/326"
         },


### PR DESCRIPTION
**Asana Task/Github Issue:**

Github: https://github.com/duckduckgo/privacy-configuration/issues/1241
Asana: https://app.asana.com/0/1200277586140538/1205344806144972/f

## Description

If a user does not accept all cookies, some features can't be run (eg streaming trailers). allocine.fr needs to be added to autoconsent exemption list so CPM does not run on the site.

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

