### PR TITLE
Disable webcompat on crocs.com

### DIFF
--- a/features/web-compat.json
+++ b/features/web-compat.json
@@ -6,5 +6,10 @@
             "reason": "site breakage"
         }
     },
-    "exceptions": []
+    "exceptions": [
+        {
+            "domain": "crocs.com",
+            "reason": "Debugger added exception"
+        }
+    ]
 }


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:** https://app.asana.com/0/1206670747178362/1207837562106973/f

## Description
When visiting crocs.com, the page loads blank after going through the Cloudflare prompt. With webcompat disabled, the page loads correctly.

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

