### PR TITLE
Add loading bar experiment feature (Android)

### DIFF
--- a/features/loading-bar-exp.json
+++ b/features/loading-bar-exp.json
@@ -1,0 +1,7 @@
+{
+    "_meta": {
+        "description": "An experiment to test immediately showing the loading bar when a link is clicked.",
+        "sampleExcludeRecords": {}
+    },
+    "exceptions": []
+}

--- a/index.js
+++ b/index.js
@@ -161,7 +161,8 @@ const excludedFeaturesFromUnprotectedTempExceptions = [
     'webBrokenSiteForm',
     'autofillSurveys',
     'marketplaceAdPostback',
-    'autocompleteTabs'
+    'autocompleteTabs',
+    'loadingBarExp'
 ]
 function applyGlobalUnprotectedTempExceptionsToFeatures (key, baseConfig, globalExceptions) {
     if (!excludedFeaturesFromUnprotectedTempExceptions.includes(key)) {

--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -565,6 +565,21 @@
                 }
             }
         },
+        "loadingBarExp": {
+            "state": "enabled",
+            "features": {
+                "allocateVariants": {
+                    "state": "enabled",
+                    "rollout": {
+                        "steps": [
+                            {
+                                "percent": 20
+                            }
+                        ]
+                    }
+                }
+            }
+        },
         "trackerAllowlist": {
             "state": "enabled",
             "settings": {


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:** https://app.asana.com/0/0/1208327006836222/f

## Description
<!--
If this is a SITE BREAKAGE MITIGATION, please include a BRIEF EXPLANATION that covers the REPORTED URL, the PLATFORMS AFFECTED, and the TRACKER(S) being unblocked or FEATURE being disabled, as well as a mention of the PROBLEM(S) users are experiencing. Please also check that you have referenced the URL of this PR as the "reason" value for the exception (where applicable).
-->

- Adds a temporary feature to test loading bar perceived performance on Android.
- Variants will be allocated to 20% of users.
- With two toggles:
   - One to disable the whole feature.
   - One to disable the allocation of variants (If we disable this users who have the test variant will still have the feature enabled).
- This feature will be removed once the experiment is complete.

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

