### PR TITLE
add apples full exception and 3pcookie for the rest of platforms

### DIFF
--- a/features/cookie.json
+++ b/features/cookie.json
@@ -54,6 +54,10 @@
         {
             "domain": "news.ti.com",
             "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1677"
+        },
+        {
+            "domain": "instructure.com",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/issues/2212"
         }
     ]
 }

--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -458,5 +458,10 @@
             "state": "enabled"
         }
     },
-    "unprotectedTemporary": []
+    "unprotectedTemporary": [
+        {
+            "domain": "instructure.com",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/issues/2212"
+        }
+    ]
 }

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -1013,5 +1013,10 @@
             }
         }
     },
-    "unprotectedTemporary": []
+    "unprotectedTemporary": [
+        {
+            "domain": "instructure.com",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/issues/2212"
+        }
+    ]
 }


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:**
https://app.asana.com/0/1206670747178362/1206642861917322/f

## Description
<!--
If this is a SITE BREAKAGE MITIGATION, please include a BRIEF EXPLANATION that covers the REPORTED URL, the PLATFORMS AFFECTED, and the TRACKER(S) being unblocked or FEATURE being disabled, as well as a mention of the PROBLEM(S) users are experiencing. Please also check that you have referenced the URL of this PR as the "reason" value for the exception (where applicable).
-->

blocking 3rd-party session cookie breaks third-party tools in use by instructure's domains. MacOS/iOS are being completely off where such cookies are turned off on other platforms.

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

