### PR TITLE
AppTP: Add scoped exception to fix Earth Inc game

### DIFF
--- a/features/app-tracker-protection.json
+++ b/features/app-tracker-protection.json
@@ -38,6 +38,14 @@
         "exceptionLists": {
             "appTrackerAllowList": [
                 {
+                    "domain": "3d.unity3d.com",
+                    "packageNames": [
+                        {
+                            "packageName": "com.treetopcrew.earthinc"
+                        }
+                    ]
+                },
+                {
                     "domain": "api2.branch.io",
                     "packageNames": [
                         {   
@@ -157,6 +165,9 @@
                         },
                         {
                             "packageName": "com.kitkagames.fallbuddies"
+                        },
+                        {
+                            "packageName": "com.treetopcrew.earthinc"
                         },
                         {
                             "packageName": "com.ubisoft.dragonfire"


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:**
https://app.asana.com/0/0/1205695767127778/1206372881150654/f
## Description
Reddit user reported issues with watching ads to earn rewards in Earth Inc, and it seems that Unity ads are being blocked.

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

