### PR TITLE
Adjust elementHiding rule to accommodate poorly loading map on Realtor.com

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -2618,6 +2618,14 @@
                 "domain": "realtor.com",
                 "rules": [
                     {
+                        "selector": ".ad-wrapper",
+                        "type": "override"
+                    },
+                    {
+                        "selector": ".lb1-ad",
+                        "type": "hide-empty"
+                    },
+                    {
                         "selector": ".ads_container",
                         "type": "hide"
                     }


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/0/1206670747178362/1209068684500232/f

### Site breakage mitigation process:

#### Brief explanation
- Reported URL: https://www.realtor.com/realestateandhomes-detail/114-34th-St-NW_Hickory_NC_28601_M52786-15965
- Problems experienced: all photos/map content only loads after a refresh
- Platforms affected:
  - [x] iOS
  - [x] Android
  - [x] Windows
  - [x] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked: N/A
- Feature being disabled: N/A -- Domain-specific rule adjusted to work around site behavior


#### Reference

-   [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
-   [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
-   [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)
