### PR TITLE
Element hiding: fix overmatching rule on deseret.com

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -679,15 +679,6 @@
                 "domain": "dallasnews.com",
                 "rules": [
                     {
-                        "selector": "[data-targeting]",
-                        "type": "hide-empty"
-                    }
-                ]
-            },
-            {
-                "domain": "dallasnews.com",
-                "rules": [
-                    {
                         "selector": ".adhesiveAdWrapper",
                         "type": "hide-empty"
                     },
@@ -702,6 +693,15 @@
                     {
                         "selector": ".bg-neutral-grey-4.items-center",
                         "type": "hide-empty"
+                    }
+                ]
+            },
+            {
+                "domain": "deseret.com",
+                "rules": [
+                    {
+                        "selector": "[data-targeting]",
+                        "type": "override"
                     }
                 ]
             },


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:** https://app.asana.com/0/1200277586140538/1205788249228115/f

## Description
Override element hiding rule that was hiding comments section on deseret.com.

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

