### PR TITLE
Fix broken page interaction on nature.scot

### DIFF
--- a/features/autoconsent.json
+++ b/features/autoconsent.json
@@ -482,6 +482,10 @@
         {
             "domain": "stamma.org",
             "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2893"
+        },
+        {
+            "domain": "nature.scot",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2898"
         }
     ],
     "settings": {


### PR DESCRIPTION
It seems after the cookie prompt is automatically handled, a grey overlay isn't
cleared and that prevents page interaction.

**Asana Task/Github Issue:** https://app.asana.com/0/1206670747178362/1209697648510195/f