### PR TITLE
Reduce element hiding timeouts

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -458,8 +458,8 @@
                 "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1058"
             }
         ],
-        "hideTimeouts": [0, 100, 300, 500, 1000, 3000, 5000],
-        "unhideTimeouts": [1250, 3250, 5250],
+        "hideTimeouts": [0, 100, 300, 500, 1000, 2000, 3000],
+        "unhideTimeouts": [1250, 2250, 3000],
         "mediaAndFormSelectors": "video,canvas,embed,object,audio,map,form,input,textarea,select,option",
         "adLabelStrings": [
             "ad",


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:** https://app.asana.com/0/892838074342800/1205394832486193/f

## Description
We've had some reports that Firefox is displaying a 'this extension is slowing down your browser' message occasionally, and we suspect it may be coming from the extended timeouts here. Dropping them back down to what they were previously to see if this is the cause.

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

