### PR TITLE
ad-tracker-unblocked-derstandard-at

### DIFF
--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -102,6 +102,11 @@
                         "rule": "ad3.adfarm1.adition.com/js",
                         "domains": ["servustv.com"],
                         "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1869"
+                    },
+                    {
+                        "rule": "imagesrv.adition.com/js",
+                        "domains": ["derstandard.at"],
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/issues/2689"
                     }
                 ]
             },


### PR DESCRIPTION
<!--
  ⚠️ ⚠️ IF YOU ARE MODIFYING `index.js` OR A FILE IN `features` ⚠️ ⚠️
  Please request a review and ping a DRI from the Config AOR or Breakage AOR.
  The quickest way to get attention for your PR is to ping the ~Breakage channel
  in MatterMost.

  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Consider adding an individual reviewer as well as the groups that are automatically added (this should create a review task in Asana for them specifically).
  Use the "merge when ready" button to automatically merge the PR as soon as it's reviewed.
-->

**Asana Task/Github Issue:**

## Description
blocking a tracker triggers an ad block wall.
<!-- 
  Please delete either or both process sections below.
-->

### Site breakage mitigation process:

#### Brief explanation
- Reported URL: https://www.derstandard.at/adblockwall/
- Problems experienced: ad block wall gets triggered 
- Platforms affected:
  - [ x] iOS
  - [ x] Android
  - [x ] Windows
  - [x ] MacOS
  - [x ] Extensions
- Tracker(s) being unblocked: imagesrv.adition.com/js
- Feature being disabled: NA


- [ x] I have referenced the URL of this PR as the "reason" value for the exception (where applicable).
- [ ] This change is a speculative mitigation to fix reported breakage.

#### Reference

-   [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
-   [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
-   [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)
