### PR TITLE
iOS & Android: Adds new autofillBreakageReporter feature flag

### DIFF
--- a/features/autofill-breakage-reporter.json
+++ b/features/autofill-breakage-reporter.json
@@ -1,0 +1,14 @@
+{
+    "_meta": {
+        "description": "Allow users to submit autofill site breakage reports",
+        "sampleExcludeRecords": {
+            "domain": "example.com",
+            "reason": "site breakage"
+        }
+    },
+    "state": "disabled",
+    "settings": {
+        "monitorIntervalDays": 42
+    },
+    "exceptions": []
+}

--- a/index.js
+++ b/index.js
@@ -151,7 +151,8 @@ const excludedFeaturesFromUnprotectedTempExceptions = [
     'pluginPointNewTabPageShortcutPlugin',
     'brokenSiteReportExperiment',
     'toggleReports',
-    'androidNewStateKillSwitch'
+    'androidNewStateKillSwitch',
+    'autofillBreakageReporter'
 ]
 function applyGlobalUnprotectedTempExceptionsToFeatures (key, baseConfig, globalExceptions) {
     if (!excludedFeaturesFromUnprotectedTempExceptions.includes(key)) {

--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -230,6 +230,14 @@
                 }
             }
         },
+        "autofillBreakageReporter": {
+            "state": "enabled",
+            "settings": {
+                "monitorIntervalDays": 42
+            },
+            "exceptions": []
+        },
+
         "androidBrowserConfig": {
             "state": "enabled",
             "features": {

--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -231,11 +231,7 @@
             }
         },
         "autofillBreakageReporter": {
-            "state": "enabled",
-            "settings": {
-                "monitorIntervalDays": 42
-            },
-            "exceptions": []
+            "state": "enabled"
         },
         "androidBrowserConfig": {
             "state": "enabled",

--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -237,7 +237,6 @@
             },
             "exceptions": []
         },
-
         "androidBrowserConfig": {
             "state": "enabled",
             "features": {

--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -150,6 +150,13 @@
                 }
             }
         },
+        "autofillBreakageReporter": {
+            "state": "enabled",
+            "settings": {
+                "monitorIntervalDays": 42
+            },
+            "exceptions": []
+        },
         "incontextSignup": {
             "state": "enabled",
             "minSupportedVersion": "7.87.0",

--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -151,11 +151,7 @@
             }
         },
         "autofillBreakageReporter": {
-            "state": "enabled",
-            "settings": {
-                "monitorIntervalDays": 42
-            },
-            "exceptions": []
+            "state": "enabled"
         },
         "incontextSignup": {
             "state": "enabled",


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:**
https://app.asana.com/0/1201645688934642/1207323756661954/f
cc: @CDRussell 

## Description
<!--
If this is a SITE BREAKAGE MITIGATION, please include a BRIEF EXPLANATION that covers the REPORTED URL, the PLATFORMS AFFECTED, and the TRACKER(S) being unblocked or FEATURE being disabled, as well as a mention of the PROBLEM(S) users are experiencing. Please also check that you have referenced the URL of this PR as the "reason" value for the exception (where applicable).
-->
This change introduces the `autofillBreakageReporter` feature to be used on both mobile platforms (iOS & Android) to dynamically control access to a new UI feature that allows users to report autofill breakages. The feature also includes the option for site exceptions and the setting `monitorIntervalDays` which will allow us to dynamically control how many days it will be before a user can report the same site again.

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

