### PR TITLE
Enable overrides with the min version for the Apple review

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -375,7 +375,7 @@
                 },
                 "isLaunchedOverride": {
                     "state": "enabled",
-                    "minSupportedVersion": "7.114.0",
+                    "minSupportedVersion": "7.114.0"
                 },
                 "allowPurchase": {
                     "state": "enabled"

--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -374,7 +374,8 @@
                     "state": "disabled"
                 },
                 "isLaunchedOverride": {
-                    "state": "disabled"
+                    "state": "enabled",
+                    "minSupportedVersion": "7.114.0",
                 },
                 "allowPurchase": {
                     "state": "enabled"

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -853,7 +853,8 @@
                     "state": "disabled"
                 },
                 "isLaunchedOverride": {
-                    "state": "disabled"
+                    "state": "enabled",
+                    "minSupportedVersion": "1.82.0"
                 },
                 "allowPurchase": {
                     "state": "enabled"


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/0/0/1206989370932989/f

## Description
Temporary enable isLaunchedOverride flag for the reviewers with the min. version of 1.82.0 for macOS and 7.114.0 for iOS

See https://github.com/duckduckgo/privacy-configuration/pull/1937/files for the PR that enabled this flag for the previous Apple review

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

