### PR TITLE
Add autofill config for importing from google password manager

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -274,6 +274,48 @@
                             }
                         ]
                     }
+                },
+                "canImportFromGooglePasswordManager": {
+                    "state": "enabled",
+                    "settings": {
+                        "launchUrl": "https://passwords.google.com/options?ep=1",
+                        "javascriptConfig": {
+                            "domains": [
+                                {
+                                    "domain": ["google.com", "localhost"],
+                                    "patchSettings": [
+                                        {
+                                            "path": "",
+                                            "op": "add",
+                                            "value": {
+                                                "settingsButton": {
+                                                    "shouldAutotap": false,
+                                                    "path": "/",
+                                                    "selectors": ["a[href*='options']"],
+                                                    "labelTexts": ["Password options"]
+                                                },
+                                                "exportButton": {
+                                                    "shouldAutotap": false,
+                                                    "path": "/options",
+                                                    "selectors": [
+                                                        "c-wiz[data-node-index*='2;0'][data-p*='options']",
+                                                        "c-wiz[data-p*='options'][jsdata='deferred-i4']"
+                                                    ],
+                                                    "labelTexts": ["Export"]
+                                                },
+                                                "signInButton": {
+                                                    "shouldAutotap": false,
+                                                    "path": "/intro",
+                                                    "selectors": ["a[href*='ServiceLogin'][target='_top']"],
+                                                    "labelTexts": ["Sign in"]
+                                                }
+                                            }
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    }
                 }
             }
         },

--- a/schema/features/autofill.ts
+++ b/schema/features/autofill.ts
@@ -1,4 +1,5 @@
 import { CSSInjectFeatureSettings, Feature, SubFeature } from '../feature';
+import { Operation } from '../json-patch';
 
 // Type of the feature `settings` object
 type SettingsType = undefined;
@@ -23,7 +24,12 @@ type SubFeatures<VersionType> = {
         VersionType,
         {
             launchUrl: string;
-            javascriptConfig: CSSInjectFeatureSettings<ImportFromGooglePasswordManager>;
+            javascriptConfig: {
+                domains: {
+                    domain: string | string[];
+                    patchSettings: Operation<ImportFromGooglePasswordManager>[];
+                }[];
+            };
         }
     >;
 };


### PR DESCRIPTION
<!-- 
  ⚠️ ⚠️ IF YOU ARE MODIFYING `index.js` OR A FILE IN `features` ⚠️ ⚠️
  Please request a review and ping a DRI from the Config AOR or Breakage AOR.
  The quickest way to get attention for your PR is to ping the ~Breakage channel
  in MatterMost.

  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:** https://app.asana.com/0/608920331025315/1208746721252597/f

## Description
<!--
If this is a SITE BREAKAGE MITIGATION, please include a BRIEF EXPLANATION that covers the REPORTED URL, the PLATFORMS AFFECTED, and the TRACKER(S) being unblocked or FEATURE being disabled, as well as a mention of the PROBLEM(S) users are experiencing. Please also check that you have referenced the URL of this PR as the "reason" value for the exception (where applicable).
-->
Enables the config for importing passwords directly from Google Password Manager. 

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

