### PR TITLE
Add adAttributionReporting feature with default iOS override

### DIFF
--- a/features/ad-attribution-reporting.json
+++ b/features/ad-attribution-reporting.json
@@ -1,0 +1,9 @@
+{
+    "_meta": {
+        "description": "Reporting Apple Search Ads attribution via pixels",
+        "howTo": "https://app.asana.com/0/1206226850447395/1208659452789126/f",
+        "sampleExcludeRecords": {}
+    },
+    "state": "disabled",
+    "exceptions": []
+}

--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -1,5 +1,12 @@
 {
     "features": {
+        "adAttributionReporting": {
+            "state": "disabled",
+            "minSupportedVersion": "7.145.0",
+            "settings": {
+                "includeToken": false
+            }
+        },
         "textZoom": {
             "state": "enabled"
         },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/0/1206226850447395/1208638248015576/f ; https://app.asana.com/0/1206226850447395/1208638248015581/f

## Description

Adds a feature allowing to control ad attribution reporting on iOS.

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

