### PR TITLE
Remove harmful wording

### DIFF
--- a/tests/config-tests.js
+++ b/tests/config-tests.js
@@ -42,7 +42,7 @@ describe('Config schema tests', () => {
             });
 
             it('all features should be named correctly', () => {
-                const grandfatheredFeatures = [
+                const legacyFeatures = [
                     'androidBrowserConfig',
                     'androidNewStateKillSwitch',
                     'windowsDownloadLink',
@@ -61,7 +61,7 @@ describe('Config schema tests', () => {
                 for (const featureName of Object.keys(config.body.features)) {
                     expect(featureName).to.match(featureNameRegex);
                     // Features should not have platform specific names so we can use the same config for all platforms.
-                    if (!grandfatheredFeatures.includes(featureName)) {
+                    if (!legacyFeatures.includes(featureName)) {
                         expect(featureName).to.not.match(deviceSpecificCheck);
                     }
 
@@ -78,9 +78,9 @@ describe('Config schema tests', () => {
 
             it('All features should have a corresponding feature file', () => {
                 // Note: We should not add more to this list, only remove
-                const grandfatheredFeatures = ['webViewBlobDownload', 'experimentTest', 'eme', 'clientContentFeatures'];
+                const legacyFeatures = ['webViewBlobDownload', 'experimentTest', 'eme', 'clientContentFeatures'];
                 for (const featureName of Object.keys(config.body.features)) {
-                    if (grandfatheredFeatures.includes(featureName)) {
+                    if (legacyFeatures.includes(featureName)) {
                         continue;
                     }
                     const dasherizedFeatureName = featureName.replace(/([a-z0-9])([A-Z0-9])/g, '$1-$2').toLowerCase();


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/0/377878547213994/1181053407775681/f

## Description

Rename badly chosen wording by myself for a better term: https://medium.com/@nriley/words-matter-why-we-should-put-an-end-to-grandfathering-8b19efe08b6a

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change
- [ ] I have tested this change locally
- [ ] This code for the config change is ready to merge
- [ ] This feature was covered by a tech design

#### Additional info:
<!--
  These questions are a friendly reminder to shipping config changes, if you're uncertain ask the AoR owners.
  It's also totally appropriate to not check some of these boxes, if they don't apply to your change.
-->
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [ ] This code for the config change is ready
- [ ] This change was covered by a ship review

### Site breakage mitigation process:

#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled:


- [ ] I have referenced the URL of this PR as the "reason" value for the exception (where applicable).
- [ ] This change is a speculative mitigation to fix reported breakage.

#### Reference

-   [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
-   [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
-   [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)
