### PR TITLE
add ima3-js exception to gamak-tv

### DIFF
--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -1423,12 +1423,14 @@
                         "domains": [
                             "rawstory.com",
                             "paper-io.com",
-                            "metro.co.uk"
+                            "metro.co.uk",
+                            "gamak.tv"
                         ],
                         "reason": [
                             "https://github.com/duckduckgo/privacy-configuration/issues/401",
                             "https://github.com/duckduckgo/privacy-configuration/issues/1510",
-                            "https://github.com/duckduckgo/privacy-configuration/issues/1513"
+                            "https://github.com/duckduckgo/privacy-configuration/issues/1513",
+                            "gamak.tv - https://github.com/duckduckgo/privacy-configuration/issues/1558"
                         ]
                     }
                 ]

--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -1430,7 +1430,7 @@
                             "https://github.com/duckduckgo/privacy-configuration/issues/401",
                             "https://github.com/duckduckgo/privacy-configuration/issues/1510",
                             "https://github.com/duckduckgo/privacy-configuration/issues/1513",
-                            "gamak.tv - https://github.com/duckduckgo/privacy-configuration/issues/1558"
+                            "https://github.com/duckduckgo/privacy-configuration/issues/1558"
                         ]
                     }
                 ]

--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -2534,8 +2534,8 @@
                             "olfactif.com"
                         ],
                         "reason": [
-                            "littleunicorn.com - https://github.com/duckduckgo/privacy-configuration/issues/1526",
-                            "olfactif.com - https://github.com/duckduckgo/privacy-configuration/issues/1554"
+                            "https://github.com/duckduckgo/privacy-configuration/issues/1526",
+                            "https://github.com/duckduckgo/privacy-configuration/issues/1554"
                         ]
                     }
                 ]


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:**
https://app.asana.com/0/1200277586140538/1205993679840857/f
https://github.com/duckduckgo/privacy-configuration/issues/1558


## Description

video player is missing and we're getting a notification to unblock https://imasdk.googleapis.com/js/sdkloader/ima3.js (iOS and MacOS).
works fine on iOS/macOS with protection OFF but not on Android.
No issue on extension.

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

