### PR TITLE
Add Remote Messaging feature flag

### DIFF
--- a/features/remote-messaging.json
+++ b/features/remote-messaging.json
@@ -1,0 +1,8 @@
+{
+    "_meta": {
+        "description": "Remote Messaging Framework for native clients. Allows to put messages in front of users without having to do a new app release.",
+        "sampleExcludeRecords": {}
+    },
+    "state": "disabled",
+    "exceptions": []
+}

--- a/index.js
+++ b/index.js
@@ -128,6 +128,7 @@ const excludedFeaturesFromUnprotectedTempExceptions = [
     'newTabContinueSetUp',
     'privacyDashboard',
     'privacyProtectionsPopup',
+    'remoteMessaging',
     'voiceSearch',
     'windowsPermissionUsage',
     'windowsWaitlist',

--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -157,6 +157,9 @@
         "referrer": {
             "state": "disabled"
         },
+        "remoteMessaging": {
+            "state": "enabled"
+        },
         "customUserAgent": {
             "state": "enabled",
             "settings": {


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:** https://app.asana.com/0/72649045549333/1207481940843750/f

## Description
This change introduces `remoteMessaging` feature to be used by desktop browsers and iOS, after we release
support for macOS (iOS gets it for free because of the shared codebase, hence this change already enables
remote messaging on iOS). Android is not using that flag for now. Flag remains disabled on macOS and Windows
until we're ready to turn it on (a separate PRs will be submitted to do that).

<!--
If this is a SITE BREAKAGE MITIGATION, please include a BRIEF EXPLANATION that covers the REPORTED URL, the PLATFORMS AFFECTED, and the TRACKER(S) being unblocked or FEATURE being disabled, as well as a mention of the PROBLEM(S) users are experiencing. Please also check that you have referenced the URL of this PR as the "reason" value for the exception (where applicable).
-->

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

