### PR TITLE
Add temp exception for chase.com on Windows only

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -275,5 +275,10 @@
             }
         }
     },
-    "unprotectedTemporary": []
+    "unprotectedTemporary": [
+        {
+            "domain": "chase.com",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2248"
+        }
+    ]
 }


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:** https://app.asana.com/0/1201048563534612/1207766415384982/f

## Description
<!--
If this is a SITE BREAKAGE MITIGATION, please include a BRIEF EXPLANATION that covers the REPORTED URL, the PLATFORMS AFFECTED, and the TRACKER(S) being unblocked or FEATURE being disabled, as well as a mention of the PROBLEM(S) users are experiencing. Please also check that you have referenced the URL of this PR as the "reason" value for the exception (where applicable).
-->
We've been receiving quite a bit of feedback from users of our Windows browser about issues logging into chase.com. We have not been able to reproduce it internally yet, so we are trying a temporary exception to see if it impacts user feedback.

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

