### PR TITLE
New sync-promotion top level feature added to iOS, android & macOS

### DIFF
--- a/features/sync-promotion.json
+++ b/features/sync-promotion.json
@@ -1,0 +1,15 @@
+{
+    "_meta": {
+        "description": "Sync promotion feature for users who have not yet enabled sync"
+    },
+    "state": "disabled",
+    "features": {
+        "bookmarks": {
+            "state": "disabled"
+        },
+        "passwords": {
+            "state": "disabled"
+        }
+    },
+    "exceptions": []
+}

--- a/index.js
+++ b/index.js
@@ -152,7 +152,8 @@ const excludedFeaturesFromUnprotectedTempExceptions = [
     'brokenSiteReportExperiment',
     'toggleReports',
     'androidNewStateKillSwitch',
-    'autofillBreakageReporter'
+    'autofillBreakageReporter',
+    'syncPromotion'
 ]
 function applyGlobalUnprotectedTempExceptionsToFeatures (key, baseConfig, globalExceptions) {
     if (!excludedFeaturesFromUnprotectedTempExceptions.includes(key)) {

--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -511,6 +511,17 @@
             "state": "enabled",
             "minSupportedVersion": 51850000
         },
+        "syncPromotion": {
+            "state": "enabled",
+            "features": {
+                "bookmarks": {
+                    "state": "enabled"
+                },
+                "passwords": {
+                    "state": "enabled"
+                }
+            }
+        },
         "trackerAllowlist": {
             "state": "enabled",
             "settings": {

--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -244,6 +244,17 @@
             "state": "enabled",
             "minSupportedVersion": "7.104.0"
         },
+        "syncPromotion": {
+            "state": "enabled",
+            "features": {
+                "bookmarks": {
+                    "state": "enabled"
+                },
+                "passwords": {
+                    "state": "enabled"
+                }
+            }
+        },
         "trackerAllowlist": {
             "state": "enabled",
             "settings": {

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -684,6 +684,17 @@
             "state": "enabled",
             "minSupportedVersion": "1.70.0"
         },
+        "syncPromotion": {
+            "state": "enabled",
+            "features": {
+                "bookmarks": {
+                    "state": "enabled"
+                },
+                "passwords": {
+                    "state": "enabled"
+                }
+            }
+        },
         "privacyDashboard": {
             "state": "enabled",
             "features": {


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:**
https://app.asana.com/0/72649045549333/1207941488349913/f
cc @CDRussell 

## Description
<!--
If this is a SITE BREAKAGE MITIGATION, please include a BRIEF EXPLANATION that covers the REPORTED URL, the PLATFORMS AFFECTED, and the TRACKER(S) being unblocked or FEATURE being disabled, as well as a mention of the PROBLEM(S) users are experiencing. Please also check that you have referenced the URL of this PR as the "reason" value for the exception (where applicable).
-->
This change introduces the `syncPromotion` feature flag to be used on iOS, Android and macOS to dynamically control a new Sync promotion that will appear in the bookmarks & passwords screen for users who do not yet have Sync enabled

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

