### PR TITLE
Mitigate chewy.com on Android looping on non-home pages

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -368,6 +368,10 @@
                 {
                     "domain": "crocs.com",
                     "reason": "https://github.com/duckduckgo/privacy-configuration/issues/567"
+                },
+                {
+                    "domain": "chewy.com",
+                    "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2154"
                 }
             ]
         },
@@ -531,6 +535,12 @@
             }
         },
         "webCompat": {
+            "exceptions": [
+                {
+                    "domain": "chewy.com",
+                    "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2154"
+                }
+            ],
             "state": "enabled",
             "settings": {
                 "domains": [
@@ -1162,12 +1172,7 @@
             }
         }
     },
-    "unprotectedTemporary": [
-            {
-                "domain": "chewy.com",
-                "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2154"
-            }
-    ],
+    "unprotectedTemporary": [],
     "experimentalVariants": {
         "variants": [
             {

--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -1162,7 +1162,12 @@
             }
         }
     },
-    "unprotectedTemporary": [],
+    "unprotectedTemporary": [
+            {
+                "domain": "chewy.com",
+                "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2154"
+            }
+    ],
     "experimentalVariants": {
         "variants": [
             {


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:**
https://app.asana.com/0/1206670747178362/1207598092378705/f

## Description
<!--
If this is a SITE BREAKAGE MITIGATION, please include a BRIEF EXPLANATION that covers the REPORTED URL, the PLATFORMS AFFECTED, and the TRACKER(S) being unblocked or FEATURE being disabled, as well as a mention of the PROBLEM(S) users are experiencing. Please also check that you have referenced the URL of this PR as the "reason" value for the exception (where applicable).
-->
All non-home pages on Chewy.com are in a never-ending loop stage and won't load with protections on. So far we can't find an individual feature that's causing the breakage so for now we're adding the domain to the unprotected temp list pending further investigation.

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

