### PR TITLE
add global tealium exception on macOS and iOS only

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -340,6 +340,17 @@
                                 "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1520"
                             }
                         ]
+                    },
+                    "tiqcdn.com": {
+                        "rules": [
+                            {
+                                "rule": "tags.tiqcdn.com/utag/",
+                                "domains": [
+                                    "<all>"
+                                ],
+                                "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1534"
+                            }
+                        ]
                     }
                 }
             }

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -637,6 +637,17 @@
                                 "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1520"
                             }
                         ]
+                    },
+                    "tiqcdn.com": {
+                        "rules": [
+                            {
+                                "rule": "tags.tiqcdn.com/utag/",
+                                "domains": [
+                                    "<all>"
+                                ],
+                                "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1534"
+                            }
+                        ]
                     }
                 }
             }


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:**
https://app.asana.com/0/0/1205966844603724/1205969342873565/f
https://github.com/duckduckgo/privacy-configuration/issues/1534

## Description
Sliding on politico's carousel is broken because of some video ad that can't be played.
A transparent overlay with the message "skip ad in" freezes the page and there's no way to escape it.
Only happening on MacOS and iOS.

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

