### PR TITLE
Bump `allowPurchaseStripe` `minSupportedVersion` on Windows due to Privacy Pro bug

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -219,7 +219,7 @@
                             }
                         ]
                     },
-                    "minSupportedVersion": "0.75.1"
+                    "minSupportedVersion": "0.76.2"
                 },
                 "allowPurchaseStripe": {
                     "state": "enabled"

--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -219,10 +219,11 @@
                             }
                         ]
                     },
-                    "minSupportedVersion": "0.76.2"
+                    "minSupportedVersion": "0.75.1"
                 },
                 "allowPurchaseStripe": {
-                    "state": "enabled"
+                    "state": "enabled",
+                    "minSupportedVersion": "0.76.2"
                 }
             }
         }


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:** https://app.asana.com/0/1201048563534612/1207054906562266/f

## Description
We identified an issue in version 0.75.1 where using the Burn button would sign the user out of their Privacy Pro account until the app was fully restarted. This PR requires users to update to the latest version before purchasing a new subscription. This PR does NOT cut off access for existing subscriptions


#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

