### PR TITLE
Keep webBrokenSiteForm enabled only for Android 5.216.0+

### DIFF
--- a/features/web-broken-site-form.json
+++ b/features/web-broken-site-form.json
@@ -2,6 +2,6 @@
     "_meta": {
         "description": "Use web version of the site breakage reporting form instead of the native one on Android."
     },
-    "state": "enabled",
+    "state": "disabled",
     "exceptions": []
 }

--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -1248,6 +1248,10 @@
                 }
             }
         },
+        "webBrokenSiteForm": {
+            "state": "enabled",
+            "minSupportedVersion": 52160000
+        },
         "webViewBlobDownload": {
             "state": "enabled"
         },


### PR DESCRIPTION
<!-- 
  ⚠️ ⚠️ IF YOU ARE MODIFYING `index.js` OR A FILE IN `features` ⚠️ ⚠️
  Please request a review and ping a DRI from the Config AOR or Breakage AOR.
  The quickest way to get attention for your PR is to ping the ~Breakage channel
  in MatterMost.

  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:** https://app.asana.com/0/1205648422731273/1208498921382199/f

## Description
<!--
If this is a SITE BREAKAGE MITIGATION, please include a BRIEF EXPLANATION that covers the REPORTED URL, the PLATFORMS AFFECTED, and the TRACKER(S) being unblocked or FEATURE being disabled, as well as a mention of the PROBLEM(S) users are experiencing. Please also check that you have referenced the URL of this PR as the "reason" value for the exception (where applicable).
-->
This is a follow-up to https://github.com/duckduckgo/privacy-configuration/pull/2337 which was supposed to enable the flag only for recent versions of the Android app. 

In older versions of the Android app, the web version of the breakage reporting screen is functional but uses an outdated design, so it’s better for those users to continue using the native version of the screen.

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

