### PR TITLE
Disable cookie prompt management for paypal.com

### DIFF
--- a/features/autoconsent.json
+++ b/features/autoconsent.json
@@ -154,6 +154,10 @@
         {
             "domain": "motorsport.com",
             "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1250"
+        },
+        {
+            "domain": "paypal.com",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1303"
         }
     ],
     "settings": {


### PR DESCRIPTION
See https://github.com/duckduckgo/privacy-configuration/issues/1303

**Asana Task/Github Issue:** https://app.asana.com/0/1200277586140538/1205482529285276/f

## Description
Cookie prompt management sometimes causes the PayPal cookie consent prompt to be displayed repeatedly.

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

