### PR TITLE
Add mediaPlaybackRequiresUserGesture exception for jumio.ai

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -665,6 +665,10 @@
                 {
                     "domain": "verify.id.me",
                     "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1865"
+                },
+                {
+                    "domain": "jumio.ai",
+                    "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1929"
                 }
             ]
         },


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:** https://app.asana.com/0/1206670747178362/1206923766259173/f / https://github.com/duckduckgo/privacy-configuration/issues/1929

## Description
Adding `mediaPlaybackRequiresUserGesture` exception for jumio.ai to unblock selfie identification via this service.

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

