### PR TITLE
Disable CPM for a couple of websites to fix page interaction

### DIFF
--- a/features/autoconsent.json
+++ b/features/autoconsent.json
@@ -438,6 +438,18 @@
         {
             "domain": "russafasingluten.com",
             "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2730"
+        },
+        {
+            "domain": "capita.com",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2765"
+        },
+        {
+            "domain": "capita.co.uk",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2765"
+        },
+        {
+            "domain": "katieloxton.com",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2765"
         }
     ],
     "settings": {


### PR DESCRIPTION
A couple of website become unresponsive to interaction when CPM is enabled,
since a prompt overlay remains on the page. Let's disable the feature for those
websites for now.

**Asana Task/Github Issues:**
- https://app.asana.com/0/1206670747178362/1209431630762380
- https://app.asana.com/0/1206670747178362/1209431477958037