### PR TITLE
 add ima3 exception for bloomberg.com and games.washingtonpost.com 

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -308,11 +308,13 @@
                                 "domains": [
                                     "nfl.com",
                                     "usatoday.com",
-                                    "bloomberg.com"
+                                    "bloomberg.com",
+                                    "games.washingtonpost.com"
                                 ],
                                 "reason": [
                                     "https://github.com/duckduckgo/privacy-configuration/issues/1488",
-                                    "https://github.com/duckduckgo/privacy-configuration/issues/1507"
+                                    "https://github.com/duckduckgo/privacy-configuration/issues/1507",
+                                    "games.washingtonpost.com - https://github.com/duckduckgo/privacy-configuration/issues/1518"
                                 ]
                             }
                         ]

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -594,11 +594,13 @@
                                 "domains": [
                                     "nfl.com",
                                     "usatoday.com",
-                                    "bloomberg.com"
+                                    "bloomberg.com",
+                                    "games.washingtonpost.com"
                                 ],
                                 "reason": [
                                     "https://github.com/duckduckgo/privacy-configuration/issues/1488",
-                                    "https://github.com/duckduckgo/privacy-configuration/issues/1507"
+                                    "https://github.com/duckduckgo/privacy-configuration/issues/1507",
+                                    "games.washingtonpost.com - https://github.com/duckduckgo/privacy-configuration/issues/1518"
                                 ]
                             }
                         ]


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:**
https://github.com/duckduckgo/privacy-configuration/issues/1518
https://app.asana.com/0/1200277586140538/1205951507492805/f

## Description
game does not load due do a video ad not playing, bloomberg.com/live doesn't load for similar reasons

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

