### PR TITLE
Add GPC exception for milesplit.live

### DIFF
--- a/features/gpc.json
+++ b/features/gpc.json
@@ -54,6 +54,10 @@
         {
             "domain": "tirerack.com",
             "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1680"
+        },
+        {
+            "domain": "milesplit.live",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2100"
         }
     ],
     "settings": {


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:** https://app.asana.com/0/1206670747178362/1207355835687714/f

## Description
For whatever reason, this site isn't loading correctly on certain platforms (iOS, Android, macOS) when the Global Privacy Control signal is set.

Sample url: https://milesplit.live/meets/579175

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

