### PR TITLE
Disable CPM for sudouest.fr to mitigate weird extra blocking pop-up

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -278,6 +278,10 @@
                 {
                     "domain": "livescience.com",
                     "reason": "https://github.com/duckduckgo/privacy-configuration/issues/326"
+                },
+                {
+                    "domain": "https://www.sudouest.fr",
+                    "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2790"
                 }
             ],
             "features": {


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/0/1206670747178362/1209521422716491

### Site breakage mitigation process:

#### Brief explanation
- Reported URL: https://www.sudouest.fr/gironde/bordeaux/un-piratage-national-vise-les-cartes-pcs-il-n-y-a-aucune-securite-deplore-une-victime-bordelaise-23344056.php
- Problems experienced: CPM triggers weird secondary pop-up that blocks all interaction
- Platforms affected:
  - [ ] iOS
  - [x] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Feature being disabled: autoconsent/cpm

#### Reference

-   [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
-   [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
-   [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)
