### PR TITLE
Add aiChat bangs + regex (Android)

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -216,12 +216,7 @@
         "aiChat": {
             "state": "enabled",
             "settings": {
-                "aiChatBangs": [
-                    "!ai",
-                    "!aichat",
-                    "!chat",
-                    "!duckai"
-                ],
+                "aiChatBangs": ["!ai", "!aichat", "!chat", "!duckai"],
                 "aiChatBangRegex": "^(?!({bangs})$)(?=.*({bangs})(?=$|\\s)).+$"
             },
             "minSupportedVersion": 52250000,

--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -215,6 +215,10 @@
         },
         "aiChat": {
             "state": "enabled",
+            "settings": {
+                "aiChatBangs": ["!ai","!aichat","!chat","!duckai"],
+                "aiChatBangRegex": "^(?!({bangs})$).*(?:{bangs}).*$"
+            },
             "minSupportedVersion": 52250000,
             "exceptions": []
         },

--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -216,8 +216,13 @@
         "aiChat": {
             "state": "enabled",
             "settings": {
-                "aiChatBangs": ["!ai","!aichat","!chat","!duckai"],
-                "aiChatBangRegex": "^(?!({bangs})$).*(?:{bangs}).*$"
+                "aiChatBangs": [
+                    "!ai",
+                    "!aichat",
+                    "!chat",
+                    "!duckai"
+                ],
+                "aiChatBangRegex": "^(?!({bangs})$)(?=.*({bangs})(?=$|\\s)).+$"
             },
             "minSupportedVersion": 52250000,
             "exceptions": []


### PR DESCRIPTION
<!--
  ⚠️ ⚠️ IF YOU ARE MODIFYING `index.js` OR A FILE IN `features` ⚠️ ⚠️
  Please request a review and ping a DRI from the Config AOR or Breakage AOR.
  The quickest way to get attention for your PR is to ping the ~Breakage channel
  in MatterMost.

  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Consider adding an individual reviewer as well as the groups that are automatically added (this should create a review task in Asana for them specifically).
  Use the "merge when ready" button to automatically merge the PR as soon as it's reviewed.
-->

**Asana Task/Github Issue:** https://app.asana.com/0/1200204095367872/1209909607255667/f

## Description

- This is required in order to fix an issue where the WebView redirects when using a bang, leaving a blank page when we open the standalone Duck.ai `Activity` (WebView limitation).
- By detecting the bang before the redirect, we avoid the blank page.
- Android PR: https://github.com/duckduckgo/Android/pull/5879

<!-- 
  Please delete either or both process sections below.
-->

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change
- [x] I have tested this change locally
- [x] This code for the config change is ready to merge
- [ ] This feature was covered by a tech design

#### Additional info:
<!--
  These questions are a friendly reminder to shipping config changes, if you're uncertain ask the AoR owners.
  It's also totally appropriate to not check some of these boxes, if they don't apply to your change.
-->
- [x] I have tested this change locally in all supported browsers
- [x] This change will be visible to users
- [x] This code for the config change is ready
- [ ] This change was covered by a ship review

### Site breakage mitigation process:

#### Brief explanation
- Reported URL: aiChat bangs (`!ai`, `!aichat`, `!chat`, `!duckai`)
- Problems experienced: aiChat bangs leave a blank page when opening the standalone Activity.
- Platforms affected:
  - [ ] iOS
  - [x] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked: -
- Feature being disabled: -


- [ ] I have referenced the URL of this PR as the "reason" value for the exception (where applicable).
- [ ] This change is a speculative mitigation to fix reported breakage.

#### Reference

-   [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
-   [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
-   [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)
