### PR TITLE
Turns off the DuckPlayer overlay experiment flag

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -88,7 +88,7 @@
                     "state": "disabled"
                 },
                 "overlayExperiment": {
-                    "state": "enabled"
+                    "state": "disabled"
                 }
             }
         },


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:** https://app.asana.com/0/1205889582400204/1207805941164526/f

## Description
The experiment created as part of https://app.asana.com/0/1205889582400204/1207588185313765 will come to an end on Friday 6th of September. By turning off this feature flag, the pixels sent will no longer receive the cohort parameter. 

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

