### PR TITLE
SBT add tracker exceptions to prevent experimental breakages

### DIFF
--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -773,6 +773,15 @@
                     }
                 ]
             },
+            "datatables.net": {
+                "rules": [
+                    {
+                        "rule": "datatables.net",
+                        "domains": ["<all>"],
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2973"
+                    }
+                ]
+            },
             "demdex.net": {
                 "rules": [
                     {
@@ -2346,6 +2355,15 @@
                         "rule": "cdn.onesignal.com/sdks/OneSignalSDK.js",
                         "domains": ["cosmicbook.news"],
                         "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1578"
+                    }
+                ]
+            },
+            "onlineaccess1.com": {
+                "rules": [
+                    {
+                        "rule": "onlineaccess1.com",
+                        "domains": ["<all>"],
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2973"
                     }
                 ]
             },


### PR DESCRIPTION
**Asana Task/Github Issue:**

## Description

### Site breakage mitigation process:

#### Brief explanation
- Reported URL: several
- Problems experienced: unblock to avoid experimental breakages to rise
- Platforms affected:
  - [ x] iOS
  - [ x] Android
  - [x] Windows
  - [x ] MacOS
  - [ x] Extensions
- Tracker(s) being unblocked: datatables.net & onlineaccess1.com
- Feature being disabled: NA


- [ x] I have referenced the URL of this PR as the "reason" value for the exception (where applicable).


#### Reference

-   [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
-   [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
-   [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)
