### PR TITLE
Android: Re-enable the tab swiping feature rollout

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -1900,13 +1900,10 @@
             }
         },
         "swipingTabs": {
-            "state": "disabled",
-            "minSupportedVersion": 52290000,
+            "state": "enabled",
+            "minSupportedVersion": 52300000,
             "features": {
-                "onForInternalUsers": {
-                    "state": "internal"
-                },
-                "onForExternalUsers": {
+                "enabledForUsers": {
                     "state": "enabled",
                     "rollout": {
                         "steps": [
@@ -1915,6 +1912,12 @@
                             }
                         ]
                     }
+                },
+                "tabSwipingFix1": {
+                    "state": "disabled"
+                },
+                "tabSwipingFix2": {
+                    "state": "disabled"
                 }
             }
         },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1207418217763355/task/1209846575622291?focus=true

## Description

This PR re-enables the `swipingTabs` feature flag after a the rollout was paused due to some issues. These have been fixed and deployed to a new version. The sub-feature flags have also been updated to [match the Android code](https://github.com/duckduckgo/Android/blob/ef56ddd33db990aa38877a7f9b08ad4926078dc3/app/src/main/java/com/duckduckgo/app/browser/SwipingTabsFeature.kt#L4):

- `enabledForUsers`: used for staged rollout, set to 20% for the `5.230.0` release (always enabled for internal users)
- `tabSwipingFix1`: (currently disabled) a potential fix attempt for an issue if the current fix does not work
- `tabSwipingFix2`: (currently disabled) another potential fix attempt for an issue if the current fix does not work

#### Reference

-   [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
-   [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
-   [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)
