### PR TITLE
Mitigate ima3.js surrogate breakage on pch.com, plex.tv & nicovideo.jp

### DIFF
--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -1308,7 +1308,10 @@
                             "cbssports.com",
                             "gbnews.com",
                             "ign.com",
-                            "mlb.com"
+                            "mlb.com",
+                            "plex.tv",
+                            "pch.com",
+                            "nicovideo.jp"
                         ],
                         "reason": [
                             "https://github.com/duckduckgo/privacy-configuration/issues/401",
@@ -1320,6 +1323,7 @@
                             "washingtonpost.com - https://github.com/duckduckgo/privacy-configuration/issues/1773",
                             "ign.com - https://github.com/duckduckgo/privacy-configuration/issues/2068",
                             "mlb.com - https://github.com/duckduckgo/privacy-configuration/pull/2345"
+                            "plex, pch, nicovideo - https://github.com/duckduckgo/privacy-configuration/pull/2787"
                         ]
                     }
                 ]

--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -1322,7 +1322,7 @@
                             "pandora.com - https://github.com/duckduckgo/privacy-configuration/issues/1710",
                             "washingtonpost.com - https://github.com/duckduckgo/privacy-configuration/issues/1773",
                             "ign.com - https://github.com/duckduckgo/privacy-configuration/issues/2068",
-                            "mlb.com - https://github.com/duckduckgo/privacy-configuration/pull/2345"
+                            "mlb.com - https://github.com/duckduckgo/privacy-configuration/pull/2345",
                             "plex, pch, nicovideo - https://github.com/duckduckgo/privacy-configuration/pull/2787"
                         ]
                     }


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/0/1206670747178362/1209495732381296
https://app.asana.com/0/1206670747178362/1209470537248517
https://app.asana.com/0/1206670747178362/1209494028887166

### Site breakage mitigation process:

#### Brief explanation
- Reported URL: plex.tv, pch.com, nicovideo.jp
- Problems experienced: video/game doesn't load or loads very slowly
- Platforms affected:
  - [x] all
- Tracker(s) being unblocked: imasdk.googleapis.com/js/sdkloader/ima3.js
