### PR TITLE
Element hiding: disable on duckduckgo.com, update timings to reduce perf overhead

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -8,6 +8,10 @@
     },
     "exceptions": [
         {
+            "domain": "duckduckgo.com",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1236"
+        },
+        {
             "domain": "bild.de",
             "reason": "https://github.com/duckduckgo/privacy-configuration/issues/589"
         },
@@ -448,14 +452,10 @@
             {
                 "domain": "github.com",
                 "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1058"
-            },
-            {
-                "domain": "duckduckgo.com",
-                "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1058"
             }
         ],
-        "hideTimeouts": [0, 100, 200, 300, 400, 500, 1000, 1500, 2000, 2500, 3000, 5000, 10000],
-        "unhideTimeouts": [750, 1500, 2250, 3000, 4500, 6000, 12000],
+        "hideTimeouts": [0, 100, 300, 500, 1000, 3000, 5000],
+        "unhideTimeouts": [1250, 3250, 5250],
         "mediaAndFormSelectors": "video,canvas,embed,object,audio,map,form,input,textarea,select,option",
         "adLabelStrings": [
             "ad",

--- a/overrides/browsers/firefox-override.json
+++ b/overrides/browsers/firefox-override.json
@@ -34,15 +34,6 @@
                     "reason": "https://github.com/duckduckgo/privacy-configuration/issues/794"
                 }
             ]
-        },
-        "elementHiding": {
-            "state": "enabled",
-            "exceptions": [
-                {
-                    "domain": "duckduckgo.com",
-                    "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1236"
-                }
-            ]
         }
     }
 }


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:** https://app.asana.com/0/1140729528379976/1205320998133366/f

## Description
Element hiding is a feature used to hide the empty containers left by blocked tracking ads. This PR does the following:
- Disables the feature on duckduckgo.com on all platforms (expands the firefox-specific exclusion), since it doesn't do anything there anyway. Also removes styletag exception for duckduckgo.com, since the feature will be disabled there.
- Updates the timings for when the DOM is checked for matching elements to reduce the perf overhead of the feature

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

