### PR TITLE
Allow convertkit.com content on kit.com

### DIFF
--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -690,6 +690,15 @@
                     }
                 ]
             },
+            "convertkit.com": {
+                "rules": [
+                    {
+                        "rule": "convertkit.com",
+                        "domains": ["kit.com"],
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/pull/3024"
+                    }
+                ]
+            },
             "cookielaw.org": {
                 "rules": [
                     {


### PR DESCRIPTION
<!--
  ⚠️ ⚠️ IF YOU ARE MODIFYING `index.js` OR A FILE IN `features` ⚠️ ⚠️
  Please request a review and ping a DRI from the Config AOR or Breakage AOR.
  The quickest way to get attention for your PR is to ping the ~Breakage channel
  in MatterMost.

  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Consider adding an individual reviewer as well as the groups that are automatically added (this should create a review task in Asana for them specifically).
  Use the "merge when ready" button to automatically merge the PR as soon as it's reviewed.
-->

**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/1206670747178362/task/1210032258516866?focus=true

## Description
Allow convertkit.com content on kit.com. ConvertKit was rebranded as Kit but kit.com subdomains still reference convertkit.com

### Site breakage mitigation process:

#### Brief explanation
- Reported URL: https://preacherjohn.kit.com and others
- Problems experienced: Hidden or badly displayed content on kit.com subdomains.
- Platforms affected:
  - [x] iOS
  - [x] Android
  - [x] Windows
  - [x] MacOS
  - [x] Extensions
- Tracker(s) being unblocked: convertkit.com
- Feature being disabled: N/A


- [X] I have referenced the URL of this PR as the "reason" value for the exception (where applicable).
- [ ] This change is a speculative mitigation to fix reported breakage.

#### Reference

-   [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
-   [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
-   [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)
