### PR TITLE
Hide empty spaces on independent.co.uk

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -1621,6 +1621,27 @@
                 ]
             },
             {
+                "domain": "independent.co.uk",
+                "rules": [
+                    {
+                        "selector": "#partners",
+                        "type": "hide-empty"
+                    },
+                    {
+                        "selector": "#top-banner-wrapper",
+                        "type": "hide-empty"
+                    },
+                    {
+                        "selector": "[data-mpu1=true]",
+                        "type": "hide-empty"
+                    },
+                    {
+                        "selector": "#stickyFooterRoot",
+                        "type": "hide"
+                    }
+                ]
+            },
+            {
                 "domain": "indiatimes.com",
                 "rules": [
                     {


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/0/1206670747178362/1207111349541053/f

## Description
Tracker blocking is leaving empty spaces both on desktop and mobile. This change hides those empty spaces.

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

