### PR TITLE
Element hiding: Address new google pop ups

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -1586,7 +1586,7 @@
                 ]
             },
             {
-                "domain": "google.com",
+                "domain": "google.ca",
                 "rules": [
                     {
                         "selector": "div:has(> iframe[src*='prid=19030391'])",

--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -1168,6 +1168,15 @@
                 ]
             },
             {
+                "domain": "ebay.ca",
+                "rules": [
+                    {
+                        "selector": "#g-yolo-overlay-holder",
+                        "type": "hide"
+                    }
+                ]
+            },
+            {
                 "domain": "ebay.com",
                 "rules": [
                     {
@@ -1580,6 +1589,15 @@
                 "domain": "google.com",
                 "rules": [
                     {
+                        "selector": "div:has(> iframe[src*='prid=19030391'])",
+                        "type": "hide"
+                    }
+                ]
+            },
+            {
+                "domain": "google.com",
+                "rules": [
+                    {
                         "selector": "div:has(> iframe[src*='prid=19026802'])",
                         "type": "hide"
                     },
@@ -1661,6 +1679,10 @@
                     },
                     {
                         "selector": "div:has(> iframe[src*='prid=19044636'])",
+                        "type": "hide"
+                    },
+                    {
+                        "selector": "div:has(> iframe[src*='prid=19046163'])",
                         "type": "hide"
                     },
                     {


### PR DESCRIPTION
<!--
  ⚠️ ⚠️ IF YOU ARE MODIFYING `index.js` OR A FILE IN `features` ⚠️ ⚠️
  Please request a review and ping a DRI from the Config AOR or Breakage AOR.
  The quickest way to get attention for your PR is to ping the ~Breakage channel
  in MatterMost.

  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Consider adding an individual reviewer as well as the groups that are automatically added (this should create a review task in Asana for them specifically).
  Use the "merge when ready" button to automatically merge the PR as soon as it's reviewed.
-->

**Asana Task/Github Issue:** https://app.asana.com/0/246491496396031/1209077670106374/f

## Description
Addresses a new "Switch to Chrome" popup on google.com and google.ca, as well as a "Sign in with Google" popup on ebay.ca.

#### Reference

-   [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
-   [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
-   [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)
