### PR TITLE
Revert "add-centerwell-and-humana-mitigations"

### DIFF
--- a/features/cookie.json
+++ b/features/cookie.json
@@ -62,10 +62,6 @@
         {
             "domain": "instructure.com",
             "reason": "https://github.com/duckduckgo/privacy-configuration/issues/2212"
-        },
-        {
-            "domain": "humana.com",
-            "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2432"
         }
     ]
 }

--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -40,14 +40,10 @@
         },
         "contentBlocking": {
             "state": "enabled",
-            "exceptions": []
-        },
-        "cookie": {
-            "state": "enabled",
             "exceptions": [
                 {
                     "domain": "centerwellpharmacy.com",
-                    "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2432"
+                    "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2407"
                 }
             ]
         },


### PR DESCRIPTION
We accidentally enabled cookie protection on a platform where part of that coverage is provided by WebKit, so we need to apply this in a slightly different way.