### PR TITLE
extension only cookie exception disneyplus

### DIFF
--- a/overrides/extension-override.json
+++ b/overrides/extension-override.json
@@ -17,6 +17,10 @@
                 {
                     "domain": "soundcloud.com",
                     "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1440"
+                },
+                {
+                    "domain": "disneyplus.com",
+                    "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1622"
                 }
             ]
         },


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:**

https://github.com/duckduckgo/privacy-configuration/issues/1622
https://app.asana.com/0/1200277586140538/1206129385306003/f

## Description
Rejecting cookies create a cookie banner loop. Accepting all cookies (or turning off protection) solve the issue.
Blocking 1st/3rd party cookies create the issue. Extension issue only.

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

