### PR TITLE
Update Asana sync action:

### DIFF
--- a/.github/workflows/asana.yml
+++ b/.github/workflows/asana.yml
@@ -15,9 +15,11 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v4
-            - uses: sammacbeth/action-asana-sync@v6
+            - uses: duckduckgo/action-asana-sync@v7
               with:
                   ASANA_ACCESS_TOKEN: ${{ secrets.ASANA_ACCESS_TOKEN }}
                   ASANA_WORKSPACE_ID: ${{ secrets.ASANA_WORKSPACE_ID }}
                   ASANA_PROJECT_ID: '1206780406371845'
+                  GITHUB_PAT: ${{ secrets.GH_PAT }}
                   USER_MAP: ${{ vars.USER_MAP }}
+                  ASSIGN_PR_AUTHOR: 'true'

--- a/.github/workflows/asana.yml
+++ b/.github/workflows/asana.yml
@@ -20,6 +20,6 @@ jobs:
                   ASANA_ACCESS_TOKEN: ${{ secrets.ASANA_ACCESS_TOKEN }}
                   ASANA_WORKSPACE_ID: ${{ secrets.ASANA_WORKSPACE_ID }}
                   ASANA_PROJECT_ID: '1206780406371845'
-                  GITHUB_PAT: ${{ secrets.GH_PAT }}
+                  GITHUB_PAT: ${{ secrets.DAXMOBILE_AUTOFILL_AUTOMATION }}
                   USER_MAP: ${{ vars.USER_MAP }}
                   ASSIGN_PR_AUTHOR: 'true'


### PR DESCRIPTION
**Asana Task/Github Issue:**

## Description
 - Pull Asana GIDs from mapping repo.
 - Assign PR tasks to the PR author.


Note, requires the following admin changes to the repo:
 - `GH_PAT` secret should be created with a PAT with access to the `internal-github-asana-utils` repo.
 - `USER_MAP` var can be updated to remove most usernames. It _can_ be kept to map automations to a specific user, e.g.:
![Screenshot 2025-03-13 at 11 34 12](https://github.com/user-attachments/assets/ebe41218-868c-4e03-91b1-1f70f5baff52)

