### PR TITLE
add roll out to ios for history

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -15,7 +15,19 @@
             "exceptions": []
         },
         "history": {
-            "state": "enabled"
+            "state": "enabled",
+            "features": {
+                "onByDefault": {
+                    "state": "enabled",
+                    "rollout": [
+                        "steps": [
+                            {
+                                "percent": 25
+                            }
+                        ]
+                    ]
+                }
+            }
         },
         "fingerprintingTemporaryStorage": {
             "state": "enabled"

--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -22,7 +22,7 @@
                     "rollout": {
                         "steps": [
                             {
-                                "percent": 25
+                                "percent": 25.0
                             }
                         ]
                     }

--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -19,13 +19,13 @@
             "features": {
                 "onByDefault": {
                     "state": "enabled",
-                    "rollout": [
+                    "rollout": {
                         "steps": [
                             {
                                 "percent": 25
                             }
                         ]
-                    ]
+                    }
                 }
             }
         },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/0/1206767823185684/1207313758905473/f

## Description

Enables rollout for history in suggestions on iOS.

Main project: https://app.asana.com/0/72649045549333/1205122649889514/f

iOS logic for determining if feature enabled for a given user: https://github.com/duckduckgo/iOS/pull/2838/files#diff-c2d91de29250923a875b096b229e3aacda7ed4a6fd704547c6624b3c615d2db1R86-R103


#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

