### PR TITLE
add-trackers-exception-recommendation-newsweek

### DIFF
--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -1956,6 +1956,25 @@
                     }
                 ]
             },
+            "mgid.com": {
+                "rules": [
+                    {
+                        "rule": "jsc.mgid.com/site",
+                        "domains": ["newsweek.com"],
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2693"
+                    },
+                    {
+                        "rule": "s-img.mgid.com/g",
+                        "domains": ["newsweek.com"],
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2693"
+                    },
+                    {
+                        "rule": "servicer.mgid.com",
+                        "domains": ["newsweek.com"],
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2693"
+                    }
+                ]
+            },
             "monetate.net": {
                 "rules": [
                     {


### PR DESCRIPTION
<!--
  ⚠️ ⚠️ IF YOU ARE MODIFYING `index.js` OR A FILE IN `features` ⚠️ ⚠️
  Please request a review and ping a DRI from the Config AOR or Breakage AOR.
  The quickest way to get attention for your PR is to ping the ~Breakage channel
  in MatterMost.

  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Consider adding an individual reviewer as well as the groups that are automatically added (this should create a review task in Asana for them specifically).
  Use the "merge when ready" button to automatically merge the PR as soon as it's reviewed.
-->

**Asana Task/Github Issue:**
https://app.asana.com/0/1206670747178362/1209246140586135/f
## Description

Unblock 3 trackers to retrieve the "Your recommendations" section

### Site breakage mitigation process:

#### Brief explanation
- Reported URL: https://www.newsweek.com/social-security-fairness-act-explained-what-changes-does-it-bring-2010067
- Problems experienced: recommended articles does not display because of blocking ad trackers
- Platforms affected:
  - [ x] iOS
  - [ x] Android
  - [ x] Windows
  - [ x] MacOS
  - [ x] Extensions
- Tracker(s) being unblocked:
- jsc.mgid.com/site
- s-img.mgid.com/g
- servicer.mgid.com
- Feature being disabled: NA


- [ x] I have referenced the URL of this PR as the "reason" value for the exception (where applicable).


#### Reference

-   [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
-   [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
-   [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)
