### PR TITLE
Add Malicious Site Protections Configuration

### DIFF
--- a/features/malicious-site-protection.json
+++ b/features/malicious-site-protection.json
@@ -1,6 +1,6 @@
 {
     "_meta": {
-        "description": "Phishing Detection",
+        "description": "Malicious Site Protection",
         "sampleExcludeRecords": {}
     },
     "state": "disabled",

--- a/features/phishing-detection.json
+++ b/features/phishing-detection.json
@@ -1,0 +1,8 @@
+{
+    "_meta": {
+        "description": "Phishing Detection",
+        "sampleExcludeRecords": {}
+    },
+    "state": "disabled",
+    "exceptions": []
+}

--- a/features/phishing-detection.json
+++ b/features/phishing-detection.json
@@ -1,6 +1,6 @@
 {
     "_meta": {
-        "description": "Phishing Detection",
+        "description": "Phishing Detection: this feature is deprecated in favour of MaliciousSiteProtection.",
         "sampleExcludeRecords": {}
     },
     "state": "disabled",

--- a/index.js
+++ b/index.js
@@ -141,6 +141,7 @@ const featuresToIncludeTempUnprotectedExceptions = [
     'navigatorInterface',
     'nonTracking3pCookies',
     'performanceMetrics',
+    'phishingDetection',
     'maliciousSiteProtection',
     'referrer',
     'requestFilterer',

--- a/index.js
+++ b/index.js
@@ -141,8 +141,6 @@ const featuresToIncludeTempUnprotectedExceptions = [
     'navigatorInterface',
     'nonTracking3pCookies',
     'performanceMetrics',
-    'phishingDetection',
-    'maliciousSiteProtection',
     'referrer',
     'requestFilterer',
     'runtimeChecks',

--- a/index.js
+++ b/index.js
@@ -141,7 +141,7 @@ const featuresToIncludeTempUnprotectedExceptions = [
     'navigatorInterface',
     'nonTracking3pCookies',
     'performanceMetrics',
-    'phishingDetection',
+    'maliciousSiteProtection',
     'referrer',
     'requestFilterer',
     'runtimeChecks',

--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -1441,7 +1441,22 @@
         },
         "showOnAppLaunch": {
             "state": "enabled"
-        }
+        },
+        "maliciousSiteProtection": {
+            "state": "internal",
+            "features": {
+                "allowPhishingURLChecks": {
+                    "state": "internal"
+                },
+                "allowMalwareURLChecks": {
+                    "state": "internal"
+                }
+            },
+	    "settings": {
+		"hashPrefixUpdateFrequency": 20,
+		"filterSetUpdateFrequency": 720
+	    }
+        },
     },
     "unprotectedTemporary": [],
     "experimentalVariants": {

--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -1452,11 +1452,12 @@
                     "state": "internal"
                 }
             },
-	    "settings": {
-		"hashPrefixUpdateFrequency": 20,
-		"filterSetUpdateFrequency": 720
-	    }
-        },
+            "settings": {
+                "hashPrefixUpdateFrequency": 20,
+                "filterSetUpdateFrequency": 720
+            },
+	    "exceptions": []
+        }
     },
     "unprotectedTemporary": [],
     "experimentalVariants": {

--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -1456,7 +1456,7 @@
                 "hashPrefixUpdateFrequency": 20,
                 "filterSetUpdateFrequency": 720
             },
-	    "exceptions": []
+            "exceptions": []
         }
     },
     "unprotectedTemporary": [],

--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -1444,14 +1444,6 @@
         },
         "maliciousSiteProtection": {
             "state": "internal",
-            "features": {
-                "allowPhishingURLChecks": {
-                    "state": "internal"
-                },
-                "allowMalwareURLChecks": {
-                    "state": "internal"
-                }
-            },
             "settings": {
                 "hashPrefixUpdateFrequency": 20,
                 "filterSetUpdateFrequency": 720

--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -582,17 +582,6 @@
                 }
             }
         },
-        "phishingDetection": {
-            "state": "internal",
-            "features": {
-                "allowErrorPage": {
-                    "state": "internal"
-                },
-                "allowPreferencesToggle": {
-                    "state": "internal"
-                }
-            }
-        },
         "maliciousSiteProtection": {
             "state": "internal",
             "settings": {

--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -584,14 +584,6 @@
         },
         "maliciousSiteProtection": {
             "state": "internal",
-            "features": {
-                "allowPhishingURLChecks": {
-                    "state": "internal"
-                },
-                "allowMalwareURLChecks": {
-                    "state": "internal"
-                }
-            },
             "settings": {
                 "hashPrefixUpdateFrequency": 20,
                 "filterSetUpdateFrequency": 720

--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -582,16 +582,20 @@
                 }
             }
         },
-        "phishingDetection": {
+        "maliciousSiteProtection": {
             "state": "internal",
             "features": {
-                "allowErrorPage": {
+                "allowPhishingURLChecks": {
                     "state": "internal"
                 },
-                "allowPreferencesToggle": {
+                "allowMalwareURLChecks": {
                     "state": "internal"
                 }
-            }
+            },
+	    "settings": {
+		"hashPrefixUpdateFrequency": 20,
+		"filterSetUpdateFrequency": 720
+	    }
         },
         "backgroundAgentPixelTest": {
             "state": "enabled",

--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -592,10 +592,11 @@
                     "state": "internal"
                 }
             },
-	    "settings": {
-		"hashPrefixUpdateFrequency": 20,
-		"filterSetUpdateFrequency": 720
-	    }
+            "settings": {
+                "hashPrefixUpdateFrequency": 20,
+                "filterSetUpdateFrequency": 720
+            },
+	    "exceptions": []
         },
         "backgroundAgentPixelTest": {
             "state": "enabled",

--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -596,7 +596,7 @@
                 "hashPrefixUpdateFrequency": 20,
                 "filterSetUpdateFrequency": 720
             },
-	    "exceptions": []
+            "exceptions": []
         },
         "backgroundAgentPixelTest": {
             "state": "enabled",

--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -582,6 +582,17 @@
                 }
             }
         },
+        "phishingDetection": {
+            "state": "internal",
+            "features": {
+                "allowErrorPage": {
+                    "state": "internal"
+                },
+                "allowPreferencesToggle": {
+                    "state": "internal"
+                }
+            }
+        },
         "maliciousSiteProtection": {
             "state": "internal",
             "settings": {

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -1049,6 +1049,17 @@
         "remoteMessaging": {
             "state": "enabled"
         },
+        "phishingDetection": {
+            "state": "internal",
+            "features": {
+                "allowErrorPage": {
+                    "state": "internal"
+                },
+                "allowPreferencesToggle": {
+                    "state": "internal"
+                }
+            }
+        },
         "maliciousSiteProtection": {
             "state": "internal",
             "settings": {

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -1063,7 +1063,7 @@
                 "hashPrefixUpdateFrequency": 20,
                 "filterSetUpdateFrequency": 720
             },
-	    "exceptions": []
+            "exceptions": []
         },
         "backgroundAgentPixelTest": {
             "state": "enabled",

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -1049,16 +1049,20 @@
         "remoteMessaging": {
             "state": "enabled"
         },
-        "phishingDetection": {
+        "maliciousSiteProtection": {
             "state": "internal",
             "features": {
-                "allowErrorPage": {
+                "allowPhishingURLChecks": {
                     "state": "internal"
                 },
-                "allowPreferencesToggle": {
+                "allowMalwareURLChecks": {
                     "state": "internal"
                 }
-            }
+            },
+	    "settings": {
+		"hashPrefixUpdateFrequency": 20,
+		"filterSetUpdateFrequency": 720
+	    }
         },
         "backgroundAgentPixelTest": {
             "state": "enabled",

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -1051,14 +1051,6 @@
         },
         "maliciousSiteProtection": {
             "state": "internal",
-            "features": {
-                "allowPhishingURLChecks": {
-                    "state": "internal"
-                },
-                "allowMalwareURLChecks": {
-                    "state": "internal"
-                }
-            },
             "settings": {
                 "hashPrefixUpdateFrequency": 20,
                 "filterSetUpdateFrequency": 720

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -1059,10 +1059,11 @@
                     "state": "internal"
                 }
             },
-	    "settings": {
-		"hashPrefixUpdateFrequency": 20,
-		"filterSetUpdateFrequency": 720
-	    }
+            "settings": {
+                "hashPrefixUpdateFrequency": 20,
+                "filterSetUpdateFrequency": 720
+            },
+	    "exceptions": []
         },
         "backgroundAgentPixelTest": {
             "state": "enabled",

--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -378,7 +378,7 @@
                 "hashPrefixUpdateFrequency": 20,
                 "filterSetUpdateFrequency": 720
             },
-	    "exceptions": []
+            "exceptions": []
         }
     },
     "unprotectedTemporary": []

--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -363,7 +363,22 @@
         },
         "windowsNewTabPageExperiment": {
             "state": "disabled"
-        }
+        },
+        "maliciousSiteProtection": {
+            "state": "internal",
+            "features": {
+                "allowPhishingURLChecks": {
+                    "state": "internal"
+                },
+                "allowMalwareURLChecks": {
+                    "state": "internal"
+                }
+            },
+	    "settings": {
+		"hashPrefixUpdateFrequency": 20,
+		"filterSetUpdateFrequency": 720
+	    }
+        },
     },
     "unprotectedTemporary": []
 }

--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -366,14 +366,6 @@
         },
         "maliciousSiteProtection": {
             "state": "internal",
-            "features": {
-                "allowPhishingURLChecks": {
-                    "state": "internal"
-                },
-                "allowMalwareURLChecks": {
-                    "state": "internal"
-                }
-            },
             "settings": {
                 "hashPrefixUpdateFrequency": 20,
                 "filterSetUpdateFrequency": 720

--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -374,11 +374,12 @@
                     "state": "internal"
                 }
             },
-	    "settings": {
-		"hashPrefixUpdateFrequency": 20,
-		"filterSetUpdateFrequency": 720
-	    }
-        },
+            "settings": {
+                "hashPrefixUpdateFrequency": 20,
+                "filterSetUpdateFrequency": 720
+            },
+	    "exceptions": []
+        }
     },
     "unprotectedTemporary": []
 }

--- a/schema/features/malicious-site-protection.ts
+++ b/schema/features/malicious-site-protection.ts
@@ -1,9 +1,4 @@
-import { Feature, CSSInjectFeatureSettings } from '../feature';
-
-type State = 'enabled' | 'disabled' | 'internal';
-type StateObject = {
-    state: State;
-};
+import { CSSInjectFeatureSettings } from '../feature';
 
 export type MaliciousSiteProtectionSettings = CSSInjectFeatureSettings<{
     hashPrefixUpdateFrequency: number;

--- a/schema/features/malicious-site-protection.ts
+++ b/schema/features/malicious-site-protection.ts
@@ -1,0 +1,11 @@
+import { Feature, CSSInjectFeatureSettings } from '../feature';
+
+type State = 'enabled' | 'disabled' | 'internal';
+type StateObject = {
+    state: State;
+};
+
+export type MaliciousSiteProtectionSettings = CSSInjectFeatureSettings<{
+    hashPrefixUpdateFrequency: number;
+    filterSetUpdateFrequency: number;
+}>;


### PR DESCRIPTION
<!--
  ⚠️ ⚠️ IF YOU ARE MODIFYING `index.js` OR A FILE IN `features` ⚠️ ⚠️
  Please request a review and ping a DRI from the Config AOR or Breakage AOR.
  The quickest way to get attention for your PR is to ping the ~Breakage channel
  in MatterMost.

  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Consider adding an individual reviewer as well as the groups that are automatically added (this should create a review task in Asana for them specifically).
  Use the "merge when ready" button to automatically merge the PR as soon as it's reviewed.
-->

**Asana Task/Github Issue:** https://app.asana.com/0/72649045549333/1208815326657419/f

## Description
Currently the malicious site protections config is named phishingDetection but as we're adding more data classes to it I'm proposing we rename it to maliciousSiteProtection for consistency.
The config currently contains the following fields:
 - allowErrorPage: when true, the phishing detection feature is enabled and checks are performed for all navigation events.
 - allowPreferencesToggle: when true, there is a settings toggle to allow users to enable/disable the feature.

We've discussed removing the subfeature flags for `allowErrorPage` and `allowPreferencesToggle` so it's combined in just one main flag for the whole feature, and adding settings:

 -  when the main feature flag is enabled, we allow phishing + malware protections to run in the browser
 - settings.hashPrefixUpdateFrequency: currently set to 20 minutes
 - settings.filterSetUpdateFrequency: currently set to 12 hours (in minutes: 720)

<!-- 
  Please delete either or both process sections below.
-->

### Feature change process:

- [x] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change
- [x] I have tested this change locally
- [x] This code for the config change is ready to merge - yes for Android + macOS.
- [x] This feature was covered by a tech design: https://app.asana.com/0/481882893211075/1207273224076495/f

#### Additional info:
<!--
  These questions are a friendly reminder to shipping config changes, if you're uncertain ask the AoR owners.
  It's also totally appropriate to not check some of these boxes, if they don't apply to your change.
-->
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [ ] This code for the config change is ready
- [ ] This change was covered by a ship review

#### Reference

-   [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
-   [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
-   [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)
