### PR TITLE
Fix breakage caused by blocking slickstream request

### DIFF
--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -2731,6 +2731,17 @@
                     }
                 ]
             },
+            "slickstream.com": {
+                "rules": [
+                    {
+                        "rule": "app.slickstream.com/d/page-boot-data",
+                        "domains": [
+                            "<all>"
+                        ],
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1549"
+                    }
+                ]
+            },
             "snapkit.com": {
                 "rules": [
                     {

--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -2734,7 +2734,7 @@
             "slickstream.com": {
                 "rules": [
                     {
-                        "rule": "app.slickstream.com/d/page-boot-data",
+                        "rule": "app.slickstream.com",
                         "domains": [
                             "<all>"
                         ],


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:** https://app.asana.com/0/1205888985840255/1205999633033282/f / https://github.com/duckduckgo/privacy-configuration/issues/1549

## Description
Blocking this slickstream request causes breakage issues around favoriting recipes on a list of sites.

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

