### PR TITLE
Re-enable CPM on by default with min version requirement

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -72,7 +72,8 @@
             ],
             "features": {
                 "onByDefault": {
-                    "state": "disabled",
+                    "state": "enabled",
+                    "minSupportedVersion": "7.113.0",
                     "rollout": {
                         "steps": [
                             {


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:** https://app.asana.com/0/414709148257752/1206940267418149/f

## Description

Re-enable CPM on by default with a minimum version requirement of the upcoming iOS version, containing bugfix for keyboard-related issues. This allows to prevent regression for existing versions.

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

