### PR TITLE
Further reduce the mitigation for asuracomic.net

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -73,12 +73,7 @@
         },
         "contentBlocking": {
             "state": "enabled",
-            "exceptions": [
-                {
-                    "domain": "asuracomic.net",
-                    "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2542"
-                }
-            ]
+            "exceptions": []
         },
         "history": {
             "state": "enabled",
@@ -368,10 +363,11 @@
                         "rules": [
                             {
                                 "rule": "securepubads.g.doubleclick.net/tag/js/gpt.js",
-                                "domains": ["solitaired.com", "uwbadgers.com"],
+                                "domains": ["solitaired.com", "uwbadgers.com", "asuracomic.net"],
                                 "reason": [
                                     "solitaired.com - https://github.com/duckduckgo/privacy-configuration/pull/2329",
-                                    "uwbadgers.com - https://github.com/duckduckgo/privacy-configuration/issues/1593"
+                                    "uwbadgers.com - https://github.com/duckduckgo/privacy-configuration/issues/1593",
+                                    "asuracomic.net - https://github.com/duckduckgo/privacy-configuration/pull/2571"
                                 ]
                             },
                             {

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -117,10 +117,6 @@
                 {
                     "domain": "wjla.com",
                     "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2319"
-                },
-                {
-                    "domain": "asuracomic.net",
-                    "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2542"
                 }
             ]
         },
@@ -872,10 +868,11 @@
                         "rules": [
                             {
                                 "rule": "securepubads.g.doubleclick.net/tag/js/gpt.js",
-                                "domains": ["solitaired.com", "uwbadgers.com"],
+                                "domains": ["solitaired.com", "uwbadgers.com", "asuracomic.net"],
                                 "reason": [
                                     "solitaired.com - https://github.com/duckduckgo/privacy-configuration/pull/2329",
-                                    "uwbadgers.com - https://github.com/duckduckgo/privacy-configuration/issues/1593"
+                                    "uwbadgers.com - https://github.com/duckduckgo/privacy-configuration/issues/1593",
+                                    "asuracomic.net - https://github.com/duckduckgo/privacy-configuration/pull/2571"
                                 ]
                             },
                             {


### PR DESCRIPTION
It seems this is another instance of "surrogate" (aka) shim script redirection
timing issues in the macOS and iOS browsers. Instead of disabling content
blocking entirely, let's just stop redirecting the problematic script.

**Asana Task/Github Issue:** https://app.asana.com/0/1206670747178362/1208879720624568/f
