### PR TITLE
Add windowsWebView2Failures feature

### DIFF
--- a/features/windows-webview-failures.json
+++ b/features/windows-webview-failures.json
@@ -1,0 +1,6 @@
+{
+    "_meta": {
+        "description": "Root feature for all WebView2 failure-related features"
+    },
+    "exceptions": []
+}

--- a/index.js
+++ b/index.js
@@ -137,6 +137,7 @@ const excludedFeaturesFromUnprotectedTempExceptions = [
     'windowsStartupBoost',
     'windowsPrecisionScroll',
     'windowsExternalPreviewReleases',
+    'windowsWebviewFailures',
     'dbp',
     'sync',
     'mediaPlaybackRequiresUserGesture',

--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -273,6 +273,20 @@
                     "state": "disabled"
                 }
             }
+        },
+        "windowsWebviewFailures": {
+            "state": "enabled",
+            "features": {
+                "enableTabUnresponsivePopup": {
+                    "state": "enabled"
+                },
+                "enableOutOfMemoryView": {
+                    "state": "enabled"
+                },
+                "preserveCrashedTabAttributes": {
+                    "state": "enabled"
+                }
+            }
         }
     },
     "unprotectedTemporary": []


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:**
https://app.asana.com/0/72649045549333/1204351174620394/f

## Description
Adds Windows-specific feature `windowsWebviewFailures` with several sub-features used as feature-toggles for WebView2 crash handling.

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

