### PR TITLE
Auto-tap export button during Google Password import

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -428,7 +428,7 @@
                                                     "labelTexts": ["Password options"]
                                                 },
                                                 "exportButton": {
-                                                    "shouldAutotap": false,
+                                                    "shouldAutotap": true,
                                                     "path": "/options",
                                                     "selectors": [
                                                         "c-wiz[data-node-index*='2;0'][data-p*='options']",


### PR DESCRIPTION
<!--
  ⚠️ ⚠️ IF YOU ARE MODIFYING `index.js` OR A FILE IN `features` ⚠️ ⚠️
  Please request a review and ping a DRI from the Config AOR or Breakage AOR.
  The quickest way to get attention for your PR is to ping the ~Breakage channel
  in MatterMost.

  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Consider adding an individual reviewer as well as the groups that are automatically added (this should create a review task in Asana for them specifically).
  Use the "merge when ready" button to automatically merge the PR as soon as it's reviewed.
-->

**Asana Task/Github Issue:** https://app.asana.com/0/1203822806345703/1209143210450862/f

## Description

Updates config to autotap the export button during the password import flow for Google Password Manager imports.


#### Reference

-   [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
-   [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
-   [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)
