### PR TITLE
feat(broker protection): add and enable internally useEnhancedCaptchaSystem

### DIFF
--- a/features/broker-protection.json
+++ b/features/broker-protection.json
@@ -5,6 +5,6 @@
     "state": "disabled",
     "exceptions": [],
     "settings": {
-        "useWebViewActionsV2": "disabled"
+        "useEnhancedCaptchaSystem": "disabled"
     }
 }

--- a/features/broker-protection.json
+++ b/features/broker-protection.json
@@ -1,0 +1,10 @@
+{
+    "_meta": {
+        "description": "Personal Information Removal"
+    },
+    "state": "disabled",
+    "exceptions": [],
+    "settings": {
+        "useWebViewActionsV2": "disabled"
+    }
+}

--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -599,6 +599,12 @@
         "breakageReporting": {
             "state": "enabled"
         },
+        "brokerProtection": {
+            "state": "enabled",
+            "settings": {
+                "useWebViewActionsV2": "disabled"
+            }
+        },
         "customUserAgent": {
             "state": "enabled",
             "settings": {

--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -602,7 +602,7 @@
         "brokerProtection": {
             "state": "enabled",
             "settings": {
-                "useWebViewActionsV2": "disabled"
+                "useEnhancedCaptchaSystem": "disabled"
             }
         },
         "customUserAgent": {

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -118,6 +118,12 @@
             },
             "minSupportedVersion": "1.70.0"
         },
+        "brokerProtection": {
+            "state": "enabled",
+            "settings": {
+                "useWebViewActionsV2": "disabled"
+            }
+        },
         "contentBlocking": {
             "state": "enabled",
             "exceptions": [

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -118,12 +118,6 @@
             },
             "minSupportedVersion": "1.70.0"
         },
-        "brokerProtection": {
-            "state": "internal",
-            "settings": {
-                "useWebViewActionsV2": "internal"
-            }
-        },
         "contentBlocking": {
             "state": "enabled",
             "exceptions": [

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -118,6 +118,12 @@
             },
             "minSupportedVersion": "1.70.0"
         },
+        "brokerProtection": {
+            "state": "internal",
+            "settings": {
+                "useWebViewActionsV2": "internal"
+            }
+        },
         "contentBlocking": {
             "state": "enabled",
             "exceptions": [

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -121,7 +121,7 @@
         "brokerProtection": {
             "state": "enabled",
             "settings": {
-                "useWebViewActionsV2": "disabled"
+                "useEnhancedCaptchaSystem": "disabled"
             }
         },
         "contentBlocking": {

--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -116,6 +116,12 @@
             },
             "minSupportedVersion": "0.64.0"
         },
+        "brokerProtection": {
+            "state": "enabled",
+            "settings": {
+                "useWebViewActionsV2": "disabled"
+            }
+        },
         "windowsPermissionUsage": {
             "state": "enabled"
         },

--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -116,12 +116,6 @@
             },
             "minSupportedVersion": "0.64.0"
         },
-        "brokerProtection": {
-            "state": "internal",
-            "settings": {
-                "useWebViewActionsV2": "internal"
-            }
-        },
         "windowsPermissionUsage": {
             "state": "enabled"
         },

--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -116,6 +116,12 @@
             },
             "minSupportedVersion": "0.64.0"
         },
+        "brokerProtection": {
+            "state": "internal",
+            "settings": {
+                "useWebViewActionsV2": "internal"
+            }
+        },
         "windowsPermissionUsage": {
             "state": "enabled"
         },

--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -119,7 +119,7 @@
         "brokerProtection": {
             "state": "enabled",
             "settings": {
-                "useWebViewActionsV2": "disabled"
+                "useEnhancedCaptchaSystem": "disabled"
             }
         },
         "windowsPermissionUsage": {

--- a/schema/features/broker-protection.ts
+++ b/schema/features/broker-protection.ts
@@ -1,0 +1,7 @@
+import { Feature, FeatureState } from '../feature';
+
+interface BrokerProtectionSettings {
+    useWebViewActionsV2: FeatureState;
+}
+
+export type BrokerProtectionFeature<VersionType> = Feature<BrokerProtectionSettings, VersionType>;

--- a/schema/features/broker-protection.ts
+++ b/schema/features/broker-protection.ts
@@ -1,7 +1,7 @@
 import { Feature, FeatureState } from '../feature';
 
 interface BrokerProtectionSettings {
-    useWebViewActionsV2: FeatureState;
+    useEnhancedCaptchaSystem: FeatureState;
 }
 
 export type BrokerProtectionFeature<VersionType> = Feature<BrokerProtectionSettings, VersionType>;


### PR DESCRIPTION
<!--
  ⚠️ ⚠️ IF YOU ARE MODIFYING `index.js` OR A FILE IN `features` ⚠️ ⚠️
  Please request a review and ping a DRI from the Config AOR or Breakage AOR.
  The quickest way to get attention for your PR is to ping the ~Breakage channel
  in MatterMost.

  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Consider adding an individual reviewer as well as the groups that are automatically added (this should create a review task in Asana for them specifically).
  Use the "merge when ready" button to automatically merge the PR as soon as it's reviewed.
-->

**Asana Task/Github Issue:**  https://app.asana.com/1/137249556945/project/0/task/1209677281046124

## Description

Adds a new feature `brokerProtection` with `useWebViewActionsV2` enabled internally.

### Feature change process:

- [x] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change
- [x] I have tested this change locally
- [x] This code for the config change is ready to merge
- [x] This feature was covered by a tech design

#### Additional info:
<!--
  These questions are a friendly reminder to shipping config changes, if you're uncertain ask the AoR owners.
  It's also totally appropriate to not check some of these boxes, if they don't apply to your change.
-->
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [x] This code for the config change is ready
- [x] This change was covered by a ship review

#### Reference

-   [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
-   [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
-   [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)
