### PR TITLE
Remove stale Vinted exceptions

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -298,9 +298,5 @@
         }
     },
     "unprotectedTemporary": [
-        {
-            "domain": "vinted.fr",
-            "reason": "https://github.com/duckduckgo/privacy-configuration/issues/794"
-        }
     ]
 }

--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -196,9 +196,5 @@
         }
     },
     "unprotectedTemporary": [
-        {
-            "domain": "vinted.fr",
-            "reason": "https://github.com/duckduckgo/privacy-configuration/issues/794"
-        }
     ]
 }


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:** https://app.asana.com/0/1200277586140538/1205209107272083/f / https://github.com/duckduckgo/privacy-configuration/issues/794

## Description
Removing stale Vinted exceptions as the underlying issue is resolved.

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

