### PR TITLE
Woot rule for element hiding

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -2796,6 +2796,15 @@
                 ]
             },
             {
+                "domain": "woot.com",
+                "rules": [
+                    {
+                        "selector": "[data-test-ui*='advertisementLeaderboard']",
+                        "type": "hide-empty"
+                    }
+                ]
+            },
+            {
                 "domain": "wsj.com",
                 "rules": [
                     {


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:**
https://app.asana.com/0/1206670747178362/1207043389637688/f
## Description
Hiding some empty ad spaces on woot.com

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

