### PR TITLE
Element hiding: address empty ad spaces on coindesk.com

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -1023,6 +1023,23 @@
                 ]
             },
             {
+                "domain": "coindesk.com",
+                "rules": [
+                    {
+                        "selector": ".animate-shimmer",
+                        "type": "hide"
+                    },
+                    {
+                        "selector": "[data-freestar-ad='true']",
+                        "type": "hide"
+                    },
+                    {
+                        "selector": "[data-freestar-ad='true']",
+                        "type": "closest-empty"
+                    }
+                ]
+            },
+            {
                 "domain": "coingecko.com",
                 "rules": [
                     {

--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -1031,10 +1031,6 @@
                     },
                     {
                         "selector": "[data-freestar-ad='true']",
-                        "type": "hide"
-                    },
-                    {
-                        "selector": "[data-freestar-ad='true']",
                         "type": "closest-empty"
                     }
                 ]


### PR DESCRIPTION
<!--
  ⚠️ ⚠️ IF YOU ARE MODIFYING `index.js` OR A FILE IN `features` ⚠️ ⚠️
  Please request a review and ping a DRI from the Config AOR or Breakage AOR.
  The quickest way to get attention for your PR is to ping the ~Breakage channel
  in MatterMost.

  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Consider adding an individual reviewer as well as the groups that are automatically added (this should create a review task in Asana for them specifically).
  Use the "merge when ready" button to automatically merge the PR as soon as it's reviewed.
-->

**Asana Task/Github Issue:** https://app.asana.com/0/246491496396031/1209696098656057/f

## Description
Addresses large empty spaces on page where tracking ads were blocked.

### Site breakage mitigation process:

#### Brief explanation
- Reported URL: https://www.coindesk.com/markets/2025/03/13/ripple-bags-dubai-license-to-offer-crypto-payments-in-uae
- Problems experienced: Empty spaces on page
- Platforms affected:
  - [x] iOS
  - [x] Android
  - [x] Windows
  - [x] MacOS
  - [x] Extensions
