### PR TITLE
add iOS and MacOS tracker mitigations on two separate sites

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -311,6 +311,24 @@
                             }
                         ]
                     },
+                    "cquotient.com": {
+                        "rules": [
+                            {
+                                "rule": "api.cquotient.com/v3",
+                                "domains": ["grillagrills.com"],
+                                "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2495"
+                            }
+                        ]
+                    },
+                    "criteo.net": {
+                        "rules": [
+                            {
+                                "rule": "static.criteo.net/js/ld/ld.js",
+                                "domains": ["jackssmallengines.com"],
+                                "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2495"
+                            }
+                        ]
+                    },
                     "doubleclick.net": {
                         "rules": [
                             {

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -804,6 +804,15 @@
                             }
                         ]
                     },
+                    "cquotient.com": {
+                        "rules": [
+                            {
+                                "rule": "api.cquotient.com/v3",
+                                "domains": ["grillagrills.com"],
+                                "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2495"
+                            }
+                        ]
+                    },
                     "criteo.net": {
                         "rules": [
                             {
@@ -815,6 +824,11 @@
                                 "rule": "static.criteo.net/js/ld/publishertag.prebid.js",
                                 "domains": ["wp.pl"],
                                 "reason": "Adwall appears which reappears when dismissed. The adwall prevents interaction with the page."
+                            },
+                            {
+                                "rule": "static.criteo.net/js/ld/ld.js",
+                                "domains": ["jackssmallengines.com"],
+                                "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2495"
                             }
                         ]
                     },


### PR DESCRIPTION
<!--
  ⚠️ ⚠️ IF YOU ARE MODIFYING `index.js` OR A FILE IN `features` ⚠️ ⚠️
  Please request a review and ping a DRI from the Config AOR or Breakage AOR.
  The quickest way to get attention for your PR is to ping the ~Breakage channel
  in MatterMost.

  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Consider adding an individual reviewer as well as the groups that are automatically added (this should create a review task in Asana for them specifically).
  Use the "merge when ready" button to automatically merge the PR as soon as it's reviewed.
-->

**Asana Task/Github Issue:**
Site 1- jacksmallengines.com: https://app.asana.com/0/1206670747178362/1208798964480679/f
Site 2 - grillagrills.com: https://app.asana.com/0/1206670747178362/1208799076109317/f

## Description

<!-- 
  Please delete either or both process sections below.
-->

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change
- [ ] I have tested this change locally
- [ ] This code for the config change is ready to merge
- [ ] This feature was covered by a tech design

#### Additional info:
<!--
  These questions are a friendly reminder to shipping config changes, if you're uncertain ask the AoR owners.
  It's also totally appropriate to not check some of these boxes, if they don't apply to your change.
-->
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [ ] This code for the config change is ready
- [ ] This change was covered by a ship review

### Site breakage mitigation process:

#### Brief explanation
- Reported URL: 
- site 1: https://www.jackssmallengines.com/jacks-parts-lookup/part/briggs-stratton/591378 
- site 2: https://www.grillagrills.com/product/ps-silverbac-alt
- Problems experienced:
- Platforms affected:
  - [x ] iOS
  - [ ] Android
  - [ ] Windows
  - [x ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked: 
- site 1: static.criteo.net/js/ld/ld.js (iOS and MacOS)
- site 2: api.cquotient.com/v3 (iOS and MacOS)
- Feature being disabled:


- [ x] I have referenced the URL of this PR as the "reason" value for the exception (where applicable).
- [ ] This change is a speculative mitigation to fix reported breakage.

#### Reference

-   [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
-   [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
-   [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)
