### PR TITLE
Enable Sync on Windows

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -159,6 +159,9 @@
             },
             "exceptions": [ ]
         },
+        "sync": {
+            "state": "enabled"
+        },
         "trackerAllowlist": {
             "state": "enabled",
             "settings": {


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/0/0/1206398190188969/f

## Description
Sync will be soft-launched to the public starting from v0.66.1.0.
Similarly to other platforms, the feature is controlled by the "sync" feature flag, which is switched to `enabled` in this PR.
Currently we don't have to set `minSupportedVersion`, because v0.66.1.0 is the first version that respects the feature flag.

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

