### PR TITLE
Hide blank space on youtube scroll

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -3589,6 +3589,15 @@
                 ]
             },
             {
+                "domain": "youtube.com",
+                "rules": [
+                    {
+                        "selector": "ytm-promoted-sparkles-web-renderer",
+                        "type": "hide"
+                    }
+                ]
+            },
+            {
                 "domain": "first-party.site",
                 "rules": [
                     {


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/0/1206670747178362/1209662493720640/f

## Description

### Site breakage mitigation process:

#### Brief explanation
- Reported URL: m.youtube.com
- Problems experienced: blank space where content from ad tracker was blocked
- Platforms affected:
  - [x] iOS
  - [x] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions

#### Reference

-   [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
-   [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
-   [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)
