### PR TITLE
macOS Freemium Feature Flag: Bump available Freemium version to 1.114

### DIFF
--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -106,7 +106,7 @@
                 },
                 "freemium": {
                     "state": "enabled",
-                    "minSupportedVersion": "1.113.0"
+                    "minSupportedVersion": "1.114.0"
                 }
             },
             "minSupportedVersion": "1.70.0"


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/0/0/1208481873925787/f

## Description
* Freemium feature code was available in macOS version 1.113. However, we discovered a bug with a pixel in that version, and decided to delay rollout of Freemium to 1.114. However, the minimum version in the privacy config was incorrect. Fixing it now.

<!-- 
  Please delete either or both process sections below.
-->

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change
- [ ] I have tested this change locally
- [ ] This code for the config change is ready to merge
- [ ] This feature was covered by a tech design

#### Additional info:
<!--
  These questions are a friendly reminder to shipping config changes, if you're uncertain ask the AoR owners.
  It's also totally appropriate to not check some of these boxes, if they don't apply to your change.
-->
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [ ] This code for the config change is ready
- [ ] This change was covered by a ship review

### Site breakage mitigation process:

#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled:


- [ ] I have referenced the URL of this PR as the "reason" value for the exception (where applicable).
- [ ] This change is a speculative mitigation to fix reported breakage.

#### Reference

-   [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
-   [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
-   [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)
