### PR TITLE
Add Startup Boost toggle

### DIFF
--- a/features/windows-startup-boost.json
+++ b/features/windows-startup-boost.json
@@ -1,0 +1,10 @@
+{
+    "_meta": {
+        "description": "Startup Boost on Windows Browser"
+    },
+    "settings": {
+        "startupBoost": {
+            "state": "enabled"
+        } 
+    }
+}

--- a/features/windows-startup-boost.json
+++ b/features/windows-startup-boost.json
@@ -2,10 +2,5 @@
     "_meta": {
         "description": "Startup Boost on Windows Browser"
     },
-    "settings": {
-        "startupBoost": {
-            "state": "enabled"
-        } 
-    },
     "exceptions": []
 }

--- a/features/windows-startup-boost.json
+++ b/features/windows-startup-boost.json
@@ -6,5 +6,6 @@
         "startupBoost": {
             "state": "enabled"
         } 
-    }
+    },
+    "exceptions": []
 }

--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -3,6 +3,9 @@
         "windowsPermissionUsage": {
             "state": "enabled"
         },
+        "windowsStartupBoost": {
+            "state": "enabled"
+        },
         "autofill": {
             "state": "enabled"
         },


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:** https://app.asana.com/0/0/1205944626965247/f

## Description
Allows toggling Windows browser Startup Boost on and off remotely.

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

