### PR TITLE
Add back GPC exception for milesplit.live since it still doesn't load in certain scenarios with GPC set

### DIFF
--- a/features/gpc.json
+++ b/features/gpc.json
@@ -33,6 +33,10 @@
             "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2101"
         },
         {
+            "domain": "milesplit.live",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2379"
+        },
+        {
             "domain": "monsterenergy.com",
             "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2122"
         },


### PR DESCRIPTION
<!-- 
  ⚠️ ⚠️ IF YOU ARE MODIFYING `index.js` OR A FILE IN `features` ⚠️ ⚠️
  Please request a review and ping a DRI from the Config AOR or Breakage AOR.
  The quickest way to get attention for your PR is to ping the ~Breakage channel
  in MatterMost.

  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:** https://app.asana.com/0/1200277586140538/1208584335921033/f

## Description
<!--
If this is a SITE BREAKAGE MITIGATION, please include a BRIEF EXPLANATION that covers the REPORTED URL, the PLATFORMS AFFECTED, and the TRACKER(S) being unblocked or FEATURE being disabled, as well as a mention of the PROBLEM(S) users are experiencing. Please also check that you have referenced the URL of this PR as the "reason" value for the exception (where applicable).
-->
Had removed this exception in https://github.com/duckduckgo/privacy-configuration/pull/2356 after confirming that the originally reported URL loaded fine with GPC set, however we are receiving user reports that other URLs on this domain still don't load when the GPC signal is present.

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

