### PR TITLE
Add next.waveapps.com to UA exceptions

### DIFF
--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -549,7 +549,11 @@
                     {
                         "domain": "zalando.fr",
                         "reason": "https://github.com/duckduckgo/privacy-configuration/issues/667"
-                    }
+                    },
+                    {
+                        "domain": "next.waveapps.com",
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1815"
+                    },
                 ],
                 "webViewDefault": [
                     {

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -553,7 +553,7 @@
                     {
                         "domain": "next.waveapps.com",
                         "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1815"
-                    },
+                    }
                 ],
                 "webViewDefault": [
                     {


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:** https://github.com/duckduckgo/privacy-configuration/issues/1815

## Description

Protections aren't changing the breakage, nothing in the console and so we can only assume it's UA.

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

