### PR TITLE
Windows: Enable deduplication of imported logins

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -49,7 +49,12 @@
             "state": "enabled"
         },
         "autofill": {
-            "state": "enabled"
+            "state": "enabled",
+            "features": {
+                "deduplicateLoginsOnImport": {
+                    "state": "enabled"
+                }
+            }
         },
         "autoconsent": {
             "state": "disabled",


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/0/72649045549333/1207597760316575/f

## Description
We're adding a feature to remove duplicate autofill login entries from imported data. We should ship with this on, but in the case that we receive negative user feedback from the results, we should also provide a quick way to disable it remotely.

This adds the autofill sub-feature and sets it to be enabled (it's not been shipped yet so this is low risk).

Reference macOS PR for the same purpose: https://github.com/duckduckgo/privacy-configuration/pull/2187

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

