### PR TITLE
Add @duckduckgo/apple-devs to CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -18,6 +18,7 @@ features/click-to-play.json @duckduckgo/config-aor @kzar @ladamski @duckduckgo/b
 features/tracker-allowlist.json @duckduckgo/config-aor @duckduckgo/breakage-aor @duckduckgo/breakage @duckduckgo/content-scope-scripts-owners
 features/incontext-signup.json @duckduckgo/config-aor @alistairjcbrown @duckduckgo/breakage-aor @duckduckgo/breakage @duckduckgo/content-scope-scripts-owners
 
+
 # Platform owners
 overrides/browsers/ @duckduckgo/config-aor @kzar @duckduckgo/breakage-aor @duckduckgo/breakage @duckduckgo/content-scope-scripts-owners
 overrides/android-override.json @duckduckgo/config-aor @marcosholgado @joshliebe @aitorvs @duckduckgo/breakage-aor @duckduckgo/breakage @duckduckgo/content-scope-scripts-owners

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -18,7 +18,6 @@ features/click-to-play.json @duckduckgo/config-aor @kzar @ladamski @duckduckgo/b
 features/tracker-allowlist.json @duckduckgo/config-aor @duckduckgo/breakage-aor @duckduckgo/breakage @duckduckgo/content-scope-scripts-owners
 features/incontext-signup.json @duckduckgo/config-aor @alistairjcbrown @duckduckgo/breakage-aor @duckduckgo/breakage @duckduckgo/content-scope-scripts-owners
 
-
 # Platform owners
 overrides/browsers/ @duckduckgo/config-aor @kzar @duckduckgo/breakage-aor @duckduckgo/breakage @duckduckgo/content-scope-scripts-owners
 overrides/android-override.json @duckduckgo/config-aor @marcosholgado @joshliebe @aitorvs @duckduckgo/breakage-aor @duckduckgo/breakage @duckduckgo/content-scope-scripts-owners

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -22,6 +22,6 @@ features/incontext-signup.json @duckduckgo/config-aor @alistairjcbrown @duckduck
 overrides/browsers/ @duckduckgo/config-aor @kzar @duckduckgo/breakage-aor @duckduckgo/breakage @duckduckgo/content-scope-scripts-owners
 overrides/android-override.json @duckduckgo/config-aor @marcosholgado @joshliebe @aitorvs @duckduckgo/breakage-aor @duckduckgo/breakage @duckduckgo/content-scope-scripts-owners
 overrides/extension-override.json @duckduckgo/config-aor @kzar @duckduckgo/breakage-aor @duckduckgo/breakage @duckduckgo/content-scope-scripts-owners
-overrides/ios-override.json @duckduckgo/config-aor @duckduckgo/breakage-aor @duckduckgo/breakage @duckduckgo/content-scope-scripts-owners
-overrides/macos-override.json @duckduckgo/config-aor @duckduckgo/breakage-aor @duckduckgo/breakage @duckduckgo/content-scope-scripts-owners
+overrides/ios-override.json @duckduckgo/config-aor @duckduckgo/apple-devs @duckduckgo/breakage-aor @duckduckgo/breakage @duckduckgo/content-scope-scripts-owners
+overrides/macos-override.json @duckduckgo/config-aor @duckduckgo/apple-devs @duckduckgo/breakage-aor @duckduckgo/breakage @duckduckgo/content-scope-scripts-owners
 overrides/windows-override.json @duckduckgo/config-aor @q71114 @szanto90balazs @duckduckgo/breakage-aor @duckduckgo/breakage @duckduckgo/content-scope-scripts-owners

--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -1117,6 +1117,23 @@
                 ]
             },
             {
+                "domain": "eurogamer.net",
+                "rules": [
+                    {
+                        "selector": "#sticky_leaderboard",
+                        "type": "hide-empty"
+                    },
+                    {
+                        "selector": ".primis_wrapper",
+                        "type": "hide"
+                    },
+                    {
+                        "selector": ".autoad",
+                        "type": "hide-empty"
+                    }
+                ]
+            },
+            {
                 "domain": "examiner.com.au",
                 "rules": [
                     {


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:** https://app.asana.com/0/0/1207002152077950/f

## Description
Adding @duckduckgo/apple-devs to CODEOWNERS for ios-override.json and macos-override.json to allow our Apple devs to merge their own PRs.

Also adding an element hiding rule for eurogamer.net to get the unit test check running.

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

