### PR TITLE
add googleapi scoped exception to bloomberg-com

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -307,9 +307,13 @@
                                 "rule": "imasdk.googleapis.com/js/sdkloader/ima3.js",
                                 "domains": [
                                     "nfl.com",
-                                    "usatoday.com"
+                                    "usatoday.com",
+                                    "bloomberg.com"
                                 ],
-                                "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1488"
+                                "reason": [
+                                    "https://github.com/duckduckgo/privacy-configuration/issues/1488",
+                                    "https://github.com/duckduckgo/privacy-configuration/issues/1507"
+                                ]
                             }
                         ]
                     },

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -593,9 +593,13 @@
                                 "rule": "imasdk.googleapis.com/js/sdkloader/ima3.js",
                                 "domains": [
                                     "nfl.com",
-                                    "usatoday.com"
+                                    "usatoday.com",
+                                    "bloomberg.com"
                                 ],
-                                "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1488"
+                                "reason": [
+                                    "https://github.com/duckduckgo/privacy-configuration/issues/1488",
+                                    "https://github.com/duckduckgo/privacy-configuration/issues/1507"
+                                ]
                             }
                         ]
                     },


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:**
https://app.asana.com/0/1200277586140538/1205951507492786/f
https://github.com/duckduckgo/privacy-configuration/issues/1507

## Description
ad blocker "banner" is preventing the live show to play. Issue is on iOS/MacOS. This is linked to some redirection issue with googleapis.com

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

