### PR TITLE
Add PhishingDetection Remote Feature

### DIFF
--- a/features/phishing-detection.json
+++ b/features/phishing-detection.json
@@ -1,0 +1,8 @@
+{
+    "_meta": {
+        "description": "Phishing Detection",
+        "sampleExcludeRecords": {}
+    },
+    "state": "disabled",
+    "exceptions": []
+}

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -1000,6 +1000,9 @@
             "features": {
                 "allowBypass": {
                     "state": "internal"
+                },
+                "allowPreferencesToggle": {
+                    "state": "internal"
                 }
             }
         }

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -998,7 +998,7 @@
         "phishingDetection": {
             "state": "internal",
             "features": {
-                "allowBypass": {
+                "allowErrorPage": {
                     "state": "internal"
                 },
                 "allowPreferencesToggle": {

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -994,6 +994,14 @@
         },
         "remoteMessaging": {
             "state": "internal"
+        },
+        "phishingDetection": {
+            "state": "internal",
+            "features": {
+                "allowBypass": {
+                    "state": "internal"
+                }
+            }
         }
     },
     "unprotectedTemporary": []


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:** https://app.asana.com/0/72649045549333/1207815984446007/f

## Description
<!--
If this is a SITE BREAKAGE MITIGATION, please include a BRIEF EXPLANATION that covers the REPORTED URL, the PLATFORMS AFFECTED, and the TRACKER(S) being unblocked or FEATURE being disabled, as well as a mention of the PROBLEM(S) users are experiencing. Please also check that you have referenced the URL of this PR as the "reason" value for the exception (where applicable).
-->
In https://app.asana.com/0/1204023833050360/1203766335877529/f we are planning a lengthened internal release cycle of our phishing protection feature. As such we want a remote configuration to allow us to enable the feature via privacy config.

There are currently two required subfeatures:
1. allowErrorPage -> allow the phishing error pages to be shown, basically the main toggle for the feature
2. allowPreferencesToggle -> allow the feature to be disabled via Settings>General 

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

