### PR TITLE
Fix embedded Google custom search on websites

### DIFF
--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -1311,6 +1311,13 @@
                         "reason": "https://github.com/duckduckgo/privacy-configuration/issues/475"
                     },
                     {
+                        "rule": "www.google.com/url",
+                        "domains": [
+                            "<all>"
+                        ],
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1484"
+                    },
+                    {
                         "rule": "www.google.com/maps/",
                         "domains": [
                             "<all>"


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:** https://app.asana.com/0/1200277586140538/1205533566068773/f / https://github.com/duckduckgo/privacy-configuration/issues/1484

## Description
Blocking requests to `www.google.com/url?...` was causing embedded Google search results to not be clickable. See https://github.com/duckduckgo/privacy-configuration/issues/1484

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

