### PR TITLE
Add broken site prompt feature

### DIFF
--- a/features/broken-site-prompt.json
+++ b/features/broken-site-prompt.json
@@ -1,0 +1,12 @@
+{
+    "_meta": {
+        "description": "Shows a toast prompt to report a broken site when the user refreshes the page multiple times."
+    },
+    "state": "disabled",
+    "exceptions": [],
+    "settings": {
+        "maxDismissStreak": 3,
+        "dismissStreakResetDays": 30,
+        "coolDownDays": 7
+    }
+}

--- a/index.js
+++ b/index.js
@@ -153,7 +153,8 @@ const excludedFeaturesFromUnprotectedTempExceptions = [
     'toggleReports',
     'androidNewStateKillSwitch',
     'autofillBreakageReporter',
-    'syncPromotion'
+    'syncPromotion',
+    'brokenSitePrompt'
 ]
 function applyGlobalUnprotectedTempExceptionsToFeatures (key, baseConfig, globalExceptions) {
     if (!excludedFeaturesFromUnprotectedTempExceptions.includes(key)) {

--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -497,6 +497,9 @@
         },
         "brokenSiteReportExperiment": {
             "state": "enabled"
+        },
+        "brokenSitePrompt": {
+            "state": "enabled"
         }
     },
     "unprotectedTemporary": [


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:** https://app.asana.com/0/414235014887631/1207889813347127/f

This PR adds a feature to control the broken site toast prompt on iOS

## Description
<!--
If this is a SITE BREAKAGE MITIGATION, please include a BRIEF EXPLANATION that covers the REPORTED URL, the PLATFORMS AFFECTED, and the TRACKER(S) being unblocked or FEATURE being disabled, as well as a mention of the PROBLEM(S) users are experiencing. Please also check that you have referenced the URL of this PR as the "reason" value for the exception (where applicable).
-->

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

