### PR TITLE
Mitigate rentio.jp by allowing one request

### DIFF
--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -1759,6 +1759,15 @@
                     }
                 ]
             },
+            "karte.io": {
+                "rules": [
+                    {
+                        "rule": "bs.karte.io",
+                        "domains": ["rentio.jp"],
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2677"
+                    }
+                ]
+            },
             "klarnaservices.com": {
                 "rules": [
                     {


### PR DESCRIPTION
### Site breakage mitigation process:

#### Brief explanation
- Reported URL: rentio.jp
- Problems experienced: sections of content don't load
- Platforms affected:
  - [x] All
- Tracker(s) being unblocked: bs.karte.io

- I have referenced the URL of this PR as the "reason" value for the exception (where applicable).

#### Reference

-   [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
-   [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
-   [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)
