### PR TITLE
Site Breakage: Buttons not clickable on tesla.com

### DIFF
--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -1335,6 +1335,7 @@
                         "domains": [
                             "abril.com.br",
                             "cosmicbook.news",
+                            "tesla.com",
                             "tradersync.com",
                             "thesimsresource.com",
                             "algomalegalclinic.com",
@@ -1348,6 +1349,7 @@
                         "reason": [
                             "https://github.com/duckduckgo/privacy-configuration/issues/929",
                             "cosmicbook.news - https://github.com/duckduckgo/privacy-configuration/issues/1578",
+                            "tesla.com - https://github.com/duckduckgo/privacy-configuration/pull/2608",
                             "tradersync.com - https://github.com/duckduckgo/privacy-configuration/issues/1687",
                             "thesimsresource.com - https://github.com/duckduckgo/privacy-configuration/issues/1706",
                             "algomalegalclinic.com - https://github.com/duckduckgo/privacy-configuration/issues/1822",


### PR DESCRIPTION
<!--
  ⚠️ ⚠️ IF YOU ARE MODIFYING `index.js` OR A FILE IN `features` ⚠️ ⚠️
  Please request a review and ping a DRI from the Config AOR or Breakage AOR.
  The quickest way to get attention for your PR is to ping the ~Breakage channel
  in MatterMost.

  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Consider adding an individual reviewer as well as the groups that are automatically added (this should create a review task in Asana for them specifically).
  Use the "merge when ready" button to automatically merge the PR as soon as it's reviewed.
-->

**Asana Task/Github Issue:** https://app.asana.com/0/246491496396031/1209057713800838/f

## Description

### Site breakage mitigation process:

#### Brief explanation
- Reported URL: tesla.com
- Problems experienced: Buttons not clickable
- Platforms affected:
  - [x] iOS
  - [x] Android
  - [ ] Windows
  - [x] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked: googletagmanager.com/gtag/js
- Feature being disabled:

- [x] I have referenced the URL of this PR as the "reason" value for the exception (where applicable).

#### Reference

-   [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
-   [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
-   [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)
