### PR TITLE
Remove sbid.org override

### DIFF
--- a/features/autoconsent.json
+++ b/features/autoconsent.json
@@ -352,10 +352,6 @@
             "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2589"
         },
         {
-            "domain": "sbid.org",
-            "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2652"
-        },
-        {
             "domain": "wunderground.com",
             "reason": "rejecting cookies breaks videos https://app.asana.com/0/1199178362774117/1207968034848950/f"
         },


### PR DESCRIPTION
Partial revert of https://github.com/duckduckgo/privacy-configuration/pull/2652.

https://github.com/duckduckgo/autoconsent/pull/625 fixed the CPM issue that was mitigated. 