### PR TITLE
Add FF for web broken site form on Android

### DIFF
--- a/features/web-broken-site-form.json
+++ b/features/web-broken-site-form.json
@@ -1,0 +1,7 @@
+{
+    "_meta": {
+        "description": "Use web version of the site breakage reporting form instead of the native one on Android."
+    },
+    "state": "disabled",
+    "exceptions": []
+}

--- a/index.js
+++ b/index.js
@@ -152,7 +152,8 @@ const excludedFeaturesFromUnprotectedTempExceptions = [
     'brokenSiteReportExperiment',
     'toggleReports',
     'androidNewStateKillSwitch',
-    'autofillBreakageReporter'
+    'autofillBreakageReporter',
+    'webBrokenSiteForm'
 ]
 function applyGlobalUnprotectedTempExceptionsToFeatures (key, baseConfig, globalExceptions) {
     if (!excludedFeaturesFromUnprotectedTempExceptions.includes(key)) {


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/0/1205648422731273/1207968466307681/f

## Description

This PR adds new feature flag to control migration from native to web version of the broken site reporting form on Android.

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

