### PR TITLE
add macOS tracker exception to idahonews.com

### DIFF
--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -706,9 +706,13 @@
                             {
                                 "rule": "www.googletagservices.com/tag/js/gpt.js",
                                 "domains": [
-                                    "wp.pl"
+                                    "wp.pl",
+                                    "idahonews.com"
                                 ],
-                                "reason": "Adwall appears which reappears when dismissed. The adwall prevents interaction with the page."
+                                "reason": [
+                                    "Adwall appears which reappears when dismissed. The adwall prevents interaction with the page.",
+                                    "idahonews.com - https://github.com/duckduckgo/privacy-configuration/issues/1834"
+                                ]
                             }
                         ]
                     },


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:**
https://github.com/duckduckgo/privacy-configuration/issues/1834
https://app.asana.com/0/1201534009035032/1206642861917328/f


## Description

On MacOS only, Pages turn blank with protection ON. This is caused by a tracker.


#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

