### PR TITLE
Mitigate adblock wall on sbs.com.au

### DIFF
--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -932,6 +932,15 @@
                             "https://github.com/duckduckgo/privacy-configuration/issues/393",
                             "sbs.com.au - https://github.com/duckduckgo/privacy-configuration/issues/1861"
                         ]
+                    },
+                    {
+                        "rule": "sbs.demdex.net",
+                        "domains": [
+                            "sbs.com.au"
+                        ],
+                        "reason": [
+                            "sbs.com.au - https://github.com/duckduckgo/privacy-configuration/issues/2436"
+                        ]
                     }
                 ]
             },
@@ -1069,6 +1078,15 @@
                             "https://github.com/duckduckgo/privacy-configuration/issues/415",
                             "rocketnews24.com - https://github.com/duckduckgo/privacy-configuration/issues/846",
                             "wunderground.com - https://github.com/duckduckgo/privacy-configuration/issues/956"
+                        ]
+                    },
+                    {
+                        "rule": "securepubads.g.doubleclick.net/pagead/ima_ppub_config",
+                        "domains": [
+                            "sbs.com.au"
+                        ],
+                        "reason": [
+                            "sbs.com.au - https://github.com/duckduckgo/privacy-configuration/issues/2436"
                         ]
                     },
                     {

--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -930,7 +930,7 @@
                         ],
                         "reason": [
                             "https://github.com/duckduckgo/privacy-configuration/issues/393",
-                            "sbs.com.au - https://github.com/duckduckgo/privacy-configuration/issues/1861"
+                            "sbs.com.au - https://github.com/duckduckgo/privacy-configuration/pull/1861"
                         ]
                     },
                     {
@@ -1086,7 +1086,7 @@
                             "sbs.com.au"
                         ],
                         "reason": [
-                            "sbs.com.au - https://github.com/duckduckgo/privacy-configuration/issues/2436"
+                            "sbs.com.au - https://github.com/duckduckgo/privacy-configuration/pull/2436"
                         ]
                     },
                     {

--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -930,7 +930,7 @@
                         ],
                         "reason": [
                             "https://github.com/duckduckgo/privacy-configuration/issues/393",
-                            "sbs.com.au - https://github.com/duckduckgo/privacy-configuration/pull/1861"
+                            "sbs.com.au - https://github.com/duckduckgo/privacy-configuration/issues/1861"
                         ]
                     },
                     {
@@ -939,7 +939,7 @@
                             "sbs.com.au"
                         ],
                         "reason": [
-                            "sbs.com.au - https://github.com/duckduckgo/privacy-configuration/issues/2436"
+                            "sbs.com.au - https://github.com/duckduckgo/privacy-configuration/pull/2436"
                         ]
                     }
                 ]


### PR DESCRIPTION
<!-- 
  ⚠️ ⚠️ IF YOU ARE MODIFYING `index.js` OR A FILE IN `features` ⚠️ ⚠️
  Please request a review and ping a DRI from the Config AOR or Breakage AOR.
  The quickest way to get attention for your PR is to ping the ~Breakage channel
  in MatterMost.

  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:**
https://app.asana.com/0/1206670747178362/1208705179145516/f

## Description
<!--
If this is a SITE BREAKAGE MITIGATION, please include a BRIEF EXPLANATION that covers the REPORTED URL, the PLATFORMS AFFECTED, and the TRACKER(S) being unblocked or FEATURE being disabled, as well as a mention of the PROBLEM(S) users are experiencing. Please also check that you have referenced the URL of this PR as the "reason" value for the exception (where applicable).
-->
This is to address the adblock wall that appears when trying to play videos on sbs.com.au

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

