### PR TITLE
Disable click to load on tinder.com (macOS only)

### DIFF
--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -483,7 +483,13 @@
                 "Youtube": {
                     "state": "disabled"
                 }
-            }
+            },
+            "exceptions": [
+                {
+                    "domain": "tinder.com",
+                    "reason": "Grayed out Facebook login button"
+                }
+            ]
         },
         "clickToPlay": {
             "state": "enabled"


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:** https://app.asana.com/0/1206670747178362/1207839588180226/f

## Description
<!--
If this is a SITE BREAKAGE MITIGATION, please include a BRIEF EXPLANATION that covers the REPORTED URL, the PLATFORMS AFFECTED, and the TRACKER(S) being unblocked or FEATURE being disabled, as well as a mention of the PROBLEM(S) users are experiencing. Please also check that you have referenced the URL of this PR as the "reason" value for the exception (where applicable).
-->
On https://tinder.com/, which trying to login, the 'Login with Facebook' button is grayed out on macOS. This is caused by blocking done by the click to load feature.

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

