### PR TITLE
Enable web version of the site breakage reporting screen on Android

### DIFF
--- a/features/web-broken-site-form.json
+++ b/features/web-broken-site-form.json
@@ -2,6 +2,6 @@
     "_meta": {
         "description": "Use web version of the site breakage reporting form instead of the native one on Android."
     },
-    "state": "disabled",
+    "state": "enabled",
     "exceptions": []
 }


### PR DESCRIPTION
<!-- 
  ⚠️ ⚠️ IF YOU ARE MODIFYING `index.js` OR A FILE IN `features` ⚠️ ⚠️
  Please request a review and ping a DRI from the Config AOR or Breakage AOR.
  The quickest way to get attention for your PR is to ping the ~Breakage channel
  in MatterMost.

  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:** https://app.asana.com/0/1205648422731273/1208498921382199/f

## Description
<!--
If this is a SITE BREAKAGE MITIGATION, please include a BRIEF EXPLANATION that covers the REPORTED URL, the PLATFORMS AFFECTED, and the TRACKER(S) being unblocked or FEATURE being disabled, as well as a mention of the PROBLEM(S) users are experiencing. Please also check that you have referenced the URL of this PR as the "reason" value for the exception (where applicable).
-->
The latest Android app release includes two versions of the site breakage reporting screen - a native one and a web-based one. Enabling this flag will make the app display the latter, which is intended to replace the former.

Modifying the feature json directly instead of adding Android override, because this feature flag is Android-specific by definition.

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

