### PR TITLE
Mitigate passkeys prompt breakage on login to jp.mercari.com

### DIFF
--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -524,6 +524,10 @@
                     {
                         "domain": "maxcomply.app",
                         "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2759"
+                    },
+                    {
+                        "domain": "mercari.com",
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2825"
                     }
                 ],
                 "webViewDefault": [

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -528,6 +528,10 @@
                     {
                         "domain": "mercari.com",
                         "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2825"
+                    },
+                    {
+                        "domain": "ichard26.github.io",
+                        "reason": "Next PR fetch errors on DDG user agent"
                     }
                 ],
                 "webViewDefault": [


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/0/1206670747178362/1209591781289952

### Site breakage mitigation process:

#### Brief explanation
- Reported URL: jp.mercari.com
- Problems experienced: passkey step after login not triggered
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [x] MacOS
  - [ ] Extensions
- Feature affected: custom UA — send as Safari 

#### Reference

-   [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
-   [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
-   [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)
