### PR TITLE
Mitigate adblock wall on kamus.net

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -1903,6 +1903,14 @@
                 ]
             },
             {
+                "domain": "kamus.net",
+                "rules": [
+                    {
+                        "type": "disable-default"
+                    }
+                ]
+            },
+            {
                 "domain": "kbb.com",
                 "rules": [
                     {


### PR DESCRIPTION
<!--
  ⚠️ ⚠️ IF YOU ARE MODIFYING `index.js` OR A FILE IN `features` ⚠️ ⚠️
  Please request a review and ping a DRI from the Config AOR or Breakage AOR.
  The quickest way to get attention for your PR is to ping the ~Breakage channel
  in MatterMost.

  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Consider adding an individual reviewer as well as the groups that are automatically added (this should create a review task in Asana for them specifically).
  Use the "merge when ready" button to automatically merge the PR as soon as it's reviewed.
-->

**Asana Task/Github Issue:** https://app.asana.com/0/1206670747178362/1208962587388307/f

## Description
Add `disable-default` element hiding rule to mitigate adblock wall on kamus.net.

### Site breakage mitigation process:

#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [x] Windows
  - [x] MacOS
  - [x] Extensions
- Tracker(s) being unblocked:
- Feature being disabled:


- [x] I have referenced the URL of this PR as the "reason" value for the exception (where applicable).
- [ ] This change is a speculative mitigation to fix reported breakage.

#### Reference

-   [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
-   [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
-   [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)
