### PR TITLE
Disable CPM on Newsforkids.net to fix stuck gray overlay

### DIFF
--- a/features/autoconsent.json
+++ b/features/autoconsent.json
@@ -278,6 +278,10 @@
         {
             "domain": "dailymail.co.uk",
             "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2216"
+        },
+        {
+            "domain": "newsforkids.net",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2223"
         }
     ],
     "settings": {


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:**
https://app.asana.com/0/1206670747178362/1207969679768408/f

## Description
<!--
If this is a SITE BREAKAGE MITIGATION, please include a BRIEF EXPLANATION that covers the REPORTED URL, the PLATFORMS AFFECTED, and the TRACKER(S) being unblocked or FEATURE being disabled, as well as a mention of the PROBLEM(S) users are experiencing. Please also check that you have referenced the URL of this PR as the "reason" value for the exception (where applicable).
-->
With current cookie pop-up handling, newsforkids.net can't be interacted with because an overlay remains.

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

