### PR TITLE
Mitigate Paramount+ and Fire TV apps on AppTP

### DIFF
--- a/features/app-tracker-protection.json
+++ b/features/app-tracker-protection.json
@@ -50,6 +50,9 @@
                     "packageNames": [
                         {
                             "packageName": "com.toyota.oneapp"
+                        },
+                        {
+                            "packageName": "com.cbs.app"
                         }
                     ]
                 },
@@ -268,6 +271,10 @@
                 {
                     "packageName": "com.alohamobile.browser.lite",
                     "reason": "App loads websites"
+                },
+                {
+                    "packageName": "com.amazon.storm.lightning.client.aosp",
+                    "reason": "App doesn't run over any VPN connection"
                 },
                 {
                     "packageName": "com.android.browser",


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/0/1200746877073315/1209066562323392/f

## Description

Adding two mitigations for App Tracking Protection to address confirmed issues:

- AppTP blocking a Branch tracker appears to cause the Paramount+ app to get stuck on the initial launch screen
   - mitigation: allow that single tracker through for the app package
- Fire TV app won't search for nearby devices with any VPN connection active
   - mitigation: exclude the app entirely from AppTP coverage

#### Reference

-   [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
-   [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
-   [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)
