### PR TITLE
Disable CPM on bobliotheek.be

### DIFF
--- a/features/autoconsent.json
+++ b/features/autoconsent.json
@@ -414,6 +414,10 @@
         {
             "domain": "ib3.org",
             "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2702"
+        },
+        {
+            "domain": "bibliotheek.be",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2709"
         }
     ],
     "settings": {


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/0/1206670747178362/1209302288539742

## Description
- Popup is incorrectly hidden by a hiding rule, leaving scrolling locked.
- Rule is `eu-cookie-compliance-banner`.