### PR TITLE
Add GPC exception for dollargeneral.com

### DIFF
--- a/features/gpc.json
+++ b/features/gpc.json
@@ -58,6 +58,10 @@
         {
             "domain": "milesplit.live",
             "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2100"
+        },
+        {
+            "domain": "dollargeneral.com",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2101"
         }
     ],
     "settings": {


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:** https://app.asana.com/0/1206670747178362/1207389227275283/f

## Description
With the Global Privacy Control signal set, the Deals section of this site (https://www.dollargeneral.com/deals) doesn't work properly. Adding an exception for now, will follow up by contacting the site owner.

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

