### PR TITLE
Disable fingerprintingHardware due to bot breakage

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -214,7 +214,7 @@
             "minSupportedVersion": "0.88.3"
         },
         "fingerprintingHardware": {
-            "state": "enabled",
+            "state": "disabled",
             "minSupportedVersion": "0.88.3",
             "exceptions": [
                 {


### PR DESCRIPTION

**Asana Task/Github Issue:** https://app.asana.com/0/1201520793593668/1209872824706465/f

## Description

Due to bot breakage disabling this on Windows due to inconsistent signals.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change
- [ ] I have tested this change locally
- [ ] This code for the config change is ready to merge
- [ ] This feature was covered by a tech design

#### Additional info:
<!--
  These questions are a friendly reminder to shipping config changes, if you're uncertain ask the AoR owners.
  It's also totally appropriate to not check some of these boxes, if they don't apply to your change.
-->
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [ ] This code for the config change is ready
- [ ] This change was covered by a ship review

### Site breakage mitigation process:

#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled:


- [ ] I have referenced the URL of this PR as the "reason" value for the exception (where applicable).
- [ ] This change is a speculative mitigation to fix reported breakage.

#### Reference

-   [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
-   [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
-   [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)
