### PR TITLE
Temporarily disable protections on theverge.com on iOS to mitigate redirect breakage

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -193,6 +193,10 @@
         {
             "domain": "vinted.fr",
             "reason": "https://github.com/duckduckgo/privacy-configuration/issues/794"
+        },
+        {
+            "domain": "theverge.com",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1326"
         }
     ]
 }


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:** https://app.asana.com/0/1200277586140538/1205587501747364/f / https://github.com/duckduckgo/privacy-configuration/issues/1326

## Description
Page is erroneously redirecting to the url of an embed.

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

