### PR TITLE
SBT hide blank space on aarp-org

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -606,6 +606,15 @@
                 ]
             },
             {
+                "domain": "aarp.org",
+                "rules": [
+                    {
+                        "selector": "[class*='AdBlock__container___']",
+                        "type": "hide-empty"
+                    }
+                ]
+            },
+            {
                 "domain": "abc.es",
                 "rules": [
                     {


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/0/1206670747178362/1209579287274872

## Description

### Site breakage mitigation process:

#### Brief explanation
- Reported URL: https://games.aarp.org/games/spider-solitaire
- Problems experienced: blank space on mobile only
- Platforms affected:
  - [x ] iOS
  - [x ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked: NA
- Feature being disabled: ElementHiding

#### Reference

-   [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
-   [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
-   [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)
