### PR TITLE
Broaden qwenlm CDN allowlist rule

### DIFF
--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -241,7 +241,7 @@
                         "reason": "https://github.com/duckduckgo/privacy-configuration/issues/460"
                     },
                     {
-                        "rule": "alicdn.com/g/qwenweb/qwen-webui-fe/0.0.15",
+                        "rule": "alicdn.com/g/qwenweb/qwen-webui-fe/",
                         "domains": ["qwenlm.ai"],
                         "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2700"
                     }


### PR DESCRIPTION
<!--
  ⚠️ ⚠️ IF YOU ARE MODIFYING `index.js` OR A FILE IN `features` ⚠️ ⚠️
  Please request a review and ping a DRI from the Config AOR or Breakage AOR.
  The quickest way to get attention for your PR is to ping the ~Breakage channel
  in MatterMost.

  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Consider adding an individual reviewer as well as the groups that are automatically added (this should create a review task in Asana for them specifically).
  Use the "merge when ready" button to automatically merge the PR as soon as it's reviewed.
-->

**Asana Task/Github Issue:** https://app.asana.com/0/1206670747178362/1209315576561957

## Description
Our original allowlist rule hard-coded a specific version of the frontend loaded from the CDN. Since then the site has already updated to a later version. This PR removes the version from the allowlist rule so this won't be an issue in future.