### PR TITLE
Add macOS and iOS UserAgent header override for maxcomply.app

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -331,6 +331,10 @@
                     {
                         "domain": "ihg.com",
                         "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2383"
+                    },
+                    {
+                        "domain": "maxcomply.app",
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2759"
                     }
                 ],
                 "ddgDefaultSites": [
@@ -358,6 +362,10 @@
                     {
                         "domain": "ihg.com",
                         "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2383"
+                    },
+                    {
+                        "domain": "maxcomply.app",
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2759"
                     }
                 ],
                 "omitVersionSites": []

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -523,6 +523,10 @@
                     {
                         "domain": "teams.microsoft.com",
                         "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2557"
+                    },
+                    {
+                        "domain": "maxcomply.app",
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2759"
                     }
                 ],
                 "webViewDefault": [


### PR DESCRIPTION
The website is blocking DuckDuckGo browser users, so let's adjust the UserAgent
header on iOS and macOS.

Note: Does not fix the issue on the DuckDuckGo Android and Windows browsers. The
      mitigation steps for those browsers are less clear.

<!--
  ⚠️ ⚠️ IF YOU ARE MODIFYING `index.js` OR A FILE IN `features` ⚠️ ⚠️
  Please request a review and ping a DRI from the Config AOR or Breakage AOR.
  The quickest way to get attention for your PR is to ping the ~Breakage channel
  in MatterMost.

  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Consider adding an individual reviewer as well as the groups that are automatically added (this should create a review task in Asana for them specifically).
  Use the "merge when ready" button to automatically merge the PR as soon as it's reviewed.
-->

**Asana Task/Github Issue:** https://app.asana.com/0/1206670747178362/1209411892349530