### PR TITLE
Enable setAccessTokenCookieForSubscriptionDomains on iOS to 50%

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -572,6 +572,9 @@
                         "steps": [
                             {
                                 "percent": 25
+                            },
+                            {
+                                "percent": 50
                             }
                         ]
                     },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/0/1142021229838617/1208817916675091/f

## Description
Enable setAccessTokenCookieForSubscriptionDomains on iOS to 50%

#### Reference

-   [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
-   [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
-   [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)
