### PR TITLE
Remove dummyWebMessageListener feature

### DIFF
--- a/features/dummy-web-message-listener.json
+++ b/features/dummy-web-message-listener.json
@@ -1,7 +1,0 @@
-{
-    "_meta": {
-        "description": "Feature toggle to test addWebMessageListener().",
-        "sampleExcludeRecords": {}
-    },
-    "exceptions": []
-}

--- a/index.js
+++ b/index.js
@@ -143,7 +143,6 @@ const excludedFeaturesFromUnprotectedTempExceptions = [
     'privacyPro',
     'sslCertificates',
     'extendedOnboarding',
-    'dummyWebMessageListener',
     'webViewBlobDownload',
     'pluginPointFocusedViewPlugin',
     'pluginPointNewTabPagePlugin',

--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -1124,10 +1124,6 @@
                 }
             }
         },
-        "dummyWebMessageListener": {
-            "state": "enabled",
-            "minSupportedVersion": 52041000
-        },
         "webViewBlobDownload": {
             "state": "disabled"
         },


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:** https://app.asana.com/0/1200204095367872/1207677591009375/f

## Description
<!--
If this is a SITE BREAKAGE MITIGATION, please include a BRIEF EXPLANATION that covers the REPORTED URL, the PLATFORMS AFFECTED, and the TRACKER(S) being unblocked or FEATURE being disabled, as well as a mention of the PROBLEM(S) users are experiencing. Please also check that you have referenced the URL of this PR as the "reason" value for the exception (where applicable).
-->
Removes the `dummyWebMessageListener` feature as it is no longer needed.

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

