### PR TITLE
Disable Next Steps widget on Windows

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -421,7 +421,12 @@
         },
         "windowsNewTabPageExperiment": {
             "state": "enabled",
-            "minSupportedVersion": "0.96.0"
+            "minSupportedVersion": "0.96.0",
+            "features": {
+                "nextStepsWidget": {
+                    "state": "disabled"
+                }
+            }
         }
     },
     "unprotectedTemporary": []


### PR DESCRIPTION
**Asana Task/Github Issue:** N/A

## Description
Disables Next Steps widget on Windows as it has not yet been released.