### PR TITLE
Android: Remove new settings page and privacy pro section feature toggles

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -1929,31 +1929,7 @@
             "minSupportedVersion": 52250000
         },
         "settingsPage": {
-            "state": "enabled",
-            "features": {
-                "newSettingsPage": {
-                    "state": "enabled",
-                    "minSupportedVersion": 52250000,
-                    "rollout": {
-                        "steps": [
-                            {
-                                "percent": 100
-                            }
-                        ]
-                    }
-                },
-                "newPrivacyProSection": {
-                    "state": "enabled",
-                    "minSupportedVersion": 52250000,
-                    "rollout": {
-                        "steps": [
-                            {
-                                "percent": 100
-                            }
-                        ]
-                    }
-                }
-            }
+            "state": "disabled"
         },
         "defaultBrowserPrompts": {
             "state": "enabled",


### PR DESCRIPTION
<!--
  ⚠️ ⚠️ IF YOU ARE MODIFYING `index.js` OR A FILE IN `features` ⚠️ ⚠️
  Please request a review and ping a DRI from the Config AOR or Breakage AOR.
  The quickest way to get attention for your PR is to ping the ~Breakage channel
  in MatterMost.

  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Consider adding an individual reviewer as well as the groups that are automatically added (this should create a review task in Asana for them specifically).
  Use the "merge when ready" button to automatically merge the PR as soon as it's reviewed.
-->

**Asana Task/Github Issue:**

## Description

The new settings screen is now the default settings screen on Android and the legacy settings screen has been removed. These toggles are no longer needed.

I'm leaving the `settingsPage` toggle as I believe this maybe useful in future but please let me know if it's better it's removed and added back if needed rather than left in the config 👍 

#### Reference

-   [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
-   [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
-   [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)
