### PR TITLE
Mitigate form breakage caused by blocking tfaforms.net requests

### DIFF
--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -2927,6 +2927,17 @@
                     }
                 ]
             },
+            "tfaforms.net": {
+                "rules": [
+                    {
+                        "rule": "tfaforms.net",
+                        "domains": [
+                            "<all>"
+                        ],
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1588"
+                    }
+                ]
+            },
             "theplatform.com": {
                 "rules": [
                     {


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:** https://app.asana.com/0/1200277586140538/1206072525687069/f

## Description
Looking at [Tracker Radar data](https://github.com/duckduckgo/tracker-radar/blob/main/domains/US/tfaforms.net.json), the requests we're blocking aren't actually trackers and are causing issues with forms on a handful of sites.

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

