### PR TITLE
add tracker exception to clionadhcosmetrics-com

### DIFF
--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -2580,11 +2580,13 @@
                         "rule": "protection-widget.route.com/protect.core.js",
                         "domains": [
                             "littleunicorn.com",
-                            "olfactif.com"
+                            "olfactif.com",
+                            "clionadhcosmetics.com"
                         ],
                         "reason": [
                             "https://github.com/duckduckgo/privacy-configuration/issues/1526",
-                            "https://github.com/duckduckgo/privacy-configuration/issues/1554"
+                            "https://github.com/duckduckgo/privacy-configuration/issues/1554",
+                            "https://github.com/duckduckgo/privacy-configuration/issues/1583"
                         ]
                     }
                 ]


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:**

https://github.com/duckduckgo/privacy-configuration/issues/1583
https://app.asana.com/0/1200277586140538/1206010202481800/f

## Description

User can't get to checkout after filling up their basket because we're blocking a tracker meant to activate an option to add to the cart. Having it visible activate the checkout button.

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

