### PR TITLE
Disable Privacy Pro override feature flags for iOS and macOS

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -374,8 +374,7 @@
                     "state": "disabled"
                 },
                 "isLaunchedOverride": {
-                    "state": "enabled",
-                    "minSupportedVersion": "7.114.0"
+                    "state": "disabled"
                 },
                 "allowPurchase": {
                     "state": "enabled"

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -853,8 +853,7 @@
                     "state": "disabled"
                 },
                 "isLaunchedOverride": {
-                    "state": "enabled",
-                    "minSupportedVersion": "1.82.0"
+                    "state": "disabled"
                 },
                 "allowPurchase": {
                     "state": "enabled"


### PR DESCRIPTION
Reverts duckduckgo/privacy-configuration#1973

We only needed these flags enabled while the apps were in review. They have now been approved, so we should shut the flag off so that users don't get cached versions stored locally before launch.