### PR TITLE
Disable tracker parameter protection for urldefense.com

### DIFF
--- a/features/tracking-parameters.json
+++ b/features/tracking-parameters.json
@@ -10,6 +10,10 @@
         {
             "domain": "axs.com",
             "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1712"
+        },
+        {
+            "domain": "urldefense.com",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2477"
         }
     ],
     "settings": {


### PR DESCRIPTION
Some websites (e.g. americanexpress.com) seem to redirect some navigations
through urldefense.com. That redirection breaks when tracker parameter
protection is enabled, since stripping some of the request parameters causes
their anti-bot wall to be triggered.

**Asana Task/Github Issue:** https://app.asana.com/0/1200277586140538/1208760644261469/f

#### Reference

-   [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
-   [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
-   [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)
