### PR TITLE
Hide empty  ads on realtor.com

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -2289,6 +2289,15 @@
                 ]
             },
             {
+                "domain": "realtor.com",
+                "rules": [
+                    {
+                        "selector": ".ads_container",
+                        "type": "hide"
+                    }
+                ]
+            },
+            {
                 "domain": "reddit.com",
                 "rules": [
                     {


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:**
https://app.asana.com/0/1206670747178362/1207187591385912

## Description
empty ad spaces on the search pages
https://www.realtor.com/realestateandhomes-search/Copper-Canyon_TX/show-newest-listings/sby-6

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

