### PR TITLE
add cpm exception to disneyplus-com

### DIFF
--- a/features/autoconsent.json
+++ b/features/autoconsent.json
@@ -214,6 +214,10 @@
         {
             "domain": "leboncoin.fr",
             "reason": "https://github.com/duckduckgo/autoconsent/issues/396"
+        },
+        {
+            "domain": "disneyplus.com",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1897"
         }
     ],
     "settings": {


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:**
https://github.com/duckduckgo/privacy-configuration/issues/1897
https://app.asana.com/0/inbox/1201534009031797/1206835018522483/1206836753527672/f

## Description
infinite protection reload on homepage due to autoconsent

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

