### PR TITLE
Add exceptions for EasyList CPM breakage

### DIFF
--- a/features/autoconsent.json
+++ b/features/autoconsent.json
@@ -658,6 +658,10 @@
         {
             "domain": "memsoft.fr",
             "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2671"
+        },
+        {
+            "domain": "bafin.de",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2671"
         }
     ],
     "settings": {
@@ -799,7 +803,8 @@
             "lta.org.uk",
             "hobbyhall.fi",
             "wienmobil.at",
-            "memsoft.fr"
+            "memsoft.fr",
+            "bafin.de"
         ]
     }
 }

--- a/features/autoconsent.json
+++ b/features/autoconsent.json
@@ -638,6 +638,26 @@
         {
             "domain": "sueddeutsche.de",
             "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2661"
+        },
+        {
+            "domain": "vital-parts.co.uk",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2671"
+        },
+        {
+            "domain": "lta.org.uk",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2671"
+        },
+        {
+            "domain": "hobbyhall.fi",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2671"
+        },
+        {
+            "domain": "wienmobil.at",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2671"
+        },
+        {
+            "domain": "memsoft.fr",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2671"
         }
     ],
     "settings": {
@@ -774,7 +794,12 @@
             "sachsen-netze.de",
             "alpharunning.co.uk",
             "lecreuset.co.uk",
-            "sueddeutsche.de"
+            "sueddeutsche.de",
+            "vital-parts.co.uk",
+            "lta.org.uk",
+            "hobbyhall.fi",
+            "wienmobil.at",
+            "memsoft.fr"
         ]
     }
 }


### PR DESCRIPTION
### Site breakage mitigation process:

#### Brief explanation
- Reported URLs:
  - vital-parts.co.uk
  - lta.org.uk
  - hobbyhall.fi
  - wienmobil.at
  - memsoft.fr
- Problems experienced: CPM hides interactable cookie pop-ups, which result in sites becoming unusable
- Platforms affected:
  - [x] iOS
  - [x] Android
  - [x] Windows
  - [x] MacOS
  - [ ] Extensions
- Feature being disabled: CPM

- [x] I have referenced the URL of this PR as the "reason" value for the exception (where applicable).

#### Reference

-   [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
-   [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
-   [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209211924192335