### PR TITLE
SBT add CPM exception to remove grey overlay on schadefonds-nl

### DIFF
--- a/features/autoconsent.json
+++ b/features/autoconsent.json
@@ -458,6 +458,10 @@
         {
             "domain": "stooq.pl",
             "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2816"
+        },
+        {
+            "domain": "schadefonds.nl",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2822"
         }
     ],
     "settings": {


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/0/1206670747178362/1209566084075745

## Description

### Site breakage mitigation process:

#### Brief explanation
- Reported URL: https://www.schadefonds.nl/
- Problems experienced: grey overlay preventing interaction with the site caused by cpm
- Platforms affected:
  - [ x] iOS
  - [x ] Android
  - [x ] Windows
  - [ x] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked: NA
- Feature being disabled: cpm


- [x ] I have referenced the URL of this PR as the "reason" value for the exception (where applicable).


#### Reference

-   [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
-   [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
-   [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)
