### PR TITLE
Activate NetP waitlist for macOS

### DIFF
--- a/features/network-protection.json
+++ b/features/network-protection.json
@@ -8,7 +8,7 @@
             "state": "disabled"
         },
         "waitlistBetaActive": {
-            "state": "enabled"
+            "state": "disabled"
         }
     },
     "exceptions": []

--- a/features/network-protection.json
+++ b/features/network-protection.json
@@ -6,6 +6,9 @@
     "features": {
         "waitlist": {
             "state": "disabled"
+        },
+        "waitlistBetaActive": {
+            "state": "enabled"
         }
     },
     "exceptions": []

--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -212,6 +212,9 @@
         "networkProtection": {
             "state": "enabled",
             "features": {
+                "waitlistBetaActive": {
+                    "state": "enabled"
+                },
                 "waitlist": {
                     "state": "enabled",
                     "rollout": {

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -21,6 +21,22 @@
                 }
             }
         },
+        "networkProtection": {
+            "state": "enabled",
+            "features": {
+                "waitlist": {
+                    "state": "enabled",
+                    "rollout": {
+                        "steps": [
+                            {
+                                "percent": 1.0
+                            }
+                        ]
+                    }
+                }
+            },
+            "minSupportedVersion": "1.57.1"
+        },
         "contentBlocking": {
             "state": "enabled",
             "exceptions": [

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -24,6 +24,9 @@
         "networkProtection": {
             "state": "enabled",
             "features": {
+                "waitlistBetaActive": {
+                    "state": "enabled"
+                },
                 "waitlist": {
                     "state": "enabled",
                     "rollout": {


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:** https://app.asana.com/0/0/1205400926163926/f

## Description

This PR activates the NetP waitlist for macOS at 1% rollout.

It targets macOS version 1.57.1 which was released Monday September 25, as this build includes necessary NetP stability improvements.

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

