### PR TITLE
enable multi-select on iOS versin 7.161.0 onwards

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -87,7 +87,7 @@
                 "autoplay": {
                     "state": "disabled"
                 },
-                "openInNew  ": {
+                "openInNewTab": {
                     "state": "enabled",
                     "minSupportedVersion": "7.144.0"
                 },

--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -87,7 +87,7 @@
                 "autoplay": {
                     "state": "disabled"
                 },
-                "openInNewTab": {
+                "openInNew  ": {
                     "state": "enabled",
                     "minSupportedVersion": "7.144.0"
                 },
@@ -838,7 +838,8 @@
             "state": "internal",
             "features": {
                 "multiSelection": {
-                    "state": "disabled"
+                    "state": "enabled",
+                    "minSupportedVersion": "7.161.0"
                 }
             }
         }


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/0/392891325557410/1209568168593153

## Description
Enable the new tab manager multi-selection from iOS version 7.161.0
