### PR TITLE
Update codot.gov with temporary content blocking exception on Apple platforms

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -12,7 +12,12 @@
             }
         },
         "contentBlocking": {
-            "exceptions": []
+            "exceptions": [
+		{
+                    "domain": "codot.gov",
+                    "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2153"
+                }
+	    ]
         },
         "history": {
             "state": "enabled",
@@ -173,10 +178,6 @@
                     {
                         "domain": "xfinity.com",
                         "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2149"
-                    },
-                    {
-                        "domain": "codot.gov",
-                        "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2152"
                     }
                 ],
                 "ddgDefaultSites": [
@@ -200,10 +201,6 @@
                     {
                         "domain": "xfinity.com",
                         "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2149"
-                    },
-                    {
-                        "domain": "codot.gov",
-                        "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2152"
                     }
                 ],
                 "omitVersionSites": []

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -82,7 +82,12 @@
         },
         "contentBlocking": {
             "state": "enabled",
-            "exceptions": []
+            "exceptions": [
+                {
+                    "domain": "codot.gov",
+                    "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2153"
+                }
+            ]
         },
         "duckPlayer": {
             "state": "enabled"
@@ -630,10 +635,6 @@
                     {
                         "domain": "xfinity.com",
                         "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2149"
-                    },
-                    {
-                        "domain": "codot.gov",
-                        "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2152"
                     }
                 ],
                 "webViewDefault": [


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:**
https://app.asana.com/0/1206670747178362/1207581550294298/f

## Description
<!--
If this is a SITE BREAKAGE MITIGATION, please include a BRIEF EXPLANATION that covers the REPORTED URL, the PLATFORMS AFFECTED, and the TRACKER(S) being unblocked or FEATURE being disabled, as well as a mention of the PROBLEM(S) users are experiencing. Please also check that you have referenced the URL of this PR as the "reason" value for the exception (where applicable).
-->
The user agent mitigation didn't work after all, so rolling back changes from PR #2152 and temporarily unblocking all trackers on codot.gov on Apple platforms while we figure out if there's a way to keep the rocket-loader script from sabotaging page load.

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

