### PR TITLE
Fix weird transparent space above Flickr.com header

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -1368,6 +1368,26 @@
                     {
                         "selector": ".feed-b",
                         "type": "hide-empty"
+                    },
+                    {
+                        "selector": ".global-nav-view, .global-nav-view .global-nav-content",
+                        "type": "modify-style",
+                        "values": [
+                            {
+                                "property": "margin-top",
+                                "value": "0px"
+                            }
+                        ]
+                    },
+                    {
+                        "selector": ".search-subnav-slender-view, .search-slender-advanced-panel-view",
+                        "type": "modify-style",
+                        "values": [
+                            {
+                                "property": "top",
+                                "value": "0px"
+                            }
+                        ]
                     }
                 ]
             },


### PR DESCRIPTION

**Asana Task/Github Issue:** https://app.asana.com/0/1206670747178362/1209460870135522

### Site breakage mitigation process:

#### Brief explanation
- Reported URL: flickr.com
- Problems experienced: blank space where header normally is
- Platforms affected:
  - [x] all

#### Reference

-   [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
-   [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
-   [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)
