### PR TITLE
Fix broken "Subscribe to our notifications" overlay on n4g.com

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -959,6 +959,10 @@
                 {
                     "domain": "realtor.com",
                     "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2855"
+                },
+                {
+                    "domain": "n4g.com",
+                    "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2892"
                 }
             ],
             "state": "enabled",


### PR DESCRIPTION
For some reason, the webcompat feature cased the to be shown for n4g.com in a
way that users couldn't dismiss. Let's disable that for now therefore.

**Asana Task/Github Issue:** https://app.asana.com/0/1206670747178362/1209759676532817/f
