### PR TITLE
Enable message bridge for macOS

### DIFF
--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -77,6 +77,25 @@
             },
             "minSupportedVersion": "1.57.1"
         },
+        "messageBridge": {
+            "exceptions": [],
+            "settings": {
+                "aiChat": "disabled",
+                "domains": [
+                    {
+                        "domain": "duckduckgo.com",
+                        "patchSettings": [
+                            {
+                                "op": "replace",
+                                "path": "/aiChat",
+                                "value": "enabled"
+                            }
+                        ]
+                    }
+                ]
+            },
+            "state": "enabled"
+        },
         "aiChat": {
             "state": "enabled",
             "features": {


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/0/1201011656765697/1209800715486729/f

## Description
Enable message bridge for duck.ai on macOS. Currently no features on macOS uses this, I just want to make sure this is live before we release the feature

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change
- [x] I have tested this change locally
- [x] This code for the config change is ready to merge
- [x] This feature was covered by a tech design

#### Additional info:
<!--
  These questions are a friendly reminder to shipping config changes, if you're uncertain ask the AoR owners.
  It's also totally appropriate to not check some of these boxes, if they don't apply to your change.
-->
- [x] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [x] This code for the config change is ready
- [ ] This change was covered by a ship review
