### PR TITLE
Enforce stricter feature naming

### DIFF
--- a/tests/config-tests.js
+++ b/tests/config-tests.js
@@ -42,9 +42,37 @@ describe('Config schema tests', () => {
             });
 
             it('all features should be named correctly', () => {
+                const grandfatheredFeatures = [
+                    'androidBrowserConfig',
+                    'androidNewStateKillSwitch',
+                    'windowsDownloadLink',
+                    'windowsExternalPreviewReleases',
+                    'windowsFireWindow',
+                    'windowsNewTabPageExperiment',
+                    'windowsPermissionUsage',
+                    'windowsPrecisionScroll',
+                    'windowsSpellChecker',
+                    'windowsStartupBoost',
+                    'windowsWaitlist',
+                    'windowsWebviewFailures',
+                ];
+                const deviceSpecificCheck = /(android|ios|windows|macos)/i;
                 const featureNameRegex = /^[a-zA-Z0-9]+$/;
                 for (const featureName of Object.keys(config.body.features)) {
                     expect(featureName).to.match(featureNameRegex);
+                    // Features should not have platform specific names so we can use the same config for all platforms.
+                    if (!grandfatheredFeatures.includes(featureName)) {
+                        expect(featureName).to.not.match(deviceSpecificCheck);
+                    }
+
+                    // All subfeatures should also be named correctly
+                    const feature = config.body.features[featureName];
+                    if (feature.features) {
+                        for (const subfeatureName of Object.keys(feature.features)) {
+                            expect(subfeatureName).to.match(featureNameRegex);
+                            expect(subfeatureName).to.not.match(deviceSpecificCheck);
+                        }
+                    }
                 }
             });
 


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/0/1200890834746050/1207684653428996/f

## Description

Enforce a stricter naming convention on features.
The intention of the config is that features share the config across platforms.
Many of these existing features will be brought to other platforms and will need a secondary feature to bring it there.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change
- [ ] I have tested this change locally
- [ ] This code for the config change is ready to merge
- [ ] This feature was covered by a tech design

#### Additional info:
<!--
  These questions are a friendly reminder to shipping config changes, if you're uncertain ask the AoR owners.
  It's also totally appropriate to not check some of these boxes, if they don't apply to your change.
-->
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [ ] This code for the config change is ready
- [ ] This change was covered by a ship review

### Site breakage mitigation process:

#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled:


- [ ] I have referenced the URL of this PR as the "reason" value for the exception (where applicable).
- [ ] This change is a speculative mitigation to fix reported breakage.

#### Reference

-   [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
-   [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
-   [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)
