### PR TITLE
unblock several klarna trackers

### DIFF
--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -1633,13 +1633,23 @@
                     {
                         "rule": "na-library.klarnaservices.com/lib.js",
                         "domains": [
-                            "brooksrunning.com",
-                            "joann.com"
+                            "<all>"
                         ],
-                        "reason": [
-                            "brooksrunning.com - When switching between product variants (e.g., different shoe colours) a loading spinner shows and the variant does not load.",
-                            "joann.com - When switching between product variants (e.g., different shirt colours) the page shows an overlay and further interaction is prevented."
-                        ]
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1266"
+                    },
+                    {
+                        "rule": "eu-library.klarnaservices.com/lib.js",
+                        "domains": [
+                            "<all>"
+                        ],
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1266"
+                    },
+                    {
+                        "rule": "osm.library.klarnaservices.com/lib.js",
+                        "domains": [
+                            "<all>"
+                        ],
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1266"
                     }
                 ]
             },


### PR DESCRIPTION
**Asana Task/Github Issue:**

Asana: https://app.asana.com/0/1201534009035032/1205332222754155/f
Github: https://github.com/duckduckgo/privacy-configuration/issues/1266

## Description
A few klarna trackers are breaking shopping sites. To prevent spiking we're unblocking known trackers on all domains.

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

