### PR TITLE
[iOS][Onboarding] Setup Set as Default Experiment

### DIFF
--- a/features/onboarding.json
+++ b/features/onboarding.json
@@ -1,7 +1,0 @@
-{
-    "_meta": {
-        "description": "Onboarding-related features on native apps.",
-        "sampleExcludeRecords": {}
-    },
-    "exceptions": []
-}

--- a/features/onboarding.json
+++ b/features/onboarding.json
@@ -1,0 +1,7 @@
+{
+    "_meta": {
+        "description": "Onboarding-related features on native apps.",
+        "sampleExcludeRecords": {}
+    },
+    "exceptions": []
+}

--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -869,6 +869,25 @@
                     "minSupportedVersion": "7.161.0"
                 }
             }
+        },
+        "onboarding": {
+            "state": "enabled",
+            "features": {
+                "setAsDefaultBrowserExperiment": {
+                    "state": "enabled",
+                    "minSupportedVersion": "7.162.0",
+                    "cohorts": [
+                        {
+                            "name": "control",
+                            "weight": 1
+                        },
+                        {
+                            "name": "treatment",
+                            "weight": 1
+                        }
+                    ]
+                }
+            }
         }
     },
     "unprotectedTemporary": []

--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -870,7 +870,7 @@
                 }
             }
         },
-        "onboarding": {
+        "extendedOnboarding": {
             "state": "enabled",
             "features": {
                 "setAsDefaultBrowserExperiment": {


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/0/72649045549333/1209505775591506

## Description

Enable "Set as Default experiment" for iOS onboarding version 7.162.0

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change
- [x] I have tested this change locally
- [ ] This code for the config change is ready to merge
- [ ] This feature was covered by a tech design

#### Additional info:
<!--
  These questions are a friendly reminder to shipping config changes, if you're uncertain ask the AoR owners.
  It's also totally appropriate to not check some of these boxes, if they don't apply to your change.
-->
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [ ] This code for the config change is ready
- [ ] This change was covered by a ship review

### Site breakage mitigation process:

#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled:


- [ ] I have referenced the URL of this PR as the "reason" value for the exception (where applicable).
- [ ] This change is a speculative mitigation to fix reported breakage.

#### Reference

-   [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
-   [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
-   [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)
