### PR TITLE
Revert "Set setAccessTokenCookieForSubscriptionDomains to enabled for iOS and macOS"

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -565,9 +565,6 @@
                 "useUnifiedFeedback": {
                     "state": "enabled",
                     "minSupportedVersion": "7.136.0"
-                },
-                "setAccessTokenCookieForSubscriptionDomains": {
-                    "state": "enabled"
                 }
             }
         },

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -1035,9 +1035,6 @@
                 "useUnifiedFeedback": {
                     "state": "enabled",
                     "minSupportedVersion": "1.113.0"
-                },
-                "setAccessTokenCookieForSubscriptionDomains": {
-                    "state": "enabled"
                 }
             }
         },


### PR DESCRIPTION
Reverts duckduckgo/privacy-configuration#2506

This change is aligned with a large increase in crashes so I'm disabling it while investigating it further, as it's the only remote change that lines up with the spike. I'll re-enable this later today if it turns out to be unrelated.