### PR TITLE
Update storeHistory rollout percentage to 25

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -410,7 +410,7 @@
                     "rollout": {
                         "steps": [
                             {
-                                "percent": 50
+                                "percent": 25
                             }
                         ]
                     }


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:** https://app.asana.com/0/0/1206414280586487/1207470901449145/f

## Description
Update storeHistory rollout percentage to 25% (feature hasn't been rolled out yet)


#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

