### PR TITLE
Set FireWindow enabled in version 0.98

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -414,7 +414,8 @@
             "state": "enabled"
         },
         "windowsFireWindow": {
-            "state": "disabled"
+            "state": "enabled",
+            "minSupportedVersion": "0.98.0"
         },
         "windowsNewTabPageExperiment": {
             "state": "enabled",


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/0/1208228079594252/1208935076401374/f

## Description
* Enables FireWindow feature and sets minimum supported version of 0.98

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change
- [x] I have tested this change locally
- [ ] This code for the config change is ready to merge
- [ ] This feature was covered by a tech design

#### Additional info:
- [x] I have tested this change locally in all supported browsers
- [x] This change will be visible to users
- [x] This code for the config change is ready
- [x] This change was covered by a ship review

#### Reference

-   [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
-   [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
-   [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)
