### PR TITLE
SBT add wunderground-com to content blocking exception

### DIFF
--- a/features/content-blocking.json
+++ b/features/content-blocking.json
@@ -31,6 +31,10 @@
         {
             "domain": "soranews24.com",
             "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1666"
+        },
+        {
+            "domain": "wunderground.com",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/issues/2835"
         }
     ]
 }


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/0/1206670747178362/1209556546959134

## Description

### Site breakage mitigation process:

#### Brief explanation
- Reported URL: https://www.wunderground.com/video/top-stories/spring-warmup-above-average-temperatures-forecast
- Problems experienced: video does not display 
- Platforms affected:
  - [ x] iOS
  - [x ] Android
  - [ x] Windows
  - [ x] MacOS
  - [ x] Extensions
- Tracker(s) being unblocked: NA
- Feature being disabled: contentBlocking (to be followed up by a narrower mitigation)


- [ x] I have referenced the URL of this PR as the "reason" value for the exception (where applicable).


#### Reference

-   [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
-   [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
-   [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)
