### PR TITLE
Add second tracker exclusion to mitigate pch.com slow loads

### DIFF
--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -798,7 +798,7 @@
                     },
                     {
                         "rule": "pubads.g.doubleclick.net/gampad/ads",
-                        "domains": ["nhl.com", "viki.com", "rocketnews24.com", "crunchyroll.com"],
+                        "domains": ["nhl.com", "viki.com", "rocketnews24.com", "crunchyroll.com", "pch.com"],
                         "reason": [
                             "https://github.com/duckduckgo/privacy-configuration/issues/1185",
                             "rocketnews24.com - https://github.com/duckduckgo/privacy-configuration/issues/846",

--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -802,7 +802,8 @@
                         "reason": [
                             "https://github.com/duckduckgo/privacy-configuration/issues/1185",
                             "rocketnews24.com - https://github.com/duckduckgo/privacy-configuration/issues/846",
-                            "crunchyroll.com - https://github.com/duckduckgo/privacy-configuration/issues/1140"
+                            "crunchyroll.com - https://github.com/duckduckgo/privacy-configuration/issues/1140",
+                            "pch.com - https://github.com/duckduckgo/privacy-configuration/pull/2793"
                         ]
                     },
                     {


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/0/1206670747178362/1209470537248517

### Site breakage mitigation process:

#### Brief explanation
- Reported URL: https://www.pch.com/games/word/word-finder-deluxe/gameplay
- Problems experienced: takes forever to load
- Platforms affected:
  - [x] all
- Tracker(s) being unblocked: pubads.g.doubleclick.net/gampad/ads
