### PR TITLE
Update rocket-loader blocking rules

### DIFF
--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -550,8 +550,22 @@
             },
             "cloudflare.com": {
                 "rules": [
+                     {
+                        "rule": "cloudflare.com/cdn-cgi/scripts/7089c43e/cloudflare-static/rocket-loader.min.js",
+                        "domains": [
+                            "<all>"
+                        ],
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1107"
+                    },
                     {
-                        "rule": "cdnjs.cloudflare.com/cdn-cgi/scripts/.*/cloudflare-static/rocket-loader.min.js",
+                        "rule": "cloudflare.com/cdn-cgi/scripts/7d0fa10a/cloudflare-static/rocket-loader.min.js",
+                        "domains": [
+                            "<all>"
+                        ],
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1107"
+                    },
+                    {
+                        "rule": "cloudflare.com/cdn-cgi/scripts/1680307200/cloudflare-static/rocket-loader.min.js",
                         "domains": [
                             "<all>"
                         ],


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/0/1200277586140538/1206601485880416/f

## Description
This change is primarily to fix breakage on https://www.riu.com/en/form_contactar/, however I've also split the rules out into 3 explicit rules for each of the versions of rocket-loader we have rules for in our blocklist. This is because the current wildcard will not work on all platforms, so for this mitigation to work everywhere, we have to include the full URL.

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

