### PR TITLE
New privacy test page added to GPC Enabled sites

### DIFF
--- a/features/gpc.json
+++ b/features/gpc.json
@@ -46,7 +46,8 @@
             "globalprivacycontrol.org",
             "washingtonpost.com",
             "nytimes.com",
-            "privacy-test-pages.glitch.me"
+            "privacy-test-pages.glitch.me",
+            "privacy-test-pages.site"
         ]
     }
 }


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:**
https://app.asana.com/0/0/1205442219109576/f

## Description
Privacy test pages are moving onto new site/domain, this domain needs to be in the list of GPC enabled sites. 

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

