### PR TITLE
added feature flag for running experiment on duck player on windows only

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -78,6 +78,9 @@
                 },
                 "openInNewTab": {
                     "state": "disabled"
+                },
+                "overlayExperiment": {
+                    "state": "enabled"
                 }
             }
         },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/0/1205889582400204/1207786329708163/f

## Description
Added a feature flag for DuckPlayer to enable or disable an experiment. The experiment will run for a short amount of time on Windows only so there is no need to add it to the main config. 

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

