### PR TITLE
Tighten up instagram element hiding rule to ensure it only targets cookie consent dialog

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -1719,7 +1719,7 @@
                 "domain": "instagram.com",
                 "rules": [
                     {
-                        "selector": ".x1n2onr6.xzkaem6:not(:has([aria-label='Close'])):not(:has(._a9--._a9_1)):not(:has(.x1swf91x))",
+                        "selector": ".x1n2onr6.xzkaem6:not(:has([aria-label='Close'])):has([aria-label='Language'])",
                         "type": "hide"
                     }
                 ]

--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -1719,7 +1719,7 @@
                 "domain": "instagram.com",
                 "rules": [
                     {
-                        "selector": ".x1n2onr6.xzkaem6",
+                        "selector": ".x1n2onr6.xzkaem6:not(:has([aria-label='Close'])):not(:has(._a9--._a9_1)):not(:has(.x1swf91x))",
                         "type": "hide"
                     }
                 ]


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:** https://app.asana.com/0/1206780406371845/1207680379720329/f

## Description
<!--
If this is a SITE BREAKAGE MITIGATION, please include a BRIEF EXPLANATION that covers the REPORTED URL, the PLATFORMS AFFECTED, and the TRACKER(S) being unblocked or FEATURE being disabled, as well as a mention of the PROBLEM(S) users are experiencing. Please also check that you have referenced the URL of this PR as the "reason" value for the exception (where applicable).
-->
Adds specificity to element hiding rule that mitigates a cookie consent bug on instagram.com to ensure other separate elements aren't affected.

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

