### PR TITLE
add cookie exception to news-ti-com

### DIFF
--- a/features/cookie.json
+++ b/features/cookie.json
@@ -44,6 +44,10 @@
         {
             "domain": "optout.networkadvertising.org",
             "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1377"
+        },
+        {
+            "domain": "news.ti.com",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1677"
         }
     ]
 }


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:**
https://github.com/duckduckgo/privacy-configuration/issues/1677
https://app.asana.com/0/1200277586140538/1206212585432909/f

## Description
CPM breaks on the site because cookie value gets lost and thus cookie settings are not saved correctly


#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

