### PR TITLE
Enable additional params for intlannouncement remote message

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -39,9 +39,7 @@
             "state": "enabled",
             "exceptions": [],
             "settings": {
-                "origins": [
-                    "funnel_newtab_android_intlannouncement"
-                ]
+                "origins": ["funnel_newtab_android_intlannouncement"]
             },
             "minSupportedVersion": 52100000
         },

--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -39,7 +39,9 @@
             "state": "enabled",
             "exceptions": [],
             "settings": {
-                "origins": []
+                "origins": [
+                    "funnel_newtab_android_intlannouncement"
+                ]
             },
             "minSupportedVersion": 52100000
         },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/0/task/1209960441359383

## Description

Enables intlannouncement origin for additional pixel parameters

#### Reference

-   [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
-   [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
-   [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)
