### PR TITLE
Avoid triggering ad blocker wall on servustv.com

### DIFF
--- a/features/autoconsent.json
+++ b/features/autoconsent.json
@@ -450,6 +450,10 @@
         {
             "domain": "katieloxton.com",
             "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2765"
+        },
+        {
+            "domain": "servustv.com",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2772"
         }
     ],
     "settings": {

--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -2772,6 +2772,15 @@
                     }
                 ]
             },
+            "theadex.com": {
+                "rules": [
+                    {
+                        "rule": "dmp.theadex.com/",
+                        "domains": ["servustv.com"],
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2772"
+                    }
+                ]
+            },
             "tfaforms.net": {
                 "rules": [
                     {


### PR DESCRIPTION
It seems that CPM triggers the ad blocker wall for iOS users, and for Android
users triggers a redirection loop that entirely breaks the website. Also, on all
platforms it seems that blocking the https://dmp.theadex.com/d/1865/7400/s/adex.js
request also triggers the ad blocker wall as well.

**Asana Task/Github Issue:** https://app.asana.com/0/1206670747178362/1209461678993622