### PR TITLE
Adds SAD & ATT popover vs banner experiment

### DIFF
--- a/features/set-as-default-and-add-to-dock.json
+++ b/features/set-as-default-and-add-to-dock.json
@@ -1,0 +1,13 @@
+{
+    "_meta": {
+        "description": "Control for SAD and ATT prompts on macOS",
+        "sampleExcludeRecords": {}
+    },
+    "state": "enabled",
+    "exceptions": [],
+    "features": {
+        "popoverVsBannerExperiment": {
+            "state": "enabled"
+        }
+    }
+}

--- a/features/set-as-default-and-add-to-dock.json
+++ b/features/set-as-default-and-add-to-dock.json
@@ -3,11 +3,11 @@
         "description": "Control for SAD and ATT prompts on macOS",
         "sampleExcludeRecords": {}
     },
-    "state": "enabled",
+    "state": "disabled",
     "exceptions": [],
     "features": {
         "popoverVsBannerExperiment": {
-            "state": "enabled"
+            "state": "disabled"
         }
     }
 }

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -207,6 +207,29 @@
         "contextualOnboarding": {
             "state": "enabled"
         },
+        "setAsDefaultAndAddToDock": {
+            "state": "enabled",
+            "exceptions": [],
+            "features": {
+                "popoverVsBannerExperiment": {
+                    "state": "enabled",
+                    "cohorts": [
+                        {
+                            "name": "control",
+                            "weight": 1
+                        },
+                        {
+                            "name": "popover",
+                            "weight": 1
+                        },
+                        {
+                            "name": "banner",
+                            "weight": 1
+                        }
+                    ]
+                }
+            }
+        },
         "elementHiding": {
             "state": "enabled",
             "exceptions": [

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -209,7 +209,7 @@
         },
         "setAsDefaultAndAddToDock": {
             "state": "enabled",
-            "exceptions": [],
+            "minSupportedVersion": "1.130.0",
             "features": {
                 "popoverVsBannerExperiment": {
                     "state": "enabled",


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/0/1204006570077678/1209598036062981

## Description

macOS banner vs. popover SAD & ATT: https://app.asana.com/0/1201621853593513/1209185383520514

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change
- [x] I have tested this change locally
- [x] This code for the config change is ready to merge
- [ ] This feature was covered by a tech design

#### Additional info:
- [x] I have tested this change locally in all supported browsers
- [x] This change will be visible to users
- [x] This code for the config change is ready
- [x] This change was covered by a ship review

### Site breakage mitigation process:

#### Brief explanation
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [x] MacOS
  - [ ] Extensions

#### Reference

-   [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
-   [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
-   [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

