### PR TITLE
unblock ad wall tracker on dangerousminds-net

### DIFF
--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -1503,6 +1503,17 @@
                     }
                 ]
             },
+            "htlbid.com": {
+                "rules": [
+                    {
+                        "rule": "htlbid.com/v3/dangerousminds.net/htlbid.js",
+                        "domains": [
+                            "dangerousminds.net"
+                        ],
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1270"
+                    }
+                ]
+            },
             "iesnare.com": {
                 "rules": [
                     {


### PR DESCRIPTION
**Asana Task/Github Issue:**

Asana: https://app.asana.com/0/1201534009035032/1205376298582586/f
Github: https://github.com/duckduckgo/privacy-configuration/issues/1270

## Description
ad wall banner triggered due to a tracker being blocked

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

