### PR TITLE
Mitigate broken product reviews on azurestandard.com

### DIFF
--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -2932,6 +2932,7 @@
                     {
                         "rule": "widget.trustpilot.com/bootstrap/v5/tp.widget.bootstrap.min.js",
                         "domains": [
+                            "azurestandard.com",
                             "domesticandgeneral.com"
                         ],
                         "reason": "https://github.com/duckduckgo/privacy-configuration/issues/466"


### PR DESCRIPTION
Product reviews on azurestandard.com are being replaced with a "Please
disable your ad blocker" message. Let's add the Trustpilot script
required to the Tracker Allowlist for azurestandard.com for the time
being.

See https://github.com/duckduckgo/privacy-configuration/issues/466 and https://app.asana.com/0/1200277586140538/1206014923612242/f .