### PR TITLE
Add subfeature config to the schema

### DIFF
--- a/schema/feature.d.ts
+++ b/schema/feature.d.ts
@@ -12,6 +12,7 @@ type FeatureMeta = {
 
 type SubFeature<VersionType> = {
     state: FeatureState;
+    config?: Record<string, string>;
     rollout?: {
         steps: { percent: number }[];
     };


### PR DESCRIPTION

**Asana Task/Github Issue:**

## Description
We're adding `config` as an option key value map on sub-features. This PR adds this to the schema.

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

