### PR TITLE
Temporarily disable CPM on instagram.com

### DIFF
--- a/features/autoconsent.json
+++ b/features/autoconsent.json
@@ -270,6 +270,10 @@
         {
             "domain": "lotusbakeries.com",
             "reason": "Scrolling is broken"
+        },
+        {
+            "domain": "instagram.com",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/issues/2172"
         }
     ],
     "settings": {


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:** https://app.asana.com/0/1206670747178362/1207674155332463/f

## Description
<!--
If this is a SITE BREAKAGE MITIGATION, please include a BRIEF EXPLANATION that covers the REPORTED URL, the PLATFORMS AFFECTED, and the TRACKER(S) being unblocked or FEATURE being disabled, as well as a mention of the PROBLEM(S) users are experiencing. Please also check that you have referenced the URL of this PR as the "reason" value for the exception (where applicable).
-->
We're receiving reports from users that they are unable to dismiss the cookie banner on instagram.com. Disabling CPM there to try to mitigate while we investigate the root cause.

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

