### PR TITLE
remove adblocker on dailyboulder

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -1062,6 +1062,22 @@
                 ]
             },
             {
+                "domain": "dailyboulder.com",
+                "rules": [
+                    {
+                        "type": "disable-default"
+                    },
+                    {
+                        "selector": ".site-access-popup",
+                        "type": "hide-empty"
+                    },
+                    {
+                        "selector": ".site-access-inner",
+                        "type": "hide-empty"
+                    }
+                ]
+            },
+            {
                 "domain": "dailyherald.com",
                 "rules": [
                     {

--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -1074,6 +1074,10 @@
                     {
                         "selector": ".site-access-inner",
                         "type": "hide-empty"
+                    },
+                    {
+                        "selector": ".top-site-ad",
+                        "type": "hide-empty"
                     }
                 ]
             },


### PR DESCRIPTION
<!--
  ⚠️ ⚠️ IF YOU ARE MODIFYING `index.js` OR A FILE IN `features` ⚠️ ⚠️
  Please request a review and ping a DRI from the Config AOR or Breakage AOR.
  The quickest way to get attention for your PR is to ping the ~Breakage channel
  in MatterMost.

  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Consider adding an individual reviewer as well as the groups that are automatically added (this should create a review task in Asana for them specifically).
  Use the "merge when ready" button to automatically merge the PR as soon as it's reviewed.
-->

**Asana Task/Github Issue:** https://app.asana.com/0/1206670747178362/1209551832824050

## Description

### Site breakage mitigation process:

#### Brief explanation
- Reported URL: dailyboulder.com
- Problems experienced: ad block wall prevents access to the site
- Platforms affected:
  - [x ] iOS
  - [x ] Android
  - [ x] Windows
  - [ x] MacOS
  - [ x] Extensions
- Tracker(s) being unblocked: NA
- Feature being disabled: ElementHiding


#### Reference

-   [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
-   [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
-   [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)
