### PR TITLE
Site breakage: mitigate adblock wall on cleveland.com

### DIFF
--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -302,6 +302,11 @@
                         "rule": "z-na.amazon-adsystem.com/widgets/onejs",
                         "domains": ["oceanofcompressed.xyz"],
                         "reason": ["https://github.com/duckduckgo/privacy-configuration/issues/1652"]
+                    },
+                    {
+                        "rule": "aax.amazon-adsystem.com/e/dtb/bid",
+                        "domains": ["cleveland.com"],
+                        "reason": ["https://github.com/duckduckgo/privacy-configuration/issues/3006"]
                     }
                 ]
             },


### PR DESCRIPTION
<!--
  ⚠️ ⚠️ IF YOU ARE MODIFYING `index.js` OR A FILE IN `features` ⚠️ ⚠️
  Please request a review and ping a DRI from the Config AOR or Breakage AOR.
  The quickest way to get attention for your PR is to ping the ~Breakage channel
  in MatterMost.

  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Consider adding an individual reviewer as well as the groups that are automatically added (this should create a review task in Asana for them specifically).
  Use the "merge when ready" button to automatically merge the PR as soon as it's reviewed.
-->

**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1200277586140538/task/1210013641838295?focus=true

## Description
Adblock wall occasionally appears on article pages. Not entirely clear why, but seems to happen more frequently when accessed via Firefox + extension, and also doesn't trigger when devtools are open, which makes it difficult to trace the trigger mechanism.

### Site breakage mitigation process:

#### Brief explanation
- Reported URL: https://www.cleveland.com/news/2025/04/after-legal-loss-ohio-lawmakers-target-app-stores-with-teen-social-media-law.html
- Problems experienced: adblock wall
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [x] Extensions
- Tracker(s) being unblocked: aax.amazon-adsystem.com/e/dtb/bid
- Feature being disabled:

- [x] I have referenced the URL of this PR as the "reason" value for the exception (where applicable).

#### Reference

-   [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
-   [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
-   [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)
