### PR TITLE
Widen adblock wall exception to address more sites

### DIFF
--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -218,14 +218,10 @@
                     {
                         "rule": "adserver.adtech.advertising.com/pubapi/3.0/1/",
                         "domains": [
-                            "collider.com",
-                            "si.com",
-                            "gamepur.com"
+                            "<all>"
                         ],
                         "reason": [
-                            "collider.com - https://github.com/duckduckgo/privacy-configuration/issues/1447",
-                            "si.com - https://github.com/duckduckgo/privacy-configuration/issues/1902",
-                            "gamepur.com - https://github.com/duckduckgo/privacy-configuration/pull/2257"
+                            "https://github.com/duckduckgo/privacy-configuration/pull/2258"
                         ]
                     }
                 ]


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:** https://app.asana.com/0/246491496396031/1208137685606726/f

## Description
<!--
If this is a SITE BREAKAGE MITIGATION, please include a BRIEF EXPLANATION that covers the REPORTED URL, the PLATFORMS AFFECTED, and the TRACKER(S) being unblocked or FEATURE being disabled, as well as a mention of the PROBLEM(S) users are experiencing. Please also check that you have referenced the URL of this PR as the "reason" value for the exception (where applicable).
-->
Surprisingly it turns out what we did in https://github.com/duckduckgo/privacy-configuration/pull/2257 resolves the same issue on many more sites - cbsnews.com, usatoday.com, etc. So expanding that exception to cover all sites.

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

