### PR TITLE
Mitigate GPC signal causing click events to be disabled on npr.org

### DIFF
--- a/features/gpc.json
+++ b/features/gpc.json
@@ -66,6 +66,10 @@
         {
             "domain": "monstergear.monsterenergy.com",
             "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2122"
+        },
+        {
+            "domain": "npr.org",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2160"
         }
     ],
     "settings": {


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:**
https://app.asana.com/0/1206670747178362/1207608850967974/f

## Description
<!--
If this is a SITE BREAKAGE MITIGATION, please include a BRIEF EXPLANATION that covers the REPORTED URL, the PLATFORMS AFFECTED, and the TRACKER(S) being unblocked or FEATURE being disabled, as well as a mention of the PROBLEM(S) users are experiencing. Please also check that you have referenced the URL of this PR as the "reason" value for the exception (where applicable).
-->
For whatever reason, US-based users sending the GPC signal are seeing breakage where clicks no longer register after about a minute on npr.org. Not sending GPC on that site seems to resolve the issue. Still working on figuring out why this doesn't seem to fix the issue for users in the EU.

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

