### PR TITLE
Disable setAccessTokenCookieForSubscriptionDomains

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -581,7 +581,7 @@
                     "minSupportedVersion": "7.136.0"
                 },
                 "setAccessTokenCookieForSubscriptionDomains": {
-                    "state": "enabled",
+                    "state": "disabled",
                     "rollout": {
                         "steps": [
                             {

--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -594,8 +594,7 @@
                                 "percent": 100
                             }
                         ]
-                    },
-                    "minSupportedVersion": "7.146.1"
+                    }
                 },
                 "freeTrials": {
                     "state": "internal"


### PR DESCRIPTION
**Asana Task/Github Issue:**

## Description
Disabling the flag for iOS per https://app.asana.com/0/72649045549333/1208885594642118/f


#### Reference

-   [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
-   [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
-   [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)
