### PR TITLE
Malicious Site Protection - Disabled state in case there are issues during rollout

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -729,10 +729,10 @@
             }
         },
         "maliciousSiteProtection": {
-            "state": "internal",
+            "state": "disabled",
             "features": {
                 "onByDefault": {
-                    "state": "internal"
+                    "state": "disabled"
                 }
             },
             "settings": {


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/0/1206329551987282/1209385826333906

## Description

This PR disables the Malicious Site Protection feature to allow for a quick response in case there are issues during the rollout phases. This change should not be merged. It is intended solely to be released if problems arise during the rollout process.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change
- [ ] I have tested this change locally
- [ ] This code for the config change is ready to merge
- [ ] This feature was covered by a tech design

#### Additional info:
<!--
  These questions are a friendly reminder to shipping config changes, if you're uncertain ask the AoR owners.
  It's also totally appropriate to not check some of these boxes, if they don't apply to your change.
-->
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [ ] This code for the config change is ready
- [ ] This change was covered by a ship review

### Site breakage mitigation process:

#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled:


- [ ] I have referenced the URL of this PR as the "reason" value for the exception (where applicable).
- [ ] This change is a speculative mitigation to fix reported breakage.

#### Reference

-   [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
-   [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
-   [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)
