### PR TITLE
Fix on demand streaming on paramountplus.com and cbs.com

### DIFF
--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -957,6 +957,14 @@
                         "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1185"
                     },
                     {
+                        "rule": "doubleclick.net/ondemand/dash/content/",
+                        "domains": [
+                            "cbs.com",
+                            "paramountplus.com"
+                        ],
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2410"
+                    },
+                    {
                         "rule": "securepubads.g.doubleclick.net/gampad/ads",
                         "domains": [
                             "ah.nl",


### PR DESCRIPTION
<!-- 
  ⚠️ ⚠️ IF YOU ARE MODIFYING `index.js` OR A FILE IN `features` ⚠️ ⚠️
  Please request a review and ping a DRI from the Config AOR or Breakage AOR.
  The quickest way to get attention for your PR is to ping the ~Breakage channel
  in MatterMost.

  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:** https://app.asana.com/0/1206670747178362/1208632063166632/f

## Description
<!--
If this is a SITE BREAKAGE MITIGATION, please include a BRIEF EXPLANATION that covers the REPORTED URL, the PLATFORMS AFFECTED, and the TRACKER(S) being unblocked or FEATURE being disabled, as well as a mention of the PROBLEM(S) users are experiencing. Please also check that you have referenced the URL of this PR as the "reason" value for the exception (where applicable).
-->
On demand videos won't start if this request is blocked.

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

