### PR TITLE
Windows `htmlNewTabPage` override, move `nextStepsWidget`

### DIFF
--- a/features/html-new-tab-page.json
+++ b/features/html-new-tab-page.json
@@ -8,6 +8,9 @@
     "features": {
         "isLaunched": {
             "state": "disabled"
+        },
+        "nextStepsWidget": {
+            "state": "disabled"
         }
     }
 }

--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -452,12 +452,15 @@
             "state": "enabled",
             "minSupportedVersion": "0.98.0"
         },
-        "windowsNewTabPageExperiment": {
-            "state": "enabled",
-            "minSupportedVersion": "0.96.0",
+        "htmlNewTabPage": {
+            "state": "internal",
+            "minSupportedVersion": <TBD>,
             "features": {
+                "isLaunched": {
+                    "state": "internal"
+                },
                 "nextStepsWidget": {
-                    "state": "disabled"
+                    "state": "internal"
                 }
             }
         },

--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -454,7 +454,6 @@
         },
         "htmlNewTabPage": {
             "state": "internal",
-            "minSupportedVersion": <TBD>,
             "features": {
                 "isLaunched": {
                     "state": "internal"

--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -452,6 +452,10 @@
             "state": "enabled",
             "minSupportedVersion": "0.98.0"
         },
+        "windowsNewTabPageExperiment": {
+            "state": "enabled",
+            "minSupportedVersion": "0.96.0"
+        },
         "htmlNewTabPage": {
             "state": "internal",
             "features": {


### PR DESCRIPTION
<!--
  ⚠️ ⚠️ IF YOU ARE MODIFYING `index.js` OR A FILE IN `features` ⚠️ ⚠️
  Please request a review and ping a DRI from the Config AOR or Breakage AOR.
  The quickest way to get attention for your PR is to ping the ~Breakage channel
  in MatterMost.

  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Consider adding an individual reviewer as well as the groups that are automatically added (this should create a review task in Asana for them specifically).
  Use the "merge when ready" button to automatically merge the PR as soon as it's reviewed.
-->

**Asana Task/Github Issue:** https://app.asana.com/0/0/1209118039592227/f

## Description
- Adds Windows override for `htmlNewTabPage` in prep for upcoming launch
- Moves `nextStepsWidget` to `htmlNewTabPage` (since we'll eventually remove `windowsNewTabPageExperiment`)

#### Brief explanation
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [x] Windows
  - [ ] MacOS
  - [ ] Extensions

#### Reference

-   [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
-   [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
-   [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)
