### PR TITLE
Element hiding: Address empty ad spaces on several popular sites

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -487,6 +487,7 @@
             "close ad",
             "close this ad",
             "x",
+            "_",
             "sponsored",
             "sponsorisé",
             "story continues below advertisement",
@@ -965,6 +966,15 @@
                 ]
             },
             {
+                "domain": "elpais.com",
+                "rules": [
+                    {
+                        "selector": ".obne_ob",
+                        "type": "hide-empty"
+                    }
+                ]
+            },
+            {
                 "domain": "eniro.se",
                 "rules": [
                     {
@@ -1117,6 +1127,14 @@
                     {
                         "selector": "fbs-ad",
                         "type": "closest-empty"
+                    },
+                    {
+                        "selector": ".top-ad-container",
+                        "type": "hide"
+                    },
+                    {
+                        "selector": ".vestpocket",
+                        "type": "hide-empty"
                     }
                 ]
             },
@@ -1418,6 +1436,19 @@
                 ]
             },
             {
+                "domain": "ieee.org",
+                "rules": [
+                    {
+                        "selector": ".top-leader-container",
+                        "type": "hide-empty"
+                    },
+                    {
+                        "selector": "[class*='rblad-ieee_']",
+                        "type": "hide-empty"
+                    }
+                ]
+            },
+            {
                 "domain": "ilfattoquotidiano.it",
                 "rules": [
                     {
@@ -1560,6 +1591,24 @@
                 ]
             },
             {
+                "domain": "livescore.com",
+                "rules": [
+                    {
+                        "selector": "#header-ads-holder",
+                        "type": "hide-empty"
+                    }
+                ]
+            },
+            {
+                "domain": "livesport.com",
+                "rules": [
+                    {
+                        "selector": "#header-ads-holder",
+                        "type": "hide-empty"
+                    }
+                ]
+            },
+            {
                 "domain": "macrumors.com",
                 "rules": [
                     {
@@ -1669,6 +1718,27 @@
                     {
                         "selector": ".kskdCls",
                         "type": "hide"
+                    }
+                ]
+            },
+            {
+                "domain": "newatlas.com",
+                "rules": [
+                    {
+                        "selector": ".OcelotAdModule",
+                        "type": "hide-empty"
+                    },
+                    {
+                        "selector": "[id*='desktop_article_']",
+                        "type": "hide-empty"
+                    },
+                    {
+                        "selector": "[id*='mobile_article_']",
+                        "type": "hide-empty"
+                    },
+                    {
+                        "selector": "[id*='native_index_desktop_']",
+                        "type": "hide-empty"
                     }
                 ]
             },
@@ -1919,6 +1989,19 @@
                     {
                         "selector": ".ad-slot-wrapper",
                         "type": "hide-empty"
+                    }
+                ]
+            },
+            {
+                "domain": "primagames.com",
+                "rules": [
+                    {
+                        "selector": ".primis-player",
+                        "type": "hide-empty"
+                    },
+                    {
+                        "selector": "[data-freestar-ad]",
+                        "type": "hide"
                     }
                 ]
             },


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:** https://app.asana.com/0/0/1206222173681862/f

## Description
Addresses empty ad spaces on the following sites:
- primagames.com
- newatlas.com
- elpais.com
- forbes.com
- livescore.com
- livesport.com
- ieee.org

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

