### PR TITLE
Stop cell sizing weirdness on docs.google.com

### DIFF
--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -500,6 +500,10 @@
                 {
                     "domain": "community.bitwarden.com",
                     "reason": "https://github.com/duckduckgo/privacy-configuration/issues/519"
+                },
+                {
+                    "domain": "docs.google.com",
+                    "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2647"
                 }
             ],
             "settings": {


### PR DESCRIPTION
<!--
  ⚠️ ⚠️ IF YOU ARE MODIFYING `index.js` OR A FILE IN `features` ⚠️ ⚠️
  Please request a review and ping a DRI from the Config AOR or Breakage AOR.
  The quickest way to get attention for your PR is to ping the ~Breakage channel
  in MatterMost.

  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Consider adding an individual reviewer as well as the groups that are automatically added (this should create a review task in Asana for them specifically).
  Use the "merge when ready" button to automatically merge the PR as soon as it's reviewed.
-->

**Asana Task/Github Issue:** https://app.asana.com/0/1204912272578138/1209154862464145/f

## Description

### Site breakage mitigation process:

#### Brief explanation
- Reported URL: https://docs.google.com/spreadsheets/d/1QWu74Ah3LKb2f2AeeQQjiWtkOROMtfKBfoqKCml021U/edit?gid=1555323777#gid=1555323777
- Problems experienced: Cell doesn’t resize properly when the browser window is resized.
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [X] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked: N/A
- Feature being disabled: WebCompat


- [X] I have referenced the URL of this PR as the "reason" value for the exception (where applicable).
- [ ] This change is a speculative mitigation to fix reported breakage.

#### Reference

-   [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
-   [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
-   [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)
