### PR TITLE
Allow one more jwplayer path to unbreak video players

### DIFF
--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -2819,14 +2819,14 @@
             "scorecardresearch.com": {
                 "rules": [
                     {
-                        "rule": "https://sb.scorecardresearch.com/c2/plugins/streamingtag_plugin_jwplayer.js",
+                        "rule": "sb.scorecardresearch.com/c2/plugins/streamingtag_plugin_jwplayer.js",
                         "domains": [
                             "<all>"
                         ],
                         "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1920"
                     },
                     {
-                        "rule": "https://sb.scorecardresearch.com/internal-c2/default/streamingtag_plugin_jwplayer.js",
+                        "rule": "sb.scorecardresearch.com/internal-c2/default/streamingtag_plugin_jwplayer.js",
                         "domains": [
                             "<all>"
                         ],

--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -2824,6 +2824,13 @@
                             "<all>"
                         ],
                         "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1920"
+                    },
+                    {
+                        "rule": "https://sb.scorecardresearch.com/internal-c2/default/streamingtag_plugin_jwplayer.js",
+                        "domains": [
+                            "<all>"
+                        ],
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1920"
                     }
                 ]
             },


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:** #1920 

## Description
Follow up to https://github.com/duckduckgo/privacy-configuration/pull/1921 - it looks like the same jwplayer.js library can be loaded from multiple url paths.

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

