### PR TITLE
Hide empty spaces on livestrong.com & genius.com + try experimental mitigation for wise.com

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -1393,6 +1393,15 @@
                     }
                 ]
             },
+	{
+            "domain": "genius.com",
+            "rules": [
+              {
+                "selector": "[class^='DfpAd']",
+                "type": "hide"
+              }
+            ]
+          },
             {
                 "domain": "getpocket.com",
                 "rules": [

--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -1784,6 +1784,27 @@
                 ]
             },
             {
+	            "domain": "livestrong.com",
+	            "rules": [
+		            {
+			            "selector": ".component-ar-horizontal-bar-ad",
+			            "type": "hide-empty"
+		            },
+		            {
+			            "selector": ".component-article-section-votd-container-outer",
+			            "type": "hide-empty"
+		            },
+		            {
+			            "selector": ".inline-ad",
+			            "type": "hide"
+		            },
+		            {
+			            "selector": ".component-header-sticky-ad",
+			            "type": "hide"
+		            }
+	            ]
+            },
+            {
                 "domain": "macrumors.com",
                 "rules": [
                     {

--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -1021,6 +1021,10 @@
                 {
                     "domain": "withpersona.com",
                     "reason": "https://github.com/duckduckgo/privacy-configuration/issues/2008"
+                },
+                {
+                    "domain": "wise.com",
+                    "reason": "experimental mitigation for unreproduced issue as description corresponds to similar breakage"
                 }
             ]
         },


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:**
https://app.asana.com/0/1200277586140538/1207327402088308/f
https://app.asana.com/0/1206670747178362/1207244160204381/f
https://app.asana.com/0/1206670747178362/1207328745672425/f

## Description
Empty spaces on livestrong.com + genius.com, and reports of id verification failure for wise.com that sound similar to those on id.me and others for which we've already made exceptions.

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

