### PR TITLE
Add https mitigation for amica.com

### DIFF
--- a/features/https.json
+++ b/features/https.json
@@ -11,6 +11,10 @@
         {
             "domain": "act.alz.org",
             "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1158"
+        },
+        {
+            "domain": "amica.com",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1336"
         }
     ]
 }


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:**  https://github.com/duckduckgo/privacy-configuration/issues/1336

## Description
Our smarter encryption protection is timing out trying to upgrade the root domain amica.com. Mitigating breakage while we investigate a fix.

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

