### PR TITLE
Add command line option to not strip reasons from the config

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,6 +12,8 @@ const defaultConfig = {
     features: {},
     unprotectedTemporary: []
 }
+// Env flag that can be used to override stripping of 'reason' strings from the config.
+const keepReasons = process.argv.includes('--keep-reasons')
 
 const platforms = require('./platforms')
 const compatibility = require('./compatibility')
@@ -51,7 +53,7 @@ function writeConfigToDisk (platform, config) {
         const version = `v${i}`
         mkdirIfNeeded(`${GENERATED_DIR}/${version}`)
 
-        if (i === CURRENT_CONFIG_VERSION) {
+        if (i === CURRENT_CONFIG_VERSION && !keepReasons) {
             stripReasons(config)
         }
 


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/0/0/1206855422417744/f

## Description
Adds a CLI option `--keep-reasons` which will disable stripping of the `reasons` attribute of exceptions in the config. This is useful for debugging versions of the config, as we can expose this reason in the UI of the tooling.

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

