### PR TITLE
Fix hyatt.com sign-in on Windows

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -150,7 +150,7 @@
             "exceptions": [
                 {
                     "domain": "hyatt.com",
-                    "reason": "Debugger added exception"
+                    "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2638"
                 }
             ]
         },

--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -146,7 +146,13 @@
             }
         },
         "googleRejected": {
-            "state": "enabled"
+            "state": "enabled",
+            "exceptions": [
+                {
+                    "domain": "hyatt.com",
+                    "reason": "Debugger added exception"
+                }
+            ]
         },
         "navigatorInterface": {
             "state": "enabled"


### PR DESCRIPTION
<!--
  ⚠️ ⚠️ IF YOU ARE MODIFYING `index.js` OR A FILE IN `features` ⚠️ ⚠️
  Please request a review and ping a DRI from the Config AOR or Breakage AOR.
  The quickest way to get attention for your PR is to ping the ~Breakage channel
  in MatterMost.

  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Consider adding an individual reviewer as well as the groups that are automatically added (this should create a review task in Asana for them specifically).
  Use the "merge when ready" button to automatically merge the PR as soon as it's reviewed.
-->

**Asana Task/Github Issue:** https://app.asana.com/0/1207686573307971/1209068712016809/f

## Description

<!-- 
  Please delete either or both process sections below.
-->

### Site breakage mitigation process:

#### Brief explanation
- Reported URL: https://www.hyatt.com/en-US/member/sign-in
- Problems experienced: Trying to sign-in just re-loads the sign-in form.
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [X] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked: N/A
- Feature being disabled: `googleRejected`


- [X] I have referenced the URL of this PR as the "reason" value for the exception (where applicable).
- [ ] This change is a speculative mitigation to fix reported breakage.

#### Reference

-   [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
-   [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
-   [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)
