### PR TITLE
Remove custom UA from macos-override.json

### DIFF
--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -711,13 +711,17 @@
                     {
                         "domain": "adobe.com",
                         "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2289"
-                    }
-                ],
-                "webViewDefault": [
+                    },
                     {
                         "domain": "accounts.google.com",
                         "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1295"
                     },
+                    {
+                        "domain": "mail.google.com",
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1295"
+                    },
+                ],
+                "webViewDefault": [
                     {
                         "domain": "flysas.com",
                         "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1347"

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -719,7 +719,7 @@
                     {
                         "domain": "mail.google.com",
                         "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1295"
-                    },
+                    }
                 ],
                 "webViewDefault": [
                     {


### PR DESCRIPTION
<!-- 
  ⚠️ ⚠️ IF YOU ARE MODIFYING `index.js` OR A FILE IN `features` ⚠️ ⚠️
  Please request a review and ping a DRI from the Config AOR or Breakage AOR.
  The quickest way to get attention for your PR is to ping the ~Breakage channel
  in MatterMost.

  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:** https://app.asana.com/0/1200277586140538/1208638871640690/f

## Description
Removes our custom UA from Gmail and also unifies Google auth to the same header too.

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

