### PR TITLE
Hide empty space in header of US local news websites

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -486,6 +486,10 @@
             {
                 "selector": ".clsy-c-advsection",
                 "type": "hide-empty"
+            },
+            {
+                "selector": "[class^='DisplayAdvert']",
+                "type": "closest-empty"
             }
         ],
         "styleTagExceptions": [
@@ -2125,10 +2129,6 @@
             {
                 "domain": "kutv.com",
                 "rules": [
-                    {
-                        "selector": "[class*='DisplayAdvert']",
-                        "type": "hide-empty"
-                    },
                     {
                         "selector": "[class*='adBeforeContent']",
                         "type": "hide-empty"


### PR DESCRIPTION
It seems quite a few US local news websites are similarly structured and have
empty space in the header. Let's make the existing DisplayAdvert rule global so
it applies to all of those websites.

**Asana Task/Github Issue:** https://app.asana.com/0/1206670747178362/1209746380480547/f
