### PR TITLE
Element hiding: address new 'switch to chrome' nags

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -1577,10 +1577,6 @@
                         "type": "hide"
                     },
                     {
-                        "selector": "div:has(> iframe[src*='prid=19030391'])",
-                        "type": "hide"
-                    },
-                    {
                         "selector": "div:has(> iframe[src*='prid=19043282'])",
                         "type": "hide"
                     },

--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -1575,6 +1575,22 @@
                     {
                         "selector": "div:has(> iframe[src*='prid=19031496'])",
                         "type": "hide"
+                    },
+                    {
+                        "selector": "div:has(> iframe[src*='prid=19030391'])",
+                        "type": "hide"
+                    },
+                    {
+                        "selector": "div:has(> iframe[src*='prid=19043282'])",
+                        "type": "hide"
+                    },
+                    {
+                        "selector": "div:has(> iframe[src*='prid=19043280'])",
+                        "type": "hide"
+                    },
+                    {
+                        "selector": "div:has(> iframe[src*='prid=19031780'])",
+                        "type": "hide"
                     }
                 ]
             },


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:** https://app.asana.com/0/0/1208102877560172/f

## Description
<!--
If this is a SITE BREAKAGE MITIGATION, please include a BRIEF EXPLANATION that covers the REPORTED URL, the PLATFORMS AFFECTED, and the TRACKER(S) being unblocked or FEATURE being disabled, as well as a mention of the PROBLEM(S) users are experiencing. Please also check that you have referenced the URL of this PR as the "reason" value for the exception (where applicable).
-->
Hides new "switch to chrome" nags on Google properties

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

