### PR TITLE
Disable extended onboarding experiment

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -1099,7 +1099,7 @@
             "state": "enabled",
             "features": {
               "comparisonChart": {
-                "state": "enabled",
+                "state": "disabled",
                 "targets": [
                   {
                     "variantKey": "mt"
@@ -1107,12 +1107,7 @@
                 ]
               },
               "aestheticUpdates": {
-                "state": "enabled",
-                "targets": [
-                  {
-                    "variantKey": "mt"
-                  }
-                ]
+                "state": "enabled"
               }
             }
         },
@@ -1132,34 +1127,6 @@
                 "desc": "this is SERP don't remove",
                 "variantKey": "se",
                 "weight": 0
-            },
-            {
-                "desc": "Control group for extended onboarding experiment",
-                "variantKey": "ms",
-                "weight": 0,
-                "filters": {
-                    "locale": [
-                        "en_US",
-                        "en_UK",
-                        "en_CA",
-                        "en_IN",
-                        "en_AU"
-                  ]
-                }
-            },
-            {
-                "desc": "Aesthetic updates in onboarding experimental group",
-                "variantKey": "mt",
-                "weight": 0,
-                "filters": {
-                    "locale": [
-                        "en_US",
-                        "en_UK",
-                        "en_CA",
-                        "en_IN",
-                        "en_AU"
-                  ]
-                }
             }
         ]
     }


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:** https://app.asana.com/0/1201807753394693/1207527924199129/f

## Description
Disable `comparison-chart` sub-feature and remove experimental variants

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

