### PR TITLE
Add samsung dialer in unhidesystemapps for app-tracker-protection.json

### DIFF
--- a/features/app-tracker-protection.json
+++ b/features/app-tracker-protection.json
@@ -729,6 +729,7 @@
                 "com.netflix.mediaclient",
                 "com.samsung.android.messaging",
                 "com.samsung.android.email.provider",
+                "com.samsung.android.dialer",
                 "com.samsung.attvvm",
                 "com.samsung.vvm",
                 "com.touchtype.swiftkey"


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:** https://app.asana.com/0/1201462763415876/1207559410044866/f

## Description


This should allow users to exclude the samsung Phone app from VPN / AppTP

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

