### PR TITLE
Prevent parallel asana sync actions

### DIFF
--- a/.github/workflows/asana.yml
+++ b/.github/workflows/asana.yml
@@ -13,6 +13,9 @@ on:
 jobs:
     sync:
         runs-on: ubuntu-latest
+        concurrency:
+          group: asana-sync
+          cancel-in-progress: false
         steps:
             - uses: actions/checkout@v4
             - uses: duckduckgo/action-asana-sync@v9


### PR DESCRIPTION
**Asana Task/Github Issue:**

## Description
Multiple review requested workflows triggered in parallel can cause duplicate tasks to be created. Let's add concurrency control to the workflow to prevent that.