### PR TITLE
Android: Remove loading bar experiment

### DIFF
--- a/features/loading-bar-exp.json
+++ b/features/loading-bar-exp.json
@@ -1,7 +1,0 @@
-{
-    "_meta": {
-        "description": "An experiment to test immediately showing the loading bar when a link is clicked.",
-        "sampleExcludeRecords": {}
-    },
-    "exceptions": []
-}

--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -738,21 +738,6 @@
                 }
             }
         },
-        "loadingBarExp": {
-            "state": "disabled",
-            "features": {
-                "allocateVariants": {
-                    "state": "disabled",
-                    "rollout": {
-                        "steps": [
-                            {
-                                "percent": 20
-                            }
-                        ]
-                    }
-                }
-            }
-        },
         "trackerAllowlist": {
             "state": "enabled",
             "settings": {


### PR DESCRIPTION
<!--
  ⚠️ ⚠️ IF YOU ARE MODIFYING `index.js` OR A FILE IN `features` ⚠️ ⚠️
  Please request a review and ping a DRI from the Config AOR or Breakage AOR.
  The quickest way to get attention for your PR is to ping the ~Breakage channel
  in MatterMost.

  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Consider adding an individual reviewer as well as the groups that are automatically added (this should create a review task in Asana for them specifically).
  Use the "merge when ready" button to automatically merge the PR as soon as it's reviewed.
-->

**Asana Task/Github Issue:** https://app.asana.com/0/1200204095367872/1208886040644863/f

## Description
Removes `loadingBarExp` from the Android config.

<!-- 
  Please delete either or both process sections below.
-->

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change
- [x] I have tested this change locally
- [x] This code for the config change is ready to merge
- [ ] This feature was covered by a tech design

#### Additional info:
<!--
  These questions are a friendly reminder to shipping config changes, if you're uncertain ask the AoR owners.
  It's also totally appropriate to not check some of these boxes, if they don't apply to your change.
-->
- [x] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [x] This code for the config change is ready
- [ ] This change was covered by a ship review

#### Reference

-   [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
-   [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
-   [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)
