### PR TITLE
Remove unnecessary ad-wall mitigation rules

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -422,10 +422,6 @@
             {
                 "selector": "#ez-content-blocker-container",
                 "type": "hide"
-            },
-            {
-                "selector": "#notify-adblock",
-                "type": "hide"
             }
         ],
         "styleTagExceptions": [

--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -843,7 +843,6 @@
                     {
                         "rule": "pubads.g.doubleclick.net/gampad/ads",
                         "domains": [
-                            "fifa.com",
                             "nhl.com",
                             "viki.com",
                             "rocketnews24.com",


### PR DESCRIPTION
With the recent "surrogate" script[1][2][3] and element hiding[4]
improvements, we should trigger the "Please disable your ad blocker"
walls less often. Let's remove some of the rules added to help
mitigate those walls in the past.

1 - https://github.com/duckduckgo/tracker-surrogates/commit/ec20dfba47bd5ceef76216c083c8317c1c1691a3
2 - https://github.com/duckduckgo/tracker-surrogates/commit/75f4e54124d72b820728ea8d25727a87e2293f26
3 - https://github.com/duckduckgo/tracker-surrogates/commit/acf0c0fd89502af696a112126178511b84f21e72
4 - https://github.com/duckduckgo/privacy-configuration/commit/bc4e0d3bd402d2b7cd8591aa0b0102306d0b0be5