### PR TITLE
Temporarily enable isLaunchedOverride for iOS and macOS for Apple review

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -361,7 +361,7 @@
                     "state": "disabled"
                 },
                 "isLaunchedOverride": {
-                    "state": "disabled"
+                    "state": "enabled"
                 },
                 "allowPurchase": {
                     "state": "enabled"

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -838,7 +838,7 @@
                     "state": "disabled"
                 },
                 "isLaunchedOverride": {
-                    "state": "disabled"
+                    "state": "enabled"
                 },
                 "allowPurchase": {
                     "state": "enabled"


### PR DESCRIPTION


**Asana Task/Github Issue:** https://app.asana.com/0/1203936086921904/1206943134226175/f

## Description
Since subscription experience is gated behind a feature flag. We need to temporarily enable it so the Apple reviewers can review the flow on iOS and macOS. 
After completing the review but before starting the rollout we will disable the flag again.


#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

