### PR TITLE
Enable the BrokenSitePrompt feature for Windows browser users

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -511,6 +511,9 @@
         "windowsWebViewPermissionsSavesInProfile": {
             "state": "disabled",
             "exceptions": []
+        },
+        "brokenSitePrompt": {
+            "state": "enabled"
         }
     },
     "unprotectedTemporary": []


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/72649045549333/task/1207889813347129?focus=true

## Description

Enable the BrokenSitePrompt feature ("Site broken? Let us know" prompt when user reloads a website repeatedly) for
Windows browser users.

#### Additional info:
<!--
  These questions are a friendly reminder to shipping config changes, if you're uncertain ask the AoR owners.
  It's also totally appropriate to not check some of these boxes, if they don't apply to your change.
-->
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [x] This code for the config change is ready
- [x] This change was covered by a ship review
