### PR TITLE
Fix header rendering issue on huffpost.com

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -1943,20 +1943,6 @@
                     {
                         "selector": ".video-container",
                         "type": "hide"
-                    },
-                    {
-                        "selector": ".top-ad-recirc",
-                        "type": "modify-style",
-                        "values": [
-                            {
-                                "property": "height",
-                                "value": "auto"
-                            },
-                            {
-                                "property": "min-height",
-                                "value": "auto"
-                            }
-                        ]
                     }
                 ]
             },


### PR DESCRIPTION
The header on huffpost.com was rendering strangely, with the contents floating
above and overlapping with the page contents. It seems related to a
"modify-style" element hiding rule, so let's remove that.

**Asana Task/Github Issue:** https://app.asana.com/0/1206670747178362/1209751901784925/f
