### PR TITLE
Disable klaviyo.com protection on usafacts.org

### DIFF
--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -2073,7 +2073,8 @@
                         "domains": [
                             "kmail-lists.com",
                             "footweartruth.com",
-                            "andieswim.com"
+                            "andieswim.com",
+                            "usafacts.org"
                         ],
                         "reason": "https://github.com/duckduckgo/privacy-configuration/issues/362"
                     },


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/0/1206670747178362/1207097497487037/f
https://github.com/duckduckgo/privacy-configuration/issues/362

## Description
Newsletter signup form is not displayed. Disabling klaviyo.com tracker protection fixes this.

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

