### PR TITLE
Remove golf.com mitigation

### DIFF
--- a/features/amp-links.json
+++ b/features/amp-links.json
@@ -20,10 +20,6 @@
             "reason": "Pages on the site end up in redirect loops in Firefox."
         },
         {
-            "domain": "golf.com",
-            "reason": "https://github.com/duckduckgo/privacy-configuration/issues/812"
-        },
-        {
             "domain": "thehustle.co",
             "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1460"
         }
@@ -36,6 +32,7 @@
             "^https?:\\/\\/\\S+ampproject\\.org\\/\\S\\/s\\/(\\S+)$"
         ],
         "keywords": [
+            "amp=",
             "=amp",
             "&amp",
             "amp&",


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:** https://app.asana.com/0/0/1206583807494618/f

## Description
This PR removes the AMP mitigation for golf.com closing #812 and adds `amp=` back to the list of parameters now that we've fixed page detection on Apple platforms.

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

