### PR TITLE
Element hiding: false positive on https://www.nfl.com/pro-bowl-games/vote/

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -304,10 +304,6 @@
                 "type": "hide-empty"
             },
             {
-                "selector": "[class*='l-ad']",
-                "type": "hide-empty"
-            },
-            {
                 "selector": "[class*='page-ad']",
                 "type": "hide-empty"
             },


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->

## Description
The selector `[class*='l-ad']` is a bit too generic and over-matching on an element with `class="d3-l-adaptive"` on https://www.nfl.com/pro-bowl-games/vote/. The site is dynamically adding content to this div, and it looks like when the div is hidden, no content is added. Since no content is added, the div appears empty and passes the heuristic used for `hide-empty` rules.

This is probably causing issues on at least a few sites so removing the rule for now.

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

