### PR TITLE
SBT remove unsupported banner on messenger-com

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -2265,6 +2265,15 @@
                 ]
             },
             {
+                "domain": "messenger.com",
+                "rules": [
+                    {
+                        "selector": ".xw7yly9.xktsk01:has(div > a[href='https://www.facebook.com/help/messenger-app/597429858389632/'])",
+                        "type": "hide"
+                    }
+                ]
+            },
+            {
                 "domain": "metro.co.uk",
                 "rules": [
                     {


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/0/1200277586140538/1209731703142670/f

## Description

### Site breakage mitigation process:

#### Brief explanation
- Reported URL: messenger.com
- Problems experienced: unsupported browser banner displays
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ x] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked: NA
- Feature being disabled: elementHiding


- [ ] I have referenced the URL of this PR as the "reason" value for the exception (where applicable).
- [ ] This change is a speculative mitigation to fix reported breakage.

#### Reference

-   [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
-   [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
-   [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)
