### PR TITLE
Element Hiding: Expand Google and ebay rules to international TLDs

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -1168,16 +1168,14 @@
                 ]
             },
             {
-                "domain": "ebay.ca",
-                "rules": [
-                    {
-                        "selector": "#g-yolo-overlay-holder",
-                        "type": "hide"
-                    }
-                ]
-            },
-            {
-                "domain": "ebay.com",
+                "domain": [
+                    "ebay.com",
+                    "ebay.ca",
+                    "ebay.co.uk",
+                    "ebay.de",
+                    "ebay.fr",
+                    "ebay.com.au"
+                ],
                 "rules": [
                     {
                         "selector": "#g-yolo-overlay-holder",
@@ -1586,16 +1584,26 @@
                 ]
             },
             {
-                "domain": "google.ca",
-                "rules": [
-                    {
-                        "selector": "div:has(> iframe[src*='prid=19030391'])",
-                        "type": "hide"
-                    }
-                ]
-            },
-            {
-                "domain": "google.com",
+                "domain": [
+                    "google.com",
+                    "google.ca",
+                    "google.de",
+                    "google.dk",
+                    "google.es",
+                    "google.fr",
+                    "google.ie",
+                    "google.it",
+                    "google.nl",
+                    "google.pl",
+                    "google.se",
+                    "google.com.au",
+                    "google.com.br",
+                    "google.com.mx",
+                    "google.co.in",
+                    "google.co.jp",
+                    "google.co.nz",
+                    "google.co.uk"
+                ],
                 "rules": [
                     {
                         "selector": "div:has(> iframe[src*='prid=19026802'])",

--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -1168,14 +1168,7 @@
                 ]
             },
             {
-                "domain": [
-                    "ebay.com",
-                    "ebay.ca",
-                    "ebay.co.uk",
-                    "ebay.de",
-                    "ebay.fr",
-                    "ebay.com.au"
-                ],
+                "domain": ["ebay.com", "ebay.ca", "ebay.co.uk", "ebay.de", "ebay.fr", "ebay.com.au"],
                 "rules": [
                     {
                         "selector": "#g-yolo-overlay-holder",


### PR DESCRIPTION
<!--
  ⚠️ ⚠️ IF YOU ARE MODIFYING `index.js` OR A FILE IN `features` ⚠️ ⚠️
  Please request a review and ping a DRI from the Config AOR or Breakage AOR.
  The quickest way to get attention for your PR is to ping the ~Breakage channel
  in MatterMost.

  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Consider adding an individual reviewer as well as the groups that are automatically added (this should create a review task in Asana for them specifically).
  Use the "merge when ready" button to automatically merge the PR as soon as it's reviewed.
-->

**Asana Task/Github Issue:** https://app.asana.com/0/0/1209077670106374/f

## Description
Google and ebay use regional TLDs, this change ensures that our element hiding rules for each will apply to their top TLDs.

#### Reference

-   [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
-   [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
-   [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)
