### PR TITLE
Enable deduplication of imported logins on macOS

### DIFF
--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -487,7 +487,12 @@
             "state": "enabled"
         },
         "autofill": {
-            "state": "enabled"
+            "state": "enabled",
+            "features": {
+                "deduplicateLoginsOnImport": {
+                    "state": "enabled"
+                }
+            }
         },
         "incontextSignup": {
             "state": "enabled"


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/0/0/1207675780406461/f

## Description

We're adding a feature to remove duplicate autofill login entries from imported data. We should ship with this on but, in the case that we receive negative user feedback from the results, we should also provide a quick way to disable it remotely.

This adds the autofill sub-feature and sets it to be enabled (it's not been shipped yet so this is low risk).

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

