### PR TITLE
Add an AppTP mitigation for the chat function in TeamSnap app

### DIFF
--- a/features/app-tracker-protection.json
+++ b/features/app-tracker-protection.json
@@ -78,6 +78,9 @@
                     "packageNames": [
                         {
                             "packageName": "org.telegram.messenger"
+                        },
+                        {
+                            "packageName": "com.teamsnap.teamsnap"
                         }
                     ]
                 },


### PR DESCRIPTION

**Asana Task/Github Issue:** https://app.asana.com/0/1202279501986195/1208991246299340/f

## Description

It appears that the Google Firebase tracker is necessary to enable chat functionality in the TeamSnap app, so we've made a limited exception for that one request.

#### Reference

-   [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
-   [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
-   [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)
