### PR TITLE
Unblock opta request on the-afc.com

### DIFF
--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -2424,7 +2424,8 @@
                             "abc.net.au",
                             "emol.com",
                             "oufc.co.uk",
-                            "theposh.com"
+                            "theposh.com",
+                            "the-afc.com"
                         ],
                         "reason": [
                             "abc.net.au - Error message displays in place of scoreboard (scoreboard does not show).",


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:** https://app.asana.com/0/1206670747178362/1207160603658539/f

## Description
Fixture and score information does not show. Unblocking `secure.widget.cloud.opta.net/v3/v3.opta-widgets.js` fixes.

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

