### PR TITLE
Disable dummyWebMessageListener

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -1106,7 +1106,7 @@
             }
         },
         "dummyWebMessageListener": {
-            "state": "enabled"
+            "state": "disabled"
         }
     },
     "unprotectedTemporary": [],


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:** https://app.asana.com/0/1200204095367872/1207356925864046/f

## Description
Disable this feature since `addWebMessageListener` is still problematic, even with our guards in place.

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

