### PR TITLE
Disable Cookie Prompt Management (CPM) for geo.fr

### DIFF
--- a/features/autoconsent.json
+++ b/features/autoconsent.json
@@ -36,6 +36,10 @@
             "reason": "https://github.com/duckduckgo/privacy-configuration/issues/2229"
         },
         {
+            "domain": "geo.fr",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2476"
+        },
+        {
             "domain": "ksta.de",
             "reason": "https://github.com/duckduckgo/privacy-configuration/issues/326"
         },


### PR DESCRIPTION
It seems CPM gets stuck attempting to manage cookies on this website, leaving
the user stuck on the preferences pane. Let's disable it for now, while the team
fix that.

**Asana Task/Github Issue:** https://app.asana.com/0/1206670747178362/1208755113708506/f

#### Reference

-   [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
-   [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
-   [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)
