### PR TITLE
[Autofill] add feature toggle for partial save for android and windows

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -380,6 +380,9 @@
                 "canIntegrateWebMessageBasedAutofillInWebView": {
                     "state": "disabled"
                 },
+                "partialFormSaves": {
+                    "state": "enabled"
+                },
                 "onByDefault": {
                     "state": "enabled",
                     "rollout": {

--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -117,6 +117,9 @@
                 },
                 "credentialsImportPromotionForExistingUsers": {
                     "state": "enabled"
+                },
+                "partialFormSaves": {
+                    "state": "disabled"
                 }
             }
         },


### PR DESCRIPTION
<!--
  ⚠️ ⚠️ IF YOU ARE MODIFYING `index.js` OR A FILE IN `features` ⚠️ ⚠️
  Please request a review and ping a DRI from the Config AOR or Breakage AOR.
  The quickest way to get attention for your PR is to ping the ~Breakage channel
  in MatterMost.

  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Consider adding an individual reviewer as well as the groups that are automatically added (this should create a review task in Asana for them specifically).
  Use the "merge when ready" button to automatically merge the PR as soon as it's reviewed.
-->

**Asana Task/Github Issue:** https://app.asana.com/0/72649045549333/1208998878408133/f

## Description
The [Increase ratio of complete credentials saves [3w]](https://app.asana.com/0/72649045549333/1206048666874230/f) project adds the in-memory saving of partial credentials during multi-page login / registration / password-reset flows. In order to reduce any risk of autofill breakage introduced by this change, we should add a feature flag that can be used to remotely deactivate the functionality in the case that we receive reports of problems.

Note: Currently doesn't effect either Windows or Android as they don't consume it yet, it's for future proofing.

<!-- 
  Please delete either or both process sections below.
-->

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change
- [ ] I have tested this change locally
- [ ] This code for the config change is ready to merge
- [ ] This feature was covered by a tech design

#### Additional info:
<!--
  These questions are a friendly reminder to shipping config changes, if you're uncertain ask the AoR owners.
  It's also totally appropriate to not check some of these boxes, if they don't apply to your change.
-->
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [ ] This code for the config change is ready
- [ ] This change was covered by a ship review

### Site breakage mitigation process:

#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled:


- [ ] I have referenced the URL of this PR as the "reason" value for the exception (where applicable).
- [ ] This change is a speculative mitigation to fix reported breakage.

#### Reference

-   [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
-   [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
-   [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)
