### PR TITLE
add tracker exception to tamashiiweb-com

### DIFF
--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -3099,6 +3099,17 @@
                     }
                 ]
             },
+            "wovn.io": {
+                "rules": [
+                    {
+                        "rule": "j.wovn.io/1",
+                        "domains": [
+                            "tamashiiweb.com"
+                        ],
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1574"
+                    }
+                ]
+            },
             "yandex.ru": {
                 "rules": [
                     {


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:**
https://github.com/duckduckgo/privacy-configuration/issues/1574
https://app.asana.com/0/1200277586140538/1205984246325012/f

## Description

A the bottom of the page there's a widget to change the page language.
When clicked, it should open a pop up stating that the translation is approximate.
When clicked on OK the page should have been translated.

Our protection is blocking a tracker that prevents this pop up to open and therefore the translation cannot happen.

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

