### PR TITLE
add cookie-setting exception on extensions windows macos

### DIFF
--- a/overrides/extension-override.json
+++ b/overrides/extension-override.json
@@ -21,6 +21,10 @@
                 {
                     "domain": "disneyplus.com",
                     "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1622"
+                },
+                {
+                    "domain": "legalandgeneral.com",
+                    "reason": "https://github.com/duckduckgo/privacy-configuration/issues/2491"
                 }
             ]
         },

--- a/overrides/extension-override.json
+++ b/overrides/extension-override.json
@@ -24,7 +24,7 @@
                 },
                 {
                     "domain": "legalandgeneral.com",
-                    "reason": "https://github.com/duckduckgo/privacy-configuration/issues/2491"
+                    "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2491"
                 }
             ]
         },

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -120,6 +120,15 @@
                 }
             ]
         },
+        "cookie": {
+            "state": "enabled",
+            "exceptions": [
+                {
+                    "domain": "legalandgeneral.com",
+                    "reason": "https://github.com/duckduckgo/privacy-configuration/issues/2491"
+                }
+            ]
+        },
         "duckPlayer": {
             "state": "enabled",
             "features": {

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -125,7 +125,7 @@
             "exceptions": [
                 {
                     "domain": "legalandgeneral.com",
-                    "reason": "https://github.com/duckduckgo/privacy-configuration/issues/2491"
+                    "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2491"
                 }
             ]
         },

--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -145,7 +145,7 @@
             "exceptions": [
                 {
                     "domain": "legalandgeneral.com",
-                    "reason": "https://github.com/duckduckgo/privacy-configuration/issues/2491"
+                    "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2491"
                 }
             ],
             "state": "enabled",

--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -142,7 +142,12 @@
             "minSupportedVersion": "0.93.0"
         },
         "cookie": {
-            "exceptions": [],
+            "exceptions": [
+                {
+                    "domain": "legalandgeneral.com",
+                    "reason": "https://github.com/duckduckgo/privacy-configuration/issues/2491"
+                }
+            ],
             "state": "enabled",
             "minSupportedVersion": "0.36.0",
             "settings": {


### PR DESCRIPTION
<!--
  ⚠️ ⚠️ IF YOU ARE MODIFYING `index.js` OR A FILE IN `features` ⚠️ ⚠️
  Please request a review and ping a DRI from the Config AOR or Breakage AOR.
  The quickest way to get attention for your PR is to ping the ~Breakage channel
  in MatterMost.

  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Consider adding an individual reviewer as well as the groups that are automatically added (this should create a review task in Asana for them specifically).
  Use the "merge when ready" button to automatically merge the PR as soon as it's reviewed.
-->

**Asana Task/Github Issue:**

## Description

<!-- 
  Please delete either or both process sections below.
-->

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change
- [ ] I have tested this change locally
- [ ] This code for the config change is ready to merge
- [ ] This feature was covered by a tech design

#### Additional info:
<!--
  These questions are a friendly reminder to shipping config changes, if you're uncertain ask the AoR owners.
  It's also totally appropriate to not check some of these boxes, if they don't apply to your change.
-->
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [ ] This code for the config change is ready
- [ ] This change was covered by a ship review

### Site breakage mitigation process:

#### Brief explanation
- Reported URL: https://www.legalandgeneral.com/
- Problems experienced: cookie-setter prevents cookie banner to close after first interaction (MacOS/extension) or lead to an infinite banner loop (Windows)
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ x] Windows
  - [ x] MacOS
  - [ x] Extensions
- Tracker(s) being unblocked: None
- Feature being disabled: cookie-setter


- [x ] I have referenced the URL of this PR as the "reason" value for the exception (where applicable).
- [ x] This change is a speculative mitigation to fix reported breakage.

#### Reference

-   [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
-   [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
-   [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)
