### PR TITLE
Fix broken layout on dallasnews.com

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -852,6 +852,13 @@
                 "domain": "dallasnews.com",
                 "rules": [
                     {
+                        "type": "disable-default"
+                    },
+                    {
+                        "selector": "[class^='dmnc_features-ads']",
+                        "type": "hide-empty"
+                    },
+                    {
                         "selector": ".adhesiveAdWrapper",
                         "type": "hide-empty"
                     },


### PR DESCRIPTION
The secondary menu was mistakenly being hidden by one of the generic (aka default) element hiding rules. Let's turn those off, but add a specific rule to ensure the advert elements are still collapsed.

**Asana Task/Github Issue:** https://github.com/duckduckgo/privacy-configuration/issues/1691 https://app.asana.com/0/1200277586140538/1206270179343338/f

## Description


#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

