### PR TITLE
id.onfido mediaPlaybackRequiresUserGesture

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -1129,7 +1129,7 @@
                 {
                     "domain": "id.onfido.com",
                     "reason": "Camera capture doesn't work for id verification"
-                },
+                }
             ]
         },
         "privacyPro": {

--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -1125,7 +1125,11 @@
                 {
                     "domain": "wise.com",
                     "reason": "experimental mitigation for unreproduced issue as description corresponds to similar breakage"
-                }
+                },
+                {
+                    "domain": "id.onfido.com",
+                    "reason": "Camera capture doesn't work for id verification"
+                },
             ]
         },
         "privacyPro": {


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/0/1206374308645191/1208292035475613/f

## Description
The id screen never plays the camera due to the autoplay issue we see on many id providers.

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

