### PR TITLE
[Autofill] add new setting for input types

### DIFF
--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -377,6 +377,30 @@
                 },
                 "partialFormSaves": {
                     "state": "enabled"
+                },
+                "siteSpecificFixes": {
+                    "state": "enabled",
+                    "settings": {
+                        "domains": [
+                            {
+                                "domain": ["zendesk.com", "localhost"],
+                                "patchSettings": [
+                                    {
+                                        "path": "",
+                                        "op": "add",
+                                        "value": {
+                                            "inputTypeSettings": [
+                                                {
+                                                    "selector": "#\\:r0\\:\\-\\-input",
+                                                    "type": "credentials.username"
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        ]
+                    }
                 }
             }
         },

--- a/schema/features/autofill.ts
+++ b/schema/features/autofill.ts
@@ -22,9 +22,15 @@ type FormTypeSetting = {
     type: 'login' | 'signup';
 };
 
+type InputTypeSetting = {
+    selector: string;
+    type: string;
+};
+
 export type SiteSpecificFixes = {
     formBoundarySelector?: string;
     formTypeSettings?: FormTypeSetting[];
+    inputTypeSettings?: InputTypeSetting[];
 };
 
 // Any subfeatures that have typed `settings` should be defined here.

--- a/schema/features/autofill.ts
+++ b/schema/features/autofill.ts
@@ -17,18 +17,20 @@ type ImportFromGooglePasswordManager = {
     signInButton: ButtonConfig;
 };
 
-type FormTypeSetting = {
+export type FormTypeSetting = {
     selector: string;
     type: 'login' | 'signup';
 };
 
-type InputTypeSetting = {
+export type InputTypeSetting = {
     selector: string;
     type: string;
 };
 
+export type FormBoundarySelector = string;
+
 export type SiteSpecificFixes = {
-    formBoundarySelector?: string;
+    formBoundarySelector?: FormBoundarySelector;
     formTypeSettings?: FormTypeSetting[];
     inputTypeSettings?: InputTypeSetting[];
 };


### PR DESCRIPTION
<!--
  ⚠️ ⚠️ IF YOU ARE MODIFYING `index.js` OR A FILE IN `features` ⚠️ ⚠️
  Please request a review and ping a DRI from the Config AOR or Breakage AOR.
  The quickest way to get attention for your PR is to ping the ~Breakage channel
  in MatterMost.

  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Consider adding an individual reviewer as well as the groups that are automatically added (this should create a review task in Asana for them specifically).
  Use the "merge when ready" button to automatically merge the PR as soon as it's reviewed.
-->

**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/72649045549333/task/1209945606697018?focus=true

## Description
Adding a new setting type in `autofill.ts` as we're introducing support for forcing input types based on selectors, in autofill.
https://github.com/duckduckgo/duckduckgo-autofill/pull/795

<!-- 
  Please delete either or both process sections below.
-->

### Feature change process:

- [x] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change
- [x] I have tested this change locally
- [ ] This code for the config change is ready to merge
- [x] This feature was covered by a tech design

#### Additional info:
<!--
  These questions are a friendly reminder to shipping config changes, if you're uncertain ask the AoR owners.
  It's also totally appropriate to not check some of these boxes, if they don't apply to your change.
-->
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [ ] This code for the config change is ready
- [ ] This change was covered by a ship review

### Site breakage mitigation process:

#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled:


- [ ] I have referenced the URL of this PR as the "reason" value for the exception (where applicable).
- [ ] This change is a speculative mitigation to fix reported breakage.

#### Reference

-   [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
-   [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
-   [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)
