### PR TITLE
Element hiding: address new 'Switch to chrome' popup

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -1243,51 +1243,55 @@
                 "domain": "google.com",
                 "rules": [
                     {
-                        "selector": ":is(div:has(> iframe[src*='prid=19026802']))",
+                        "selector": "div:has(> iframe[src*='prid=19026802'])",
                         "type": "hide"
                     },
                     {
-                        "selector": ":is(div:has(> iframe[src*='prid=19015398']))",
+                        "selector": "div:has(> iframe[src*='prid=19015398'])",
                         "type": "hide"
                     },
                     {
-                        "selector": ":is(div:has(> iframe[src*='prid=19026796']))",
+                        "selector": "div:has(> iframe[src*='prid=19026796'])",
                         "type": "hide"
                     },
                     {
-                        "selector": ":is(div:has(> iframe[src*='prid=19018053']))",
+                        "selector": "div:has(> iframe[src*='prid=19018053'])",
                         "type": "hide"
                     },
                     {
-                        "selector": ":is(div:has(> iframe[src*='prid=19018054']))",
+                        "selector": "div:has(> iframe[src*='prid=19018054'])",
                         "type": "hide"
                     },
                     {
-                        "selector": ":is(div:has(> iframe[src*='prid=19016403']))",
+                        "selector": "div:has(> iframe[src*='prid=19016403'])",
                         "type": "hide"
                     },
                     {
-                        "selector": ":is(div:has(> iframe[src*='prid=19015972']))",
+                        "selector": "div:has(> iframe[src*='prid=19015972'])",
                         "type": "hide"
                     },
                     {
-                        "selector": ":is(div:has(> iframe[src*='prid=19016223']))",
+                        "selector": "div:has(> iframe[src*='prid=19016223'])",
                         "type": "hide"
                     },
                     {
-                        "selector": ":is(div:has(> iframe[src*='prid=19015952']))",
+                        "selector": "div:has(> iframe[src*='prid=19015952'])",
                         "type": "hide"
                     },
                     {
-                        "selector": ":is(div:has(> iframe[src*='prid=19030391']))",
+                        "selector": "div:has(> iframe[src*='prid=19030391'])",
                         "type": "hide"
                     },
                     {
-                        "selector": ":is(div:has(> iframe[src*='prid=19030389']))",
+                        "selector": "div:has(> iframe[src*='prid=19030389'])",
                         "type": "hide"
                     },
                     {
-                        "selector": ":is(div:has(> iframe[src*='prid=19030167']))",
+                        "selector": "div:has(> iframe[src*='prid=19030167'])",
+                        "type": "hide"
+                    },
+                    {
+                        "selector": "div:has(> iframe[src*='prid=19031496'])",
                         "type": "hide"
                     }
                 ]


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:** https://app.asana.com/0/1177771139624306/1206304330006534/f

## Description
This PR addresses a new 'switch to chrome' popup showing up on Google Drive in the EU region. This also removes the `:is()` wrapper from these rules, as that is automatically added after https://github.com/duckduckgo/content-scope-scripts/pull/683.

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

