### PR TITLE
Create auto-assign-assignees-as-reviewers.yml

### DIFF
--- a/.github/workflows/auto-assign-assignees-as-reviewers.yml
+++ b/.github/workflows/auto-assign-assignees-as-reviewers.yml
@@ -36,7 +36,7 @@ jobs:
               uses: actions/github-script@v7
               with:
                   script: |
-                      const assignees = JSON.parse(`${{ steps.pr.outputs.result }}`).assignees;
+                      const assignees = ${{ steps.pr.outputs.result }}.assignees;
                       if (assignees.length > 0) {
                         await github.rest.pulls.requestReviewers({
                           owner: context.repo.owner,

--- a/.github/workflows/auto-assign-assignees-as-reviewers.yml
+++ b/.github/workflows/auto-assign-assignees-as-reviewers.yml
@@ -2,7 +2,7 @@ name: Auto Assign Assignees as Reviewers
 
 on:
     pull_request:
-        types: [opened, ready_for_review, reopened, synchronize]
+        types: [opened, ready_for_review, reopened, synchronize, assigned, unassigned]
 
 jobs:
     assign-and-request-review:

--- a/.github/workflows/auto-assign-assignees-as-reviewers.yml
+++ b/.github/workflows/auto-assign-assignees-as-reviewers.yml
@@ -26,17 +26,8 @@ jobs:
                         pull_number: context.payload.pull_request.number,
                       });
 
-                      return {
-                        assignees: pr.data.assignees.map(a => a.login)
-                      };
-                  result-encoding: string
+                      const assignees = pr.data.assignees.map(a => a.login)
 
-            - name: Request review from assignees
-              if: steps.pr.outputs.result != '[]'
-              uses: actions/github-script@v7
-              with:
-                  script: |
-                      const assignees = ${{ steps.pr.outputs.result }}.assignees;
                       if (assignees.length > 0) {
                         await github.rest.pulls.requestReviewers({
                           owner: context.repo.owner,

--- a/.github/workflows/auto-assign-assignees-as-reviewers.yml
+++ b/.github/workflows/auto-assign-assignees-as-reviewers.yml
@@ -1,0 +1,47 @@
+name: Auto Assign Assignees as Reviewers
+
+on:
+    pull_request:
+        types: [opened, ready_for_review, reopened, synchronize]
+
+jobs:
+    assign-and-request-review:
+        runs-on: ubuntu-latest
+
+        permissions:
+            pull-requests: write
+
+        steps:
+            - name: Checkout repo
+              uses: actions/checkout@v3
+
+            - name: Get PR details
+              id: pr
+              uses: actions/github-script@v7
+              with:
+                  script: |
+                      const pr = await github.rest.pulls.get({
+                        owner: context.repo.owner,
+                        repo: context.repo.repo,
+                        pull_number: context.payload.pull_request.number,
+                      });
+
+                      return {
+                        assignees: pr.data.assignees.map(a => a.login)
+                      };
+                  result-encoding: string
+
+            - name: Request review from assignees
+              if: steps.pr.outputs.result != '[]'
+              uses: actions/github-script@v7
+              with:
+                  script: |
+                      const assignees = JSON.parse(`${{ steps.pr.outputs.result }}`).assignees;
+                      if (assignees.length > 0) {
+                        await github.rest.pulls.requestReviewers({
+                          owner: context.repo.owner,
+                          repo: context.repo.repo,
+                          pull_number: context.payload.pull_request.number,
+                          reviewers: assignees
+                        });
+                      }


### PR DESCRIPTION
<!--
  ⚠️ ⚠️ IF YOU ARE MODIFYING `index.js` OR A FILE IN `features` ⚠️ ⚠️
  Please request a review and ping a DRI from the Config AOR or Breakage AOR.
  The quickest way to get attention for your PR is to ping the ~Breakage channel
  in MatterMost.

  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Consider adding an individual reviewer as well as the groups that are automatically added (this should create a review task in Asana for them specifically).
  Use the "merge when ready" button to automatically merge the PR as soon as it's reviewed.
-->

**Asana Task/Github Issue:**

## Description

Folk continue to use assign instead of reviewers which we have automation to place into Asana. This just sets any Assignee also as a Reviewer which in turn will make the Asana task.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change
- [ ] I have tested this change locally
- [ ] This code for the config change is ready to merge
- [ ] This feature was covered by a tech design

#### Additional info:
<!--
  These questions are a friendly reminder to shipping config changes, if you're uncertain ask the AoR owners.
  It's also totally appropriate to not check some of these boxes, if they don't apply to your change.
-->
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [ ] This code for the config change is ready
- [ ] This change was covered by a ship review

### Site breakage mitigation process:

#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled:


- [ ] I have referenced the URL of this PR as the "reason" value for the exception (where applicable).
- [ ] This change is a speculative mitigation to fix reported breakage.

#### Reference

-   [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
-   [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
-   [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)
