### PR TITLE
SBT add tracker exception to load wps-com

### DIFF
--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -1397,7 +1397,8 @@
                             "xpn.org",
                             "ljsilvers.com",
                             "newsweek.com",
-                            "vizio.com"
+                            "vizio.com",
+                            "wps.com"
                         ],
                         "reason": [
                             "https://github.com/duckduckgo/privacy-configuration/issues/929",
@@ -1412,7 +1413,8 @@
                             "experian.com - https://github.com/duckduckgo/privacy-configuration/pull/2351",
                             "ljsilvers.com - https://github.com/duckduckgo/privacy-configuration/pull/2496",
                             "newsweek.com - https://github.com/duckduckgo/privacy-configuration/pull/2697",
-                            "vizio.com - https://github.com/duckduckgo/privacy-configuration/pull/2761"
+                            "vizio.com - https://github.com/duckduckgo/privacy-configuration/pull/2761",
+                            "wps.com - https://github.com/duckduckgo/privacy-configuration/pull/2826"
                         ]
                     }
                 ]


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/0/1206670747178362/1209579678583849

## Description

### Site breakage mitigation process:

#### Brief explanation
- Reported URL: https://ru.docs.wps.com/module/common/loadPlatform/
- Problems experienced: page does not load because of blocking a tracker
- Platforms affected:
  - [ x] iOS
  - [ x] Android
  - [ x] Windows
  - [ x] MacOS
  - [ x] Extensions
- Tracker(s) being unblocked: googletagmanager.com/gtag/js
- Feature being disabled: NA

- [ x] I have referenced the URL of this PR as the "reason" value for the exception (where applicable).


#### Reference

-   [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
-   [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
-   [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)
