### PR TITLE
hide thewindowsclub selector causing empty space

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -2175,7 +2175,16 @@
                         "type": "hide-empty"
                     }
                 ]
-            },
+            },  
+            {
+                "domain": "thewindowsclub.com",
+                "rules": [
+                  {
+                    "selector": ".adtester-container",
+                    "type": "hide"
+                  }
+                ]
+              },
             {
                 "domain": "thewordfinder.com",
                 "rules": [


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:**
https://app.asana.com/0/1200277586140538/1206176325132987/f
https://github.com/duckduckgo/privacy-configuration/issues/592

## Description
hide selector to remove empty ads space

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

