### PR TITLE
Update element hiding rules for uzone.id

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -2659,6 +2659,23 @@
                 ]
             },
             {
+                "domain": "uzone.id",
+                "rules": [
+                    {
+                        "selector": "[class^='box-ads']",
+                        "type": "hide-empty"
+                    },
+                    {
+                        "selector": "[class^='section-ads']",
+                        "type": "hide-empty"
+                    },
+                    {
+                        "selector": ".parallax-container",
+                        "type": "hide-empty"
+                    }
+                ]
+            },
+            {
                 "domain": "washingtontimes.com",
                 "rules": [
                     {


### PR DESCRIPTION
On mobile quite a few empty ad elements needed to be collapsed on
uzone.id, let's do that now.

<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:**

## Description


#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

