### PR TITLE
Element hiding: address large empty ad space at top of page on eporner.com

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -1143,6 +1143,15 @@
                 ]
             },
             {
+                "domain": "eporner.com",
+                "rules": [
+                    {
+                        "selector": "#admobiletop",
+                        "type": "hide"
+                    }
+                ]
+            },
+            {
                 "domain": "essentiallysports.com",
                 "rules": [
                     {


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:** https://app.asana.com/0/246491496396031/1207693176717769/f

## Description
<!--
If this is a SITE BREAKAGE MITIGATION, please include a BRIEF EXPLANATION that covers the REPORTED URL, the PLATFORMS AFFECTED, and the TRACKER(S) being unblocked or FEATURE being disabled, as well as a mention of the PROBLEM(S) users are experiencing. Please also check that you have referenced the URL of this PR as the "reason" value for the exception (where applicable).
-->
Address large empty ad space at top of page on eporner.com

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

