### PR TITLE
Move iOS UA exceptions to ddgFixedSites

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -146,8 +146,7 @@
             "state": "enabled",
             "settings": {
                 "defaultPolicy": "brand",
-                "ddgFixedSites": [],
-                "ddgDefaultSites": [
+                "ddgFixedSites": [
                     {
                         "domain": "chase.com",
                         "reason": "Login issues"
@@ -155,7 +154,9 @@
                     {
                         "domain": "www.canva.com",
                         "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1818"
-                    },
+                    }
+                ],
+                "ddgDefaultSites": [
                     {
                         "domain": "duckduckgo.com",
                         "reason": "Internal exclusion to roll out experiment"


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:** https://app.asana.com/0/0/1207025606695759/f

## Description
We should be using a combination of `ddgFixedSites` and `omitApplicationSites` for iOS UA exceptions. This PR moves a couple exceptions out of `ddgDefaultSites` and into `ddgFixedSites`.

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

