### PR TITLE
add cpm exception to hertz-com

### DIFF
--- a/features/autoconsent.json
+++ b/features/autoconsent.json
@@ -250,6 +250,10 @@
         {
             "domain": "malmostadsteater.se",
             "reason": "https://github.com/duckduckgo/autoconsent/issues/432"
+        },
+        {
+            "domain": "hertz.com",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/issues/2061"
         }
     ],
     "settings": {


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:**
https://github.com/duckduckgo/privacy-configuration/issues/2061
https://app.asana.com/0/1206670747178362/1207219283679036/f

## Description
grey overlay caused by CPM (US only issue)

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

