### PR TITLE
Element hiding: address empty ad spaces on economictimes.com & indiatimes.com

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -172,6 +172,10 @@
                 "type": "hide-empty"
             },
             {
+                "selector": "#topAd",
+                "type": "hide-empty"
+            },
+            {
                 "selector": ".ad-banner-container",
                 "type": "hide-empty"
             },
@@ -250,6 +254,10 @@
             {
                 "selector": ".adcontainer",
                 "type": "closest-empty"
+            },
+            {
+                "selector": ".adContainer",
+                "type": "hide-empty"
             },
             {
                 "selector": ".ad-current",


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:** https://app.asana.com/0/1200277586140538/1206933304884204/f

## Description
Collapses large empty ad spaces on indiatimes.com & economictimes.com

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

