### PR TITLE
Roll back speculative mitigations for instructure.com

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -790,10 +790,5 @@
             }
         }
     },
-    "unprotectedTemporary": [
-        {
-            "domain": "instructure.com",
-            "reason": "https://github.com/duckduckgo/privacy-configuration/issues/2212"
-        }
-    ]
+    "unprotectedTemporary": [ ]
 }

--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -790,5 +790,5 @@
             }
         }
     },
-    "unprotectedTemporary": [ ]
+    "unprotectedTemporary": []
 }

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -924,5 +924,5 @@
             }
         }
     },
-    "unprotectedTemporary": [ ]
+    "unprotectedTemporary": []
 }

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -460,10 +460,6 @@
                         "reason": "https://github.com/duckduckgo/privacy-configuration/issues/988"
                     },
                     {
-                        "domain": "instructure.com",
-                        "reason": "Experimental mitigation to reduce breakage"
-                    },
-                    {
                         "domain": "web.whatsapp.com",
                         "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1780"
                     },
@@ -928,10 +924,5 @@
             }
         }
     },
-    "unprotectedTemporary": [
-        {
-            "domain": "instructure.com",
-            "reason": "https://github.com/duckduckgo/privacy-configuration/issues/2212"
-        }
-    ]
+    "unprotectedTemporary": [ ]
 }


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/0/1206670747178362/1208677647456776

## Description
These speculative mitigations had no effect on reports, and we think reported breakage here may be due to an underlying webkit limitations that prevent us from (even if we wanted to) allowing 3rd-party cookies globally in the browser.

#### Reference

-   [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
-   [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
-   [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)
