### PR TITLE
Fix broken video player on yandex.cloud

### DIFF
--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -2931,6 +2931,11 @@
                         "reason": "https://github.com/duckduckgo/privacy-configuration/issues/366"
                     },
                     {
+                        "rule": "runtime.strm.yandex.ru/player/video/",
+                        "domains": ["yandex.cloud"],
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2481"
+                    },
+                    {
                         "rule": "strm.yandex.ru/vh-special-converted/vod-content/",
                         "domains": ["<all>"],
                         "reason": "https://github.com/duckduckgo/privacy-configuration/issues/366"


### PR DESCRIPTION
The yandex.cloud domain was missing from the Yandex entity, so requests to the
Yandex video player from the domain were being blocked incorrectly. That's being
fixed, but in the meantime let's add a mitigation to fix the video player right
away.


**Asana Task/Github Issue:** https://app.asana.com/0/1204912272578138/1208770882638354/f

#### Reference

-   [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
-   [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
-   [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)
