### PR TITLE
Avoid triggering ad blocker wall on freetubetv.net

### DIFF
--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -1530,7 +1530,8 @@
                             "arcadepunks.com",
                             "air-journal.fr",
                             "hscprojects.com",
-                            "kits4beats.com"
+                            "kits4beats.com",
+                            "freetubetv.net"
                         ],
                         "reason": [
                             "https://github.com/duckduckgo/privacy-configuration/issues/388",
@@ -1540,7 +1541,8 @@
                             "arcadepunks.com - https://github.com/duckduckgo/privacy-configuration/issues/1625",
                             "air-journal.fr - https://github.com/duckduckgo/privacy-configuration/issues/1630",
                             "hscprojects.com - https://github.com/duckduckgo/privacy-configuration/issues/1695",
-                            "kits4beats.com  - https://github.com/duckduckgo/privacy-configuration/issues/1697"
+                            "kits4beats.com  - https://github.com/duckduckgo/privacy-configuration/issues/1697",
+                            "freetubetv.net - https://github.com/duckduckgo/privacy-configuration/issues/1699"
                         ]
                     },
                     {


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:** https://github.com/duckduckgo/privacy-configuration/issues/1699 https://app.asana.com/0/1200277586140538/1206270359240356/f

## Description


#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

