### PR TITLE
SBT unblock wunderground forecast video

### DIFF
--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -2012,7 +2012,7 @@
             "moatads.com": {
                 "rules": [
                     {
-                        "rule": "z.moatads.com/weatherprebidheader264491819464/moatheader.js",
+                        "rule": "z.moatads.com/weatherprebidheader",
                         "domains": ["wunderground.com"],
                         "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2805"
                     }

--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -2009,6 +2009,15 @@
                     }
                 ]
             },
+            "moatads.com": {
+                "rules": [
+                    {
+                        "rule": "z.moatads.com/weatherprebidheader264491819464/moatheader.js",
+                        "domains": ["wunderground.com"],
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2805"
+                    }
+                ]
+            },
             "monetate.net": {
                 "rules": [
                     {


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/0/1206670747178362/1209556546959134

## Description

### Site breakage mitigation process:

#### Brief explanation
- Reported URL: https://www.wunderground.com/video/top-stories/severe-outbreak-with-tornadoes-likely-starting-monday-night
- Problems experienced: Video not displaying
- Platforms affected:
  - [x] iOS
  - [x] Android
  - [x] Windows
  - [x] MacOS
  - [x] Extensions
- Tracker(s) being unblocked: z.moatads.com/weatherprebidheader264491819464/moatheader.js
- Feature being disabled: NA


- [x] I have referenced the URL of this PR as the "reason" value for the exception (where applicable).

#### Reference

-   [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
-   [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
-   [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)
