### PR TITLE
Element hiding: Re-enable styletag injection

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -85,7 +85,7 @@
         }
     ],
     "settings": {
-        "useStrictHideStyleTag": false,
+        "useStrictHideStyleTag": true,
         "rules": [
             {
                 "selector": "[id*='gpt-']",


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:** https://app.asana.com/0/0/1205693429987634/f

## Description
Re-enabling styletag injection after we temporarily turned it off in https://github.com/duckduckgo/privacy-configuration/pull/1376, now that clients have all been updated to use the latest version of content-scope-scripts.

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

