### PR TITLE
Add asana-sentry exception for apptp

### DIFF
--- a/features/app-tracker-protection.json
+++ b/features/app-tracker-protection.json
@@ -109,6 +109,14 @@
                     ]
                 },
                 {
+                    "domain": "ingest.sentry.io",
+                    "packageNames": [
+                        {
+                            "packageName": "com.asana.app"
+                        }
+                    ]
+                },
+                {
                     "domain": "insight.adsrvr.org",
                     "packageNames": [
                         {


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:**
https://app.asana.com/0/1202279501986195/1206752051778574/f

## Description
Something seems to have changed in either how sentry does requests or how asana integrates their sdk so that blocking this tracker is now sending the app into continual ANRs.

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

