### PR TITLE
Added exception for larazon.es

### DIFF
--- a/features/autoconsent.json
+++ b/features/autoconsent.json
@@ -36,6 +36,10 @@
             "reason": "https://github.com/duckduckgo/privacy-configuration/issues/326"
         },
         {
+            "domain": "larazon.es",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/issues/326"
+        },
+        {
             "domain": "motherdenim.com",
             "reason": "https://github.com/duckduckgo/privacy-configuration/issues/326"
         },


### PR DESCRIPTION
**Asana Task/Github Issue:**
- https://app.asana.com/0/1201844467387842/1207097434253108/f
- https://github.com/duckduckgo/privacy-configuration/issues/326

## Description
**Steps to repro:**
Go to https://www.larazon.es/
Wait or scroll around a bit until you see the cookie popup.

**What should happen:**
You should see a “Rechazar” (reject) button which hides the cookie popup when clicked, or ideally it should disappear automatically with our cookie popup management.

**What actually happens:**
You get a list of cookies to refuse. If you click the "Rechazar todo” (reject all) button they are rejected but the cookie popup doesn’t disappear. See attached “normal” and “unusable” screenshots.

It looks like our cookie popup management is clicking the “Configurar” (configure) button on the initial popup instead of “Rechazar” (reject).

Works fine in other browsers or with “Cookie Pop-up Protection” disabled.

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

