### PR TITLE
add exception for forecast site map

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -373,6 +373,17 @@
                                 "reason": "https://github.com/duckduckgo/privacy-configuration/issues/675"
                             }
                         ]
+                    },
+                    "yandex.ru": {
+                        "rules": [
+                            {
+                                "rule": "api-maps.yandex.ru/services/startup/v1",
+                                "domains": [
+                                    "m.dzen.ru"
+                                ],
+                                "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1627"
+                            }
+                        ]
                     }
                 }
             },


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:**
https://github.com/duckduckgo/privacy-configuration/issues/1627
https://app.asana.com/0/1200277586140538/1206150603846439/f

## Description
https://app.asana.com/0/1200277586140538/1206150603846439/f

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

