### PR TITLE
Disable GPC on visible.com

### DIFF
--- a/features/gpc.json
+++ b/features/gpc.json
@@ -51,6 +51,10 @@
         {
             "domain": "madewell.com",
             "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2563"
+        },
+        {
+            "domain": "visible.com",
+            "reason": "Page goes blank when GPC signal is detected"
         }
     ],
     "settings": {


### PR DESCRIPTION

**Asana Task/Github Issue:** https://app.asana.com/0/1206670747178362/1208978859568995/f

## Description
Page goes blank when GPC signal is detected. Must be in response to the GPC DOM API, as this happens on macOS where we don't send the GPC header.

<!-- 
  Please delete either or both process sections below.
-->

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change
- [ ] I have tested this change locally
- [ ] This code for the config change is ready to merge
- [ ] This feature was covered by a tech design

#### Additional info:
<!--
  These questions are a friendly reminder to shipping config changes, if you're uncertain ask the AoR owners.
  It's also totally appropriate to not check some of these boxes, if they don't apply to your change.
-->
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [ ] This code for the config change is ready
- [ ] This change was covered by a ship review

### Site breakage mitigation process:

#### Brief explanation
- Reported URL: https://www.visible.com/shop/smartphones
- Problems experienced: Blank page
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [x] MacOS
  - [x] Extensions
- Feature being disabled: GPC


- [ ] I have referenced the URL of this PR as the "reason" value for the exception (where applicable).
- [ ] This change is a speculative mitigation to fix reported breakage.

#### Reference

-   [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
-   [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
-   [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)
