### PR TITLE
redirection on noaprints 

### DIFF
--- a/features/unprotected-temporary.json
+++ b/features/unprotected-temporary.json
@@ -17,6 +17,7 @@
         },
         {
             "domain": "noaprints.com",
-            "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2142"
+            "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2143"
+        }
     ]
 }

--- a/features/unprotected-temporary.json
+++ b/features/unprotected-temporary.json
@@ -14,6 +14,9 @@
         {
             "domain": "sundancecatalog.com",
             "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1420"
-        }
+        },
+        {
+            "domain": "noaprints.com",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2142"
     ]
 }


### PR DESCRIPTION
disable protections on noaprints

<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:**
https://app.asana.com/0/1206670747178362/1207570078578572

## Description
Page doesn't load due to a 'www' subdomain redirection. Needed to completely disable to fix this for now. 

<!--
If this is a SITE BREAKAGE MITIGATION, please include a BRIEF EXPLANATION that covers the REPORTED URL, the PLATFORMS AFFECTED, and the TRACKER(S) being unblocked or FEATURE being disabled, as well as a mention of the PROBLEM(S) users are experiencing. Please also check that you have referenced the URL of this PR as the "reason" value for the exception (where applicable).
-->

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

