### PR TITLE
SBT add CPM exception to unfreeze jomajewellery-com homepage

### DIFF
--- a/features/autoconsent.json
+++ b/features/autoconsent.json
@@ -454,6 +454,10 @@
         {
             "domain": "tfl.gov.uk",
             "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2803"
+        },
+        {
+            "domain": "jomajewellery.com",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2817"
         }
     ],
     "settings": {


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/0/1206670747178362/1209577688432441

## Description

### Site breakage mitigation process: 

#### Brief explanation
- Reported URL: [jomajewellery.com](https://jomajewellery.com/)
- Problems experienced: page freezes with CPM on
- Platforms affected:
  - [x] iOS
  - [x] Android
  - [x] Windows
  - [x] MacOS
  - [x] Extensions
- Tracker(s) being unblocked: NA
- Feature being disabled: CPM


- [x] I have referenced the URL of this PR as the "reason" value for the exception (where applicable).

#### Reference

-   [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
-   [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
-   [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)
