### PR TITLE
Add Signal to AppTP unprotected list.

### DIFF
--- a/features/app-tracker-protection.json
+++ b/features/app-tracker-protection.json
@@ -200,14 +200,6 @@
                     ]
                 },
                 {
-                    "domain": "www.facebook.com",
-                    "packageNames": [
-                        {
-                            "packageName": "org.thoughtcrime.securesms"
-                        }
-                    ]
-                },
-                {
                     "domain": "www.googletagmanager.com",
                     "packageNames": [
                         {
@@ -232,9 +224,6 @@
                         },
                         {
                             "packageName": "get.instagram.followers.unfollowers"
-                        },
-                        {
-                            "packageName": "org.thoughtcrime.securesms"
                         }
                     ]
                 }
@@ -695,6 +684,10 @@
                 {
                     "packageName": "sa.gov.nic.tawakkalna",
                     "reason": "App doesn't run over any VPN connection"
+                },
+                {
+                    "packageName": "org.thoughtcrime.securesms",
+                    "reason": "Users report app issues with AppTP enabled"
                 }
             ],
             "unhideSystemApps": [


### PR DESCRIPTION
## Description
Hi there, we've had some users report that they're unable to use [Signal](https://play.google.com/store/apps/details?id=org.thoughtcrime.securesms&hl=en_US) properly while AppTP is enabled. There's been reports of people having issues sending/receiving messages. I personally cannot reproduce the issue, but these particular users were adamant that the issue is tied to AppTP and goes away when they disable it. One of the users has a Moto G Power (pretty sure it's [this one](https://www.gsmarena.com/motorola_moto_g_power-10076.php)?) running Android 11.

So I made this PR to add us to the exclusion list by default, but I'll leave it up to ya'll on whether that's the best course of action, or whether there's more information I can get you.
