### PR TITLE
Add Windows spell checker toggle

### DIFF
--- a/features/windows-spell-checker.json
+++ b/features/windows-spell-checker.json
@@ -1,0 +1,7 @@
+{
+    "_meta": {
+        "description": "Spell checker on Windows Browser"
+    },
+    "exceptions": [],
+    "state": "enabled"
+}

--- a/features/windows-spell-checker.json
+++ b/features/windows-spell-checker.json
@@ -2,6 +2,5 @@
     "_meta": {
         "description": "Spell checker on Windows Browser"
     },
-    "exceptions": [],
-    "state": "enabled"
+    "exceptions": []
 }

--- a/index.js
+++ b/index.js
@@ -132,6 +132,8 @@ const excludedFeaturesFromUnprotectedTempExceptions = [
     'windowsPermissionUsage',
     'windowsWaitlist',
     'windowsDownloadLink',
+    'windowsSpellChecker',
+    'windowsStartupBoost',
     'dbp',
     'sync',
     'mediaPlaybackRequiresUserGesture',

--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -240,6 +240,9 @@
                     "state": "enabled"
                 }
             }
+        },
+        "windowsSpellChecker": {
+            "state": "enabled"
         }
     },
     "unprotectedTemporary": []


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/0/72649045549333/1207193591594854/f

## Description
Allows toggling Windows browser spell checker on and off remotely. The default is "on".

#### Additionally
Add the `windowsStartupBoost` feature to the `excludedFeaturesFromUnprotectedTempExceptions` list.

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

