### PR TITLE
Disable strato.de autoconsent rule

### DIFF
--- a/features/autoconsent.json
+++ b/features/autoconsent.json
@@ -223,7 +223,8 @@
     "settings": {
         "disabledCMPs": [
             "generic-cosmetic",
-            "termsfeed3"
+            "termsfeed3",
+            "strato.de"
         ]
     }
 }


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/0/1203409672862476/1206890055633210/f

## Description
This rule is currently broken and causing an issue on Gitlab sites. 
Once https://github.com/duckduckgo/autoconsent/pull/399 is release on all platforms, this can be reverted.

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

