### PR TITLE
New subfeature for Duck Player with overrides for MacOS and Windows

### DIFF
--- a/features/duck-player.json
+++ b/features/duck-player.json
@@ -7,6 +7,9 @@
     "features": {
         "pip": {
             "state": "disabled"
+        },
+        "autoplay": {
+            "state": "disabled"
         }
     },
     "settings": {

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -89,7 +89,11 @@
             "features": {
                 "pip": {
                     "state": "enabled"
+                },
+                "autoplay": {
+                    "state": "disabled"
                 }
+
             }
         },
         "newTabContinueSetUp": {

--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -72,6 +72,9 @@
             "features": {
                 "pip": {
                     "state": "enabled"
+                },
+                "autoplay": {
+                    "state": "disabled"
                 }
             }
         },


### PR DESCRIPTION

**Asana Task/Github Issue:**https://app.asana.com/0/0/1207677983109067/f

## Description
I would like to add `autoplay` as new sub-feature flag for Duck Player. I updated the overloads for MacOS and Windows. 

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

