### PR TITLE
add fingerprinting hardware exception on macOs for Zoom

### DIFF
--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -501,6 +501,10 @@
                 {
                     "domain": "airbnb.com.br",
                     "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1224"
+                },
+                {
+                    "domain": "zoom.us",
+                    "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1635"
                 }
             ]
         },


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:**
https://app.asana.com/0/1200277586140538/1206118254943918/f
https://github.com/duckduckgo/privacy-configuration/issues/1635


## Description
on MacOS only, a user's video remains blank with protection ON. This is caused by the fingerprinting hardware protection.

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

