### PR TITLE
Allow five9.com everywhere

### DIFF
--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -1206,8 +1206,7 @@
                     {
                         "rule": "app.five9.com",
                         "domains": [
-                            "machiassavings.bank",
-                            "gmsdnv.com"
+                            "<all>"
                         ],
                         "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1111"
                     }


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:** https://app.asana.com/0/1200277586140538/1201771280084053/f

## Description
Extending five9.com mitigation to all sites - there are several hundred sites in our crawl data using this who will also be affected by our blocking here.

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

