### PR TITLE
Revert "Disable cookie management on barmer.de"

### DIFF
--- a/features/autoconsent.json
+++ b/features/autoconsent.json
@@ -12,10 +12,6 @@
             "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1241"
         },
         {
-            "domain": "barmer.de",
-            "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2618"
-        },
-        {
             "domain": "bild.de",
             "reason": "https://github.com/duckduckgo/privacy-configuration/issues/326"
         },


### PR DESCRIPTION
Reverts duckduckgo/privacy-configuration#2618

https://github.com/duckduckgo/autoconsent/pull/628 fixed the CPM issue that was mitigated.