### PR TITLE
Mitigate CPM breakage on Google SERP

### DIFF
--- a/features/autoconsent.json
+++ b/features/autoconsent.json
@@ -590,6 +590,26 @@
         {
             "domain": "outlet46.de",
             "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2501"
+        },
+        {
+            "domain": "www.google.com",
+            "reason": "false positive cosmetic filter hiding top of results"
+        },
+        {
+            "domain": "www.google.fr",
+            "reason": "false positive cosmetic filter hiding top of results"
+        },
+        {
+            "domain": "www.google.de",
+            "reason": "false positive cosmetic filter hiding top of results"
+        },
+        {
+            "domain": "www.google.ca",
+            "reason": "false positive cosmetic filter hiding top of results"
+        },
+        {
+            "domain": "www.google.co.uk",
+            "reason": "false positive cosmetic filter hiding top of results"
         }
     ],
     "settings": {


### PR DESCRIPTION
<!--
  ⚠️ ⚠️ IF YOU ARE MODIFYING `index.js` OR A FILE IN `features` ⚠️ ⚠️
  Please request a review and ping a DRI from the Config AOR or Breakage AOR.
  The quickest way to get attention for your PR is to ping the ~Breakage channel
  in MatterMost.

  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Consider adding an individual reviewer as well as the groups that are automatically added (this should create a review task in Asana for them specifically).
  Use the "merge when ready" button to automatically merge the PR as soon as it's reviewed.
-->

**Asana Task/Github Issue:** https://app.asana.com/0/1200277586140538/1208919292827292/f

## Description
Temporary CPM mitigation Google domains. A cosmetic rule for `#taw > div > [data-ved]` seems to be over-matching on something unrelated to cookies.


### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change
- [ ] I have tested this change locally
- [ ] This code for the config change is ready to merge
- [ ] This feature was covered by a tech design

#### Additional info:
<!--
  These questions are a friendly reminder to shipping config changes, if you're uncertain ask the AoR owners.
  It's also totally appropriate to not check some of these boxes, if they don't apply to your change.
-->
- [x] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [ ] This code for the config change is ready
- [ ] This change was covered by a ship review

### Site breakage mitigation process:

#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [x] Windows
  - [x] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled:


- [ ] I have referenced the URL of this PR as the "reason" value for the exception (where applicable).
- [ ] This change is a speculative mitigation to fix reported breakage.

#### Reference

-   [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
-   [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
-   [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)
