### PR TITLE
[Autofill] Disable partial saves

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -438,7 +438,7 @@
                     "state": "disabled"
                 },
                 "partialFormSaves": {
-                    "state": "enabled"
+                    "state": "disabled"
                 },
                 "onByDefault": {
                     "state": "enabled",

--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -285,7 +285,7 @@
                     }
                 },
                 "partialFormSaves": {
-                    "state": "enabled"
+                    "state": "disabled"
                 }
             }
         },

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -336,7 +336,7 @@
                     "state": "enabled"
                 },
                 "partialFormSaves": {
-                    "state": "enabled"
+                    "state": "disabled"
                 }
             }
         },


### PR DESCRIPTION
<!--
  ⚠️ ⚠️ IF YOU ARE MODIFYING `index.js` OR A FILE IN `features` ⚠️ ⚠️
  Please request a review and ping a DRI from the Config AOR or Breakage AOR.
  The quickest way to get attention for your PR is to ping the ~Breakage channel
  in MatterMost.

  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Consider adding an individual reviewer as well as the groups that are automatically added (this should create a review task in Asana for them specifically).
  Use the "merge when ready" button to automatically merge the PR as soon as it's reviewed.
-->

**Asana Task/Github Issue:** https://app.asana.com/0/1203822806345703/1209282738083555

## Description
Disabling `partial_form_saves` as a step to investigate drop in autofill accuracy metrics https://app.asana.com/0/1203822806345703/1209282738083555/f.


<!-- 
  Please delete either or both process sections below.
-->

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change
- [ ] I have tested this change locally
- [x] This code for the config change is ready to merge
- [ ] This feature was covered by a tech design

#### Additional info:
<!--
  These questions are a friendly reminder to shipping config changes, if you're uncertain ask the AoR owners.
  It's also totally appropriate to not check some of these boxes, if they don't apply to your change.
-->
- [ ] I have tested this change locally in all supported browsers
- [x] This change will be visible to users
- [x] This code for the config change is ready
- [ ] This change was covered by a ship review

### Site breakage mitigation process:

#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [x] iOS
  - [x] Android
  - [ ] Windows
  - [x] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled:


- [ ] I have referenced the URL of this PR as the "reason" value for the exception (where applicable).
- [ ] This change is a speculative mitigation to fix reported breakage.

#### Reference

-   [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
-   [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
-   [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)
