### PR TITLE
Add UA override for web.de on macOS

### DIFF
--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -591,6 +591,10 @@
                     {
                         "domain": "spectrum.net",
                         "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1876"
+                    },
+                    {
+                        "domain": "web.de",
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1931"
                     }
                 ],
                 "webViewDefault": [


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:** https://app.asana.com/0/1200277586140538/1206933090224070/f

## Description
Site only partially loads with our custom UA on macOS, and displays a message at the top of the page about using a supported browser.

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

