### PR TITLE
Fix the "Play another game" button on solitaired.com for macOS and iO…

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -299,9 +299,13 @@
                             {
                                 "rule": "securepubads.g.doubleclick.net/tag/js/gpt.js",
                                 "domains": [
+                                    "solitaired.com",
                                     "uwbadgers.com"
                                 ],
-                                "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1593"
+                                "reason": [
+                                    "solitaired.com - https://github.com/duckduckgo/privacy-configuration/pull/2329",
+                                    "uwbadgers.com - https://github.com/duckduckgo/privacy-configuration/issues/1593"
+                                ]
                             },
                             {
                                 "rule": "www3.doubleclick.net",
@@ -309,6 +313,19 @@
                                     "scrolller.com"
                                 ],
                                 "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1968"
+                            }
+                        ]
+                    },
+                    "facebook.net": {
+                        "rules": [
+                            {
+                                "rule": "connect.facebook.net/en_US/sdk.js",
+                                "domains": [
+                                    "solitaired.com"
+                                ],
+                                "reason": [
+                                    "solitaired.com - https://github.com/duckduckgo/privacy-configuration/pull/2329"
+                                ]
                             }
                         ]
                     },

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -793,9 +793,13 @@
                             {
                                 "rule": "securepubads.g.doubleclick.net/tag/js/gpt.js",
                                 "domains": [
+                                    "solitaired.com",
                                     "uwbadgers.com"
                                 ],
-                                "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1593"
+                                "reason": [
+                                    "solitaired.com - https://github.com/duckduckgo/privacy-configuration/pull/2329",
+                                    "uwbadgers.com - https://github.com/duckduckgo/privacy-configuration/issues/1593"
+                                ]
                             },
                             {
                                 "rule": "www3.doubleclick.net",
@@ -832,11 +836,13 @@
                                 "rule": "connect.facebook.net/en_US/sdk.js",
                                 "domains": [
                                     "mytrackman.com",
-                                    "nextdoor.com"
+                                    "nextdoor.com",
+                                    "solitaired.com"
                                 ],
                                 "reason": [
                                     "mytrackman.com - https://github.com/duckduckgo/privacy-configuration/issues/1426",
-                                    "nextdoor.com - https://github.com/duckduckgo/privacy-configuration/issues/1190"
+                                    "nextdoor.com - https://github.com/duckduckgo/privacy-configuration/issues/1190",
+                                    "solitaired.com - https://github.com/duckduckgo/privacy-configuration/pull/2329"
                                 ]
                             },
                             {


### PR DESCRIPTION
After completing a game of solitaire on solitaired, the "Play again" button
was broken in the macOS and iOS DuckDuckGo browsers. The user was navigated to
https://solitaired.com/undefined (with a "404 Page not found" error), instead of
given a new game. This wasn't reproducible on the other DuckDuckGo platforms
that I tried.

<!-- 
  ⚠️ ⚠️ IF YOU ARE MODIFYING `index.js` OR A FILE IN `features` ⚠️ ⚠️
  Please request a review and ping a DRI from the Config AOR or Breakage AOR.
  The quickest way to get attention for your PR is to ping the ~Breakage channel
  in MatterMost.

  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:**

## Description
<!--
If this is a SITE BREAKAGE MITIGATION, please include a BRIEF EXPLANATION that covers the REPORTED URL, the PLATFORMS AFFECTED, and the TRACKER(S) being unblocked or FEATURE being disabled, as well as a mention of the PROBLEM(S) users are experiencing. Please also check that you have referenced the URL of this PR as the "reason" value for the exception (where applicable).
-->

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

