### PR TITLE
Disabling autoconsent on thrifty.com

### DIFF
--- a/features/autoconsent.json
+++ b/features/autoconsent.json
@@ -254,6 +254,10 @@
         {
             "domain": "hertz.com",
             "reason": "https://github.com/duckduckgo/privacy-configuration/issues/2061"
+        },
+        {
+            "domain": "www.thrifty.com",
+            "reason": "Page loads with gray overlay over content."
         }
     ],
     "settings": {


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/0/1200277586140538/1207323331740984/f

## Description
On https://www.thrifty.com/us/en, when accessed from a US IP, the page is left with a gray overlay on top. This is caused by the Cookie prompt management feature.
