### PR TITLE
SBT unblock kutv site access

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -2074,6 +2074,19 @@
                 ]
             },
             {
+                "domain": "kutv.com",
+                "rules": [
+                    {
+                        "selector": "[class*='DisplayAdvert']",
+                        "type": "hide-empty"
+                    },
+                    {
+                        "selector": "[class*='adBeforeContent']",
+                        "type": "hide-empty"
+                    }
+                ]
+            },
+            {
                 "domain": "leboncoin.fr",
                 "rules": [
                     {

--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -833,7 +833,8 @@
                             "stuff.co.nz",
                             "goplay.be",
                             "repretel.com",
-                            "fincopilot.net"
+                            "fincopilot.net",
+                            "kutv.com"
                         ],
                         "reason": [
                             "ah.nl - 'Bonus offer' elements do not render and are not clickable.",
@@ -847,7 +848,8 @@
                             "stuff.co.nz - https://github.com/duckduckgo/privacy-configuration/issues/1740",
                             "goplay.be - https://github.com/duckduckgo/privacy-configuration/issues/1185",
                             "repretel.com - broken videos",
-                            "fincopilot.net - https://github.com/duckduckgo/privacy-configuration/pull/2791"
+                            "fincopilot.net - https://github.com/duckduckgo/privacy-configuration/pull/2791",
+                            "kutv.com - https://github.com/duckduckgo/privacy-configuration/pull/2806"
                         ]
                     },
                     {
@@ -881,11 +883,12 @@
                     },
                     {
                         "rule": "securepubads.g.doubleclick.net/pagead/managed/js/gpt",
-                        "domains": ["applesfera.com", "itsthevibe.com", "triblive.com"],
+                        "domains": ["applesfera.com", "itsthevibe.com", "triblive.com", "kutv.com"],
                         "reason": [
                             "applesfera.com - https://github.com/duckduckgo/privacy-configuration/issues/1723",
                             "itsthevibe - https://github.com/duckduckgo/privacy-configuration/pull/2482",
-                            "triblive.com - https://github.com/duckduckgo/privacy-configuration/issues/1730"
+                            "triblive.com - https://github.com/duckduckgo/privacy-configuration/issues/1730",
+                            "kutv.com - https://github.com/duckduckgo/privacy-configuration/pull/2806"
                         ]
                     },
                     {


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/0/1206670747178362/1209554178914766/f

## Description

### Site breakage mitigation process:

#### Brief explanation
- Reported URL: https://kutv.com/
- Problems experienced: 500 error message preventing access to the site. Unblocking 2 trackers mitigates the issue.
- Platforms affected:
  - [x] iOS
  - [x] Android
  - [x] Windows
  - [x] MacOS
  - [x] Extensions
- Tracker(s) being unblocked: securepubads.g.doubleclick.net/pagead/managed/js/gpt AND securepubads.g.doubleclick.net/tag/js/gpt.js
- Feature being disabled: NA


- [x] I have referenced the URL of this PR as the "reason" value for the exception (where applicable).

#### Reference

-   [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
-   [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
-   [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)
