### PR TITLE
Enable iOS Autofill `onByDefault` at 1% rollout

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -67,6 +67,17 @@
                 "autofillPasswordGeneration": {
                     "state": "enabled",
                     "minSupportedVersion": "7.75.0"
+                },
+                "onByDefault": {
+                    "state": "enabled",
+                    "minSupportedVersion": "7.93.0",
+                    "rollout": {
+                        "steps": [
+                            {
+                                "percent": 1.0
+                            }
+                        ]
+                    }
                 }
             }
         },


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:** https://app.asana.com/0/1201462886803403/1205725550956731

## Description
Adds `onByDefault` flag to iOS Autofill using the incremental rollout flag functionality as discussed [here](https://app.asana.com/0/0/1205590415076770/f) 

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

