### PR TITLE
Enable `noBrowserCtas` experiment variants

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -1194,12 +1194,12 @@
             {
                 "desc": "Control group for not showing onboarding CTAs experiment",
                 "variantKey": "mp",
-                "weight": 0
+                "weight": 1
             },
             {
                 "desc": "Dax dialogs removal during onboarding experimental group",
                 "variantKey": "mo",
-                "weight": 0
+                "weight": 1
             }
         ]
     }


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:** https://app.asana.com/0/1201807753394693/1207612915823912/f

## Description
Enable experimental variants for remove in-context dax dialogs experiment.

- `mp`: Control
- `mo`: Experiment

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

