### PR TITLE
Broken site: tunein.com radio doesn't play

### DIFF
--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -127,6 +127,13 @@
                             "tunein.com"
                         ],
                         "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1438"
+                    },
+                    {
+                        "rule": "adswizz.com/adswizz/js/SynchroClient2.js",
+                        "domains": [
+                            "tunein.com"
+                        ],
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1438"
                     }
                 ]
             },


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:** https://app.asana.com/0/1200277586140538/1205929175977589/f

## Description
Need to unblock `adswizz.com/adswizz/js/SynchroClient2.js` to play radio.

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

