### PR TITLE
Enable additionalCampaignPixelParams origins on iOS for upcoming remote message

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -7,6 +7,16 @@
                 "includeToken": false
             }
         },
+        "additionalCampaignPixelParams": {
+            "state": "enabled",
+            "exceptions": [],
+            "settings": {
+                "origins": [
+                    "funnel_pro_iosrmf_announcement"
+                ]
+            },
+            "minSupportedVersion": "7.131.0"
+        },
         "textZoom": {
             "state": "enabled"
         },

--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -11,9 +11,7 @@
             "state": "enabled",
             "exceptions": [],
             "settings": {
-                "origins": [
-                    "funnel_pro_iosrmf_announcement"
-                ]
+                "origins": ["funnel_pro_iosrmf_announcement"]
             },
             "minSupportedVersion": "7.131.0"
         },


### PR DESCRIPTION
<!--
  ⚠️ ⚠️ IF YOU ARE MODIFYING `index.js` OR A FILE IN `features` ⚠️ ⚠️
  Please request a review and ping a DRI from the Config AOR or Breakage AOR.
  The quickest way to get attention for your PR is to ping the ~Breakage channel
  in MatterMost.

  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Consider adding an individual reviewer as well as the groups that are automatically added (this should create a review task in Asana for them specifically).
  Use the "merge when ready" button to automatically merge the PR as soon as it's reviewed.
-->

**Asana Task/Github Issue:**
https://app.asana.com/0/1204739911139421/1208921574824124/f

## Description
Enables `additionalCampaignPixelParams` for the upcoming remote message with id `funnel_pro_iosrmf_announcement`

<!-- 
  Please delete either or both process sections below.
-->


#### Reference

-   [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
-   [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
-   [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)
