### PR TITLE
Element hiding: Tighten up *ad-content rule that was overmatching

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -10,10 +10,6 @@
         {
             "domain": "duckduckgo.com",
             "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1236"
-        },
-        {
-            "domain": "openai.com",
-            "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2850"
         }
     ],
     "settings": {
@@ -112,7 +108,7 @@
                 "type": "hide-empty"
             },
             {
-                "selector": "[class*='ad-content']",
+                "selector": "[class^='ad-content']",
                 "type": "hide-empty"
             },
             {


### PR DESCRIPTION
<!--
  ⚠️ ⚠️ IF YOU ARE MODIFYING `index.js` OR A FILE IN `features` ⚠️ ⚠️
  Please request a review and ping a DRI from the Config AOR or Breakage AOR.
  The quickest way to get attention for your PR is to ping the ~Breakage channel
  in MatterMost.

  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Consider adding an individual reviewer as well as the groups that are automatically added (this should create a review task in Asana for them specifically).
  Use the "merge when ready" button to automatically merge the PR as soon as it's reviewed.
-->

**Asana Task/Github Issue:** https://app.asana.com/0/246491496396031/1209669965698327/f

## Description
This PR changes the `[class*='ad-content']` element hiding rule to no longer be a full wildcard match and instead only match on classes that begin with "ad-content". This was matching an empty element with `class="thread-content"`, which was hiding responses in empty chats on platform.openai.com/playground/assistants.

### Site breakage mitigation process:

#### Brief explanation
- Reported URL: https://platform.openai.com/playground/assistants
- Problems experienced: messages in empty chat not appearing until page reload
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions