### PR TITLE
Added autoconsent exception for alpharunning.co.uk

### DIFF
--- a/features/autoconsent.json
+++ b/features/autoconsent.json
@@ -626,6 +626,10 @@
         {
             "domain": "sbid.org",
             "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2652"
+        },
+        {
+            "domain": "alpharunning.co.uk",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2654"
         }
     ],
     "settings": {


### PR DESCRIPTION
<!--
  ⚠️ ⚠️ IF YOU ARE MODIFYING `index.js` OR A FILE IN `features` ⚠️ ⚠️
  Please request a review and ping a DRI from the Config AOR or Breakage AOR.
  The quickest way to get attention for your PR is to ping the ~Breakage channel
  in MatterMost.

  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Consider adding an individual reviewer as well as the groups that are automatically added (this should create a review task in Asana for them specifically).
  Use the "merge when ready" button to automatically merge the PR as soon as it's reviewed.
-->

**Asana Task/Github Issue:** https://app.asana.com/0/1204912272578138/1209168604557381/f

## Description

<!-- 
  Please delete either or both process sections below.
-->

### Site breakage mitigation process:

#### Brief explanation
- Reported URL: https://www.alpharunning.co.uk/index.asp
- Problems experienced: CPM causing a grey overlay.
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [X] Windows
  - [X] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked: N/A
- Feature being disabled: autoconsent


- [X] I have referenced the URL of this PR as the "reason" value for the exception (where applicable).
- [ ] This change is a speculative mitigation to fix reported breakage.

#### Reference

-   [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
-   [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
-   [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)
