### PR TITLE
Disable autoconsent for older windows versions.

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -156,7 +156,7 @@
         },
         "autoconsent": {
             "state": "enabled",
-            "minSupportedVersion": "0.50.0",
+            "minSupportedVersion": "0.99.0",
             "features": {
                 "filterlist": {
                     "state": "disabled"


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/0/1140729528379976/1209244181226565

## Description
- There is a bug in autoconsent <12.5.0 which will throw an exception in the console on every site.
- Windows browser users <0.99 have an older autoconsent version.
- To prevent spamming the console across the web, let's disable the feature for those users - they should be shortly updated to a newer version anyway.