### PR TITLE
Workaround issue collapsing empty spaces on finance.yahoo.com

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -2966,11 +2966,11 @@
                         "selector": ".gam-placeholder",
                         "type": "closest-empty"
                     },
-              	    {
+                    {
                         "selector": "[class*='sdaContainer']",
-                        "type": "hide-empty"
-              	    }
-                ]    
+                        "type": "hide"
+                    }
+                ]
             },
             {
                 "domain": "gazeta.pl",


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/0/1206670747178362/1207407943495825/f

## Description
There seems to be an issue with "hide-empty" element hiding rules
causing the matching elements to sometimes not be collapsed, even when
they are empty. This led to lots of empty space on
finance.yahoo.com. For now, let's switch the failing rule to type
"hide" as a workaround.

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

