### PR TITLE
sync.seamlessAccountSwitching macOS/iOS overrides

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -316,7 +316,12 @@
         },
         "sync": {
             "state": "enabled",
-            "minSupportedVersion": "7.104.0"
+            "minSupportedVersion": "7.104.0",
+            "features": {
+                "seamlessAccountSwitching": {
+                    "state": "enabled"
+                }
+            }
         },
         "syncPromotion": {
             "state": "enabled",

--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -318,6 +318,18 @@
             "state": "enabled",
             "minSupportedVersion": "7.104.0",
             "features": {
+                "level0ShowSync": {
+                    "state": "enabled"
+                },
+                "level1AllowDataSyncing": {
+                    "state": "enabled"
+                },
+                "level2AllowSetupFlows": {
+                    "state": "enabled"
+                },
+                "level3AllowCreateAccount": {
+                    "state": "enabled"
+                },
                 "seamlessAccountSwitching": {
                     "state": "enabled"
                 }

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -510,6 +510,18 @@
             "state": "enabled",
             "minSupportedVersion": "1.70.0",
             "features": {
+                "level0ShowSync": {
+                    "state": "enabled"
+                },
+                "level1AllowDataSyncing": {
+                    "state": "enabled"
+                },
+                "level2AllowSetupFlows": {
+                    "state": "enabled"
+                },
+                "level3AllowCreateAccount": {
+                    "state": "enabled"
+                },
                 "seamlessAccountSwitching": {
                     "state": "enabled"
                 }

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -508,7 +508,12 @@
         },
         "sync": {
             "state": "enabled",
-            "minSupportedVersion": "1.70.0"
+            "minSupportedVersion": "1.70.0",
+            "features": {
+                "seamlessAccountSwitching": {
+                    "state": "enabled"
+                }
+            }
         },
         "syncPromotion": {
             "state": "enabled",


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/0/72649045549333/1209014391063074/f

## Description

This adds a feature flag to macOS an iOS called `seamlessAccountSwitching` as a subfeature to sync to ship enabled. If there's an issue on launch, we'll disable it.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change
- [x] I have tested this change locally
- [x] This code for the config change is ready to merge
- [ ] This feature was covered by a tech design

#### Additional info:
<!--
  These questions are a friendly reminder to shipping config changes, if you're uncertain ask the AoR owners.
  It's also totally appropriate to not check some of these boxes, if they don't apply to your change.
-->
- [x] I have tested this change locally in all supported browsers
- [x] This change will be visible to users
- [x] This code for the config change is ready
- [x] This change was covered by a ship review

### Site breakage mitigation process:

#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [x] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled:


- [ ] I have referenced the URL of this PR as the "reason" value for the exception (where applicable).
- [ ] This change is a speculative mitigation to fix reported breakage.

#### Reference

-   [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
-   [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
-   [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)
