### PR TITLE
Remove timeanddate.com content blocking exception

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -4,12 +4,7 @@
             "state": "enabled"
         },
         "contentBlocking": {
-            "exceptions": [
-                {
-                    "domain": "timeanddate.com",
-                    "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1407"
-                }
-            ]
+            "exceptions": [ ]
         },
         "eme": {
             "state": "enabled",


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:** https://app.asana.com/0/1200277586140538/1205727436463673/f

## Description
Removing the content blocking exception since the star map issue seems to be resolved. Closes https://github.com/duckduckgo/privacy-configuration/issues/1407

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

