### PR TITLE
Element hiding: address Switch to Chrome pop-up on chrome web store

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -1587,6 +1587,10 @@
                     {
                         "selector": "div:has(> iframe[src*='prid=19031780'])",
                         "type": "hide"
+                    },
+                    {
+                        "selector": "[aria-labelledby='promo-header']",
+                        "type": "hide"
                     }
                 ]
             },


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:** https://app.asana.com/0/1203557590179903/1208137685606735/f

## Description
<!--
If this is a SITE BREAKAGE MITIGATION, please include a BRIEF EXPLANATION that covers the REPORTED URL, the PLATFORMS AFFECTED, and the TRACKER(S) being unblocked or FEATURE being disabled, as well as a mention of the PROBLEM(S) users are experiencing. Please also check that you have referenced the URL of this PR as the "reason" value for the exception (where applicable).
-->
Hides "Switch to Chrome" nag on chrome store pages

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

