### PR TITLE
Element hiding: Address new "Switch to Chrome" popup variants

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -1626,6 +1626,26 @@
                         "type": "hide"
                     },
                     {
+                        "selector": "div:has(> iframe[src*='prid=19044580'])",
+                        "type": "hide"
+                    },
+                    {
+                        "selector": "div:has(> iframe[src*='prid=19044578'])",
+                        "type": "hide"
+                    },
+                    {
+                        "selector": "div:has(> iframe[src*='prid=19044538'])",
+                        "type": "hide"
+                    },
+                    {
+                        "selector": "div:has(> iframe[src*='prid=19044687'])",
+                        "type": "hide"
+                    },
+                    {
+                        "selector": "div:has(> iframe[src*='prid=19044636'])",
+                        "type": "hide"
+                    },
+                    {
                         "selector": "[aria-labelledby='promo-header']",
                         "type": "hide"
                     },


### PR DESCRIPTION
<!--
  ⚠️ ⚠️ IF YOU ARE MODIFYING `index.js` OR A FILE IN `features` ⚠️ ⚠️
  Please request a review and ping a DRI from the Config AOR or Breakage AOR.
  The quickest way to get attention for your PR is to ping the ~Breakage channel
  in MatterMost.

  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Consider adding an individual reviewer as well as the groups that are automatically added (this should create a review task in Asana for them specifically).
  Use the "merge when ready" button to automatically merge the PR as soon as it's reviewed.
-->

**Asana Task/Github Issue:** https://app.asana.com/0/1203557590179903/1208967414233737/f

## Description
Google appears to be back with more Switch to Chrome nags. This PR addresses them.

#### Reference

-   [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
-   [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
-   [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)
