### PR TITLE
Enable macOS Privacy Pro override flag for 1.82.1

### DIFF
--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -853,7 +853,8 @@
                     "state": "disabled"
                 },
                 "isLaunchedOverride": {
-                    "state": "disabled"
+                    "state": "enabled",
+                    "minSupportedVersion": "1.82.1"
                 },
                 "allowPurchase": {
                     "state": "enabled"


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:** https://app.asana.com/0/0/1207040559993369/f

## Description

Enabled the override flag for macOS 1.82.1 in the App Store.

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

