### PR TITLE
Add persistExemptions sub-feature flag for adClickAttribution in privacy config

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -1,5 +1,13 @@
 {
     "features": {
+        "adClickAttribution": {
+            "state": "enabled",
+            "features": {
+                "persistExemptions": {
+                    "state": "disabled"
+                }
+            }
+        },
         "appTrackerProtection": {
             "state": "enabled"
         },


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:** https://app.asana.com/0/1200581511062568/1208063540038800/f
See also: https://app.asana.com/0/1200581511062568/1207644177832301/f

## Description
<!--
If this is a SITE BREAKAGE MITIGATION, please include a BRIEF EXPLANATION that covers the REPORTED URL, the PLATFORMS AFFECTED, and the TRACKER(S) being unblocked or FEATURE being disabled, as well as a mention of the PROBLEM(S) users are experiencing. Please also check that you have referenced the URL of this PR as the "reason" value for the exception (where applicable).
-->
Added `persistExemptions` sub-feature flag for `adClickAttribution` on Android only.

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

