### PR TITLE
Revert "Enable Malicious Site Protection on macOS"

### DIFF
--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -1119,7 +1119,7 @@
             }
         },
         "maliciousSiteProtection": {
-            "state": "enabled",
+            "state": "internal",
             "settings": {
                 "hashPrefixUpdateFrequency": 20,
                 "filterSetUpdateFrequency": 720


### PR DESCRIPTION
Reverts duckduckgo/privacy-configuration#2623 and disables Malicious Site Protection for macOS users