### PR TITLE
Element hiding: allow slideshow on takealot.com

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -1827,6 +1827,15 @@
                 ]
             },
             {
+                "domain": "takealot.com",
+                "rules": [
+                    {
+                        "selector": "[class*='ad-slot_']",
+                        "type": "override"
+                    }
+                ]
+            },
+            {
                 "domain": "target.com",
                 "rules": [
                     {


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:** https://app.asana.com/0/1200277586140538/1205973024541360/f

## Description
Main slider content hidden by element hiding due to using ad class.

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

