### PR TITLE
Add `daysBeforeSurvey` setting for DBP on Windows

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -31,6 +31,9 @@
                     }
                 }
             },
+            "settings": {
+                "daysBeforeSurvey": 3
+            },
             "minSupportedVersion": "0.64.0"
         },
         "windowsPermissionUsage": {


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/0/492600419927320/1206433090121042/f

## Description
- Adding a new `settings` field for `dbp` feature on Windows with `daysBeforeSurvey=3` to allow the browser to show survey for DBP waitlist users after 3 days.
- The change to support this in the Windows browser is not released yet, so this PR can be merged as soon as it's approved.
- Note: that in the project's description the initial decision was to use the value `5`, but we changed that during the kick-off (see timeline accelerators) which is the task I linked.

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

