### PR TITLE
MItigate images not showing on mobile for onestopplus.com

### DIFF
--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -3078,19 +3078,9 @@
                         "reason": "https://github.com/duckduckgo/privacy-configuration/issues/830"
                     },
                     {
-                        "rule": "rapid-cdn.yottaa.com/rapid/lib/ows8CdAyrC5lTw.js",
-                        "domains": ["scheels.com"],
-                        "reason": "https://github.com/duckduckgo/privacy-configuration/issues/492"
-                    },
-                    {
-                        "rule": "rapid-cdn.yottaa.com/rapid/lib/3ZzYwky2C-3YQw.js",
-                        "domains": ["fashionnova.com"],
-                        "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1453"
-                    },
-                    {
-                        "rule": "rapid-cdn.yottaa.com/rapid/lib/ZfJxptseJcUQIA.js",
-                        "domains": ["aviatornation.com"],
-                        "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1847"
+                        "rule": "rapid-cdn.yottaa.com/rapid/lib/",
+                        "domains": ["<all>"],
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2792"
                     }
                 ]
             },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/0/1206670747178362/1209493992664141

### Site breakage mitigation process:

#### Brief explanation
- Reported URL: https://www.onestopplus.com/products/clarissa-long-lace-wedding-dress/6103919.html
- Problems experienced: images don't load on mobile (expanded to cover lib/ and all domains as there were already 3 existing exceptions of the same type)
- Platforms affected:
  - [x] iOS
  - [x] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked: rapid-cdn.yottaa.com/rapid/lib/

#### Reference

-   [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
-   [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
-   [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)
