### PR TITLE
add-tracker-exception

### DIFF
--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -1334,7 +1334,8 @@
                             "vanguardplan.com",
                             "bodyelectricvitality.com.au",
                             "experian.com",
-                            "xpn.org"
+                            "xpn.org",
+                            "ljsilvers.com"
                         ],
                         "reason": [
                             "https://github.com/duckduckgo/privacy-configuration/issues/929",
@@ -1345,7 +1346,8 @@
                             "eatroyo.com - https://github.com/duckduckgo/privacy-configuration/issues/1830",
                             "vanguardplan.com -https://github.com/duckduckgo/privacy-configuration/issues/1941",
                             "bodyelectricvitality.com.au - https://github.com/duckduckgo/privacy-configuration/issues/2097",
-                            "experian.com - https://github.com/duckduckgo/privacy-configuration/pull/2351"
+                            "experian.com - https://github.com/duckduckgo/privacy-configuration/pull/2351",
+                            "ljsilvers.com - https://github.com/duckduckgo/privacy-configuration/pull/2496"
                         ]
                     }
                 ]


### PR DESCRIPTION
<!--
  ⚠️ ⚠️ IF YOU ARE MODIFYING `index.js` OR A FILE IN `features` ⚠️ ⚠️
  Please request a review and ping a DRI from the Config AOR or Breakage AOR.
  The quickest way to get attention for your PR is to ping the ~Breakage channel
  in MatterMost.

  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Consider adding an individual reviewer as well as the groups that are automatically added (this should create a review task in Asana for them specifically).
  Use the "merge when ready" button to automatically merge the PR as soon as it's reviewed.
-->

**Asana Task/Github Issue:**
https://app.asana.com/0/1206670747178362/1208799221959929/f

## Description

<!-- 
  Please delete either or both process sections below.
-->

### Site breakage mitigation process:

#### Brief explanation
- Reported URL:  ljsilvers.com
- Problems experienced: site freezes/does not load (depending on the platform) because we're blocking a tracker that allows an ad banner to display
- Platforms affected:
  - [ x] iOS
  - [x ] Android
  - [ x] Windows
  - [ x] MacOS
  - [ x] Extensions
- Tracker(s) being unblocked: googletagmanager.com/gtag/js
- Feature being disabled: 


- [ x] I have referenced the URL of this PR as the "reason" value for the exception (where applicable).
- [ ] This change is a speculative mitigation to fix reported breakage.

#### Reference

-   [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
-   [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
-   [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)
