### PR TITLE
Avoid triggering the ad-blocker wall on tumblr.com

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -2459,6 +2459,14 @@
                 ]
             },
             {
+                "domain": "tumblr.com",
+                "rules": [
+                    {
+                        "type": "disable-default"
+                    }
+                ]
+            },
+            {
                 "domain": "tvtropes.org",
                 "rules": [
                   {


### PR DESCRIPTION
One of the default element hiding rules we use triggers the website's
"Please disable your ad blocker" wall, let's disable those rules for
now.

<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:** https://github.com/duckduckgo/privacy-configuration/issues/1894

## Description


#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

