### PR TITLE
 Add Canva.com UA override to iOS

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -132,6 +132,10 @@
                         "reason": "Login issues"
                     },
                     {
+                        "domain": "www.canva.com",
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1818"
+                    },
+                    {
                         "domain": "duckduckgo.com",
                         "reason": "Internal exclusion to roll out experiment"
                     }
@@ -144,6 +148,10 @@
                     {
                         "domain": "chase.com",
                         "reason": "Login issues"
+                    },
+                    {
+                        "domain": "www.canva.com",
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1818"
                     }
                 ],
                 "omitVersionSites": [


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:**  https://github.com/duckduckgo/privacy-configuration/issues/1818

## Description

Expands our exception to also include iOS as at least on iPad it behaves the same.

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

