### PR TITLE
Bumps `incrementalRolloutTest2` rollout to 5%

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -13,6 +13,9 @@
                         "steps": [
                             {
                                 "percent": 1.0
+                            },
+                            {
+                                "percent": 5.0
                             }
                         ]
                     }


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:** https://app.asana.com/0/414235014887631/1205515530563285/f

## Description
This PR increases the macOS incremental rollout flag test to 5%.

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

