### PR TITLE
Android: Enable tab swiping for 20% of prod users

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -1842,8 +1842,23 @@
             }
         },
         "swipingTabs": {
-            "state": "internal",
-            "minSupportedVersion": 52271000
+            "state": "enabled",
+            "minSupportedVersion": 52290000,
+            "features": {
+                "onForInternalUsers": {
+                    "state": "internal"
+                },
+                "onForExternalUsers": {
+                    "state": "enabled",
+                    "rollout": {
+                        "steps": [
+                            {
+                                "percent": 20
+                            }
+                        ]
+                    }
+                }
+            }
         },
         "showOnAppLaunch": {
             "state": "enabled"


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/0/1207418217763355/1209846575622291/f

## Description

This PR updates the Android tab-swiping feature from internal-only to also include 20% of users in production.

#### Reference

-   [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
-   [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
-   [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)
