### PR TITLE
Turn on the iOS incremental feature flag test

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -1,5 +1,9 @@
 {
     "features": {
+        "contentBlocking": {
+            "exceptions": [
+            ]
+        },
         "incrementalRolloutTest2": {
             "state": "enabled",
             "features": {
@@ -14,10 +18,6 @@
                     }
                 }
             }
-        },
-        "contentBlocking": {
-            "exceptions": [
-            ]
         },
         "fingerprintingTemporaryStorage": {
             "state": "enabled"

--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -17,7 +17,9 @@
                         ]
                     }
                 }
-            }
+            },
+            "exceptions": [
+            ]
         },
         "fingerprintingTemporaryStorage": {
             "state": "enabled"

--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -1,5 +1,20 @@
 {
     "features": {
+        "incrementalRolloutTest2": {
+            "state": "enabled",
+            "features": {
+                "rollout": {
+                    "state": "enabled",
+                    "rollout": {
+                        "steps": [
+                            {
+                                "percent": 1.0
+                            }
+                        ]
+                    }
+                }
+            }
+        },
         "contentBlocking": {
             "exceptions": [
             ]


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:** https://app.asana.com/0/0/1205431733474504/f

## Description
This is the iOS test equivalent of [Turn on the macOS incremental feature flag test](https://github.com/duckduckgo/privacy-configuration/pull/1232) 

This PR turns on the `incrementalRolloutTest2` flag, support for which was added in the latest iOS build and sends a pixel the first time that the client detects that this flag is enabled. This is so that we can verify that the incremental rollout support recently added to feature flags is working as intended.

Once the test has proven that the incremental rollout feature is working correctly, support for this feature flag will be removed.

Note that I added `"exceptions": []` as the unit tests were failing without it - please let me know if there is something else I should be modifying and I'll be happy to make the change

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

