### PR TITLE
add exceptions for major streaming services

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -45,6 +45,86 @@
                 {
                     "domain": "peacocktv.com",
                     "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1356"
+                },
+                {
+                    "domain": "disneyplus.com",
+                    "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1363"
+                },
+                {
+                    "domain": "hulu.com",
+                    "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1363"
+                },
+                {
+                    "domain": "plus.espn.com",
+                    "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1363"
+                },
+                {
+                    "domain": "netflix.com",
+                    "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1363"
+                },
+                {
+                    "domain": "paramountplus.com",
+                    "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1363"
+                },
+                {
+                    "domain": "tv.apple.com",
+                    "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1363"
+                },
+                {
+                    "domain": "curiositystream.com",
+                    "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1363"
+                },
+                {
+                    "domain": "starz.com",
+                    "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1363"
+                },
+                {
+                    "domain": "dazn.com",
+                    "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1363"
+                },
+                {
+                    "domain": "crunchyroll.com",
+                    "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1363"
+                },
+                {
+                    "domain": "funimation.com",
+                    "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1363"
+                },
+                {
+                    "domain": "mubi.com",
+                    "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1363"
+                },
+                {
+                    "domain": "crave.ca",
+                    "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1363"
+                },
+                {
+                    "domain": "britbox.com",
+                    "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1363"
+                },
+                {
+                    "domain": "dailywire.com",
+                    "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1363"
+                },
+                {
+                    "domain": "fubo.tv",
+                    "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1363"
+                },
+                {
+                    "domain": "acorn.tv",
+                    "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1363"
+                },
+                {
+                    "domain": "shudder.com",
+                    "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1363"
+                },
+                {
+                    "domain": "music.amazon.com",
+                    "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1363"
+                },
+                {
+                    "domain": "youtube.com",
+                    "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1363"
                 }
             ]
         },


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:**

Asana: https://app.asana.com/0/0/1205673862497030/f
Github: https://github.com/duckduckgo/privacy-configuration/issues/1363

## Description
Android only exceptions to tackle eme/drm issue on major streaming sites

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

