### PR TITLE
Mitigate adobe product downloads on macOS

### DIFF
--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -669,6 +669,10 @@
                     {
                         "domain": "beta.maps.apple.com",
                         "reason": "Unsupported browser warning"
+                    },
+                    {
+                        "domain": "adobe.com",
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2289"
                     }
                 ],
                 "webViewDefault": [


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:**
https://app.asana.com/0/1200277586140538/1208281646241251/f

## Description
<!--
If this is a SITE BREAKAGE MITIGATION, please include a BRIEF EXPLANATION that covers the REPORTED URL, the PLATFORMS AFFECTED, and the TRACKER(S) being unblocked or FEATURE being disabled, as well as a mention of the PROBLEM(S) users are experiencing. Please also check that you have referenced the URL of this PR as the "reason" value for the exception (where applicable).
-->
Adobe does some kind of browser check where we come back as "undefined" on macOS so it assumes the system requirements are lacking. Sending a straight Safari UA fixes the problem.

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

