### PR TITLE
Remove wetransfer.com mitigation

### DIFF
--- a/features/autoconsent.json
+++ b/features/autoconsent.json
@@ -340,10 +340,6 @@
             "reason": "Easylist breakage: https://app.asana.com/0/1200930669568058/1208959135934596/f"
         },
         {
-            "domain": "wetransfer.com",
-            "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2580"
-        },
-        {
             "domain": "collectcheckout.com",
             "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2589"
         },
@@ -622,6 +618,7 @@
             "vital-parts.co.uk",
             "lta.org.uk",
             "hobbyhall.fi",
+            "wetransfer.com",
             "wienmobil.at",
             "memsoft.fr",
             "bafin.de",


### PR DESCRIPTION
Partially reverts https://github.com/duckduckgo/privacy-configuration/pull/2580.

https://github.com/duckduckgo/autoconsent/pull/626 fixed the CPM issue that was mitigated. 