### PR TITLE
Disable autoconsent on elmundotoday.com

### DIFF
--- a/features/autoconsent.json
+++ b/features/autoconsent.json
@@ -158,6 +158,10 @@
         {
             "domain": "paypal.com",
             "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1303"
+        },
+        {
+            "domain": "elmundotoday.com",
+            "reason": "https://github.com/duckduckgo/autoconsent/issues/254"
         }
     ],
     "settings": {


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:** https://app.asana.com/0/1201844467387842/1205476105871190/f

## Description
Infinite reload caused by autoconsent.

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

