### PR TITLE
Add Samsung email app to unhideSystemApps

### DIFF
--- a/features/app-tracker-protection.json
+++ b/features/app-tracker-protection.json
@@ -686,6 +686,7 @@
                 "com.google.android.youtube.tv",
                 "com.netflix.mediaclient",
                 "com.samsung.android.messaging",
+                "com.samsung.android.email.provider",
                 "com.touchtype.swiftkey"
             ]
         }        


### PR DESCRIPTION
**Asana Task/Github Issue:**https://app.asana.com/0/1202279501986195/1205931472223167/f

## Description
Add Samsung email app to unhideSystemApps so that it shows in the exclusion list UX for users to be able to unprotect it


#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

