### PR TITLE
Mitigate more mystery map breakage in AppTP

### DIFF
--- a/features/app-tracker-protection.json
+++ b/features/app-tracker-protection.json
@@ -495,6 +495,10 @@
                     "reason": "App loads websites"
                 },
                 {
+                    "packageName": "com.hyundai.bluelink.eu.ux20",
+                    "reason": "Users report app issues with AppTP enabled"
+                },
+                {
                     "packageName": "com.kiwibrowser.browser",
                     "reason": "App loads websites"
                 },
@@ -577,6 +581,10 @@
                 {
                     "packageName": "com.sec.android.app.sbrowser.beta",
                     "reason": "App loads websites"
+                },
+                {
+                    "packageName": "com.stationdm.bluelink",
+                    "reason": "Users report app issues with AppTP enabled"
                 },
                 {
                     "packageName": "com.strava",


### PR DESCRIPTION
**Asana Task/Github Issue:**

## Description

As in #3009, the Hyundai Bluelink apps (EU & US) seem to be unable to load maps when AppTP is enabled. Excluding them from the tun until we can figure out exactly what's breaking.