### PR TITLE
Mitigate missing feedback button on walgreens.com

### DIFF
--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -2320,6 +2320,13 @@
                         "reason": "https://github.com/duckduckgo/privacy-configuration/issues/884"
                     },
                     {
+                        "rule": "digital-cloud-west.medallia.com/",
+                        "domains": [
+                            "walgreens.com"
+                        ],
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2161"
+                    },
+                    {
                         "rule": "survey.medallia.com/",
                         "domains": [
                             "<all>"


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:**
https://app.asana.com/0/1206670747178362/1207617867013676/f

## Description
<!--
If this is a SITE BREAKAGE MITIGATION, please include a BRIEF EXPLANATION that covers the REPORTED URL, the PLATFORMS AFFECTED, and the TRACKER(S) being unblocked or FEATURE being disabled, as well as a mention of the PROBLEM(S) users are experiencing. Please also check that you have referenced the URL of this PR as the "reason" value for the exception (where applicable).
-->
There's a sidebar feedback button missing on Walgreens.com due to us blocking a couple of requests to `digital-cloud-west.medallia.com`. By unblocking this Medallia subdomain on that site only, we can resolve the issue.

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

