### PR TITLE
Rename subfeature in windows-external-preview-releases

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -264,7 +264,7 @@
         "windowsExternalPreviewReleases": {
             "state": "disabled",
             "features": {
-                "allowLaunchingPreviewInstaller": {
+                "allowOpenPreviewReleaseHelpPage": {
                     "state": "disabled"
                 }
             }


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:** https://app.asana.com/0/72649045549333/1207029129196913/f

## Description
<!--
If this is a SITE BREAKAGE MITIGATION, please include a BRIEF EXPLANATION that covers the REPORTED URL, the PLATFORMS AFFECTED, and the TRACKER(S) being unblocked or FEATURE being disabled, as well as a mention of the PROBLEM(S) users are experiencing. Please also check that you have referenced the URL of this PR as the "reason" value for the exception (where applicable).
-->
Rename the subfeature `allowLaunchingPreviewInstaller `to `allowOpenPreviewReleaseHelpPage `to match the approach we are taking for installing preview releases.


#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

