### PR TITLE
Mitigate adblock wall on foxnews.com

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -990,8 +990,45 @@
                 "domain": "foxnews.com",
                 "rules": [
                     {
+                        "type": "disable-default"
+                    },
+                    {
                         "selector": ".vendor-unit",
                         "type": "hide-empty"
+                    },
+                    {
+                        "selector": ".pre-content",
+                        "type": "hide-empty"
+                    },
+                    {
+                        "selector": "[class*='rr-ad-']",
+                        "type": "hide-empty"
+                    },
+                    {
+                        "selector": ".ad-h-250",
+                        "type": "hide-empty"
+                    },
+                    {
+                        "selector": ".sticky-pre-header",
+                        "type": "hide-empty"
+                    },
+                    {
+                        "selector": ".adhesion-ad",
+                        "type": "hide-empty"
+                    },
+                    {
+                        "selector": ".sticky-pre-header-inner",
+                        "type": "hide-empty"
+                    },
+                    {
+                        "selector": ".site-header",
+                        "type": "modify-style",
+                        "values": [
+                            {
+                                "property": "min-height",
+                                "value": "50px"
+                            }
+                        ]
                     }
                 ]
             },


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:** https://app.asana.com/0/1200277586140538/1205967799812882/f

## Description
Mitigate adblock wall on foxnews.com while still hiding empty ad spaces

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

