### PR TITLE
Element hiding: Address empty ad spaces on yahoo.com

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -3251,6 +3251,18 @@
                     {
                         "selector": "[class*='sdaContainer']",
                         "type": "hide"
+                    },
+                    {
+                        "selector": "#sda-Horizon-viewer",
+                        "type": "hide-empty"
+                    },
+                    {
+                        "selector": "[id*='mrt-node-Lead']",
+                        "type": "hide-empty"
+                    },
+                    {
+                        "selector": "[id*='mrt-node-Secondary']",
+                        "type": "hide-empty"
                     }
                 ]
             },

--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -3263,6 +3263,10 @@
                     {
                         "selector": "[id*='mrt-node-Secondary']",
                         "type": "hide-empty"
+                    },
+                    {
+                        "selector": "[id*='rrvkqH1']",
+                        "type": "hide-empty"
                     }
                 ]
             },


### PR DESCRIPTION
<!--
  ⚠️ ⚠️ IF YOU ARE MODIFYING `index.js` OR A FILE IN `features` ⚠️ ⚠️
  Please request a review and ping a DRI from the Config AOR or Breakage AOR.
  The quickest way to get attention for your PR is to ping the ~Breakage channel
  in MatterMost.

  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Consider adding an individual reviewer as well as the groups that are automatically added (this should create a review task in Asana for them specifically).
  Use the "merge when ready" button to automatically merge the PR as soon as it's reviewed.
-->

**Asana Task/Github Issue:** https://app.asana.com/0/246491496396031/1209044318203341/f

## Description
Addresses empty ad spaces on yahoo.com.

#### Brief explanation
- Reported URL: https://www.yahoo.com/news/winner-fifth-largest-jackpot-mega-232407624.html
- Problems experienced: Empty spaces on page where ads didn't load
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [x] Windows
  - [x] MacOS
  - [x] Extensions
- Tracker(s) being unblocked:
- Feature being disabled:

#### Reference

-   [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
-   [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
-   [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)
