### PR TITLE
SBT add tracker exception to load site

### DIFF
--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -3225,6 +3225,15 @@
                     }
                 ]
             },
+            "weglot.com": {
+                "rules": [
+                    {
+                        "rule": "cdn.weglot.com/weglot.min.js",
+                        "domains": ["cherrycreekschools.org"],
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/issues/2968"
+                    }
+                ]
+            },
             "wpadmngr.com": {
                 "rules": [
                     {


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1206670747178362/task/1209946938241022

## Description

### Site breakage mitigation process:

#### Brief explanation
- Reported URL: https://www.cherrycreekschools.org/
- Problems experienced: site does not load; blank page instead
- Platforms affected:
  - [x] iOS
  - [ x] Android
  - [ x] Windows
  - [x ] MacOS
  - [ x Extensions
- Tracker(s) being unblocked: cdn.weglot.com/weglot.min.js
- Feature being disabled: NA


- [ x] I have referenced the URL of this PR as the "reason" value for the exception (where applicable).

#### Reference

-   [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
-   [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
-   [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)
