### PR TITLE
timesmachine.nytimes.com exception

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -98,6 +98,10 @@
                     {
                         "domain": "unclaimedmoneyinfo.com",
                         "reason": "https://github.com/duckduckgo/privacy-configuration/issues/667"
+                    },
+                    {
+                        "domain": "timesmachine.nytimes.com",
+                        "reason": "Site is blank (never loads)"
                     }
                 ],
                 "omitVersionSites": [


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:** https://app.asana.com/0/414709148257752/1205385172689606/f
## Description
Site breakage fix for: timesmachine.nytimes.com 
Page does not load. (blank).  Caused by user agent.  (Adding to overrides)

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

