### PR TITLE
Disable autoconsent on bergwelten.com

### DIFF
--- a/features/autoconsent.json
+++ b/features/autoconsent.json
@@ -417,7 +417,7 @@
         },
         {
             "domain": "bergwelten.com",
-            "reason": "Pay or Okay wall"
+            "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2706"
         }
     ],
     "settings": {

--- a/features/autoconsent.json
+++ b/features/autoconsent.json
@@ -414,6 +414,10 @@
         {
             "domain": "ib3.org",
             "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2702"
+        },
+        {
+            "domain": "bergwelten.com",
+            "reason": "Pay or Okay wall"
         }
     ],
     "settings": {


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/0/1206670747178362/1209303617391589

## Description
Onetrust pay-or-okay wall. Rejecting consent just brings back the banner.
