### PR TITLE
Fix hyatt.com not loading on Android

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -719,6 +719,10 @@
                 {
                     "domain": "chewy.com",
                     "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2154"
+                },
+                {
+                    "domain": "hyatt.com",
+                    "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2637"
                 }
             ]
         },


### PR DESCRIPTION
<!--
  ⚠️ ⚠️ IF YOU ARE MODIFYING `index.js` OR A FILE IN `features` ⚠️ ⚠️
  Please request a review and ping a DRI from the Config AOR or Breakage AOR.
  The quickest way to get attention for your PR is to ping the ~Breakage channel
  in MatterMost.

  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Consider adding an individual reviewer as well as the groups that are automatically added (this should create a review task in Asana for them specifically).
  Use the "merge when ready" button to automatically merge the PR as soon as it's reviewed.
-->

**Asana Task/Github Issue:** https://app.asana.com/0/1206670747178362/1209068699411989/f

## Description

<!-- 
  Please delete either or both process sections below.
-->

### Site breakage mitigation process:

#### Brief explanation
- Reported URL: https://world.hyatt.com/content/gp/en/tiers-and-benefits.html
- Problems experienced: Site is not loading – just a blank page.
- Platforms affected:
  - [ ] iOS
  - [X] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked: N/A
- Feature being disabled: Hardware fingerprinting


- [X] I have referenced the URL of this PR as the "reason" value for the exception (where applicable).
- [ ] This change is a speculative mitigation to fix reported breakage.

#### Reference

-   [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
-   [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
-   [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)
