### PR TITLE
Add Windows Fire Window feature flag

### DIFF
--- a/features/windows-fire-window.json
+++ b/features/windows-fire-window.json
@@ -1,0 +1,6 @@
+{
+    "_meta": {
+        "description": "Fire Window on Windows Browser"
+    },
+    "exceptions": []
+}

--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -340,6 +340,9 @@
         },
         "remoteMessaging": {
             "state": "enabled"
+        },
+        "windowsFireWindow": {
+            "state": "disabled"
         }
     },
     "unprotectedTemporary": []


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/0/1201048563534612/1208148877934817/f

## Description
Allows toggling Windows Fire Window on and off remotely. The default is "off".

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

