### PR TITLE
Duck Player custom error config

### DIFF
--- a/features/duck-player.json
+++ b/features/duck-player.json
@@ -13,6 +13,9 @@
         },
         "openInNewTab": {
             "state": "disabled"
+        },
+        "customError": {
+            "state": "disabled"
         }
     },
     "settings": {

--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -94,6 +94,13 @@
                 "enableDuckPlayer": {
                     "state": "enabled",
                     "minSupportedVersion": "7.139.0"
+                },
+                "customError": {
+                    "state": "enabled",
+                    "minSupportedVersion": "7.159.0",
+                    "settings": {
+                        "signInRequiredSelector": "[href*=\"//support.google.com/youtube/answer/3037019\"]"
+                    }
                 }
             }
         },

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -175,6 +175,13 @@
                 "openInNewTab": {
                     "state": "enabled",
                     "minSupportedVersion": "1.101.0"
+                },
+                "customError": {
+                    "state": "enabled",
+                    "minSupportedVersion": "1.128.0",
+                    "settings": {
+                        "signInRequiredSelector": "[href*=\"//support.google.com/youtube/answer/3037019\"]"
+                    }
                 }
             }
         },


### PR DESCRIPTION
<!--
  ⚠️ ⚠️ IF YOU ARE MODIFYING `index.js` OR A FILE IN `features` ⚠️ ⚠️
  Please request a review and ping a DRI from the Config AOR or Breakage AOR.
  The quickest way to get attention for your PR is to ping the ~Breakage channel
  in MatterMost.

  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Consider adding an individual reviewer as well as the groups that are automatically added (this should create a review task in Asana for them specifically).
  Use the "merge when ready" button to automatically merge the PR as soon as it's reviewed.
-->

**Asana Task/Github Issue:** https://app.asana.com/0/1206594217596623/1209496302231804

## Description

Introduces a Duck Player subfeature config for new the Custom Error view (more info in the [parent task](https://app.asana.com/0/1206594217596623/1208283441580816)).

The supporting code change has been released internally to Apple platforms as part of https://github.com/duckduckgo/apple-browsers/pull/23

### Testing steps

Testing requires one of the internal release versions below
**iOS v7.159.0** or above
**macOS v1.128.0** or above

1. Set Duck Player to "Always open videos in Duck Player"

2. Open the url https://youtube.com/watch?v=PGaO6KUR9fk . You should see Duck Player load with a regular YouTube error
![](https://github.com/user-attachments/assets/a0aae143-971b-4ff5-9a4c-67ca35a4c011)


4. Switch to the privacy config below and restart the browser
iOS: https://www.jsonblob.com/api/jsonBlob/1344268832977641472
macOS: https://www.jsonblob.com/api/jsonBlob/1344268488746917888

5. Open the url https://youtube.com/watch?v=PGaO6KUR9fk again. You should see Duck Player load with the new custom error screen
![](https://github.com/user-attachments/assets/a46e31ca-0b64-4d57-a9d5-0188f69f883c)



### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change
- [x] I have tested this change locally
- [ ] This code for the config change is ready to merge
- [ ] This feature was covered by a tech design

#### Additional info:
<!—
  These questions are a friendly reminder to shipping config changes, if you're uncertain ask the AoR owners.
  It's also totally appropriate to not check some of these boxes, if they don't apply to your change.
—>
- [x] I have tested this change locally in all supported browsers
- [x] This change will be visible to users
- [ ] This code for the config change is ready
- [x] This change was covered by a ship review

### Site breakage mitigation process:

#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled:


- [ ] I have referenced the URL of this PR as the "reason" value for the exception (where applicable).
- [ ] This change is a speculative mitigation to fix reported breakage.

#### Reference

-   [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
-   [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
-   [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)
