### PR TITLE
Add windows-external-preview-releases feature

### DIFF
--- a/features/windows-external-preview-releases.json
+++ b/features/windows-external-preview-releases.json
@@ -1,0 +1,6 @@
+{
+    "_meta": {
+        "description": "Allowing external users to get access to preview releases"
+    },
+    "exceptions": []
+}

--- a/index.js
+++ b/index.js
@@ -135,6 +135,7 @@ const excludedFeaturesFromUnprotectedTempExceptions = [
     'windowsSpellChecker',
     'windowsStartupBoost',
     'windowsPrecisionScroll',
+    'windowsExternalPreviewReleases',
     'dbp',
     'sync',
     'mediaPlaybackRequiresUserGesture',

--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -251,6 +251,14 @@
         },
         "windowsPrecisionScroll": {
             "state": "enabled"
+        },
+        "windowsExternalPreviewReleases": {
+            "state": "disabled",
+            "features": {
+                "allowLaunchingPreviewInstaller": {
+                    "state": "disabled"
+                }
+            }
         }
     },
     "unprotectedTemporary": []


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:** https://app.asana.com/0/72649045549333/1207029129196913/f

## Description
Adds a new Windows specific feature to control access to preview experiences. This way we can avoid oversubscribing to the preview versions.

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

