### PR TITLE
Disable import promo in autofill for Windows

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -113,10 +113,10 @@
                     "state": "enabled"
                 },
                 "credentialsImportPromotion": {
-                    "state": "enabled"
+                    "state": "disabled"
                 },
                 "credentialsImportPromotionForExistingUsers": {
-                    "state": "enabled"
+                    "state": "disabled"
                 },
                 "partialFormSaves": {
                     "state": "disabled"


### PR DESCRIPTION
<!--
  ⚠️ ⚠️ IF YOU ARE MODIFYING `index.js` OR A FILE IN `features` ⚠️ ⚠️
  Please request a review and ping a DRI from the Config AOR or Breakage AOR.
  The quickest way to get attention for your PR is to ping the ~Breakage channel
  in MatterMost.

  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Consider adding an individual reviewer as well as the groups that are automatically added (this should create a review task in Asana for them specifically).
  Use the "merge when ready" button to automatically merge the PR as soon as it's reviewed.
-->

**Asana Task/Github Issue:** https://app.asana.com/0/1203709236521659/1209004797220300/f

## Description
Temporarily disables password import promotion on Windows for all users, because the button doesn't work since the v0.96 version. The feature flags will be re-enabled after rolling out the fix to the majority of users.

<!-- 
  Please delete either or both process sections below.
-->

#### Reference

-   [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
-   [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
-   [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)
