### PR TITLE
Mitigate Mapquest maps not loading because of hidden cookie pop-up

### DIFF
--- a/features/autoconsent.json
+++ b/features/autoconsent.json
@@ -670,6 +670,10 @@
         {
             "domain": "premiumegeszsegpenztar.hu",
             "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2678"
+        },
+        {
+            "domain": "mapquest.com",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2679"
         }
     ],
     "settings": {
@@ -814,7 +818,8 @@
             "memsoft.fr",
             "bafin.de",
             "levi.pt",
-            "premiumegeszsegpenztar.hu"
+            "premiumegeszsegpenztar.hu",
+            "mapquest.com"
         ]
     }
 }


### PR DESCRIPTION
### Site breakage mitigation process:

#### Brief explanation
- Reported URL: mapquest.com
- Problems experienced: page elements won't load while cookie pop-up hidden
- Platforms affected:
  - [x] All except extensions
- Feature being disabled: CPM
- [x] I have referenced the URL of this PR as the "reason" value for the exception (where applicable).

#### Reference

-   [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
-   [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
-   [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)
