### PR TITLE
Enables sending full package for app which installed our Android app

### DIFF
--- a/features/send-full-package-install-source.json
+++ b/features/send-full-package-install-source.json
@@ -1,0 +1,9 @@
+{
+    "_meta": {
+        "description": "Allows sending of full package of the app which installed ours",
+        "sampleExcludeRecords": {}
+    },
+    "state": "enabled",
+    "settings": {},
+    "exceptions": []
+}

--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -540,6 +540,15 @@
             },
             "exceptions": []
         },
+        "sendFullPackageInstallSource": {
+            "state": "enabled",
+            "settings": {
+                "includedPackages": [
+                    "*"
+                ]
+            },
+            "exceptions": []
+        },
         "sync": {
             "state": "enabled",
             "minSupportedVersion": 51850000


### PR DESCRIPTION
<!-- 
  ⚠️ ⚠️ IF YOU ARE MODIFYING `index.js` OR A FILE IN `features` ⚠️ ⚠️
  Please request a review and ping a DRI from the Config AOR or Breakage AOR.
  The quickest way to get attention for your PR is to ping the ~Breakage channel
  in MatterMost.

  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:** https://app.asana.com/0/0/1208315780180372/f

## Description
Enables the `sendFullPackageInstallSource` feature flag. This is temporarily wildcarded so that it matches all packages, and will configured to a non-wildcarded list later.

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

