### PR TITLE
Fix photo album paging on hgtv.com

### DIFF
--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -2388,6 +2388,13 @@
                             "<all>"
                         ],
                         "reason": "https://github.com/duckduckgo/privacy-configuration/issues/916"
+                    },
+                    {
+                        "rule": "cdn.optimizely.com/js/24096340716.js",
+                        "domains": [
+                            "hgtv.com"
+                        ],
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1904"
                     }
                 ]
             },


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:** https://github.com/duckduckgo/privacy-configuration/issues/1904

## Description


#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

