### PR TITLE
Mitigate adblock wall on soranews24.com

### DIFF
--- a/features/content-blocking.json
+++ b/features/content-blocking.json
@@ -27,6 +27,10 @@
         {
             "domain": "ads.google.com",
             "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1401"
+        },
+        {
+            "domain": "soranews24.com",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1666"
         }
     ]
 }

--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -1892,6 +1892,14 @@
                 ]
             },
             {
+                "domain": "soranews24.com",
+                "rules": [
+                    {
+                        "type": "disable-default"
+                    }
+                ]
+            },
+            {
                 "domain": "spanishdict.com",
                 "rules": [
                     {

--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -974,7 +974,8 @@
                     {
                         "rule": "doubleclick.net",
                         "domains": [
-                            "rocketnews24.com"
+                            "rocketnews24.com",
+                            "soranews24.com"
                         ],
                         "reason": "https://github.com/duckduckgo/privacy-configuration/issues/846"
                     }
@@ -1360,6 +1361,13 @@
                         "reason": "https://github.com/duckduckgo/privacy-configuration/issues/475"
                     },
                     {
+                        "rule": "fundingchoicesmessages.google.com/",
+                        "domains": [
+                            "soranews24.com"
+                        ],
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/issues/846"
+                    },
+                    {
                         "rule": "google.com/cse/cse.js",
                         "domains": [
                             "<all>"
@@ -1372,6 +1380,13 @@
                             "<all>"
                         ],
                         "reason": "https://github.com/duckduckgo/privacy-configuration/issues/475"
+                    },
+                    {
+                        "rule": "www.google.com/pagead/",
+                        "domains": [
+                            "soranews24.com"
+                        ],
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/issues/846"
                     },
                     {
                         "rule": "www.google.com/url",
@@ -1514,6 +1529,7 @@
                         "rule": "googlesyndication.com",
                         "domains": [
                             "rocketnews24.com",
+                            "soranews24.com",
                             "zefoy.com"
                         ],
                         "reason": [

--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -994,8 +994,7 @@
                     {
                         "rule": "doubleclick.net",
                         "domains": [
-                            "rocketnews24.com",
-                            "soranews24.com"
+                            "rocketnews24.com"
                         ],
                         "reason": "https://github.com/duckduckgo/privacy-configuration/issues/846"
                     }
@@ -1392,13 +1391,6 @@
                         "reason": "https://github.com/duckduckgo/privacy-configuration/issues/475"
                     },
                     {
-                        "rule": "fundingchoicesmessages.google.com/",
-                        "domains": [
-                            "soranews24.com"
-                        ],
-                        "reason": "https://github.com/duckduckgo/privacy-configuration/issues/846"
-                    },
-                    {
                         "rule": "google.com/cse/cse.js",
                         "domains": [
                             "<all>"
@@ -1411,13 +1403,6 @@
                             "<all>"
                         ],
                         "reason": "https://github.com/duckduckgo/privacy-configuration/issues/475"
-                    },
-                    {
-                        "rule": "www.google.com/pagead/",
-                        "domains": [
-                            "soranews24.com"
-                        ],
-                        "reason": "https://github.com/duckduckgo/privacy-configuration/issues/846"
                     },
                     {
                         "rule": "www.google.com/url",
@@ -1569,7 +1554,6 @@
                         "rule": "googlesyndication.com",
                         "domains": [
                             "rocketnews24.com",
-                            "soranews24.com",
                             "zefoy.com"
                         ],
                         "reason": [


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:** https://app.asana.com/0/1200277586140538/1206016296107059/f

## Description
Allow required requests in order to mitigate adblock wall breakage on soranews24.com.

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

