### PR TITLE
Element hiding: Address empty ad containers on yahoo.com

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -1766,6 +1766,10 @@
                     {
                         "selector": ".darla",
                         "type": "closest-empty"
+                    },
+                    {
+                        "selector": "[data-content='Advertisement']",
+                        "type": "hide-empty"
                     }
                 ]
             },


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:** https://app.asana.com/0/1200277586140538/1205664748089997/f

## Description
Hide empty ad containers on yahoo.com when 3p ads are blocked due to tracker blocking.

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

