### PR TITLE
Revert docs.llamaindex.ai mitigation -- fix released in macOS v. 1.106.0

### DIFF
--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -866,17 +866,6 @@
                             }
                         ]
                     },
-                    "googletagmanager.com": {
-                        "rules": [
-                            {
-                                "rule": "googletagmanager.com/gtag/js",
-                                "domains": [
-                                    "docs.llamaindex.ai"
-                                ],
-                                "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2125"
-                            }
-                        ]
-                    },
                     "googletagservices.com": {
                         "rules": [
                             {
@@ -897,13 +886,9 @@
                             {
                                 "rule": "google-analytics.com/analytics.js",
                                 "domains": [
-                                    "edx.org",
-                                    "docs.llamaindex.ai"
+                                    "edx.org"
                                 ],
-                                "reason": [
-                                    "edx.org - https://github.com/duckduckgo/privacy-configuration/issues/1596",
-                                    "llamaindex.ai - https://github.com/duckduckgo/privacy-configuration/pull/2125"
-                                ]
+                                "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1596"
                             }
                         ]
                     },


### PR DESCRIPTION
Reverts duckduckgo/privacy-configuration#2125

**Asana:** https://app.asana.com/0/0/1207495642634963/f