### PR TITLE
Fix stylesheet issue on pocketbook.digital

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -460,6 +460,10 @@
             {
                 "domain": "github.com",
                 "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1058"
+            },
+            {
+                "domain": "pocketbook.digital",
+                "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1365"
             }
         ],
         "hideTimeouts": [0, 100, 300, 500, 1000, 2000, 3000],


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:** https://app.asana.com/0/1201720254973470/1204278961589521/f https://github.com/duckduckgo/privacy-configuration/issues/1365

## Description
Injecting a stylesheet appears to cause this site to go blank because the site is interrogating all stylesheets, but lacks permission to interrogate the one we inject.

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

