### PR TITLE
Unprotected libre apps as reported by users

### DIFF
--- a/features/app-tracker-protection.json
+++ b/features/app-tracker-protection.json
@@ -241,6 +241,14 @@
             ],
             "unprotectedApps": [
                 {
+                    "packageName": "com.freestylelibre.app.nl",
+                    "reason": "Users report app issues with AppTP enabled"
+                },
+                {
+                    "packageName": "com.freestylelibre3.app.nl",
+                    "reason": "Users report app issues with AppTP enabled"
+                },
+                {
                     "packageName": "android.service.ims",
                     "reason": "App is a system app that supports other apps and system functions"
                 },


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:**https://app.asana.com/0/1198194956794324/1207397568920995/f

## Description
Unprotect libre (health) apps as reported by users not working when AppTP is enabled.


#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

