### PR TITLE
Revert macOS Privacy Pro override flag for 1.82.1

### DIFF
--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -853,8 +853,7 @@
                     "state": "disabled"
                 },
                 "isLaunchedOverride": {
-                    "state": "enabled",
-                    "minSupportedVersion": "1.82.1"
+                    "state": "disabled"
                 },
                 "allowPurchase": {
                     "state": "enabled"


### PR DESCRIPTION
Task: https://app.asana.com/0/0/1207040559993369/f

Reverts duckduckgo/privacy-configuration#1988 as we only want this flag live while Apple reviews it.