### PR TITLE
Add Android team as code owners for android-override.json

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -20,7 +20,7 @@ features/incontext-signup.json @duckduckgo/config-aor @alistairjcbrown @duckduck
 
 # Platform owners
 overrides/browsers/ @duckduckgo/config-aor @kzar @duckduckgo/breakage-aor @duckduckgo/breakage @duckduckgo/content-scope-scripts-owners
-overrides/android-override.json @duckduckgo/config-aor @marcosholgado @joshliebe @aitorvs @duckduckgo/breakage-aor @duckduckgo/breakage @duckduckgo/content-scope-scripts-owners
+overrides/android-override.json @duckduckgo/config-aor @duckduckgo/android-devs @duckduckgo/breakage-aor @duckduckgo/breakage @duckduckgo/content-scope-scripts-owners
 overrides/extension-override.json @duckduckgo/config-aor @kzar @duckduckgo/breakage-aor @duckduckgo/breakage @duckduckgo/content-scope-scripts-owners
 overrides/ios-override.json @duckduckgo/config-aor @duckduckgo/apple-devs @duckduckgo/breakage-aor @duckduckgo/breakage @duckduckgo/content-scope-scripts-owners
 overrides/macos-override.json @duckduckgo/config-aor @duckduckgo/apple-devs @duckduckgo/breakage-aor @duckduckgo/breakage @duckduckgo/content-scope-scripts-owners


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:** n/a

## Description
Currently, only a few people from the Android team are flagged as codeowners for the `android-override` and we'd like to be able to merge PRs affecting just us, especially in case we need to activate a kill-switch in case of an incident.

Android equivalent of what we did for Windows devs: https://github.com/duckduckgo/privacy-configuration/pull/2191

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

