### PR TITLE
override berverfood-com selector to remove adblock banner

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -646,6 +646,18 @@
                 ]
             },
             {
+              "domain": "beverfood.com",
+              "rules": [
+                {
+                  "type": "disable-default"
+                },
+                {
+                  "selector": ".adsbygoogle",
+                  "type": "override"
+                }
+              ]
+            },
+            {
                 "domain": "bild.de",
                 "rules": [
                     {


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:**
https://app.asana.com/0/1200277586140538/1206200473867498/f
https://github.com/duckduckgo/privacy-configuration/issues/592

## Description
element hiding triggers adblock wall. requires to override a common selector to remove banner.

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

