### PR TITLE
Element hiding: Address empty ad spaces on independent.co.uk

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -1860,6 +1860,10 @@
                         "type": "hide-empty"
                     },
                     {
+                        "selector": "[data-ad-unit-path]",
+                        "type": "closest-empty"
+                    },
+                    {
                         "selector": "#stickyFooterRoot",
                         "type": "hide"
                     }


### PR DESCRIPTION
<!--
  ⚠️ ⚠️ IF YOU ARE MODIFYING `index.js` OR A FILE IN `features` ⚠️ ⚠️
  Please request a review and ping a DRI from the Config AOR or Breakage AOR.
  The quickest way to get attention for your PR is to ping the ~Breakage channel
  in MatterMost.

  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Consider adding an individual reviewer as well as the groups that are automatically added (this should create a review task in Asana for them specifically).
  Use the "merge when ready" button to automatically merge the PR as soon as it's reviewed.
-->

**Asana Task/Github Issue:** https://app.asana.com/0/1203557590179903/1209126972136791/f

## Description
Addresses empty spaces left by third-party tracking ads on independent.co.uk article pages

### Site breakage mitigation process:

#### Brief explanation
- Reported URL: https://www.independent.co.uk/arts-entertainment/tv/news/elon-musk-ian-hislop-labour-have-i-got-news-for-you-b2677250.html
- Problems experienced: Blank spaces on page
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions

#### Reference

-   [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
-   [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
-   [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)
