### PR TITLE
Fix broken interaction on stamma.org

### DIFF
--- a/features/autoconsent.json
+++ b/features/autoconsent.json
@@ -474,6 +474,10 @@
         {
             "domain": "hobbies.co.uk",
             "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2843"
+        },
+        {
+            "domain": "stamma.org",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2893"
         }
     ],
     "settings": {


### PR DESCRIPTION
It seems after the cookie prompt is automatically handled, scrolling on the
website breaks. So let's disable that for now.


**Asana Task/Github Issue:** https://app.asana.com/0/1206670747178362/1209724647074238/f