### PR TITLE
Fix element hiding false positive on sports.yahoo.com

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -2107,11 +2107,7 @@
                     {
                         "selector": "[data-content='Advertisement']",
                         "type": "hide-empty"
-                    },
-                    {
-                        "selector": "[id*='default']",
-                        "type": "hide-empty"
-                      }
+                    }
                 ]    
             },
             {


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:** https://app.asana.com/0/0/1205942163698674/f

## Description
We're overmatching and hiding non-ad content on https://sports.yahoo.com/nfl/gamechannel/

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

