### PR TITLE
SBT unprotect intuit-com as speculative mitigation

### DIFF
--- a/features/unprotected-temporary.json
+++ b/features/unprotected-temporary.json
@@ -22,6 +22,10 @@
         {
             "domain": "flexmls.com",
             "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2228"
+        },
+        {
+            "domain": "intuit.com",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2858"
         }
     ]
 }


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1200277586140538/task/1209239943836382?focus=true

## Description

### Site breakage mitigation process:

#### Brief explanation
- Reported URL: intuit.com
- Problems experienced: Account required. Site does not seem to load. Testing an unprotected speculative mitigation to rule in/out protection to cause the breakage.
- Platforms affected:
  - [x ] iOS
  - [ x] Android
  - [ x] Windows
  - [x ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked: NA
- Feature being disabled: unprotect fully


- [ x] I have referenced the URL of this PR as the "reason" value for the exception (where applicable).
- [x ] This change is a speculative mitigation to fix reported breakage.

#### Reference

-   [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
-   [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
-   [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)
