### PR TITLE
Fix broken page interaction on fairlawns.co.uk

### DIFF
--- a/features/autoconsent.json
+++ b/features/autoconsent.json
@@ -474,6 +474,10 @@
         {
             "domain": "hobbies.co.uk",
             "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2843"
+        },
+        {
+            "domain": "fairlawns.co.uk",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2894"
         }
     ],
     "settings": {


### PR DESCRIPTION
After the website's cookie prompt is automatically managed, a grey overlay
remains that prevents users from interacting with the website. Let's disable
cookie prompt management on the website for now therefore.

**Asana Task/Github Issue:** https://app.asana.com/0/1206670747178362/1209692857557585/f
