### PR TITLE
Disable Facebook "Click to Load" for Vinted

### DIFF
--- a/features/click-to-load.json
+++ b/features/click-to-load.json
@@ -606,7 +606,74 @@
     }, {
         "domain": "pocketbook.digital",
         "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1368"
-    }],
+    }, {
+        "domain": "vinted.at",
+        "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2174"
+    }, {
+        "domain": "vinted.be",
+        "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2174"
+    }, {
+        "domain": "vinted.com",
+        "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2174"
+    }, {
+        "domain": "vinted.co.uk",
+        "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2174"
+    }, {
+        "domain": "vinted.cz",
+        "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2174"
+    }, {
+        "domain": "vinted.de",
+        "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2174"
+    }, {
+        "domain": "vinted.dk",
+        "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2174"
+    }, {
+        "domain": "vinted.es",
+        "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2174"
+    }, {
+        "domain": "vinted.fi",
+        "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2174"
+    }, {
+        "domain": "vinted.fr",
+        "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2174"
+    }, {
+        "domain": "vinted.gr",
+        "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2174"
+    }, {
+        "domain": "vinted.hr",
+        "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2174"
+    }, {
+        "domain": "vinted.hu",
+        "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2174"
+    }, {
+        "domain": "vinted.it",
+        "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2174"
+    }, {
+        "domain": "vinted.lt",
+        "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2174"
+    }, {
+        "domain": "vinted.lu",
+        "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2174"
+    }, {
+        "domain": "vinted.nl",
+        "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2174"
+    }, {
+        "domain": "vinted.pl",
+        "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2174"
+    }, {
+        "domain": "vinted.pt",
+        "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2174"
+    }, {
+        "domain": "vinted.ro",
+        "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2174"
+    }, {
+        "domain": "vinted.se",
+        "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2174"
+    }, {
+        "domain": "vinted.sk",
+        "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2174"
+    }
+  ],
     "settings": {
         "Facebook, Inc.": {
             "ruleActions": ["block-ctl-fb"]


### PR DESCRIPTION
The Facebook login button on Vinted is greyed out, until we can
investigate what's happening let's just disable Facebook "Click to
Load" for the website.

<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:** https://app.asana.com/0/1206670747178362/1207681516223914/f

## Description
<!--
If this is a SITE BREAKAGE MITIGATION, please include a BRIEF EXPLANATION that covers the REPORTED URL, the PLATFORMS AFFECTED, and the TRACKER(S) being unblocked or FEATURE being disabled, as well as a mention of the PROBLEM(S) users are experiencing. Please also check that you have referenced the URL of this PR as the "reason" value for the exception (where applicable).
-->

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

