### PR TITLE
Site Breakage: Hard adblock wall on virtualpiano.net

### DIFF
--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -2949,6 +2949,13 @@
                             "signupgenius.com - https://github.com/duckduckgo/privacy-configuration/pull/2234",
                             "titantv.com - https://github.com/duckduckgo/privacy-configuration/issues/1925"
                         ]
+                    },
+                    {
+                        "rule": "a.pub.network/virtualpiano-net/pubfig.min.js",
+                        "domains": [
+                            "virtualpiano.net"
+                        ],
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2251"
                     }
                 ]
             },


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:** https://app.asana.com/0/1200277586140538/1208126891192524/f

## Description
<!--
If this is a SITE BREAKAGE MITIGATION, please include a BRIEF EXPLANATION that covers the REPORTED URL, the PLATFORMS AFFECTED, and the TRACKER(S) being unblocked or FEATURE being disabled, as well as a mention of the PROBLEM(S) users are experiencing. Please also check that you have referenced the URL of this PR as the "reason" value for the exception (where applicable).
-->
Addressing adblock detection via tracker allowlist entry on virtualpiano.net.

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

