### PR TITLE
Hide header and body ads on apnews.com

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -658,6 +658,14 @@
                     {
                         "selector": ".proper-dynamic-insertion",
                         "type": "closest-empty"
+                    },
+                    {
+                        "selector": ".Page-header-leaderboardAd",
+                        "type": "hide-empty"
+                    },
+                    {
+                        "selector": ".SovrnAd",
+                        "type": "hide-empty"
                     }
                 ]
             },


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:**
https://app.asana.com/0/1206670747178362/1207003039482240/f
## Description
Hide empty ad spaces on apnews.com

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

