### PR TITLE
Disable client brand on Android

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -4,7 +4,7 @@
             "state": "enabled"
         },
         "clientBrandHint": {
-            "state": "enabled"
+            "state": "disabled"
         },
         "contentBlocking": {
             "exceptions": [ ]


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:**
https://app.asana.com/0/0/1206404107857737/f

## Description
Disable client hint brand on Android

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

