### PR TITLE
add client brand hint schema for domains

### DIFF
--- a/features/client-brand-hint.json
+++ b/features/client-brand-hint.json
@@ -6,5 +6,10 @@
             "reason": "site breakage"
         }
     },
-    "exceptions": []
+    "exceptions": [],
+    "settings": [
+        {
+            "domains": []
+        }
+    ]
 }

--- a/features/client-brand-hint.json
+++ b/features/client-brand-hint.json
@@ -7,9 +7,7 @@
         }
     },
     "exceptions": [],
-    "settings": [
-        {
-            "domains": []
-        }
-    ]
+    "settings": {
+        "domains": []
+    }
 }

--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -5,7 +5,13 @@
         },
         "clientBrandHint": {
             "state": "enabled",
-            "minSupportedVersion": 51852000
+            "minSupportedVersion": 51852000,
+            "exceptions": [ ],
+            "settings": [
+                {
+                    "domains": []
+                }
+            ]
         },
         "contentBlocking": {
             "exceptions": [ ]

--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -7,11 +7,10 @@
             "state": "enabled",
             "minSupportedVersion": 51852000,
             "exceptions": [ ],
-            "settings": [
+            "settings": 
                 {
                     "domains": []
                 }
-            ]
         },
         "contentBlocking": {
             "exceptions": [ ]


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:** https://app.asana.com/0/1157893581871903/1206703123735625/f

## Description
Update `clientBrandHint` feature to accommodate domains. This enabled setting the `SEC-CH-UA` on a site per site basis.

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

