### PR TITLE
Hide empty space under initial graphic on livebeaches.com

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -478,10 +478,6 @@
             {
                 "selector": ".clsy-c-advsection",
                 "type": "hide-empty"
-            },
-            {
-                "selector": "[class*='random-ad']",
-                "type": "hide-empty"
             }
         ],
         "styleTagExceptions": [
@@ -1883,6 +1879,15 @@
                     },
                     {
                         "selector": "[class*='styles__ad']",
+                        "type": "hide-empty"
+                    }
+                ]
+            },
+            {
+                "domain": "livebeaches.com",
+                "rules": [
+                    {
+                        "selector": "[class*='random-ad']",
                         "type": "hide-empty"
                     }
                 ]

--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -478,6 +478,10 @@
             {
                 "selector": ".clsy-c-advsection",
                 "type": "hide-empty"
+            },
+            {
+                "selector": "[class*='random-ad']",
+                "type": "hide-empty"
             }
         ],
         "styleTagExceptions": [


### PR DESCRIPTION
<!-- 
  ⚠️ ⚠️ IF YOU ARE MODIFYING `index.js` OR A FILE IN `features` ⚠️ ⚠️
  Please request a review and ping a DRI from the Config AOR or Breakage AOR.
  The quickest way to get attention for your PR is to ping the ~Breakage channel
  in MatterMost.

  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:**
https://app.asana.com/0/1206670747178362/1208527012274813/f
## Description
<!--
If this is a SITE BREAKAGE MITIGATION, please include a BRIEF EXPLANATION that covers the REPORTED URL, the PLATFORMS AFFECTED, and the TRACKER(S) being unblocked or FEATURE being disabled, as well as a mention of the PROBLEM(S) users are experiencing. Please also check that you have referenced the URL of this PR as the "reason" value for the exception (where applicable).
—>
There's a big empty space under the top photo on [one page](https://www.livebeaches.com/webcams/the-resort-at-longboat-key-club-pool-cam/) (and probably others), which we can zap with an extra ad class.

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

