### PR TITLE
add disable-default for adblock banners

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -1746,6 +1746,9 @@
                 "domain": "newser.com",
                 "rules": [
                     {
+                        "type": "disable-default"
+                    },
+                    {
                         "selector": ".RightRailAds",
                         "type": "hide-empty"
                     },


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:**
https://github.com/duckduckgo/privacy-configuration/issues/592
https://app.asana.com/0/72649045549333/1206743977003100/f

## Description
Ad block banner triggers because of elementHiding

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

