### PR TITLE
Mitigate Strava map breakage with AppTP

### DIFF
--- a/features/app-tracker-protection.json
+++ b/features/app-tracker-protection.json
@@ -579,6 +579,10 @@
                     "reason": "App loads websites"
                 },
                 {
+                    "packageName": "com.strava",
+                    "reason": "Users report app issues with AppTP enabled"
+                },
+                {
                     "packageName": "com.transsion.phoenix",
                     "reason": "App loads websites"
                 },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1202279501986195/task/1210016254995768?focus=true

## Description

Users report issues loading maps in the Strava app with App Tracking Protection enabled. So far there doesn't seem to be any particular tracker indicated, so until we can figure out the root cause we'll exclude it from protections to preserve functionality.