### PR TITLE
Element hiding: address empty ad spaces on dexerto.com

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -867,6 +867,23 @@
                 ]
             },
             {
+                "domain": "dexerto.com",
+                "rules": [
+                    {
+                        "selector": "#leaderboard-top-adhesion",
+                        "type": "closest-empty"
+                    },
+                    {
+                        "selector": "[data-cy='Ad']",
+                        "type": "closest-empty"
+                    },
+                    {
+                        "selector": "[data-cy='VidazooPlayer']",
+                        "type": "closest-empty"
+                    }
+                ]
+            },
+            {
                 "domain": "dpreview.com",
                 "rules": [
                     {


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->

## Description
Collapses empty ad spaces on https://www.dexerto.com/fortnite/lego-fortnite-player-goes-viral-after-starting-a-marijuana-farm-operation-2435856/

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

