### PR TITLE
add-CPM-exception-tfl

### DIFF
--- a/features/autoconsent.json
+++ b/features/autoconsent.json
@@ -450,6 +450,10 @@
         {
             "domain": "xxlmag.com",
             "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2796"
+        },
+        {
+            "domain": "tfl.gov.uk",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2803"
         }
     ],
     "settings": {


### PR DESCRIPTION
**Asana Task/Github Issue:**
- https://app.asana.com/0/1206670747178362/1209549288303014
- https://app.asana.com/0/0/1209464321643492/1209495998111925/f

## Description

### Site breakage mitigation process:

#### Brief explanation
- Reported URL: tfl.gov.uk
- Problems experienced: Grey Overlay triggered by CPM on certain platforms and versions
- Platforms affected:
  - [x] iOS
  - [x] Android
  - [x] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked: NA
- Feature being disabled: CPM


- [x] I have referenced the URL of this PR as the "reason" value for the exception (where applicable).