### PR TITLE
Exclude sephora.com in gpc.json

### DIFF
--- a/features/gpc.json
+++ b/features/gpc.json
@@ -50,6 +50,10 @@
         {
             "domain": "tirerack.com",
             "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1680"
+        },
+        {
+            "domain": "sephora.com",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1758"
         }
     ],
     "settings": {


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/0/1200277586140538/1206396792812754/f

## Description

GPC breaking loading of sephora.com

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

