### PR TITLE
rivergrandrapids-player-tracker-cpm-exceptions

### DIFF
--- a/features/autoconsent.json
+++ b/features/autoconsent.json
@@ -286,6 +286,10 @@
         {
             "domain": "lehmannaudio.com",
             "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2278"
+        },
+        {
+            "domain": "rivergrandrapids.com",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2301"
         }
     ],
     "settings": {

--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -1653,7 +1653,8 @@
                             "kits4beats.com",
                             "freetubetv.net",
                             "ncaa.com",
-                            "edealinfo.com"
+                            "edealinfo.com",
+                            "rivergrandrapids.com"
                         ],
                         "reason": [
                             "https://github.com/duckduckgo/privacy-configuration/issues/388",
@@ -1666,7 +1667,9 @@
                             "kits4beats.com  - https://github.com/duckduckgo/privacy-configuration/issues/1697",
                             "freetubetv.net - https://github.com/duckduckgo/privacy-configuration/issues/1699",
                             "ncaa.com - https://github.com/duckduckgo/privacy-configuration/issues/1915",
-                            "edealinfo.com - https://github.com/duckduckgo/privacy-configuration/issues/1960"
+                            "edealinfo.com - https://github.com/duckduckgo/privacy-configuration/issues/1960",
+                            "rivergrandrapids.com - https://github.com/duckduckgo/privacy-configuration/pull/2301"
+
                         ]
                     },
                     {

--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -1669,7 +1669,6 @@
                             "ncaa.com - https://github.com/duckduckgo/privacy-configuration/issues/1915",
                             "edealinfo.com - https://github.com/duckduckgo/privacy-configuration/issues/1960",
                             "rivergrandrapids.com - https://github.com/duckduckgo/privacy-configuration/pull/2301"
-
                         ]
                     },
                     {


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:**
https://app.asana.com/0/1206670747178362/1208313754397635/f

## Description
<!--
If this is a SITE BREAKAGE MITIGATION, please include a BRIEF EXPLANATION that covers the REPORTED URL, the PLATFORMS AFFECTED, and the TRACKER(S) being unblocked or FEATURE being disabled, as well as a mention of the PROBLEM(S) users are experiencing. Please also check that you have referenced the URL of this PR as the "reason" value for the exception (where applicable).
-->

Adblock wall shows on [rivergrandrapids.com](https://rivergrandrapids.com/) radio player
cpm and one tracker exceptions needed to have the player works:
- when ON, cpm creates a page refresh loop
- where that tracker; when blocked; creates that wall

Steps to reproduce issue:
- go to above site
- click on the “Listen now” button at the top of the page (likely to open a pop-up)
- on a cpm platform, that pop-up will keep reloading itself
- on any platform, following message displays: "It appears that you have an ad blocker enabled.
Please disable the ad blocker and refresh this page in order to listen to our stream."

Tracker to allow: pagead2.googlesyndication.com/pagead/js/adsbygoogle.js

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

