### PR TITLE
Add Windows team as code owners for `windows-override.json`

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -24,4 +24,4 @@ overrides/android-override.json @duckduckgo/config-aor @marcosholgado @joshliebe
 overrides/extension-override.json @duckduckgo/config-aor @kzar @duckduckgo/breakage-aor @duckduckgo/breakage @duckduckgo/content-scope-scripts-owners
 overrides/ios-override.json @duckduckgo/config-aor @duckduckgo/apple-devs @duckduckgo/breakage-aor @duckduckgo/breakage @duckduckgo/content-scope-scripts-owners
 overrides/macos-override.json @duckduckgo/config-aor @duckduckgo/apple-devs @duckduckgo/breakage-aor @duckduckgo/breakage @duckduckgo/content-scope-scripts-owners
-overrides/windows-override.json @duckduckgo/config-aor @q71114 @szanto90balazs @duckduckgo/breakage-aor @duckduckgo/breakage @duckduckgo/content-scope-scripts-owners
+overrides/windows-override.json @duckduckgo/config-aor @duckduckgo/team-windows-development @duckduckgo/breakage-aor @duckduckgo/breakage @duckduckgo/content-scope-scripts-owners


### PR DESCRIPTION
**Asana Task/Github Issue:** N/A

## Description
The Windows team grew from 4 to 15 engineers but the code owners file hasn't been updated to accommodate this change.

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

