### PR TITLE
Enable broken site toast on macos

### DIFF
--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -21,6 +21,9 @@
                 }
             }
         },
+        "brokenSitePrompt": {
+            "state": "enabled"
+        },
         "networkProtection": {
             "state": "enabled",
             "features": {


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/0/72649045549333/1207889813347128/f

## Description
Enable broken site toast on macos

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

