### PR TITLE
Element hiding: address ad spaces on tinybeans.com, petapixel.com, timeanddate.com, thewordfinder.com

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -276,6 +276,14 @@
                 "type": "closest-empty"
             },
             {
+                "selector": "#ad-top",
+                "type": "hide-empty"
+            },
+            {
+                "selector": "#ad-wrap",
+                "type": "hide-empty"
+            },
+            {
                 "selector": ".ad-wrap",
                 "type": "closest-empty"
             },
@@ -365,6 +373,10 @@
             },
             {
                 "selector": "[data-ad]",
+                "type": "hide-empty"
+            },
+            {
+                "selector": ".instream_ad",
                 "type": "hide-empty"
             },
             {
@@ -1521,6 +1533,19 @@
                 ]
             },
             {
+                "domain": "petapixel.com",
+                "rules": [
+                    {
+                        "selector": ".banners",
+                        "type": "hide-empty"
+                    },
+                    {
+                        "selector": "#ppvideoadvertisement",
+                        "type": "closest-empty"
+                    }
+                ]
+            },
+            {
                 "domain": "peterboroughtoday.co.uk",
                 "rules": [
                     {
@@ -1868,6 +1893,15 @@
                 "rules": [
                     {
                         "selector": "[class*='AdCard__leaderboard']",
+                        "type": "hide-empty"
+                    }
+                ]
+            },
+            {
+                "domain": "tinybeans.com",
+                "rules": [
+                    {
+                        "selector": ".tb-ad",
                         "type": "hide-empty"
                     }
                 ]

--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -1889,6 +1889,15 @@
                 ]
             },
             {
+                "domain": "thewordfinder.com",
+                "rules": [
+                    {
+                        "selector": "[id*='adngin']",
+                        "type": "closest-empty"
+                    }
+                ]
+            },
+            {
                 "domain": "thingiverse.com",
                 "rules": [
                     {


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:** https://app.asana.com/0/1203557590179903/1205202206641497/f

## Description
Collapses a few ad containers that were missed.

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

