### PR TITLE
Disable 1p-cookie expiry on SERP.

### DIFF
--- a/features/cookie.json
+++ b/features/cookie.json
@@ -57,6 +57,10 @@
         {
             "domain": "instructure.com",
             "reason": "https://github.com/duckduckgo/privacy-configuration/issues/2212"
+        },
+        {
+            "domain": "duckduckgo.com",
+            "reason": "Prevent expiry of SERP settings"
         }
     ]
 }


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/0/1200123405659223/1207370736410846/f

## Description
Prevents SERP settings from being reset after 7 days.