### PR TITLE
SBT add webcompat exception to load skechers-com

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -985,6 +985,10 @@
                 {
                     "domain": "ctvnews.ca",
                     "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2766"
+                },
+                {
+                    "domain": "skechers.com",
+                    "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2827"
                 }
             ],
             "state": "enabled",


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/0/1206670747178362/1209581730319431

## Description

### Site breakage mitigation process:

#### Brief explanation
- Reported URL: https://www.skechers.com/complete-account/
- Problems experienced: Android only, page does not load because of some webcompat issues
- Platforms affected:
  - [ ] iOS
  - [x ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked: NA
- Feature being disabled: Webcompat

- [ x] I have referenced the URL of this PR as the "reason" value for the exception (where applicable).

#### Reference

-   [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
-   [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
-   [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)
