### PR TITLE
Element hiding: disable generic rules on startpagina.nl

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -1905,6 +1905,18 @@
                 ]
             },
             {
+                "domain": "startpagina.nl",
+                "rules": [
+                    {
+                        "type": "disable-default"
+                    },
+                    {
+                        "selector": ".ad-widget",
+                        "type": "closest-empty"
+                    }
+                ]
+            },
+            {
                 "domain": "takealot.com",
                 "rules": [
                     {


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:** https://app.asana.com/0/1200277586140538/1206022301197701/f / https://github.com/duckduckgo/privacy-configuration/issues/1565

## Description
A generic element hiding rule is causing this site to become unresponsive

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

