### PR TITLE
End PIR waitlist on Windows for Privacy Pro launch

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -24,7 +24,7 @@
                     "state": "enabled"
                 },
                 "waitlist": {
-                    "state": "enabled",
+                    "state": "disabled",
                     "rollout": {
                         "steps": [
                             {


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/0/0/1206863449001531/f

## Description
End waitlist beta for `Personal Information Removal` on Windows to avoid new users joining the waitlist and then have their access cut off immediately after Privacy Pro is launched.
Current waitlist users who aren't getting Privacy Pro through the incremental roll out will still be able to use PIR as `waitlistBetaActive` flag is still `enabled`.

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

