### PR TITLE
Enable iOS waitlist flags

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -1,5 +1,16 @@
 {
     "features": {
+        "networkProtection": {
+            "state": "enabled",
+            "features": {
+                "waitlistBetaActive": {
+                    "state": "enabled"
+                },
+                "waitlist": {
+                    "state": "enabled"
+                }
+            }
+        },
         "contentBlocking": {
             "exceptions": [
             ]


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:**  https://app.asana.com/0/0/1205946767230199/f

## Description

This PR enables the iOS waitlist flags for NetP. This feature has not shipped, but we're enabling the flags now for testing purposes.

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

