### PR TITLE
Element hiding: address erroneous 'unsupported browser' message on Gmail

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -1609,6 +1609,10 @@
                     {
                         "selector": "[aria-labelledby='promo-header']",
                         "type": "hide"
+                    },
+                    {
+                        "selector": "div[role='banner']:has(div > a[href='https://support.google.com/a/answer/33864'])",
+                        "type": "hide"
                     }
                 ]
             },


### PR DESCRIPTION
<!-- 
  ⚠️ ⚠️ IF YOU ARE MODIFYING `index.js` OR A FILE IN `features` ⚠️ ⚠️
  Please request a review and ping a DRI from the Config AOR or Breakage AOR.
  The quickest way to get attention for your PR is to ping the ~Breakage channel
  in MatterMost.

  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:** https://app.asana.com/0/1201048563534612/1208638871640690/f

## Description
<!--
If this is a SITE BREAKAGE MITIGATION, please include a BRIEF EXPLANATION that covers the REPORTED URL, the PLATFORMS AFFECTED, and the TRACKER(S) being unblocked or FEATURE being disabled, as well as a mention of the PROBLEM(S) users are experiencing. Please also check that you have referenced the URL of this PR as the "reason" value for the exception (where applicable).
-->
Users of our macOS browser are reporting that they're seeing an 'unsupported browser' banner at the top of the page when they visit gmail.com. Investigation showed this banner is being shown due to our custom user agent, there's nothing unsupported about our browser. This PR simply hides that specific banner.

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

