### PR TITLE
Add a feature flag for the bottom omnibar

### DIFF
--- a/features/change-omnibar-position.json
+++ b/features/change-omnibar-position.json
@@ -1,0 +1,7 @@
+{
+    "_meta": {
+        "description": "A feature flag that determines if the omnibar position can be changed.",
+        "sampleExcludeRecords": {}
+    },
+    "exceptions": []
+}

--- a/index.js
+++ b/index.js
@@ -162,7 +162,8 @@ const excludedFeaturesFromUnprotectedTempExceptions = [
     'autofillSurveys',
     'marketplaceAdPostback',
     'autocompleteTabs',
-    'loadingBarExp'
+    'loadingBarExp',
+    'changeOmnibarPosition'
 ]
 function applyGlobalUnprotectedTempExceptionsToFeatures (key, baseConfig, globalExceptions) {
     if (!excludedFeaturesFromUnprotectedTempExceptions.includes(key)) {

--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -1271,6 +1271,14 @@
         },
         "androidNewStateKillSwitch": {
             "state": "disabled"
+        },
+        "changeOmnibarPosition": {
+            "state": "internal",
+            "features": {
+                "refactor": {
+                    "state": "disabled"
+                }
+            }
         }
     },
     "unprotectedTemporary": [],
@@ -1313,13 +1321,5 @@
                 }
             }
         ]
-    },
-    "changeOmnibarPosition": {
-        "state": "internal",
-        "features": {
-            "refactor": {
-                "state": "disabled"
-            }
-        }
     }
 }

--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -1313,5 +1313,13 @@
                 }
             }
         ]
+    },
+    "changeOmnibarPosition": {
+        "state": "internal",
+        "features": {
+            "refactor": {
+                "state": "disabled"
+            }
+        }
     }
 }


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:** https://app.asana.com/0/1207418217763355/1208319036523676/f

## Description
<!--
If this is a SITE BREAKAGE MITIGATION, please include a BRIEF EXPLANATION that covers the REPORTED URL, the PLATFORMS AFFECTED, and the TRACKER(S) being unblocked or FEATURE being disabled, as well as a mention of the PROBLEM(S) users are experiencing. Please also check that you have referenced the URL of this PR as the "reason" value for the exception (where applicable).
-->

- Adds a feature flag for the bottom address bar feature on Android.
- With two toggles:
   - One to disable the whole bottom bar feature, including the settings option (the default value will be `internal`).
   - One to disable the refactored omnibar component specifically and use the legacy omnibar.

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

