### PR TITLE
add UA exception on godaddy-com

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -283,6 +283,10 @@
                 {
                     "domain": "fanfiction.net",
                     "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1443"
+                },
+                {
+                    "domain": "godaddy.com",
+                    "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1845"
                 }
             ]
         },


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:**

https://app.asana.com/0/1200277586140538/1206704608201982/f
https://github.com/duckduckgo/privacy-configuration/issues/1845

## Description
Access blocked to DDG users to the site on android.
A banner pops up a few minutes after landing and remaining on the page.

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

