### PR TITLE
Set rollout of autoconsent  onByDefault for iOS to 25%

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -54,7 +54,19 @@
             "state": "enabled"
         },
         "autoconsent": {
-            "state": "enabled"
+            "state": "enabled",
+            "features": {
+                "onByDefault": {
+                    "state": "enabled",
+                    "rollout": {
+                        "steps": [
+                            {
+                                "percent": 25.0
+                            }
+                        ]
+                    }
+                }
+            }
         },
         "autofill": {
             "state": "enabled",


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->

**Asana Task:** https://app.asana.com/0/1206264112133008/1206441673559120/f

## Description
Initial rollout step for onByDefault autoconsent subfeature on iOS. 

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

