### PR TITLE
Add autofill.credentialsImportPromotionForExistingUsers feature

### DIFF
--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -526,6 +526,9 @@
                 },
                 "credentialsImportPromotion": {
                     "state": "enabled"
+                },
+                "credentialsImportPromotionForExistingUsers": {
+                    "state": "enabled"
                 }
             }
         },

--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -59,6 +59,9 @@
                 },
                 "credentialsImportPromotion": {
                     "state": "enabled"
+                },
+                "credentialsImportPromotionForExistingUsers": {
+                    "state": "enabled"
                 }
             }
         },


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/0/0/1208378183297876/f

## Description
This just adds a feature flag autofill.credentialsImportPromotionForExistingUsers to macOS and windows which will be on when released but can be switched off in case of an issue.

This only covers enabling the prompt for existing users. It will not flag the updates to the import prompt UI.

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

