### PR TITLE
Remove unnecessary element hiding exceptions

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -10,78 +10,6 @@
         {
             "domain": "duckduckgo.com",
             "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1236"
-        },
-        {
-            "domain": "bild.de",
-            "reason": "https://github.com/duckduckgo/privacy-configuration/issues/589"
-        },
-        {
-            "domain": "derstandard.at",
-            "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1101"
-        },
-        {
-            "domain": "foxnews.com",
-            "reason": "https://github.com/duckduckgo/privacy-configuration/issues/965"
-        },
-        {
-            "domain": "kbb.com",
-            "reason": "Adblocker wall"
-        },
-        {
-            "domain": "wiwo.de",
-            "reason": "https://github.com/duckduckgo/privacy-configuration/issues/592"
-        },
-        {
-            "domain": "metro.co.uk",
-            "reason": "https://github.com/duckduckgo/privacy-configuration/issues/592"
-        },
-        {
-            "domain": "blick.ch",
-            "reason": "https://github.com/duckduckgo/privacy-configuration/issues/592"
-        },
-        {
-            "domain": "thechive.com",
-            "reason": "https://github.com/duckduckgo/privacy-configuration/issues/592"
-        },
-        {
-            "domain": "bizjournals.com",
-            "reason": "https://github.com/duckduckgo/privacy-configuration/issues/592"
-        },
-        {
-            "domain": "slate.com",
-            "reason": "https://github.com/duckduckgo/privacy-configuration/issues/592"
-        },
-        {
-            "domain": "dailycaller.com",
-            "reason": "https://github.com/duckduckgo/privacy-configuration/issues/592"
-        },
-        {
-            "domain": "dailymail.co.uk",
-            "reason": "https://github.com/duckduckgo/privacy-configuration/issues/592"
-        },
-        {
-            "domain": "eltiempo.com",
-            "reason": "https://github.com/duckduckgo/privacy-configuration/issues/592"
-        },
-        {
-            "domain": "dailyherald.com",
-            "reason": "https://github.com/duckduckgo/privacy-configuration/issues/592"
-        },
-        {
-            "domain": "publico.es",
-            "reason": "https://github.com/duckduckgo/privacy-configuration/issues/592"
-        },
-        {
-            "domain": "rawstory.com",
-            "reason": "https://github.com/duckduckgo/privacy-configuration/issues/592"
-        },
-        {
-            "domain": "allgemeine-zeitung.de",
-            "reason": "https://github.com/duckduckgo/privacy-configuration/issues/592"
-        },
-        {
-            "domain": "thehindu.com",
-            "reason": "https://github.com/duckduckgo/privacy-configuration/issues/592"
         }
     ],
     "settings": {
@@ -578,6 +506,26 @@
                 ]
             },
             {
+                "domain": "allgemeine-zeitung.de",
+                "rules": [
+                    {
+                        "type": "disable-default"
+                    },
+                    {
+                        "selector": ".adSlot",
+                        "type": "hide-empty"
+                    },
+                    {
+                        "selector": ".adBorder",
+                        "type": "hide-empty"
+                    },
+                    {
+                        "selector": ".nativeAd",
+                        "type": "closest-empty"
+                    }
+                ]
+            },
+            {
                 "domain": "apnews.com",
                 "rules": [
                     {
@@ -618,6 +566,31 @@
                 ]
             },
             {
+                "domain": "bild.de",
+                "rules": [
+                    {
+                        "type": "disable-default"
+                    },
+                    {
+                        "selector": "[id^='mrec']",
+                        "type": "hide-empty"
+                    },
+                    {
+                        "selector": "#superbanner",
+                        "type": "hide-empty"
+                    }
+                ]
+            },
+            {
+                "domain": "bizjournals.com",
+                "rules": [
+                    {
+                        "selector": ".adwrap",
+                        "type": "closest-empty"
+                    }
+                ]
+            },
+            {
                 "domain": "bleacherreport.com",
                 "rules": [
                     {
@@ -632,6 +605,15 @@
                     {
                         "selector": "[class*='ad_unit']",
                         "type": "override"
+                    }
+                ]
+            },
+            {
+                "domain": "blick.ch",
+                "rules": [
+                    {
+                        "selector": "[id*='appnexus-placement-']",
+                        "type": "hide-empty"
                     }
                 ]
             },
@@ -732,6 +714,31 @@
                 "rules": [
                     {
                         "selector": "[data-block-name='ads']",
+                        "type": "closest-empty"
+                    }
+                ]
+            },
+            {
+                "domain": "dailyherald.com",
+                "rules": [
+                    {
+                        "selector": ".instoryAdBlock",
+                        "type": "hide"
+                    }
+                ]
+            },
+            {
+                "domain": "dailymail.co.uk",
+                "rules": [
+                    {
+                        "type": "disable-default"
+                    },
+                    {
+                        "selector": "[class*='dmg-ads']",
+                        "type": "hide-empty"
+                    },
+                    {
+                        "selector": ".mol-ads-label-container",
                         "type": "closest-empty"
                     }
                 ]
@@ -1248,6 +1255,18 @@
                 ]
             },
             {
+                "domain": "metro.co.uk",
+                "rules": [
+                    {
+                        "type": "disable-default"
+                    },
+                    {
+                        "selector": ".ad-slot-container",
+                        "type": "hide-empty"
+                    }
+                ]
+            },
+            {
                 "domain": "mirror.co.uk",
                 "rules": [
                     {
@@ -1514,11 +1533,53 @@
                 ]
             },
             {
+                "domain": "publico.es",
+                "rules": [
+                    {
+                        "selector": ".pb-ads",
+                        "type": "hide-empty"
+                    },
+                    {
+                        "selector": "#sc_intxt_container",
+                        "type": "hide"
+                    }
+                ]
+            },
+            {
                 "domain": "qz.com",
                 "rules": [
                     {
                         "selector": "#marquee-ad",
                         "type": "closest-empty"
+                    }
+                ]
+            },
+            {
+                "domain": "rawstory.com",
+                "rules": [
+                    {
+                        "selector": ".container_proper-ad-unit",
+                        "type": "hide"
+                    },
+                    {
+                        "selector": ".controlled_via_ad_manager",
+                        "type": "hide"
+                    },
+                    {
+                        "selector": ".mgid_3x2",
+                        "type": "hide-empty"
+                    },
+                    {
+                        "selector": ".proper-ad-unit",
+                        "type": "hide"
+                    },
+                    {
+                        "selector": "[id^='rc-widget-']",
+                        "type": "hide-empty"
+                    },
+                    {
+                        "selector": "#story-top-ad",
+                        "type": "hide"
                     }
                 ]
             },
@@ -1649,6 +1710,10 @@
                     {
                         "selector": ".slate-ad",
                         "type": "hide-empty"
+                    },
+                    {
+                        "selector": ".top-ad",
+                        "type": "hide"
                     }
                 ]
             },
@@ -1711,7 +1776,16 @@
                     {
                         "selector": ".belowMastheadWrapper",
                         "type": "hide-empty"
-                    }    
+                    }
+                ]
+            },
+            {
+                "domain": "thehindu.com",
+                "rules": [
+                    {
+                        "selector": "#articledivrec",
+                        "type": "hide-empty"
+                    }
                 ]
             },
             {
@@ -1910,6 +1984,14 @@
                     {
                         "selector": ".article-ad",
                         "type": "hide"
+                    }
+                ]
+            },
+            {
+                "domain": "wiwo.de",
+                "rules": [
+                    {
+                        "type": "disable-default"
                     }
                 ]
             },


### PR DESCRIPTION
Some websites attempt to detect ad blockers by checking if an element
with a common class (e.g. class="ad") is hidden. Sometimes those
websites will display a "Please disable your ad blocker" message to
users when they suspect an ad blocker is active. To avoid getting
caught up in that, we added some websites to our element hiding
exception list. That prevented us from hiding any elements for those
websites.

Let's go back through the list and remove which ones we can. Some of
those ad walls were actually fixed by our "surrogate" script
improvements[1][2][3]. Where necessary though, let's use the new
"disable-default" element hiding rule (which works similarly to
$generichide[4]) so that we avoid hiding elements with the usual
selectors. While we're at it, let's also add the relevant element
hiding rules to hide any blank spaces left by blocking tracking
scripts (since they often relate to ads) that still aren't hidden on
those websites.

1 - https://github.com/duckduckgo/tracker-surrogates/commit/ec20dfba47bd5ceef76216c083c8317c1c1691a3
2 - https://github.com/duckduckgo/tracker-surrogates/commit/75f4e54124d72b820728ea8d25727a87e2293f26
3 - https://github.com/duckduckgo/tracker-surrogates/commit/acf0c0fd89502af696a112126178511b84f21e72
4 - https://blog.adblockplus.org/development-builds/new-filter-options-generichide-and-genericblock

**Asana Task/Github Issue:** https://app.asana.com/0/0/1205594040522080/f