### PR TITLE
Mitigate blank page on codot.gov on Apple platforms

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -173,6 +173,10 @@
                     {
                         "domain": "xfinity.com",
                         "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2149"
+                    },
+                    {
+                        "domain": "codot.gov",
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2152"
                     }
                 ],
                 "ddgDefaultSites": [
@@ -196,6 +200,10 @@
                     {
                         "domain": "xfinity.com",
                         "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2149"
+                    },
+                    {
+                        "domain": "codot.gov",
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2152"
                     }
                 ],
                 "omitVersionSites": []

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -630,6 +630,10 @@
                     {
                         "domain": "xfinity.com",
                         "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2149"
+                    },
+                    {
+                        "domain": "codot.gov",
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2152"
                     }
                 ],
                 "webViewDefault": [


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:**
https://app.asana.com/0/1206670747178362/1207581550294298/f

## Description
<!--
If this is a SITE BREAKAGE MITIGATION, please include a BRIEF EXPLANATION that covers the REPORTED URL, the PLATFORMS AFFECTED, and the TRACKER(S) being unblocked or FEATURE being disabled, as well as a mention of the PROBLEM(S) users are experiencing. Please also check that you have referenced the URL of this PR as the "reason" value for the exception (where applicable).
-->
Users are reporting a blank page when attempting to go to codot.gov on iOS or macOS. By not sending our custom user agent, we can avoid this breakage for these platforms.

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

