### PR TITLE
Disable CPM on dwaalzin.nu and volcanoteide.com

### DIFF
--- a/features/autoconsent.json
+++ b/features/autoconsent.json
@@ -422,6 +422,14 @@
         {
             "domain": "bibliotheek.be",
             "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2709"
+        },
+        {
+            "domain": "volcanoteide.com",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2721"
+        },
+        {
+            "domain": "dwaalzin.nu",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2721"
         }
     ],
     "settings": {


### PR DESCRIPTION
<!--
  ⚠️ ⚠️ IF YOU ARE MODIFYING `index.js` OR A FILE IN `features` ⚠️ ⚠️
  Please request a review and ping a DRI from the Config AOR or Breakage AOR.
  The quickest way to get attention for your PR is to ping the ~Breakage channel
  in MatterMost.

  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Consider adding an individual reviewer as well as the groups that are automatically added (this should create a review task in Asana for them specifically).
  Use the "merge when ready" button to automatically merge the PR as soon as it's reviewed.
-->

**Asana Task/Github Issue:** https://app.asana.com/0/1206670747178362/1209298139686639 https://app.asana.com/0/1206670747178362/1209302321891321

## Description
CPM breakage due to 'Complianz notice' rule: page is left with an overlay blocking interactions on the following sites:
- dwaalzin.nu
- volcanoteide.com

