### PR TITLE
SBT display videos on wunderground-com and previous mitigation removed

### DIFF
--- a/features/content-blocking.json
+++ b/features/content-blocking.json
@@ -31,10 +31,6 @@
         {
             "domain": "soranews24.com",
             "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1666"
-        },
-        {
-            "domain": "wunderground.com",
-            "reason": "https://github.com/duckduckgo/privacy-configuration/issues/2835"
         }
     ]
 }

--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -791,12 +791,13 @@
                     },
                     {
                         "rule": "securepubads.g.doubleclick.net/gampad/ads",
-                        "domains": ["ah.nl", "applesfera.com", "rocketnews24.com", "servustv.com"],
+                        "domains": ["ah.nl", "applesfera.com", "rocketnews24.com", "servustv.com", "wunderground.com"],
                         "reason": [
                             "ah.nl - 'Bonus offer' elements do not render and are not clickable.",
                             "applesfera.com - https://github.com/duckduckgo/privacy-configuration/issues/1723",
                             "rocketnews24.com - https://github.com/duckduckgo/privacy-configuration/issues/846",
-                            "servustv.com - https://github.com/duckduckgo/privacy-configuration/issues/2188"
+                            "servustv.com - https://github.com/duckduckgo/privacy-configuration/issues/2188",
+                            "wunderground.com - https://github.com/duckduckgo/privacy-configuration/issues/2885"
                         ]
                     },
                     {
@@ -1030,13 +1031,14 @@
                     },
                     {
                         "rule": "securepubads.g.doubleclick.net/pagead/managed/js/gpt",
-                        "domains": ["applesfera.com", "itsthevibe.com", "triblive.com", "kutv.com", "lowes.com"],
+                        "domains": ["applesfera.com", "itsthevibe.com", "triblive.com", "kutv.com", "lowes.com", "wunderground.com"],
                         "reason": [
                             "applesfera.com - https://github.com/duckduckgo/privacy-configuration/issues/1723",
                             "itsthevibe - https://github.com/duckduckgo/privacy-configuration/pull/2482",
                             "triblive.com - https://github.com/duckduckgo/privacy-configuration/issues/1730",
                             "kutv.com - https://github.com/duckduckgo/privacy-configuration/pull/2806",
-                            "lowes.com - https://github.com/duckduckgo/privacy-configuration/pull/2833"
+                            "lowes.com - https://github.com/duckduckgo/privacy-configuration/pull/2833",
+                             "wunderground.com - https://github.com/duckduckgo/privacy-configuration/pull/2885"
                         ]
                     },
                     {

--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -1038,7 +1038,7 @@
                             "triblive.com - https://github.com/duckduckgo/privacy-configuration/issues/1730",
                             "kutv.com - https://github.com/duckduckgo/privacy-configuration/pull/2806",
                             "lowes.com - https://github.com/duckduckgo/privacy-configuration/pull/2833",
-                             "wunderground.com - https://github.com/duckduckgo/privacy-configuration/pull/2885"
+                            "wunderground.com - https://github.com/duckduckgo/privacy-configuration/pull/2885"
                         ]
                     },
                     {


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/0/1206670747178362/1209628337618335/f

## Description

### Site breakage mitigation process:

#### Brief explanation
- Reported URL: https://www.wunderground.com/video/top-stories/winter-storm-garnett-snow-ice-february
- Problems experienced: videos don't display. This PR removes the previous content-blocking mitigation and replaces it with 2 trackers exception
- Platforms affected:
  - [ x] iOS
  - [x ] Android
  - [x ] Windows
  - [ x] MacOS
  - [ x] Extensions
- Tracker(s) being unblocked: [securepubads.g.doubleclick.net/pagead/managed/js/gpt](https://securepubads.g.doubleclick.net/pagead/managed/js/gpt/m202503060101/pubads_impl.js) , 
[securepubads.g.doubleclick.net/gampad/ads](https://securepubads.g.doubleclick.net/gampad/ads)
- Feature being disabled: 


- [x ] I have referenced the URL of this PR as the "reason" value for the exception (where applicable).
- [ ] This change is a speculative mitigation to fix reported breakage.

#### Reference

-   [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
-   [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
-   [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)
