### PR TITLE
add amp exception to pbs login

### DIFF
--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -526,7 +526,7 @@
             "exceptions": [
                 {
                     "domain": "publicmediasignin.org",
-                    "reason": "https://github.com/duckduckgo/privacy-configuration/issues/2312"
+                    "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2312"
                 }
             ]
         },

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -522,7 +522,13 @@
             "state": "enabled"
         },
         "ampLinks": {
-            "state": "enabled"
+            "state": "enabled",
+            "exceptions": [
+                {
+                    "domain": "publicmediasignin.org",
+                    "reason": "https://github.com/duckduckgo/privacy-configuration/issues/2312"
+                }
+            ]
         },
         "trackingParameters": {
             "state": "enabled",


### PR DESCRIPTION
<!-- 
  ⚠️ ⚠️ IF YOU ARE MODIFYING `index.js` OR A FILE IN `features` ⚠️ ⚠️
  Please request a review and ping a DRI from the Config AOR or Breakage AOR.
  The quickest way to get attention for your PR is to ping the ~Breakage channel
  in MatterMost.

  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:**

https://app.asana.com/0/1206670747178362/1208342656964572/f

## Description
<!--
If this is a SITE BREAKAGE MITIGATION, please include a BRIEF EXPLANATION that covers the REPORTED URL, the PLATFORMS AFFECTED, and the TRACKER(S) being unblocked or FEATURE being disabled, as well as a mention of the PROBLEM(S) users are experiencing. Please also check that you have referenced the URL of this PR as the "reason" value for the exception (where applicable).
-->

Amp link exception to pbs site when using apple login on MacOS only

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

