### PR TITLE
Add a missing element hiding rule for bleacherreport.com

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -687,6 +687,10 @@
                 "domain": "bleacherreport.com",
                 "rules": [
                     {
+                        "selector": ".br-ad-renderer",
+                        "type": "hide-empty"
+                    },
+                    {
                         "selector": ".br-ad-wrapper",
                         "type": "closest-empty"
                     }


### PR DESCRIPTION
The top bar sometimes contains an advert, if it's blocked as a part of
tracker blocking we should collapse (hide) the element.

<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:** https://app.asana.com/0/1177771139624306/1206333117887366/f

## Description


#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

