### PR TITLE
Disable iOS Privacy Pro override flag for 7.114.1

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -374,8 +374,7 @@
                     "state": "disabled"
                 },
                 "isLaunchedOverride": {
-                    "state": "enabled",
-                    "minSupportedVersion": "7.114.1"
+                    "state": "disabled"
                 },
                 "allowPurchase": {
                     "state": "enabled"


### PR DESCRIPTION
Task: https://app.asana.com/0/0/1207029506783023/f

Reverts duckduckgo/privacy-configuration#1984. We only need this flag enabled while Apple reviews the change, and it should be reverted as soon as we're approved.