### PR TITLE
Mitigate tf1.fr video adwall

### DIFF
--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -193,6 +193,13 @@
                         "reason": "Adwall displays over video and prevents video from being played."
                     },
                     {
+                        "rule": "static.adsafeprotected.com/skeleton.gif",
+                        "domains": [
+                            "tf1.fr"
+                        ],
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2286"
+                    },
+                    {
                         "rule": "static.adsafeprotected.com/iasPET.1.js",
                         "domains": [
                             "corriere.it",


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:**

## Description
<!--
If this is a SITE BREAKAGE MITIGATION, please include a BRIEF EXPLANATION that covers the REPORTED URL, the PLATFORMS AFFECTED, and the TRACKER(S) being unblocked or FEATURE being disabled, as well as a mention of the PROBLEM(S) users are experiencing. Please also check that you have referenced the URL of this PR as the "reason" value for the exception (where applicable).
-->
Adwall prevents video playback when an `adsafeprotected.com` request is blocked. Adding this request to our tracker allowlist mitigates this issue.

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

