### PR TITLE
[ON HOLD] Disable toggle reporting on Android until dashboard support is merged

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -1459,7 +1459,7 @@
         }
     },
     "toggleReports": {
-        "state": "disabled"
+        "state": "disabled",
         "exceptions": []
     },
     "unprotectedTemporary": [],

--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -1458,6 +1458,10 @@
             "exceptions": []
         }
     },
+    "toggleReports": {
+        "state": "disabled"
+        "exceptions": []
+    },
     "unprotectedTemporary": [],
     "experimentalVariants": {
         "variants": [


### PR DESCRIPTION
<!--
  ⚠️ ⚠️ IF YOU ARE MODIFYING `index.js` OR A FILE IN `features` ⚠️ ⚠️
  Please request a review and ping a DRI from the Config AOR or Breakage AOR.
  The quickest way to get attention for your PR is to ping the ~Breakage channel
  in MatterMost.

  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Consider adding an individual reviewer as well as the groups that are automatically added (this should create a review task in Asana for them specifically).
  Use the "merge when ready" button to automatically merge the PR as soon as it's reviewed.
-->

**Asana Task/Github Issue:**
https://app.asana.com/0/1201870266890790/1206465215684034/f
https://app.asana.com/0/0/1208865759492772/f

## Description
Just-in-case PR to disable toggle reports in case we're able to merge the native changes before dashboard support is available.

<!-- 
  Please delete either or both process sections below.
-->

#### Reference

-   [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
-   [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
-   [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)
