### PR TITLE
Enable Autofill surveys for iOS and Android

### DIFF
--- a/features/autofill-surveys.json
+++ b/features/autofill-surveys.json
@@ -1,0 +1,9 @@
+{
+    "_meta": {
+        "description": "Allow users to see and take autofill-related surveys",
+        "sampleExcludeRecords": {}
+    },
+    "state": "enabled",
+    "settings": {},
+    "exceptions": []
+}

--- a/index.js
+++ b/index.js
@@ -156,7 +156,8 @@ const excludedFeaturesFromUnprotectedTempExceptions = [
     'autofillBreakageReporter',
     'syncPromotion',
     'brokenSitePrompt',
-    'webBrokenSiteForm'
+    'webBrokenSiteForm',
+    'autofillSurveys'
 ]
 function applyGlobalUnprotectedTempExceptionsToFeatures (key, baseConfig, globalExceptions) {
     if (!excludedFeaturesFromUnprotectedTempExceptions.includes(key)) {

--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -252,6 +252,17 @@
         "autofillBreakageReporter": {
             "state": "enabled"
         },
+        "autofillSurveys": {
+            "state": "enabled",
+            "settings": {
+                "surveys": [
+                    {
+                        "id": "2024-09-10",
+                        "url": "https://selfserve.decipherinc.com/survey/selfserve/32ab/240802"
+                    }
+                ]
+            }
+        },
         "androidBrowserConfig": {
             "state": "enabled",
             "features": {

--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -187,6 +187,17 @@
         "autofillBreakageReporter": {
             "state": "enabled"
         },
+        "autofillSurveys": {
+            "state": "enabled",
+            "settings": {
+                "surveys": [
+                    {
+                        "id": "2024-09-10",
+                        "url": "https://selfserve.decipherinc.com/survey/selfserve/32ab/240900"
+                    }
+                ]
+            }
+        },
         "incontextSignup": {
             "state": "enabled",
             "minSupportedVersion": "7.87.0",


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:** https://app.asana.com/0/608920331025315/1208266427701896/f

## Description
Enables autofill surveys for iOS and Android.

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

