### PR TITLE
Element hiding: clean up empty ad spaces on healthline.com

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -1156,6 +1156,23 @@
                 ]
             },
             {
+                "domain": "healthline.com",
+                "rules": [
+                    {
+                        "selector": "[data-testid='header-leaderboard']",
+                        "type": "hide-empty"
+                    },
+                    {
+                        "selector": "[data-testid='sticky-inline-ad']",
+                        "type": "closest-empty"
+                    },
+                    {
+                        "selector": "[data-ad='true']",
+                        "type": "closest-empty"
+                    }
+                ]
+            },
+            {
                 "domain": "hindustantimes.com",
                 "rules": [
                     {


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:** https://app.asana.com/0/1200277586140538/1206078803983257/f

## Description
Address large empty ad spaces on https://www.healthline.com/health/high-cholesterol/levels-by-age

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

