### PR TITLE
add tracker exception to 6play-fr

### DIFF
--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -1298,6 +1298,13 @@
                             "channel4.com"
                         ],
                         "reason": "Unskippable adblock warning when trying to play a video."
+                    },
+                    {
+                        "rule": "7cbf2.v.fwmrm.net/ad/g/1",
+                        "domains": [
+                            "6play.fr"
+                        ],
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1854"
                     }
                 ]
             },


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:**
https://github.com/duckduckgo/privacy-configuration/issues/1854
https://app.asana.com/0/0/1206737287578819/f

## Description
ad block banner prevents video to play


#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

