### PR TITLE
Address yet another chrome popup on google drive

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -1651,6 +1651,10 @@
                         "type": "hide"
                     },
                     {
+                        "selector": "div:has(> iframe[src*='prid=19031497'])",
+                        "type": "hide"
+                    },
+                    {
                         "selector": "div:has(> iframe[src*='prid=19043282'])",
                         "type": "hide"
                     },


### PR DESCRIPTION
<!--
  ⚠️ ⚠️ IF YOU ARE MODIFYING `index.js` OR A FILE IN `features` ⚠️ ⚠️
  Please request a review and ping a DRI from the Config AOR or Breakage AOR.
  The quickest way to get attention for your PR is to ping the ~Breakage channel
  in MatterMost.

  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Consider adding an individual reviewer as well as the groups that are automatically added (this should create a review task in Asana for them specifically).
  Use the "merge when ready" button to automatically merge the PR as soon as it's reviewed.
-->

**Asana Task/Github Issue:** https://app.asana.com/0/1201048563534612/1209311287835297

## Description
Another "switch to chrome" popup was flagged on drive.google.com, this PR hides it.

### Site breakage mitigation process:

#### Brief explanation
- Reported URL: https://drive.google.com
- Problems experienced: Popup appears prompting user to switch to Chrome
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [x] Windows
  - [x] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled:

#### Reference

-   [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
-   [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
-   [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)
