### PR TITLE
Fix blank banner space on front page + opinion on WSJ

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -1739,6 +1739,10 @@
                     {
                         "selector": "#cx-what-to-read-next",
                         "type": "closest-empty"
+                    },
+                    {
+                       "selector": "[class*='WSJTheme--adWrapper']",
+                       "type": "hide-empty"
                     }
                 ]
             },


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:** https://app.asana.com/0/1200277586140538/1202050706553539/f

## Description
Banner ad leaves a blank space on front page and opinion page

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

