### PR TITLE
Disable CPM on la-becanerie.com to fix stuck gray overlay

### DIFF
--- a/features/autoconsent.json
+++ b/features/autoconsent.json
@@ -298,6 +298,10 @@
         {
             "domain": "speedweek.com",
             "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2311"
+        },
+        {
+            "domain": "la-becanerie.com",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2391"
         }
     ],
     "settings": {


### PR DESCRIPTION
<!-- 
  ⚠️ ⚠️ IF YOU ARE MODIFYING `index.js` OR A FILE IN `features` ⚠️ ⚠️
  Please request a review and ping a DRI from the Config AOR or Breakage AOR.
  The quickest way to get attention for your PR is to ping the ~Breakage channel
  in MatterMost.

  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:**
https://app.asana.com/0/1206670747178362/1208611410206076/f

## Description
With current cookie pop-up handling, la-becanerie.com can't be interacted with because an overlay remains.

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

