### PR TITLE
add-tracker-exception

### DIFF
--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -754,6 +754,11 @@
                         "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2410"
                     },
                     {
+                        "rule": "securepubads.g.doubleclick.net",
+                        "domains": ["xataka.com"],
+                        "reason": ["xataka.com - https://github.com/duckduckgo/privacy-configuration/pull/2506"]
+                    },
+                    {
                         "rule": "securepubads.g.doubleclick.net/gampad/ads",
                         "domains": ["ah.nl", "applesfera.com", "rocketnews24.com", "servustv.com"],
                         "reason": [

--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -756,7 +756,7 @@
                     {
                         "rule": "securepubads.g.doubleclick.net",
                         "domains": ["xataka.com"],
-                        "reason": ["xataka.com - https://github.com/duckduckgo/privacy-configuration/pull/2506"]
+                        "reason": ["xataka.com - https://github.com/duckduckgo/privacy-configuration/pull/2507"]
                     },
                     {
                         "rule": "securepubads.g.doubleclick.net/gampad/ads",


### PR DESCRIPTION
<!--
  ⚠️ ⚠️ IF YOU ARE MODIFYING `index.js` OR A FILE IN `features` ⚠️ ⚠️
  Please request a review and ping a DRI from the Config AOR or Breakage AOR.
  The quickest way to get attention for your PR is to ping the ~Breakage channel
  in MatterMost.

  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Consider adding an individual reviewer as well as the groups that are automatically added (this should create a review task in Asana for them specifically).
  Use the "merge when ready" button to automatically merge the PR as soon as it's reviewed.
-->

**Asana Task/Github Issue:**
https://app.asana.com/0/1206670747178362/1208820592713388/f

## Description

<!-- 
  Please delete either or both process sections below.
-->


### Site breakage mitigation process:

#### Brief explanation
- Reported URL: https://www.xataka.com/basics/que-bluesky-que-opciones-ofrece-como-te-puedes-registrar-a-esta-alternativa-a-twitter
- Problems experienced: video does not load because of blocking a tracker
- Platforms affected:
  - [ x] iOS
  - [ x] Android
  - [ x] Windows
  - [ x] MacOS
  - [ x] Extensions
- Tracker(s) being unblocked: securepubads.g.doubleclick.net
- Feature being disabled:


- [ x] I have referenced the URL of this PR as the "reason" value for the exception (where applicable).
- [ ] This change is a speculative mitigation to fix reported breakage.

#### Reference

-   [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
-   [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
-   [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)
