### PR TITLE
Hide spaces on doodle.com

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -1037,6 +1037,15 @@
                 ]
             },
             {
+                "domain": "doodle.com",
+                "rules": [
+                    {
+                        "selector": "[data-testid*='ads-layout-placement']",
+                        "type": "hide"
+                    }
+                ]
+            },
+            {
                 "domain": "dpreview.com",
                 "rules": [
                     {


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:**
https://app.asana.com/0/1206670747178362/1207029284255625/f
## Description
Empty ad spaces on doodle.com across platforms

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

