### PR TITLE
Disable Cookie Prompt Management (CPM) for wetransfer.com

### DIFF
--- a/features/autoconsent.json
+++ b/features/autoconsent.json
@@ -854,6 +854,10 @@
         {
             "domain": "serif.com",
             "reason": "Easylist breakage: https://app.asana.com/0/1200930669568058/1208959135934596/f"
+        },
+        {
+            "domain": "wetransfer.com",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2580"
         }
     ],
     "settings": {


### PR DESCRIPTION
It seems that CPM is causing issues on wetransfer.com, causing the "Add files"
dialogue not to work. Let's disable it for now therefore.

**Asana Task/Github Issue:** https://app.asana.com/0/1200277586140538/1208972648974591/f