### PR TITLE
Add exception for d3qpjnspil4z56.cloudfront.net

### DIFF
--- a/features/malicious-site-protection.json
+++ b/features/malicious-site-protection.json
@@ -8,6 +8,10 @@
         {
             "domain": "broken.third-party.site",
             "reason": "A test page that helps us verify if exceptions work correctly."
+        },
+        {
+            "domain": "d3qpjnspil4z56.cloudfront.net",
+            "reason": "Currently causing breakage on Facebook for the official Zynga Texas Hold'em game."
         }
     ]
 }


### PR DESCRIPTION
<!--
  ⚠️ ⚠️ IF YOU ARE MODIFYING `index.js` OR A FILE IN `features` ⚠️ ⚠️
  Please request a review and ping a DRI from the Config AOR or Breakage AOR.
  The quickest way to get attention for your PR is to ping the ~Breakage channel
  in MatterMost.

  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Consider adding an individual reviewer as well as the groups that are automatically added (this should create a review task in Asana for them specifically).
  Use the "merge when ready" button to automatically merge the PR as soon as it's reviewed.
-->

**Asana Task/Github Issue:** https://app.asana.com/0/1208859185135959/1209357181668521

## Description
We are getting reports that apps.facebook.com/texas_holdem is causing breakage due to it loading an iframe that is flagged as malicious in our dataset. 
<!-- 
  Please delete either or both process sections below.
-->

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change
- [x] I have tested this change locally
- [x] This code for the config change is ready to merge
- [x] This feature was covered by a tech design

#### Additional info:
<!--
  These questions are a friendly reminder to shipping config changes, if you're uncertain ask the AoR owners.
  It's also totally appropriate to not check some of these boxes, if they don't apply to your change.
-->
- [x] I have tested this change locally in all supported browsers
- [x] This change will be visible to users
- [x] This code for the config change is ready
- [ ] This change was covered by a ship review

### Site breakage mitigation process:

#### Brief explanation
- Reported URL: https://apps.facebook.com/texas_holdem
- Problems experienced: Malicious site protection warning page is shown and since it's embedded in an iframe that redirects, it causes users to get stuck in a loop unable to bypass the error page.
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [x] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked: None.
- Feature being disabled: None, just adding exception for domain


- [ ] I have referenced the URL of this PR as the "reason" value for the exception (where applicable).
- [ ] This change is a speculative mitigation to fix reported breakage.

#### Reference

-   [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
-   [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
-   [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)
