### PR TITLE
Hide large empty space in header on bloomberglaw.com

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -871,6 +871,15 @@
                 ]
             },
             {
+                "domain": "bloomberglaw.com",
+                "rules": [
+                    {
+                        "selector": "[class^='HeaderAdSpot_']",
+                        "type": "hide-empty"
+                    }
+                ]
+            },
+            {
                 "domain": "bostonglobe.com",
                 "rules": [
                     {


### PR DESCRIPTION
It seems that if the user declines optional cookies, the large header space for
adverts is left blank. Let's collapse that if empty, to improve the UX.

**Asana Task/Github Issue:** https://app.asana.com/0/1200277586140538/1209437088800226