### PR TITLE
Remove UA mitigation for FB Messenger to fix video/reels

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -1303,6 +1303,15 @@
                 ]
             },
             {
+                "domain": "facebook.com",
+                "rules": [
+                    {
+                        "selector": ".xnw9j1v:has(div > a[href='https://www.facebook.com/help/597429858389632/'])",
+                        "type": "hide"
+                    }
+                ]
+            },
+            {
                 "domain": "fandom.com",
                 "rules": [
                     {

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -776,10 +776,6 @@
                         "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1347"
                     },
                     {
-                        "domain": "facebook.com",
-                        "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1641"
-                    },
-                    {
                         "domain": "sas.dk",
                         "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1347"
                     },


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/0/1199178362774117/1208649328610231/f

### Site breakage mitigation process:

#### Brief explanation
- Reported URL: facebook.com
- Problems experienced: reels and other video won't autoplay because of UA mitigation we were using to avoid the "unsupported browser" warning, so we're switching to an element-hiding rule instead
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [x] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked: N/A
- Feature being disabled: N/A

#### Reference

-   [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
-   [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
-   [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)
