### PR TITLE
Remove unnecessary unprotected temp exceptions

### DIFF
--- a/features/unprotected-temporary.json
+++ b/features/unprotected-temporary.json
@@ -8,14 +8,6 @@
     },
     "exceptions": [
         {
-            "domain": "earth.google.com",
-            "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1099"
-        },
-        {
-            "domain": "iscorp.com",
-            "reason": "https://github.com/duckduckgo/privacy-configuration/issues/794"
-        },
-        {
             "domain": "marvel.com",
             "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1194"
         },


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:**
https://app.asana.com/0/1200277586140538/1205010492882704/f
https://app.asana.com/0/1200277586140538/1205189838780921/f
## Description
Given that underlying issue on Google Earth has been addressed on Windows and is a platform rather than protections issue on older MacOS versions, and that the iscorp exception hasn't made a dent in the report rate, I think we can remove both these domains from the broad exception list.

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

