### PR TITLE
add-ios-content-blocking-exception-humana

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -36,6 +36,7 @@
             "state": "enabled"
         },
         "contentBlocking": {
+            "state": "enabled",
             "exceptions": [
                 {
                     "domain": "humana.com",

--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -36,7 +36,12 @@
             "state": "enabled"
         },
         "contentBlocking": {
-            "exceptions": []
+            "exceptions": [
+                {
+                    "domain": "humana.com",
+                    "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2376"
+                }
+            ]
         },
         "history": {
             "state": "enabled",


### PR DESCRIPTION
<!-- 
  ⚠️ ⚠️ IF YOU ARE MODIFYING `index.js` OR A FILE IN `features` ⚠️ ⚠️
  Please request a review and ping a DRI from the Config AOR or Breakage AOR.
  The quickest way to get attention for your PR is to ping the ~Breakage channel
  in MatterMost.

  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:**
https://app.asana.com/0/1200277586140538/1207713794772442/f

## Description
<!--
If this is a SITE BREAKAGE MITIGATION, please include a BRIEF EXPLANATION that covers the REPORTED URL, the PLATFORMS AFFECTED, and the TRACKER(S) being unblocked or FEATURE being disabled, as well as a mention of the PROBLEM(S) users are experiencing. Please also check that you have referenced the URL of this PR as the "reason" value for the exception (where applicable).
-->

Adding a content-blocking exception for humana.com on iOS to resolve post-login blank page loading issues.

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

