### PR TITLE
Tracker Allowlist: fix rules not keyed on domain

### DIFF
--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -108,17 +108,6 @@
                     }
                 ]
             },
-            "adserver.adtech.advertising.com": {
-                "rules": [
-                    {
-                        "rule": "adserver.adtech.advertising.com/pubapi/3.0/1/54669.7/0/0/ADTECH;v=2;cmd=bid;cors=yes",
-                        "domains": [
-                            "collider.com"
-                        ],
-                        "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1447"
-                    }
-                ]
-            },
             "adswizz.com": {
                 "rules": [
                     {
@@ -186,6 +175,17 @@
                             "nhl.com"
                         ],
                         "reason": "Videos show a spinner and never load."
+                    }
+                ]
+            },
+            "advertising.com": {
+                "rules": [
+                    {
+                        "rule": "adserver.adtech.advertising.com/pubapi/3.0/1/54669.7/0/0/ADTECH;v=2;cmd=bid;cors=yes",
+                        "domains": [
+                            "collider.com"
+                        ],
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1447"
                     }
                 ]
             },
@@ -2007,18 +2007,6 @@
                     }
                 ]
             },
-            "live.primis.tech": {
-                "rules": [
-                    {
-                        "rule": "live.primis.tech/live/liveView.php",
-                        "domains": [
-                            "cornwalllive.com",
-                            "belfastlive.co.uk"
-                        ],
-                        "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1529"
-                    }
-                ]
-            },
             "loggly.com": {
                 "rules": [
                     {
@@ -2363,6 +2351,18 @@
                     }
                 ]
             },
+            "primis.tech": {
+                "rules": [
+                    {
+                        "rule": "live.primis.tech/live/liveView.php",
+                        "domains": [
+                            "cornwalllive.com",
+                            "belfastlive.co.uk"
+                        ],
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1529"
+                    }
+                ]
+            },
             "privacy-center.org": {
                 "rules": [
                     {
@@ -2505,17 +2505,6 @@
                     }
                 ]
             },
-            "protection-widget.route.com": {
-                "rules": [
-                    {
-                        "rule": "protection-widget.route.com/protect.core.js",
-                        "domains": [
-                            "littleunicorn.com"
-                        ],
-                        "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1526"
-                    }
-                ]
-            },
             "pubmatic.com": {
                 "rules": [
                     {
@@ -2615,6 +2604,17 @@
                             "pch.com"
                         ],
                         "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1344"
+                    }
+                ]
+            },
+            "route.com": {
+                "rules": [
+                    {
+                        "rule": "protection-widget.route.com/protect.core.js",
+                        "domains": [
+                            "littleunicorn.com"
+                        ],
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1526"
                     }
                 ]
             },


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->

## Description
A few tracker allow list rules were keyed on a subdomain so they weren't being applied correctly. This PR fixes them and keys them on the domain.

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

