### PR TITLE
Mitigate adblock wall on maxroll.gg

### DIFF
--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -1993,6 +1993,15 @@
                     }
                 ]
             },
+            "nitropay.com": {
+                "rules": [
+                    {
+                        "rule": "nitropay.com/ads",
+                        "domains": ["maxroll.gg"],
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2607"
+                    }
+                ]
+            },
             "nosto.com": {
                 "rules": [
                     {


### PR DESCRIPTION
<!--
  ⚠️ ⚠️ IF YOU ARE MODIFYING `index.js` OR A FILE IN `features` ⚠️ ⚠️
  Please request a review and ping a DRI from the Config AOR or Breakage AOR.
  The quickest way to get attention for your PR is to ping the ~Breakage channel
  in MatterMost.

  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Consider adding an individual reviewer as well as the groups that are automatically added (this should create a review task in Asana for them specifically).
  Use the "merge when ready" button to automatically merge the PR as soon as it's reviewed.
-->

**Asana Task/Github Issue:** https://app.asana.com/0/1200277586140538/1209052928545157/f

### Site breakage mitigation process:

#### Brief explanation
- Reported URL: https://maxroll.gg/poe2/planner/tolch01z
- Problems experienced: Soft adblock wall
- Platforms affected:
  - [x] iOS
  - [x] Android
  - [x] Windows
  - [x] MacOS
  - [x] Extensions
- Tracker(s) being unblocked: nitropay.com/ads

- [x] I have referenced the URL of this PR as the "reason" value for the exception (where applicable).

#### Reference

-   [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
-   [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
-   [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)
