### PR TITLE
markt-de-add-element-hiding

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -470,6 +470,10 @@
             {
                 "selector": ".m-in-content-ad-row",
                 "type": "hide-empty"
+            },
+            {
+                "selector": ".clsy-c-advsection",
+                "type": "hide-empty"
             }
         ],
         "styleTagExceptions": [


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:**
https://app.asana.com/0/1201534009035032/1208309475758805/f

## Description
<!--
If this is a SITE BREAKAGE MITIGATION, please include a BRIEF EXPLANATION that covers the REPORTED URL, the PLATFORMS AFFECTED, and the TRACKER(S) being unblocked or FEATURE being disabled, as well as a mention of the PROBLEM(S) users are experiencing. Please also check that you have referenced the URL of this PR as the "reason" value for the exception (where applicable).
-->

Steps to reproduce:
On iOS/Android
Go to https://www.markt.de/
Click on “Accept All” to dismiss the ad notice.
Scroll down a little to see a grey space between sections

Solution:
Adding a css class to element hiding removes that space


#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

