### PR TITLE
Add DuckPlayer openInNewTab feature

### DIFF
--- a/features/duck-player.json
+++ b/features/duck-player.json
@@ -10,6 +10,9 @@
         },
         "autoplay": {
             "state": "disabled"
+        },
+        "openInNewTab": {
+            "state": "disabled"
         }
     },
     "settings": {

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -92,6 +92,9 @@
                 },
                 "autoplay": {
                     "state": "disabled"
+                },
+                "openInNewTab": {
+                    "state": "disabled"
                 }
 
             }

--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -75,6 +75,9 @@
                 },
                 "autoplay": {
                     "state": "disabled"
+                },
+                "openInNewTab": {
+                    "state": "disabled"
                 }
             }
         },


### PR DESCRIPTION
**Asana Task/Github Issue:**
Task: https://app.asana.com/0/1201011656765697/1207755055886854/f

## Description
Adds `openInNewTab` as new sub-feature flag for Duck Player. Adds overrides for MacOS and Windows.

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

