### PR TITLE
New variantManager remote config parameter

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -431,7 +431,7 @@
     },
     "unprotectedTemporary": [
     ],
-    "variantManager": {
+    "experimentalVariants": {
         "variants": [
           {
             "desc": "this is SERP don't remove",

--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -446,12 +446,18 @@
           {
             "desc": "Control variant for AskForDefaultBrowserMoreThanOnce experiment",
             "variantKey": "zh",
-            "weight": 0.0
+            "weight": 0.0,
+            "filters": {
+                "locale": ["en_US", "en_CA", "en_GB", "en_AU"]
+            }
           },
           {
             "desc": "Experimental variant for AskForDefaultBrowserMoreThanOnce",
             "variantKey": "zj",
-            "weight": 0.0
+            "weight": 0.0,
+            "filters": {
+                "locale": ["en_US", "en_CA", "en_GB", "en_AU"]
+            }
           }
         ]
     }

--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -430,5 +430,29 @@
         }
     },
     "unprotectedTemporary": [
-    ]
+    ],
+    "variantManager": {
+        "variants": [
+          {
+            "desc": "this is SERP don't remove",
+            "variantKey": "sc",
+            "weight": 0.0
+          },
+          {
+            "desc": "this is SERP don't remove",
+            "variantKey": "se",
+            "weight": 0.0
+          },
+          {
+            "desc": "Control variant for AskForDefaultBrowserMoreThanOnce experiment",
+            "variantKey": "zh",
+            "weight": 0.0
+          },
+          {
+            "desc": "Experimental variant for AskForDefaultBrowserMoreThanOnce",
+            "variantKey": "zj",
+            "weight": 0.0
+          }
+        ]
+    }
 }


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:** https://app.asana.com/0/0/1205908353497982/f

## Description
New top level parameter `variantManager` has been added to the Android privacy configuration in order to manage experiments variants remotely. 
- SERP variants will remain there with a _weight 0.0_, ensuring they are not assigned to users unless we decide to change it.
- I also added `zj` and `zh` variants because we currently have an experiment running, and we need to keep them in the remote config to avoid their removal from existing users until the [project](https://app.asana.com/0/72649045549333/1205122649889482/f) is finished


#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

