### PR TITLE
Re-enable Facebook sign up button on zoosk.com

### DIFF
--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -117,10 +117,6 @@
                 {
                     "domain": "wjla.com",
                     "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2319"
-                },
-                {
-                    "domain": "zoosk.com",
-                    "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2646"
                 }
             ]
         },
@@ -576,7 +572,11 @@
             "exceptions": [
                 {
                     "domain": "tinder.com",
-                    "reason": "Grayed out Facebook login button"
+                    "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2207"
+                },
+                {
+                    "domain": "zoosk.com",
+                    "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2646"
                 }
             ]
         },

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -117,6 +117,10 @@
                 {
                     "domain": "wjla.com",
                     "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2319"
+                },
+                {
+                    "domain": "zoosk.com",
+                    "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2646"
                 }
             ]
         },


### PR DESCRIPTION
<!--
  ⚠️ ⚠️ IF YOU ARE MODIFYING `index.js` OR A FILE IN `features` ⚠️ ⚠️
  Please request a review and ping a DRI from the Config AOR or Breakage AOR.
  The quickest way to get attention for your PR is to ping the ~Breakage channel
  in MatterMost.

  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Consider adding an individual reviewer as well as the groups that are automatically added (this should create a review task in Asana for them specifically).
  Use the "merge when ready" button to automatically merge the PR as soon as it's reviewed.
-->

**Asana Task/Github Issue:** https://app.asana.com/0/1206670747178362/1209134973490513/f

## Description

<!-- 
  Please delete either or both process sections below.
-->

### Site breakage mitigation process:

#### Brief explanation
- Reported URL: https://www.zoosk.com/login/registration
- Problems experienced: Facebook “Sign up” is disabled on macOS.
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [X] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked: N/A
- Feature being disabled: `clickToLoad`

- [X] I have referenced the URL of this PR as the "reason" value for the exception (where applicable).
- [ ] This change is a speculative mitigation to fix reported breakage.

Note: Also added a PR link for another `clickToLoad` mitigation.

#### Reference

-   [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
-   [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
-   [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)
