### PR TITLE
add a cpm exception for autoconsent again due to a bug on the disneyplus website

### DIFF
--- a/features/autoconsent.json
+++ b/features/autoconsent.json
@@ -218,6 +218,10 @@
         {
             "domain": "mitglieder.franzspitzer.de",
             "reason": "https://github.com/duckduckgo/autoconsent/issues/408"
+        },
+        {
+            "domain": "disneyplus.com",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1897"
         }
     ],
     "settings": {


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:**
- https://app.asana.com/0/1201048563534612/1206756966631352/f
- https://app.asana.com/0/1201279386299865/1206964863473808/f

## Description
Reject button does not work on disneyplus.com in some regions


#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

