### PR TITLE
Avoid ad block wall on servustv.com

### DIFF
--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -119,6 +119,17 @@
                     }
                 ]
             },
+            "adition.com": {
+                "rules": [
+                    {
+                        "rule": "ad3.adfarm1.adition.com/js",
+                        "domains": [
+                            "servustv.com"
+                        ],
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1869"
+                    }
+                ]
+            },
             "adlightning.com": {
                 "rules": [
                     {


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:**
https://app.asana.com/0/1200277586140538/1206743930272429/f

## Description
Un-dismissable adblock wall with protections on, keyed to this one tracker domain

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

