### PR TITLE
Added androidHeader feature flag for Android.

### DIFF
--- a/features/android-header.json
+++ b/features/android-header.json
@@ -1,0 +1,7 @@
+{
+    "_meta": {
+        "description": "Feature toggle for adding the X-Duckduckgo-Android custom request header on DuckDuckGo search requests.",
+        "sampleExcludeRecords": {}
+    },
+    "exceptions": []
+}

--- a/index.js
+++ b/index.js
@@ -152,7 +152,8 @@ const featuresToIncludeTempUnprotectedExceptions = [
     'userAgentRotation',
     'webCompat',
     'swipingTabs',
-    'showOnAppLaunch'
+    'showOnAppLaunch',
+    'androidHeader'
 ]
 function applyGlobalUnprotectedTempExceptionsToFeatures (key, baseConfig, globalExceptions) {
     if (featuresToIncludeTempUnprotectedExceptions.includes(key)) {

--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -1385,6 +1385,9 @@
         },
         "showOnAppLaunch": {
             "state": "enabled"
+        },
+        "androidHeader": {
+            "state": "enabled"
         }
     },
     "unprotectedTemporary": [],


### PR DESCRIPTION
<!-- 
  ⚠️ ⚠️ IF YOU ARE MODIFYING `index.js` OR A FILE IN `features` ⚠️ ⚠️
  Please request a review and ping a DRI from the Config AOR or Breakage AOR.
  The quickest way to get attention for your PR is to ping the ~Breakage channel
  in MatterMost.

  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->


**Asana Task/Github Issue:** https://app.asana.com/0/1200581511062568/1208737359937183/f

## Description
<!--
If this is a SITE BREAKAGE MITIGATION, please include a BRIEF EXPLANATION that covers the REPORTED URL, the PLATFORMS AFFECTED, and the TRACKER(S) being unblocked or FEATURE being disabled, as well as a mention of the PROBLEM(S) users are experiencing. Please also check that you have referenced the URL of this PR as the "reason" value for the exception (where applicable).
-->
Added a feature toggle to easily enable / disable sending the `X-Duckduckgo-Android` request header.

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

