### PR TITLE
Add windowsPrecisionScroll feature

### DIFF
--- a/features/windows-precision-scroll.json
+++ b/features/windows-precision-scroll.json
@@ -1,0 +1,6 @@
+{
+    "_meta": {
+        "description": "Support for scrolling with precision touchpads in Windows Browser"
+    },
+    "exceptions": []
+}

--- a/index.js
+++ b/index.js
@@ -134,6 +134,7 @@ const excludedFeaturesFromUnprotectedTempExceptions = [
     'windowsDownloadLink',
     'windowsSpellChecker',
     'windowsStartupBoost',
+    'windowsPrecisionScroll',
     'dbp',
     'sync',
     'mediaPlaybackRequiresUserGesture',

--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -243,6 +243,9 @@
         },
         "windowsSpellChecker": {
             "state": "enabled"
+        },
+        "windowsPrecisionScroll": {
+            "state": "enabled"
         }
     },
     "unprotectedTemporary": []


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:**
https://app.asana.com/0/1201048563534612/1206815709655703/f

## Description
Allows toggling of Windows support for precision touchpads remotely. The default is "on".

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

