### PR TITLE
Disable Cookie Prompt Management (CPM) for dailymail.co.uk

### DIFF
--- a/features/autoconsent.json
+++ b/features/autoconsent.json
@@ -274,6 +274,10 @@
         {
             "domain": "harley-davidson.com",
             "reason": "blank screen"
+        },
+        {
+            "domain": "dailymail.co.uk",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2216"
         }
     ],
     "settings": {


### PR DESCRIPTION
Cookie Prompt Management isn't working for dailymail.co.uk at the
moment. The prompt is hidden initially, but the user can't then scroll
and has to wait for the prompt to be shown again some time later.

<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:**

## Description
<!--
If this is a SITE BREAKAGE MITIGATION, please include a BRIEF EXPLANATION that covers the REPORTED URL, the PLATFORMS AFFECTED, and the TRACKER(S) being unblocked or FEATURE being disabled, as well as a mention of the PROBLEM(S) users are experiencing. Please also check that you have referenced the URL of this PR as the "reason" value for the exception (where applicable).
-->

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

