### PR TITLE
Add a feature flag for the swiping tabs feature

### DIFF
--- a/features/swiping-tabs.json
+++ b/features/swiping-tabs.json
@@ -1,0 +1,7 @@
+{
+    "_meta": {
+        "description": "A feature flag that determines whether the tab-swiping feature is enabled.",
+        "sampleExcludeRecords": {}
+    },
+    "exceptions": []
+}

--- a/index.js
+++ b/index.js
@@ -150,7 +150,8 @@ const featuresToIncludeTempUnprotectedExceptions = [
     'trackingParameters',
     'unprotectedTemporary',
     'userAgentRotation',
-    'webCompat'
+    'webCompat',
+    'swipingTabs'
 ]
 function applyGlobalUnprotectedTempExceptionsToFeatures (key, baseConfig, globalExceptions) {
     if (featuresToIncludeTempUnprotectedExceptions.includes(key)) {

--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -1368,6 +1368,9 @@
                     "state": "internal"
                 }
             }
+        },
+        "swipingTabs": {
+            "state": "disabled"
         }
     },
     "unprotectedTemporary": [],


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/0/1202552961248957/1208659739219427/f

## Description

This PR adds a new feature flag that will be used for determining whether the tab-swiping feature is enabled.

The feature will be disabled by default while it’s in development.

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

