### PR TITLE
Enable autofill surveys on iOS and Android (December 2024)

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -373,7 +373,12 @@
         "autofillSurveys": {
             "state": "enabled",
             "settings": {
-                "surveys": []
+                "surveys": [
+                    {
+                        "id": "2024-12-04",
+                        "url": "https://selfserve.decipherinc.com/survey/selfserve/32ab/241200"
+                    }
+                ]
             }
         },
         "androidBrowserConfig": {

--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -229,7 +229,12 @@
         "autofillSurveys": {
             "state": "enabled",
             "settings": {
-                "surveys": []
+                "surveys": [
+                    {
+                        "id": "2024-12-04",
+                        "url": "https://selfserve.decipherinc.com/survey/selfserve/32ab/241201"
+                    }
+                ]
             }
         },
         "incontextSignup": {


### PR DESCRIPTION
<!--
  ⚠️ ⚠️ IF YOU ARE MODIFYING `index.js` OR A FILE IN `features` ⚠️ ⚠️
  Please request a review and ping a DRI from the Config AOR or Breakage AOR.
  The quickest way to get attention for your PR is to ping the ~Breakage channel
  in MatterMost.

  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Consider adding an individual reviewer as well as the groups that are automatically added (this should create a review task in Asana for them specifically).
  Use the "merge when ready" button to automatically merge the PR as soon as it's reviewed.
-->

**Asana Task/Github Issue:** https://app.asana.com/0/72649045549333/1208900584454362/f

## Description
Enables autofill surveys (December 2024 edition) for iOS and Android


#### Additional info:
<!--
  These questions are a friendly reminder to shipping config changes, if you're uncertain ask the AoR owners.
  It's also totally appropriate to not check some of these boxes, if they don't apply to your change.
-->
- [x] I have tested this change locally in all supported browsers
- [x] This change will be visible to users
- [x] This code for the config change is ready
- [x] This change was covered by a ship review


#### Reference

-   [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
-   [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
-   [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)
