### PR TITLE
Enable Privacy Stats experiment on Windows New Tab Page

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -362,7 +362,8 @@
             "state": "disabled"
         },
         "windowsNewTabPageExperiment": {
-            "state": "enabled"
+            "state": "enabled",
+            "minSupportedVersion": "0.96.0"
         }
     },
     "unprotectedTemporary": []

--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -362,7 +362,7 @@
             "state": "disabled"
         },
         "windowsNewTabPageExperiment": {
-            "state": "disabled"
+            "state": "enabled"
         }
     },
     "unprotectedTemporary": []


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/0/72649045549333/1208335220657027/f

## Description
Enables the Privacy Stats A/B experiment on Windows New Tab Page **for new users**.

#### Additional info:
<!--
  These questions are a friendly reminder to shipping config changes, if you're uncertain ask the AoR owners.
  It's also totally appropriate to not check some of these boxes, if they don't apply to your change.
-->
- [x] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [x] This code for the config change is ready
- [x] This change was covered by a ship review

#### Reference

-   [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
-   [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
-   [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)
