### PR TITLE
Enable EME for peacocktv

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -41,6 +41,10 @@
                 {
                     "domain": "showtime.com",
                     "reason": "https://github.com/duckduckgo/privacy-configuration/issues/867"
+                },
+                {
+                    "domain": "peacocktv.com",
+                    "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1356"
                 }
             ]
         },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://github.com/duckduckgo/privacy-configuration/issues/1356 https://app.asana.com/0/1200277586140538/1205656158673329/f

## Description

Surge of reports that playback doesn't work on peacocktv.com - most probable cause is EME

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

