### PR TITLE
Hide broken recommended for you section on oldnavy.gap.com

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -1298,6 +1298,19 @@
                 ]
             },
             {
+                "domain": "gap.com",
+                "rules": [
+                    {
+                        "selector": ".ONhome1-recs",
+                        "type": "hide"
+                    },
+                    {
+                        "selector": ".ONhome1-recs",
+                        "type": "closest-empty"
+                    }
+                ]
+            },
+            {
                 "domain": "gbnews.com",
                 "rules": [
                     {


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:** https://app.asana.com/0/1206374308645191/1206862748831964/f

## Description
This section is loaded via a request to certona.net, which is on our tracker list. With the Global Privacy Control signal set, this section will never load because the site is considering it to be sharing/selling data.

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

