### PR TITLE
Add Windows Network Protection 'daysBeforeSurvey' setting.

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -9,6 +9,9 @@
                 "waitlistBetaActive": {
                     "state": "enabled"
                 }
+            },
+            "settings": {
+                "daysBeforeSurvey": 5
             }
         },
         "dbp": {


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:** https://app.asana.com/0/0/1206322157933351/f

## Description
This PR adds `settings` field to the Windows `networkProtection` feature that remotely controls the VPN survey logic.

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

