### PR TITLE
Remove some old entries from the tracker allowlist

### DIFF
--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -262,49 +262,13 @@
                         "rule": "c.amazon-adsystem.com/aax2/apstag.js",
                         "domains": [
                             "applesfera.com",
-                            "corriere.it",
-                            "cnn.com",
-                            "eurogamer.net",
-                            "seattletimes.com",
-                            "wildrivers.lostcoastoutpost.com",
-                            "4029tv.com",
-                            "foxweather.com",
-                            "kcci.com",
-                            "kcra.com",
-                            "ketv.com",
-                            "kmbc.com",
-                            "koat.com",
-                            "koco.com",
-                            "ksbw.com",
-                            "mynbc5.com",
-                            "wapt.com",
-                            "wbaltv.com",
-                            "wcvb.com",
-                            "wdsu.com",
-                            "wesh.com",
-                            "wgal.com",
-                            "wisn.com",
-                            "wlky.com",
-                            "wlwt.com",
-                            "wmtw.com",
-                            "wmur.com",
-                            "wpbf.com",
-                            "wtae.com",
-                            "wvtm13.com",
-                            "wxii12.com",
-                            "wyff4.com",
-                            "thesurfersview.com"
+                            "thesurfersview.com",
+                            "wildrivers.lostcoastoutpost.com"
                         ],
                         "reason": [
                             "applesfera.com - https://github.com/duckduckgo/privacy-configuration/issues/1723",
-                            "corriere.it - ",
-                            "Example URL: https://www.corriere.it/video-articoli/2022/07/13/missione-wwf-liberare-mare-plastica/9abb64de-029d-11ed-a0cc-ad3c68cacbae.shtml;",
-                            "Clicking on the video to play causes a still frame to show and the video does not continue.",
-                            "eurogamer.net, seattletimes.com - An unskippable adwall appears which prevents interaction with the page.",
-                            "cnn.com - https://github.com/duckduckgo/privacy-configuration/issues/1220",
-                            "wcvb.com - https://github.com/duckduckgo/privacy-configuration/issues/1088",
-                            "wildrivers.lostcoastoutpost.com - https://github.com/duckduckgo/privacy-configuration/issues/1252",
-                            "thesurfersview.com - https://github.com/duckduckgo/privacy-configuration/issues/1516"
+                            "thesurfersview.com - https://github.com/duckduckgo/privacy-configuration/issues/1516",
+                            "wildrivers.lostcoastoutpost.com - https://github.com/duckduckgo/privacy-configuration/issues/1252"
                         ]
                     },
                     {
@@ -1287,13 +1251,6 @@
             "gemius.pl": {
                 "rules": [
                     {
-                        "rule": "gapl.hit.gemius.pl/gplayer.js",
-                        "domains": [
-                            "tvp.pl"
-                        ],
-                        "reason": "https://github.com/duckduckgo/privacy-configuration/issues/376"
-                    },
-                    {
                         "rule": "pro.hit.gemius.pl/gstream.js",
                         "domains": [
                             "tvp.pl"
@@ -1769,17 +1726,6 @@
                             "mejuri.com"
                         ],
                         "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1081"
-                    }
-                ]
-            },
-            "htlbid.com": {
-                "rules": [
-                    {
-                        "rule": "htlbid.com/v3/dangerousminds.net/htlbid.js",
-                        "domains": [
-                            "dangerousminds.net"
-                        ],
-                        "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1270"
                     }
                 ]
             },


### PR DESCRIPTION
Since we added some new "surrogate" (aka shim) scripts and redirection
rules, some of the tracker allowlist entries can be removed. Let's do
that now.

<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:**

## Description


#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

