### PR TITLE
Disable autoconsent on ffbb.com

### DIFF
--- a/features/autoconsent.json
+++ b/features/autoconsent.json
@@ -218,6 +218,10 @@
         {
             "domain": "disneyplus.com",
             "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1897"
+        },
+        {
+            "domain": "www.ffbb.com",
+            "reason": "Debugger added exception"
         }
     ],
     "settings": {

--- a/features/autoconsent.json
+++ b/features/autoconsent.json
@@ -221,7 +221,7 @@
         },
         {
             "domain": "www.ffbb.com",
-            "reason": "Debugger added exception"
+            "reason": "https://github.com/duckduckgo/autoconsent/issues/401"
         }
     ],
     "settings": {


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:** https://app.asana.com/0/1199178362774117/1206853518122614/f

## Description
Rule leaves page with overlay blocking content.

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

