### PR TITLE
Revert "Add next.waveapps.com to UA exceptions"

### DIFF
--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -549,10 +549,6 @@
                     {
                         "domain": "zalando.fr",
                         "reason": "https://github.com/duckduckgo/privacy-configuration/issues/667"
-                    },
-                    {
-                        "domain": "next.waveapps.com",
-                        "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1815"
                     }
                 ],
                 "webViewDefault": [


### PR DESCRIPTION
Reverts duckduckgo/privacy-configuration#1816 as didn't fix.