### PR TITLE
Set DuckPlayer Open In new tab to ‘internal’

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -24,7 +24,7 @@
                     "state": "disabled"
                 },
                 "openInNewTab": {
-                    "state": "disabled"
+                    "state": "internal"
                 },
                 "enableDuckPlayer": {
                     "state": "enabled",


### PR DESCRIPTION
<!-- 
  ⚠️ ⚠️ IF YOU ARE MODIFYING `index.js` OR A FILE IN `features` ⚠️ ⚠️
  Please request a review and ping a DRI from the Config AOR or Breakage AOR.
  The quickest way to get attention for your PR is to ping the ~Breakage channel
  in MatterMost.

  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:**
- https://app.asana.com/0/1204099484721401/1208516694627011/f

## Description
- Sets OpenInNewTab feature for DuckPlayer to 'internal'

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

