### PR TITLE
add 3 tracker exceptions to cosmicbook

### DIFF
--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -1527,9 +1527,14 @@
                     {
                         "rule": "googletagmanager.com/gtag/js",
                         "domains": [
-                            "abril.com.br"
+                            "abril.com.br",
+                            "cosmicbook.news"
                         ],
-                        "reason": "https://github.com/duckduckgo/privacy-configuration/issues/929"
+                        "reason": [
+                            "https://github.com/duckduckgo/privacy-configuration/issues/929",
+                            "cosmicbook.news - https://github.com/duckduckgo/privacy-configuration/issues/1578"
+                        ] 
+                       
                     }
                 ]
             },
@@ -2110,6 +2115,18 @@
                     }
                 ]
             },
+            "mediavine.com": {
+                "rules": [
+                    {
+                        "rule": "scripts.mediavine.com/tags/cosmic-book-news.js",
+                        "domains": [
+                            "cosmicbook.news"
+                        ],
+                        "reason":
+                            "https://github.com/duckduckgo/privacy-configuration/issues/1578"
+                    }
+                ]
+            },
             "medicare.gov": {
                 "rules": [
                     {
@@ -2245,6 +2262,18 @@
                             "pizzahut.com"
                         ],
                         "reason": "https://github.com/duckduckgo/privacy-configuration/issues/805"
+                    }
+                ]
+            },
+            "onesignal.com": {
+                "rules": [
+                    {
+                        "rule": "cdn.onesignal.com/sdks/OneSignalSDK.js",
+                        "domains": [
+                            "cosmicbook.news"
+                        ],
+                        "reason":
+                            "https://github.com/duckduckgo/privacy-configuration/issues/1578"
                     }
                 ]
             },


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:**
https://github.com/duckduckgo/privacy-configuration/issues/1578
https://app.asana.com/0/1200277586140538/1206007564305132/f

## Description
two items (search function and menu) are being blocked by different set of trackers:
- unblock the search function, unblock gtag and mediavine.com
- unblock the menu, unblock gtag, mediavine.com and onesignal.com


#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

