### PR TITLE
add mitigations for andieswim.com

### DIFF
--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -1678,7 +1678,8 @@
                         "rule": "klaviyo.com/",
                         "domains": [
                             "kmail-lists.com",
-                            "footweartruth.com"
+                            "footweartruth.com",
+                            "andieswim.com"
                         ],
                         "reason": "https://github.com/duckduckgo/privacy-configuration/issues/362"
                     },
@@ -1688,6 +1689,17 @@
                             "kidsguide.com"
                         ],
                         "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1277"
+                    }
+                ]
+            },
+            "lightboxcdn.com": {
+                "rules": [
+                    {
+                        "rule": "www.lightboxcdn.com/vendor/c605dbd7-cbfb-4e9b-801e-387b0656384c/user.js",
+                        "domains": [
+                            "andieswim.com"
+                        ],
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1285"
                     }
                 ]
             },


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:** 
- https://app.asana.com/0/1200277586140538/1205411019486968/f
- https://github.com/duckduckgo/privacy-configuration/pull/1285

## Description

2 separate things

- `lightboxcdn` fixes the bug mentioned in the Asana task
- whilst there I noticed that adding a `klaviyo.com` exception also fixed the signup form

Not sure if it's a good idea or not to be so specific on the lightboxcdn.com one?


#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

