### PR TITLE
Mitigate weird layout breakage when GPC signal is transmitted

### DIFF
--- a/features/gpc.json
+++ b/features/gpc.json
@@ -74,6 +74,10 @@
         {
             "domain": "norton.com",
             "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2240"
+        },
+        {
+            "domain": "jcrew.com",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2287"
         }
     ],
     "settings": {


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:** https://app.asana.com/0/1206670747178362/1208251202186665/f

## Description
<!--
If this is a SITE BREAKAGE MITIGATION, please include a BRIEF EXPLANATION that covers the REPORTED URL, the PLATFORMS AFFECTED, and the TRACKER(S) being unblocked or FEATURE being disabled, as well as a mention of the PROBLEM(S) users are experiencing. Please also check that you have referenced the URL of this PR as the "reason" value for the exception (where applicable).
-->
Looks as though sending the GPC signal means the site disables the "save 15%" pop-up, but that also seems to break the site layout for some reason.


#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

