### PR TITLE
SBT add cpm exception to load stooq-pl homepage

### DIFF
--- a/features/autoconsent.json
+++ b/features/autoconsent.json
@@ -454,6 +454,10 @@
         {
             "domain": "tfl.gov.uk",
             "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2803"
+        },
+        {
+            "domain": "stooq.pl",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2816"
         }
     ],
     "settings": {


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/0/1206670747178362/1209592805569326/f

## Description

### Site breakage mitigation process:

#### Brief explanation
- Reported URL: stooq-pl
- Problems experienced: page not loading when CPM is on
- Platforms affected:
  - [x] iOS
  - [x] Android
  - [x] Windows
  - [x] MacOS
  - [x] Extensions
- Tracker(s) being unblocked: NA
- Feature being disabled: CPM


- [x] I have referenced the URL of this PR as the "reason" value for the exception (where applicable).


#### Reference

-   [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
-   [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
-   [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)
