### PR TITLE
Move global unprotected temporary exceptions to selected features on build

### DIFF
--- a/index.js
+++ b/index.js
@@ -104,14 +104,12 @@ const listData = JSON.parse(fs.readFileSync(`${LISTS_DIR}/${unprotectedListName}
 addExceptionsToUnprotected(listData.exceptions)
 addExceptionsToUnprotected(defaultConfig.features.contentBlocking.exceptions)
 
-const notExcluded = ['adClickAttribution', 'appTrackerProtection', 'autofill', 'duckPlayer', 'incontextSignup',
+const excludedFeaturesFromUnprotectedTempExceptions = ['adClickAttribution', 'appTrackerProtection', 'autofill', 'duckPlayer', 'incontextSignup',
     'incrementalRolloutTest', 'networkProtection', 'newTabContinueSetUp', 'voiceSearch', 'windowsPermissionUsage',
     'windowsWaitlist', 'windowsDownloadLink']
-for (const exception of listData.exceptions) {
-    for (const key of Object.keys(defaultConfig.features)) {
-        if (!(notExcluded.includes(key))) {
-            defaultConfig.features[key].exceptions = defaultConfig.features[key].exceptions.concat(exception)
-        }
+for (const key of Object.keys(defaultConfig.features)) {
+    if (!(excludedFeaturesFromUnprotectedTempExceptions.includes(key))) {
+        defaultConfig.features[key].exceptions = defaultConfig.features[key].exceptions.concat(listData.exceptions)
     }
 }
 

--- a/index.js
+++ b/index.js
@@ -104,9 +104,21 @@ const listData = JSON.parse(fs.readFileSync(`${LISTS_DIR}/${unprotectedListName}
 addExceptionsToUnprotected(listData.exceptions)
 addExceptionsToUnprotected(defaultConfig.features.contentBlocking.exceptions)
 
-const excludedFeaturesFromUnprotectedTempExceptions = ['adClickAttribution', 'appTrackerProtection', 'autofill', 'duckPlayer', 'incontextSignup',
-    'incrementalRolloutTest', 'networkProtection', 'newTabContinueSetUp', 'voiceSearch', 'windowsPermissionUsage',
-    'windowsWaitlist', 'windowsDownloadLink']
+// Exclude selected features from the global unprotected-temporary.json domain exceptions
+const excludedFeaturesFromUnprotectedTempExceptions = [
+    'adClickAttribution',
+    'appTrackerProtection',
+    'autofill',
+    'duckPlayer',
+    'incontextSignup',
+    'incrementalRolloutTest',
+    'networkProtection',
+    'newTabContinueSetUp',
+    'voiceSearch',
+    'windowsPermissionUsage',
+    'windowsWaitlist',
+    'windowsDownloadLink'
+]
 for (const key of Object.keys(defaultConfig.features)) {
     if (!(excludedFeaturesFromUnprotectedTempExceptions.includes(key))) {
         defaultConfig.features[key].exceptions = defaultConfig.features[key].exceptions.concat(listData.exceptions)

--- a/index.js
+++ b/index.js
@@ -257,7 +257,6 @@ buildPlatforms().then((platformConfigs) => {
         }
         protections[legacyNaming[key]] = legacyConfig
     }
-
     fs.writeFileSync(`${GENERATED_DIR}/protections.json`, JSON.stringify(protections, null, 4))
     fs.writeFileSync(`${GENERATED_DIR}/fingerprinting.json`, JSON.stringify(protections, null, 4))
 })


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:** https://app.asana.com/0/1200890834746050/1202346295795542/f

## Description
We shouldn't be globally excluding certain non-explicitly-privacy-protecting or otherwise-unrelated-to-web-pages features when we mitigate for breakage. This change distributes the domain exceptions individually to only the features we should disable in these cases.

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

