### PR TITLE
Removed duplicate ojbect for maliciousSiteProtection in macOS override

### DIFF
--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -893,14 +893,6 @@
                 }
             }
         },
-        "maliciousSiteProtection": {
-            "state": "enabled",
-            "settings": {
-                "hashPrefixUpdateFrequency": 20,
-                "filterSetUpdateFrequency": 720
-            },
-            "exceptions": []
-        },
         "backgroundAgentPixelTest": {
             "state": "enabled",
             "features": {


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/0/0/1209326067557299/f

## Description

This PR removes a duplicated object for “maliciousSiteProtection” for macOS already defined at line 917.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change
- [ ] I have tested this change locally
- [ ] This code for the config change is ready to merge
- [ ] This feature was covered by a tech design

#### Additional info:
<!--
  These questions are a friendly reminder to shipping config changes, if you're uncertain ask the AoR owners.
  It's also totally appropriate to not check some of these boxes, if they don't apply to your change.
-->
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [ ] This code for the config change is ready
- [ ] This change was covered by a ship review

### Site breakage mitigation process:

#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled:


- [ ] I have referenced the URL of this PR as the "reason" value for the exception (where applicable).
- [ ] This change is a speculative mitigation to fix reported breakage.

#### Reference

-   [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
-   [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
-   [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)
