### PR TITLE
Fix pageload issue on itsthevibe.com

### DIFF
--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -790,6 +790,7 @@
                         "domains": [
                             "ah.nl",
                             "applesfera.com",
+                            "itsthevibe.com",
                             "nytimes.com",
                             "wunderground.com",
                             "youmath.it",
@@ -801,6 +802,7 @@
                         "reason": [
                             "ah.nl - 'Bonus offer' elements do not render and are not clickable.",
                             "applesfera.com - https://github.com/duckduckgo/privacy-configuration/issues/1723",
+                            "itsthevibe.com - https://github.com/duckduckgo/privacy-configuration/pull/2482",
                             "nytimes.com - https://github.com/duckduckgo/privacy-configuration/issues/1045",
                             "wunderground.com - Video element does not display.",
                             "youmath.it - Adwall displays which prevents page interaction and resets the page view when clicked.",
@@ -840,9 +842,10 @@
                     },
                     {
                         "rule": "securepubads.g.doubleclick.net/pagead/managed/js/gpt",
-                        "domains": ["applesfera.com", "triblive.com"],
+                        "domains": ["applesfera.com", "itsthevibe.com", "triblive.com"],
                         "reason": [
                             "applesfera.com - https://github.com/duckduckgo/privacy-configuration/issues/1723",
+                            "itsthevibe - https://github.com/duckduckgo/privacy-configuration/pull/2482",
                             "triblive.com - https://github.com/duckduckgo/privacy-configuration/issues/1730"
                         ]
                     },


### PR DESCRIPTION
It turns out that some of the pages on
itsthevibe.com (e.g. https://itsthevibe.com/most-loyal-dog-breeds/) fail to load
when these requests are blocked. It seems that a value that they set on the
"FCCDCF" property of some Object is later read back, if that fails the page
stops loading. Let's unblock those for now, to get them working again.

Note: There are also some rendering issues in the DuckDuckGo iOS browser, but
      those are also present in Safari.

**Asana Task/Github Issue:** https://app.asana.com/0/1200277586140538/1208762277986372/f

#### Reference

-   [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
-   [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
-   [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)
