### PR TITLE
Validate that cohort names do not contain special characters

### DIFF
--- a/tests/config-tests.js
+++ b/tests/config-tests.js
@@ -109,6 +109,22 @@ describe('Config schema tests', () => {
                     }
                 }
             });
+
+            it('All experiment cohorts should be named correctly', () => {
+                const cohortNameRegex = /^[a-zA-Z0-9]+$/;
+                /** @type {Record<string, import('../schema/feature').GenericFeature>} */
+                const features = config.body.features;
+                for (const featureName of Object.keys(config.body.features)) {
+                    for (const subfeatureName of Object.keys(features[featureName].features || {})) {
+                        const subFeature = features[featureName].features[subfeatureName];
+                        if (subFeature.cohorts) {
+                            for (const cohort of subFeature.cohorts) {
+                                expect(cohort.name).to.match(cohortNameRegex);
+                            }
+                        }
+                    }
+                }
+            });
         });
     }
 


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/0/1208889145294658/1208747415972722/f

## Description

Cohort names are passed directly to some pixels, so we should make sure that they don't contain any special characters that could break the analysis pipeline (e.g. `_`, `.` or `?`). This PR adds a unit-test to validate all cohort names in the config against the regex `/^[a-zA-Z0-9]+$/`.