### PR TITLE
Mitigate more adblock walls

### DIFF
--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -195,9 +195,9 @@
                     {
                         "rule": "static.adsafeprotected.com/skeleton.gif",
                         "domains": [
-                            "tf1.fr"
+                            "<all>"
                         ],
-                        "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2286"
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2294"
                     },
                     {
                         "rule": "static.adsafeprotected.com/iasPET.1.js",


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:**

- https://app.asana.com/0/1206670747178362/1208253331785672
- https://app.asana.com/0/1206670747178362/1208301696211616
- https://app.asana.com/0/1206670747178362/1208291425495852
- https://app.asana.com/0/1206670747178362/1208301664526547

## Description
<!--
If this is a SITE BREAKAGE MITIGATION, please include a BRIEF EXPLANATION that covers the REPORTED URL, the PLATFORMS AFFECTED, and the TRACKER(S) being unblocked or FEATURE being disabled, as well as a mention of the PROBLEM(S) users are experiencing. Please also check that you have referenced the URL of this PR as the "reason" value for the exception (where applicable).
-->
Allowing this one tracker seems to diffuse adwalls on at least four sites we've seen this week (3 Admiral -- nypost.com, cbsnews.com & biblestudytools.com, plus one seemingly unrelated on tf1.fr).

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

