### PR TITLE
Hide new switch-to-chrome pop-up on maps.google.com

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -1752,6 +1752,10 @@
                         "type": "hide"
                     },
                     {
+                        "selector": "div:has(> iframe[src*='prid=19046509'])",
+                        "type": "hide"
+                    },
+                    {
                         "selector": "[aria-labelledby='promo-header']",
                         "type": "hide"
                     },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/0/1200277586140538/1209552503370269

### Site breakage mitigation process:

#### Brief explanation
- Reported URL: maps.google.com
- Problems experienced: annoying "switch to Chrome" pop-up
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [x] MacOS
  - [ ] Extensions
