### PR TITLE
Add onByDefault rollout to autoconsent

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -149,7 +149,19 @@
                     "domain": "healthline.com",
                     "reason": "https://github.com/duckduckgo/privacy-configuration/issues/326"
                 }
-            ]
+            ],
+            "features": {
+                "onByDefault": {
+                    "state": "enabled",
+                    "rollout": {
+                        "steps": [
+                            {
+                                "percent": 25.0
+                            }
+                        ]
+                    }
+                }
+            }
         },
         "autofill": {
             "state": "enabled",


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:** https://app.asana.com/0/0/1206446781259751/f

## Description
Add subfeature to enable autoconsent by default. Add support for incremental rollout


#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

