### PR TITLE
Disable Cookie Prompt Management (CPM) for hertz.co.uk

### DIFF
--- a/features/autoconsent.json
+++ b/features/autoconsent.json
@@ -252,6 +252,10 @@
             "reason": "https://github.com/duckduckgo/autoconsent/issues/432"
         },
         {
+            "domain": "hertz.co.uk",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/issues/2061"
+        },
+        {
             "domain": "hertz.com",
             "reason": "https://github.com/duckduckgo/privacy-configuration/issues/2061"
         },


### PR DESCRIPTION
It seems that some pages on hertz.co.uk break entirely and won't load
if cookies are declined. We shouldn't automatically decline the
cookies for now therefore.

**Asana Task/Github Issue:** https://github.com/duckduckgo/privacy-configuration/issues/2061 and https://app.asana.com/0/1206670747178362/1207640308628819/f
