### PR TITLE
Allow sundaysky.com for united.com video page

### DIFF
--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -3300,11 +3300,13 @@
                         "rule": "sundaysky.com",
                         "domains": [
                             "bankofamerica.com",
-                            "idnotify.com"
+                            "idnotify.com",
+                            "united.com"
                         ],
                         "reason": [
                             "BoA - https://github.com/duckduckgo/privacy-configuration/issues/1970",
-                            "idnotify - https://github.com/duckduckgo/privacy-configuration/issues/2081"
+                            "idnotify - https://github.com/duckduckgo/privacy-configuration/issues/2081",
+                            "United - https://github.com/duckduckgo/privacy-configuration/issues/2313"
                         ]
                     }
                 ]

--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -3306,7 +3306,7 @@
                         "reason": [
                             "BoA - https://github.com/duckduckgo/privacy-configuration/issues/1970",
                             "idnotify - https://github.com/duckduckgo/privacy-configuration/issues/2081",
-                            "United - https://github.com/duckduckgo/privacy-configuration/issues/2313"
+                            "United - https://github.com/duckduckgo/privacy-configuration/pull/2313"
                         ]
                     }
                 ]


### PR DESCRIPTION
<!-- 
  ⚠️ ⚠️ IF YOU ARE MODIFYING `index.js` OR A FILE IN `features` ⚠️ ⚠️
  Please request a review and ping a DRI from the Config AOR or Breakage AOR.
  The quickest way to get attention for your PR is to ping the ~Breakage channel
  in MatterMost.

  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:**
https://app.asana.com/0/1200277586140538/1208359439622438/f

## Description
The [personalized video page on united.com](https://myvideos.united.com/MileagePlus/index.php) relies on the SundaySky player and API, so need to allow sundaysky.com for the page to load.

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

