### PR TITLE
Switch to new privacy test pages domain

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -1836,6 +1836,27 @@
                 ]
             },
             {
+                "domain": "privacy-test-pages.glitch.me",
+                "rules": [
+                    {
+                        "selector": ".hide-test",
+                        "type": "hide"
+                    },
+                    {
+                        "selector": ".hide-empty-test",
+                        "type": "hide-empty"
+                    },
+                    {
+                        "selector": ".closest-empty-test",
+                        "type": "closest-empty"
+                    },
+                    {
+                        "selector": "[class^='ad-container']",
+                        "type": "override"
+                    }
+                ]
+            },
+            {
                 "domain": "privacy-test-pages.site",
                 "rules": [
                     {

--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -1836,7 +1836,7 @@
                 ]
             },
             {
-                "domain": "privacy-test-pages.glitch.me",
+                "domain": "privacy-test-pages.site",
                 "rules": [
                     {
                         "selector": ".hide-test",

--- a/features/gpc.json
+++ b/features/gpc.json
@@ -46,6 +46,7 @@
             "globalprivacycontrol.org",
             "washingtonpost.com",
             "nytimes.com",
+            "privacy-test-pages.glitch.me",
             "privacy-test-pages.site"
         ]
     }

--- a/features/gpc.json
+++ b/features/gpc.json
@@ -46,7 +46,7 @@
             "globalprivacycontrol.org",
             "washingtonpost.com",
             "nytimes.com",
-            "privacy-test-pages.glitch.me"
+            "privacy-test-pages.site"
         ]
     }
 }


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:** https://app.asana.com/0/0/1205478117578849/f

## Description
This PR switches from the old privacy test pages host to the new one where referenced in the config.

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

