### PR TITLE
Disable certain tracker paths to mitigate breakage on sbs.com.au

### DIFF
--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -993,6 +993,15 @@
                         ]
                     },
                     {
+                        "rule": "doubleclick.net/pixel",
+                        "domains": [
+                          "www.sbs.com.au"
+                        ],
+                        "reason": [
+                            "www.sbs.com.au - https://github.com/duckduckgo/privacy-configuration/issues/1761"
+                        ]
+                    },
+                    {
                         "rule": "doubleclick.net",
                         "domains": [
                             "rocketnews24.com"
@@ -2972,6 +2981,17 @@
                     }
                 ]
             },
+            "tremorhub.com": {
+                "rules": [
+                  {
+                    "rule": "tremorhub.com/getTVID",
+                    "domains": [
+                      "www.sbs.com.au"
+                    ],
+                    "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1761"
+                  }
+                ]
+            },     
             "trustpilot.com": {
                 "rules": [
                     {

--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -995,7 +995,7 @@
                     {
                         "rule": "doubleclick.net/pixel",
                         "domains": [
-                          "www.sbs.com.au"
+                          "sbs.com.au"
                         ],
                         "reason": [
                             "www.sbs.com.au - https://github.com/duckduckgo/privacy-configuration/issues/1761"
@@ -2986,7 +2986,7 @@
                   {
                     "rule": "tremorhub.com/getTVID",
                     "domains": [
-                      "www.sbs.com.au"
+                      "sbs.com.au"
                     ],
                     "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1761"
                   }


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/0/1200277586140538/1206416061023227/f

## Description

sbs.com.au shows an adblock wall for on demand videos


#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

