### PR TITLE
add macos only cpm exception sueddeutsche.de

### DIFF
--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -520,7 +520,13 @@
                 "filterlist": {
                     "state": "enabled"
                 }
-            }
+            },
+            "exceptions": [
+                {
+                    "domain": "sueddeutsche.de",
+                    "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2500"
+                }
+            ]
         },
         "navigatorInterface": {
             "state": "enabled"


### PR DESCRIPTION
<!--
  ⚠️ ⚠️ IF YOU ARE MODIFYING `index.js` OR A FILE IN `features` ⚠️ ⚠️
  Please request a review and ping a DRI from the Config AOR or Breakage AOR.
  The quickest way to get attention for your PR is to ping the ~Breakage channel
  in MatterMost.

  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Consider adding an individual reviewer as well as the groups that are automatically added (this should create a review task in Asana for them specifically).
  Use the "merge when ready" button to automatically merge the PR as soon as it's reviewed.
-->

**Asana Task/Github Issue:**
https://app.asana.com/0/1206670747178362/1208804261945326/f

## Description

<!-- 
  Please delete either or both process sections below.
-->

### Site breakage mitigation process:

#### Brief explanation
- Reported URL: sueddeutsche.de
- Problems experienced: on MacOS, cpm prevents the site to function properly (crash or scrolling impossible)
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ x] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled: cpm


- [x ] I have referenced the URL of this PR as the "reason" value for the exception (where applicable).
- [ ] This change is a speculative mitigation to fix reported breakage.

#### Reference

-   [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
-   [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
-   [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)
