### PR TITLE
Mitigate blocking issues for docs.llamaindex.ai on macos

### DIFF
--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -796,14 +796,14 @@
                             }
                         ]
                     },
-                                        "googletagmanager.com": {
+                    "googletagmanager.com": {
                         "rules": [
                             {
                                 "rule": "googletagmanager.com/gtag/js",
                                 "domains": [
                                     "docs.llamaindex.ai"
                                 ],
-                                "reason": "blinking privacy icon"
+                                "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2125"
                             }
                         ]
                     },
@@ -830,7 +830,10 @@
                                     "edx.org",
                                     "docs.llamaindex.ai"
                                 ],
-                                "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1596"
+                                "reason": [
+                                    "edx.org - https://github.com/duckduckgo/privacy-configuration/issues/1596",
+                                    "llamaindex.ai - https://github.com/duckduckgo/privacy-configuration/pull/2125"
+                                ]
                             }
                         ]
                     },

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -796,6 +796,17 @@
                             }
                         ]
                     },
+                                        "googletagmanager.com": {
+                        "rules": [
+                            {
+                                "rule": "googletagmanager.com/gtag/js",
+                                "domains": [
+                                    "docs.llamaindex.ai"
+                                ],
+                                "reason": "blinking privacy icon"
+                            }
+                        ]
+                    },
                     "googletagservices.com": {
                         "rules": [
                             {
@@ -816,7 +827,8 @@
                             {
                                 "rule": "google-analytics.com/analytics.js",
                                 "domains": [
-                                    "edx.org"
+                                    "edx.org",
+                                    "docs.llamaindex.ai"
                                 ],
                                 "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1596"
                             }


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:**
https://app.asana.com/0/1201048563534612/1207415423508161/f

## Description
Something peculiar is happening with the privacy icon when blocking trackers on this site, so we're unblocking a couple of google domains while we figure out what the underlying fix should be.

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

