### PR TITLE
Add Nastia to apptp owners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -10,7 +10,7 @@ overrides/ @duckduckgo/config-aor @duckduckgo/breakage-aor @duckduckgo/breakage 
 # Feature owners
 features/ad-click-attribution.json @duckduckgo/config-aor @englehardt @duckduckgo/breakage-aor @duckduckgo/breakage @duckduckgo/content-scope-scripts-owners
 features/amp-links.json @duckduckgo/config-aor @joshliebe @duckduckgo/breakage-aor @duckduckgo/breakage @duckduckgo/content-scope-scripts-owners
-features/app-tracker-protection.json @duckduckgo/config-aor @aitorvs @duckduckgo/breakage-aor @duckduckgo/breakage @duckduckgo/content-scope-scripts-owners
+features/app-tracker-protection.json @duckduckgo/config-aor @aitorvs @nshuba @duckduckgo/breakage-aor @duckduckgo/breakage @duckduckgo/content-scope-scripts-owners
 features/autofill.json @duckduckgo/config-aor @GioSensation @duckduckgo/breakage-aor @duckduckgo/breakage @duckduckgo/content-scope-scripts-owners
 features/autoconsent.json @duckduckgo/config-aor @muodov @sammacbeth @duckduckgo/breakage-aor @duckduckgo/breakage @duckduckgo/content-scope-scripts-owners
 features/fingerprinting-* @duckduckgo/config-aor @englehardt @duckduckgo/breakage-aor @duckduckgo/breakage @duckduckgo/content-scope-scripts-owners


### PR DESCRIPTION

**Asana Task/Github Issue:** https://github.com/duckduckgo/privacy-configuration/pull/3009

## Description
Add @nshuba as an owner of the apptp feature.
### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change
- [ ] I have tested this change locally
- [ ] This code for the config change is ready to merge
- [ ] This feature was covered by a tech design

#### Additional info:
<!--
  These questions are a friendly reminder to shipping config changes, if you're uncertain ask the AoR owners.
  It's also totally appropriate to not check some of these boxes, if they don't apply to your change.
-->
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [ ] This code for the config change is ready
- [ ] This change was covered by a ship review

### Site breakage mitigation process:

#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled:


- [ ] I have referenced the URL of this PR as the "reason" value for the exception (where applicable).
- [ ] This change is a speculative mitigation to fix reported breakage.

#### Reference

-   [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
-   [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
-   [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)
