### PR TITLE
Android: Add settings for auto-exclude in network protection

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -521,6 +521,64 @@
                     }
                 }
             },
+            "settings": {
+                "autoExcludeApps": [
+                    {
+                        "packageName": "com.google.android.projection.gearhead"
+                    },
+                    {
+                        "packageName": "app.aawireless"
+                    },
+                    {
+                        "packageName": "com.ticketmaster.tickets.international"
+                    },
+                    {
+                        "packageName": "com.disney.disneyplus"
+                    },
+                    {
+                        "packageName": "us.current.android"
+                    },
+                    {
+                        "packageName": "com.cbs.ca"
+                    },
+                    {
+                        "packageName": "com.capitalJ.onJuno"
+                    },
+                    {
+                        "packageName": "com.bunq.android"
+                    },
+                    {
+                        "packageName": "com.mobile.canaraepassbook"
+                    },
+                    {
+                        "packageName": "com.truthsocial.android.app"
+                    },
+                    {
+                        "packageName": "com.directoriotigo.hwm"
+                    },
+                    {
+                        "packageName": "com.myyearbook.m"
+                    },
+                    {
+                        "packageName": "com.ringapp"
+                    },
+                    {
+                        "packageName": "com.sonos.acr2"
+                    },
+                    {
+                        "packageName": "com.nest.android"
+                    },
+                    {
+                        "packageName": "com.immediasemi.android.blink"
+                    },
+                    {
+                        "packageName": "com.ivuu"
+                    },
+                    {
+                        "packageName": "com.openai.chatgpt"
+                    }
+                ]
+            },
             "minSupportedVersion": 51670000
         },
         "privacyDashboard": {


### PR DESCRIPTION
<!-- 
  ⚠️ ⚠️ IF YOU ARE MODIFYING `index.js` OR A FILE IN `features` ⚠️ ⚠️
  Please request a review and ping a DRI from the Config AOR or Breakage AOR.
  The quickest way to get attention for your PR is to ping the ~Breakage channel
  in MatterMost.

  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:** https://app.asana.com/0/72649045549333/1207253938158590/f

## Description
<!--
If this is a SITE BREAKAGE MITIGATION, please include a BRIEF EXPLANATION that covers the REPORTED URL, the PLATFORMS AFFECTED, and the TRACKER(S) being unblocked or FEATURE being disabled, as well as a mention of the PROBLEM(S) users are experiencing. Please also check that you have referenced the URL of this PR as the "reason" value for the exception (where applicable).
-->
Adds the new setting for auto-exclude feature in Network Protection

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

