### PR TITLE
Remove toggle reports subfeature

### DIFF
--- a/features/privacy-dashboard.json
+++ b/features/privacy-dashboard.json
@@ -13,9 +13,6 @@
             "rollout": {
                 "steps": []
             }
-        },
-        "toggleReports": {
-            "state": "disabled"
         }
     }
 }


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/0/1201392122292466/1207666181963617/f

Removing deprecated toggleReports subfeature from within PrivacyDashboard. We should use toggleReports feature instead.

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)
