### PR TITLE
SBT add UA exception to ihg-com

### DIFF
--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -571,6 +571,10 @@
                     {
                         "domain": "app.lyssna.com",
                         "reason": "Unsupported browser message"
+                    },
+                    {
+                        "domain": "ihg.com",
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2872"
                     }
                 ],
                 "webViewDefault": [


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/0/1200277586140538/1209711920242282/f

## Description

### Site breakage mitigation process:

#### Brief explanation
- Reported URL: ihg.com
- Problems experienced: unsuported browser banner displayed
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [x ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked: NA
- Feature being disabled: CustomUA


- [x ] I have referenced the URL of this PR as the "reason" value for the exception (where applicable).
- [ ] This change is a speculative mitigation to fix reported breakage.

#### Reference

-   [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
-   [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
-   [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)
