### PR TITLE
Override user agent for macOS browser for Microsoft Teams

### DIFF
--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -757,6 +757,10 @@
                     {
                         "domain": "mail.google.com",
                         "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1295"
+                    },
+                    {
+                        "domain": "teams.microsoft.com",
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2557"
                     }
                 ],
                 "webViewDefault": [


### PR DESCRIPTION
There is an issue with Microsoft Teams that is stopping macOS DuckDuckGo users
from joining calls. It seems related to the UserAgent header, sending a
different header is enough to workaround the problem.

**Asana Task/Github Issue:** https://app.asana.com/0/1200277586140538/1208936174052173/f