### PR TITLE
Enable auto-tapping on import password flow when not signed in

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -429,7 +429,7 @@
                                             "op": "add",
                                             "value": {
                                                 "settingsButton": {
-                                                    "shouldAutotap": false,
+                                                    "shouldAutotap": true,
                                                     "path": "/",
                                                     "selectors": ["a[href*='options']"],
                                                     "labelTexts": ["Password options"]
@@ -444,7 +444,7 @@
                                                     "labelTexts": ["Export"]
                                                 },
                                                 "signInButton": {
-                                                    "shouldAutotap": false,
+                                                    "shouldAutotap": true,
                                                     "path": "/intro",
                                                     "selectors": ["a[href*='ServiceLogin'][target='_top']"],
                                                     "labelTexts": ["Sign in"]


### PR DESCRIPTION
<!--
  ⚠️ ⚠️ IF YOU ARE MODIFYING `index.js` OR A FILE IN `features` ⚠️ ⚠️
  Please request a review and ping a DRI from the Config AOR or Breakage AOR.
  The quickest way to get attention for your PR is to ping the ~Breakage channel
  in MatterMost.

  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Consider adding an individual reviewer as well as the groups that are automatically added (this should create a review task in Asana for them specifically).
  Use the "merge when ready" button to automatically merge the PR as soon as it's reviewed.
-->

**Asana Task/Github Issue:** https://app.asana.com/0/608920331025315/1208992440597713/f

## Description
Enables the auto-tapping of two buttons inside the import Google Password flow. Right now, we show a UI hint in the form of a button animation in three places:
1. [if user not already signed in] Sign In button on initial landing page
2. [if user wasn’t signed in] After signing in, on the settings cog which is on the screen prior to where they can export
3. On the final export button

This PR converts `#1` and `#2` to auto-tap instead of showing an animation. 