### PR TITLE
Revert espn autoconsent exception

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -158,10 +158,6 @@
                 {
                     "domain": "instagram.com",
                     "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1856"
-                },
-                {
-                    "domain": "espn.com",
-                    "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1945"
                 }
             ],
             "settings": {


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:**
https://app.asana.com/0/1206670747178362/1206956633398518/f

## Description
<!--
If this is a SITE BREAKAGE MITIGATION, please include a BRIEF EXPLANATION that covers the REPORTED URL, the PLATFORMS AFFECTED, and the TRACKER(S) being unblocked or FEATURE being disabled, as well as a mention of the PROBLEM(S) users are experiencing. Please also check that you have referenced the URL of this PR as the "reason" value for the exception (where applicable).
-->
We should be in the clear here to remove the mitigation for cookie pop-up management (part of PR #1947) on espn.com for Android as the feature fix has rolled out to the vast majority of users.

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

