### PR TITLE
add site to amazon exception list due to adwall

### DIFF
--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -201,7 +201,8 @@
                             "cnn.com",
                             "eurogamer.net",
                             "seattletimes.com",
-                            "wcvb.com"
+                            "wcvb.com",
+                            "wildrivers.lostcoastoutpost.com"
                         ],
                         "reason": [
                             "corriere.it - ",
@@ -209,7 +210,8 @@
                             "Clicking on the video to play causes a still frame to show and the video does not continue.",
                             "eurogamer.net, seattletimes.com - An unskippable adwall appears which prevents interaction with the page.",
                             "cnn.com - https://github.com/duckduckgo/privacy-configuration/issues/1220",
-                            "wcvb.com - https://github.com/duckduckgo/privacy-configuration/issues/1088"
+                            "wcvb.com - https://github.com/duckduckgo/privacy-configuration/issues/1088",
+                            "wildrivers.lostcoastoutpost.com - https://github.com/duckduckgo/privacy-configuration/issues/592"
                         ]
                     }
                 ]

--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -211,7 +211,7 @@
                             "eurogamer.net, seattletimes.com - An unskippable adwall appears which prevents interaction with the page.",
                             "cnn.com - https://github.com/duckduckgo/privacy-configuration/issues/1220",
                             "wcvb.com - https://github.com/duckduckgo/privacy-configuration/issues/1088",
-                            "wildrivers.lostcoastoutpost.com - https://github.com/duckduckgo/privacy-configuration/issues/592"
+                            "wildrivers.lostcoastoutpost.com - https://github.com/duckduckgo/privacy-configuration/issues/1252"
                         ]
                     }
                 ]


### PR DESCRIPTION
**Asana Task/Github Issue:**

Github: https://github.com/duckduckgo/privacy-configuration/issues/1252
Asana: https://app.asana.com/0/1200277586140538/1205332339199964/f

## Description

Adblocking banner caused by bloking amazon-adsystem.com - add wildrivers.lostcoastoutpost.com to the list of exception.

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

