### PR TITLE
Element hiding: temporarily disable styletag injection

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -85,7 +85,7 @@
         }
     ],
     "settings": {
-        "useStrictHideStyleTag": true,
+        "useStrictHideStyleTag": false,
         "rules": [
             {
                 "selector": "[id*='gpt-']",


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->

## Description
Temporarily disabling styletag injection until the bugfix in https://github.com/duckduckgo/content-scope-scripts/pull/775 is released on all platforms. Strict hide rules will still apply as expected, the only noticeable difference is it might take a second for them to be applied (instead of instantly). Will re-enable just as soon as clients update to C-S-S 4.39.0.

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

