### PR TITLE
Update CapitalOne exception to address increased android breakage

### DIFF
--- a/features/unprotected-temporary.json
+++ b/features/unprotected-temporary.json
@@ -22,10 +22,6 @@
         {
             "domain": "flexmls.com",
             "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2228"
-        },
-        {
-            "domain": "capitalone.com",
-            "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2256"
         }
     ]
 }

--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -14,7 +14,12 @@
         "clientBrandHint": {
             "state": "enabled",
             "minSupportedVersion": 51852000,
-            "exceptions": [],
+            "exceptions": [
+                {
+                    "domain": "capitalone.com",
+                    "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2269"
+                }
+            ],
             "settings": {
                 "domains": []
             }

--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -506,6 +506,10 @@
         {
             "domain": "instructure.com",
             "reason": "https://github.com/duckduckgo/privacy-configuration/issues/2212"
+        },
+        {
+            "domain": "capitalone.com",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2269"
         }
     ]
 }


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:**
Original: https://app.asana.com/0/1206670747178362/1207020216597101/f
Monitoring: https://app.asana.com/0/1206670747178362/1208135257866542/f
New breakage: https://app.asana.com/0/1200277586140538/1208146724930282/f

## Description
<!--
If this is a SITE BREAKAGE MITIGATION, please include a BRIEF EXPLANATION that covers the REPORTED URL, the PLATFORMS AFFECTED, and the TRACKER(S) being unblocked or FEATURE being disabled, as well as a mention of the PROBLEM(S) users are experiencing. Please also check that you have referenced the URL of this PR as the "reason" value for the exception (where applicable).
-->
Our global exception in PR #2256 seems to have helped on iOS, but made things much worse on Android -- users are either unable to log in or get only a blank white page once they have attempted it. It seems to be intermittent, but we suspect it may be user-agent-related, possibly in conjunction with a fraud check. We've updated the mitigation to be more precise now by exempting CapitalOne.com completely from protections on iOS and removing our UA client brand hint on Android, and we'll continue to monitor.

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

