### PR TITLE
Disable `crashAutoRecovery` in Windows browser

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -459,7 +459,7 @@
                     "state": "enabled"
                 },
                 "crashAutoRecovery": {
-                    "state": "enabled"
+                    "state": "disabled"
                 }
             }
         },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/0/0/1209328534453625/f

## Description
Remove the auto recovery feature when tab crashes in Windows browser to speculatively resolve issue with tab not loading.

#### Reference

-   [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
-   [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
-   [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)
