### PR TITLE
Make interactive elements work on lecreuset.co.uk and sueddeutsche.de

### DIFF
--- a/features/autoconsent.json
+++ b/features/autoconsent.json
@@ -764,7 +764,8 @@
             "google.se",
             "google.sk",
             "sachsen-netze.de",
-            "alpharunning.co.uk"
+            "alpharunning.co.uk",
+            "lecreuset.co.uk"
         ]
     }
 }

--- a/features/autoconsent.json
+++ b/features/autoconsent.json
@@ -630,6 +630,14 @@
         {
             "domain": "wunderground.com",
             "reason": "rejecting cookies breaks videos https://app.asana.com/0/1199178362774117/1207968034848950/f"
+        },
+        {
+            "domain": "lecreuset.co.uk",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2661"
+        },
+        {
+            "domain": "sueddeutsche.de",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2661"
         }
     ],
     "settings": {
@@ -765,7 +773,8 @@
             "google.sk",
             "sachsen-netze.de",
             "alpharunning.co.uk",
-            "lecreuset.co.uk"
+            "lecreuset.co.uk",
+            "sueddeutsche.de"
         ]
     }
 }

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -272,13 +272,7 @@
                 "filterlist": {
                     "state": "enabled"
                 }
-            },
-            "exceptions": [
-                {
-                    "domain": "sueddeutsche.de",
-                    "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2500"
-                }
-            ]
+            }
         },
         "navigatorInterface": {
             "state": "enabled"


### PR DESCRIPTION
<!--
  ⚠️ ⚠️ IF YOU ARE MODIFYING `index.js` OR A FILE IN `features` ⚠️ ⚠️
  Please request a review and ping a DRI from the Config AOR or Breakage AOR.
  The quickest way to get attention for your PR is to ping the ~Breakage channel
  in MatterMost.

  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Consider adding an individual reviewer as well as the groups that are automatically added (this should create a review task in Asana for them specifically).
  Use the "merge when ready" button to automatically merge the PR as soon as it's reviewed.
-->

**Asana Task/Github Issue:** https://app.asana.com/0/1206670747178362/1209166313175058/f

## Description

### Site breakage mitigation process:

#### Brief explanation
- Reported URL: https://www.lecreuset.co.uk/en_GB/
- Problems experienced: Cookie popup hiding is causing menus etc. to not be clickable.
- Platforms affected:
  - [X] iOS
  - [X] Android
  - [X] Windows
  - [X] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked: N/A
- Feature being disabled: `filterlistExceptions` for CPM


- [ ] I have referenced the URL of this PR as the "reason" value for the exception (where applicable).
- [ ] This change is a speculative mitigation to fix reported breakage.

#### Reference

-   [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
-   [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
-   [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)
