### PR TITLE
Revert "Temporarily enable isLaunchedOverride for iOS and macOS for Apple review (#1935)"

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -361,7 +361,7 @@
                     "state": "disabled"
                 },
                 "isLaunchedOverride": {
-                    "state": "enabled"
+                    "state": "disabled"
                 },
                 "allowPurchase": {
                     "state": "enabled"

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -838,7 +838,7 @@
                     "state": "disabled"
                 },
                 "isLaunchedOverride": {
-                    "state": "enabled"
+                    "state": "disabled"
                 },
                 "allowPurchase": {
                     "state": "enabled"


### PR DESCRIPTION
This reverts commit d8890070cb74c813553fbf6739d007fed9f0a828.

**Asana Task/Github Issue:** https://app.asana.com/0/1203936086921904/1206943134226175/f

## Description
Previous PR was merged too rapidly and the isLaunchedOverride would be embedded in the apps on build time.

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

