### PR TITLE
Windows: Add authv2 rollout to non-stable builds setting to privacy pro

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -391,6 +391,9 @@
                 "authApiV2": {
                     "state": "disabled"
                 }
+            },
+            "settings": {
+                "authApiV2NonStableRollout": false
             }
         },
         "webCompat": {


### PR DESCRIPTION
<!--
  ⚠️ ⚠️ IF YOU ARE MODIFYING `index.js` OR A FILE IN `features` ⚠️ ⚠️
  Please request a review and ping a DRI from the Config AOR or Breakage AOR.
  The quickest way to get attention for your PR is to ping the ~Breakage channel
  in MatterMost.

  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Consider adding an individual reviewer as well as the groups that are automatically added (this should create a review task in Asana for them specifically).
  Use the "merge when ready" button to automatically merge the PR as soon as it's reviewed.
-->

**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1205044477659400/task/1210034963533409?focus=true

## Description

This adds a `settings `section to `privacyPro` with a single Boolean field `authApiV2NonStableRollout `that can be used to enable rollout of AuthApiV2 for non-stable builds only, ie preview, canary, and ship review builds. This is needed as the Windows browser does not yet support the `internal `state for feature flags.
Note: The flag is currently set to false.

#### Reference

-   [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
-   [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
-   [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)
