### PR TITLE
Hide empty whitespace in footer of asuracomit.net

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -693,6 +693,15 @@
                 ]
             },
             {
+                "domain": "asuracomic.net",
+                "rules": [
+                    {
+                        "selector": ".h12container",
+                        "type": "hide"
+                    }
+                ]
+            },
+            {
                 "domain": "avito.ru",
                 "rules": [
                     {


### PR DESCRIPTION
For some reason, the `.h12container` element that sometimes contains
adverts at the footer of the page is displayed as a white block that
users complain breaks the site. Hiding that seems to fix the issue,
note that it doesn't hide the advert contained, but it looks less
broken and seems to help fix the close advert button.

Note: I initially tried adding a "hide-empty" rule, but it didn't seem
      to be enough here.

<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:**

## Description
<!--
If this is a SITE BREAKAGE MITIGATION, please include a BRIEF EXPLANATION that covers the REPORTED URL, the PLATFORMS AFFECTED, and the TRACKER(S) being unblocked or FEATURE being disabled, as well as a mention of the PROBLEM(S) users are experiencing. Please also check that you have referenced the URL of this PR as the "reason" value for the exception (where applicable).
-->

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

