### PR TITLE
Add element hiding override for xhamster.com

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -3046,6 +3046,15 @@
                 ]
             },
             {
+                "domain": "xhamster.com",
+                "rules": [
+                    {
+                        "selector": "#credential_picker_container",
+                        "type": "override"
+                    }
+                ]
+            },
+            {
                 "domain": "first-party.site",
                 "rules": [
                     {


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:** https://app.asana.com/0/1206670747178362/1207317116127615/f

## Description
There seems to be a race condition on xhamster.com where sometimes the page loads with a blur filter and the age consent dialog doesn't appear. We've noticed that the Sign in with Google pop up provides an escape hatch in this situation, so we are unhiding it to allow users to access the site when they find themselves in this state.

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

