### PR TITLE
Revert "Add Malicious Site Protections Configuration"

### DIFF
--- a/features/malicious-site-protection.json
+++ b/features/malicious-site-protection.json
@@ -1,8 +1,0 @@
-{
-    "_meta": {
-        "description": "Malicious Site Protection",
-        "sampleExcludeRecords": {}
-    },
-    "state": "disabled",
-    "exceptions": []
-}

--- a/features/phishing-detection.json
+++ b/features/phishing-detection.json
@@ -1,6 +1,6 @@
 {
     "_meta": {
-        "description": "Phishing Detection: this feature is deprecated in favour of MaliciousSiteProtection.",
+        "description": "Phishing Detection",
         "sampleExcludeRecords": {}
     },
     "state": "disabled",

--- a/index.js
+++ b/index.js
@@ -141,6 +141,7 @@ const featuresToIncludeTempUnprotectedExceptions = [
     'navigatorInterface',
     'nonTracking3pCookies',
     'performanceMetrics',
+    'phishingDetection',
     'referrer',
     'requestFilterer',
     'runtimeChecks',

--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -1448,14 +1448,6 @@
         },
         "showOnAppLaunch": {
             "state": "enabled"
-        },
-        "maliciousSiteProtection": {
-            "state": "internal",
-            "settings": {
-                "hashPrefixUpdateFrequency": 20,
-                "filterSetUpdateFrequency": 720
-            },
-            "exceptions": []
         }
     },
     "unprotectedTemporary": [],

--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -596,13 +596,16 @@
                 }
             }
         },
-        "maliciousSiteProtection": {
+        "phishingDetection": {
             "state": "internal",
-            "settings": {
-                "hashPrefixUpdateFrequency": 20,
-                "filterSetUpdateFrequency": 720
-            },
-            "exceptions": []
+            "features": {
+                "allowErrorPage": {
+                    "state": "internal"
+                },
+                "allowPreferencesToggle": {
+                    "state": "internal"
+                }
+            }
         },
         "backgroundAgentPixelTest": {
             "state": "enabled",

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -1060,14 +1060,6 @@
                 }
             }
         },
-        "maliciousSiteProtection": {
-            "state": "internal",
-            "settings": {
-                "hashPrefixUpdateFrequency": 20,
-                "filterSetUpdateFrequency": 720
-            },
-            "exceptions": []
-        },
         "backgroundAgentPixelTest": {
             "state": "enabled",
             "features": {

--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -363,14 +363,6 @@
         },
         "windowsNewTabPageExperiment": {
             "state": "disabled"
-        },
-        "maliciousSiteProtection": {
-            "state": "internal",
-            "settings": {
-                "hashPrefixUpdateFrequency": 20,
-                "filterSetUpdateFrequency": 720
-            },
-            "exceptions": []
         }
     },
     "unprotectedTemporary": []

--- a/schema/features/malicious-site-protection.ts
+++ b/schema/features/malicious-site-protection.ts
@@ -1,6 +1,0 @@
-import { CSSInjectFeatureSettings } from '../feature';
-
-export type MaliciousSiteProtectionSettings = CSSInjectFeatureSettings<{
-    hashPrefixUpdateFrequency: number;
-    filterSetUpdateFrequency: number;
-}>;


### PR DESCRIPTION
Reverts the Windows changes in duckduckgo/privacy-configuration#2502. Windows does not support the "internal" state for feature flags yet.