### PR TITLE
Hide empty spaces on finance.yahoo.com

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -2967,8 +2967,8 @@
                         "type": "closest-empty"
                     },
               	    {
-                	"selector": "[class*='sdaContainer']",
-                	"type": "hide-empty"
+                        "selector": "[class*='sdaContainer']",
+                        "type": "hide-empty"
               	    }
                 ]    
             },

--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -2965,7 +2965,11 @@
                     {
                         "selector": ".gam-placeholder",
                         "type": "closest-empty"
-                    }
+                    },
+              	    {
+                	"selector": "[class*='sdaContainer']",
+                	"type": "hide-empty"
+              	    }
                 ]    
             },
             {


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:**
https://app.asana.com/0/1200277586140538/1207389230504250/f

## Description
Adding a rule to hide empty banner head and middle space on finance section of yahoo.com.

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

