### PR TITLE
Add ddg.gg, duck.com, duck.it to DDG default sites

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -285,6 +285,14 @@
                     {
                         "domain": "ddg.gg",
                         "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1956"
+                    },
+                    {
+                        "domain": "duck.com",
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1958"
+                    },
+                    {
+                        "domain": "duck.it",
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1959"
                     }
                 ],
                 "ddgFixedUserAgent": {

--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -281,6 +281,10 @@
                     {
                         "domain": "duckduckgo.com",
                         "reason": "Internal exclusion to roll out experiment"
+                    },
+                    {
+                        "domain": "ddg.gg",
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1956"
                     }
                 ],
                 "ddgFixedUserAgent": {


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:** https://app.asana.com/0/414730916066338/1206984412858858/f

## Description
Adds ddg.gg, duck.it and duck.com to `ddgDefaultSites`
See: https://github.com/duckduckgo/privacy-configuration/issues/1956

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

