### PR TITLE
add motorsport-com to cpm exception list

### DIFF
--- a/features/autoconsent.json
+++ b/features/autoconsent.json
@@ -150,6 +150,10 @@
         {
             "domain": "gfds.de",
             "reason": "https://github.com/duckduckgo/autoconsent/issues/130"
+        },
+        {
+            "domain": "motorsport.com",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1250"
         }
     ],
     "settings": {


### PR DESCRIPTION
**Asana Task/Github Issue:**

Asana: https://app.asana.com/0/1200277586140538/1205352141277025/f
Github: https://github.com/duckduckgo/privacy-configuration/issues/1250

## Description

[motorsport.com](https://motorsport.com/) forces users to accept analytics cookies to access the content. Otherwise it triggers an ad blocker banner.
On platforms where CPM is implemented this banner is automatically triggered. We need to turn off CPM for this domain.

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

