### PR TITLE
Add windowsWebviewFailures/crashAutoRecovery subfeature

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -342,6 +342,9 @@
                 },
                 "preserveCrashedTabAttributes": {
                     "state": "enabled"
+                },
+                "crashAutoRecovery": {
+                    "state": "enabled"
                 }
             }
         },


### PR DESCRIPTION
<!-- 
  ⚠️ ⚠️ IF YOU ARE MODIFYING `index.js` OR A FILE IN `features` ⚠️ ⚠️
  Please request a review and ping a DRI from the Config AOR or Breakage AOR.
  The quickest way to get attention for your PR is to ping the ~Breakage channel
  in MatterMost.

  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:**
https://app.asana.com/0/72649045549333/1208221979816846/f

## Description
Add the `windowsWebviewFailures/crashAutoRecovery` subfeature in an enabled state to `overrides/windows-override.json`.

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

