### PR TITLE
Added variants and feature flag for extendedOnboarding experiment

### DIFF
--- a/features/extended-onboarding.json
+++ b/features/extended-onboarding.json
@@ -1,0 +1,7 @@
+{
+    "_meta": {
+        "description": "Extended onboarding features. Allow us to show/hide features in onboarding",
+        "sampleExcludeRecords": {}
+    },
+    "exceptions": []
+}

--- a/index.js
+++ b/index.js
@@ -137,7 +137,8 @@ const excludedFeaturesFromUnprotectedTempExceptions = [
     'mediaPlaybackRequiresUserGesture',
     'history',
     'privacyPro',
-    'sslCertificates'
+    'sslCertificates',
+    'extendedOnboarding'
 ]
 function applyGlobalUnprotectedTempExceptionsToFeatures (key, baseConfig, globalExceptions) {
     if (!excludedFeaturesFromUnprotectedTempExceptions.includes(key)) {

--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -1041,6 +1041,27 @@
                 "state": "internal"
               }
             }
+        },
+        "extendedOnboarding": {
+            "state": "enabled",
+            "features": {
+              "comparisonChart": {
+                "state": "enabled",
+                "targets": [
+                  {
+                    "variantKey": "mt"
+                  }
+                ]
+              },
+              "aestheticUpdates": {
+                "state": "enabled",
+                "targets": [
+                  {
+                    "variantKey": "mt"
+                  }
+                ]
+              }
+            }
         }
     },
     "unprotectedTemporary": [],
@@ -1055,6 +1076,34 @@
                 "desc": "this is SERP don't remove",
                 "variantKey": "se",
                 "weight": 0
+            },
+            {
+                "desc": "Control group for extended onboarding experiment",
+                "variantKey": "ms",
+                "weight": 0,
+                "filters": {
+                    "locale": [
+                        "en_US",
+                        "en_UK",
+                        "en_CA",
+                        "en_IN",
+                        "en_AU"
+                  ]
+                }
+            },
+            {
+                "desc": "Aesthetic updates in onboarding experimental group",
+                "variantKey": "mt",
+                "weight": 0,
+                "filters": {
+                    "locale": [
+                        "en_US",
+                        "en_UK",
+                        "en_CA",
+                        "en_IN",
+                        "en_AU"
+                  ]
+                }
             }
         ]
     }


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:** https://app.asana.com/0/0/1207158919095753/f

## Description
Added new 2 experimental variants:

- Control: `ms`
- Experimental variant `mt`

Also added experiment as a feature called `extendedOnboarding` with subfeatures:
    - `comparisonChart`
    - `aestheticUpdates`

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

