### PR TITLE
mitigate athleticbrewing chat widget

### DIFF
--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -1664,6 +1664,24 @@
                     }
                 ]
             },
+            "gorgias.chat": {
+                "rules": [
+                    {
+                        "rule": "config.gorgias.chat",
+                        "domains": [
+                            "help.athleticbrewing.com"
+                        ],
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1552"
+                    },
+                    {
+                        "rule": "assets.gorgias.chat",
+                        "domains": [
+                            "help.athleticbrewing.com"
+                        ],
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1552"
+                    }
+                ]
+            },
             "greylabeldelivery.com": {
                 "rules": [
                     {


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:**
https://github.com/duckduckgo/privacy-configuration/issues/1552
https://app.asana.com/0/1200277586140538/1205983420198464/f


## Description
At the bottom of the page, the chat widget does not work:
- The opening hours does not display -> tracker: config.gorgias.chat
-  The widget itself does not open -> assets.gorgias.chat


#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

