### PR TITLE
Disable `noBrowserCtas` experiment

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -1107,7 +1107,7 @@
                     "state": "enabled"
                 },
                 "noBrowserCtas": {
-                    "state": "enabled",
+                    "state": "disabled",
                     "targets": [
                         {
                             "variantKey": "mo"
@@ -1198,12 +1198,12 @@
             {
                 "desc": "Control group for not showing onboarding CTAs experiment",
                 "variantKey": "mp",
-                "weight": 1
+                "weight": 0
             },
             {
                 "desc": "Dax dialogs removal during onboarding experimental group",
                 "variantKey": "mo",
-                "weight": 1
+                "weight": 0
             }
         ]
     }


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:** https://app.asana.com/0/1201807753394693/1207562036454792/f

## Description
Disable `noBrowserCtas` subfeature and set weight to 0 for experimental variants

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

