### PR TITLE
Element hiding: address empty space above nav bar on abcnews.go.com

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -611,6 +611,21 @@
                 ]
             },
             {
+                "domain": "abcnews.go.com",
+                "rules": [
+                    {
+                        "selector": ".navigation",
+                        "type": "modify-style",
+                        "values": [
+                            {
+                                "property": "top",
+                                "value": "0px"
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
                 "domain": "accuweather.com",
                 "rules": [
                     {


### PR DESCRIPTION
<!--
  ⚠️ ⚠️ IF YOU ARE MODIFYING `index.js` OR A FILE IN `features` ⚠️ ⚠️
  Please request a review and ping a DRI from the Config AOR or Breakage AOR.
  The quickest way to get attention for your PR is to ping the ~Breakage channel
  in MatterMost.

  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Consider adding an individual reviewer as well as the groups that are automatically added (this should create a review task in Asana for them specifically).
  Use the "merge when ready" button to automatically merge the PR as soon as it's reviewed.
-->

**Asana Task/Github Issue:** https://app.asana.com/0/1206670747178362/1209238322357549

## Description
The navigation bar on https://abcnews.go.com is shifted down from the top of the page in order to display an ad (which doesn't load due to trackers). This PR addresses that empty space.
