### PR TITLE
add the-hindu-com to elementHiding exception list

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -74,6 +74,10 @@
         {
             "domain": "allgemeine-zeitung.de",
             "reason": "https://github.com/duckduckgo/privacy-configuration/issues/592"
+        },
+        {
+            "domain": "thehindu.com",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/issues/592"
         }
     ],
     "settings": {


### PR DESCRIPTION
**Asana Task/Github Issue:**
Asana: [thehindu.com elementHiding triggers adblocker banner and google sign in notification](https://app.asana.com/0/1200277586140538/1205326380537950/f)
Github: https://github.com/duckduckgo/privacy-configuration/issues/592

## Description

With elementHiding ON users can't interact with the google sign in pop up which triggers an annoying and repetitive overlay asking users to optionally sign into their account. 
Besides it triggers an adblock wall. 

To reproduce the breakage you need to click on a few articles. That's especially the case for the adblocker banner to appear.

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

