### PR TITLE
SBT tracker exception for dunkinrunsonyou-com to load

### DIFF
--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -1955,6 +1955,11 @@
                         "reason": "https://github.com/duckduckgo/privacy-configuration/issues/884"
                     },
                     {
+                        "rule": "cdn.medallia.com/react-surveys-next/",
+                        "domains": ["dunkinrunsonyou.com"],
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2823"
+                    },
+                    {
                         "rule": "digital-cloud-west.medallia.com/",
                         "domains": ["walgreens.com"],
                         "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2161"


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/0/1206670747178362/1209596265243330

## Description

### Site breakage mitigation process:

#### Brief explanation
- Reported URL: https://dunkinrunsonyou.com/
- Problems experienced: Page does not load because of blocking some tracker
- Platforms affected:
  - [ x] iOS
  - [ x] Android
  - [x ] Windows
  - [x ] MacOS
  - [ x] Extensions
- Tracker(s) being unblocked: cdn.medallia.com/react-surveys-next/
- Feature being disabled: NA


- [ x] I have referenced the URL of this PR as the "reason" value for the exception (where applicable).


#### Reference

-   [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
-   [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
-   [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)
