### PR TITLE
Remove GPC exception for abcnews.go.com

### DIFF
--- a/features/gpc.json
+++ b/features/gpc.json
@@ -9,10 +9,6 @@
     "state": "enabled",
     "exceptions": [
         {
-            "domain": "abcnews.go.com",
-            "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1539"
-        },
-        {
             "domain": "allegiantair.com",
             "reason": [
                 "Example URL: https://www.allegiantair.com/seating-checking-boarding;",


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:** https://app.asana.com/0/1200277586140538/1205979723109029/f closes https://github.com/duckduckgo/privacy-configuration/issues/1539

## Description
Site has resolved the breakage caused here after I reached out.

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

