### PR TITLE
Removed subdomain from exception

### DIFF
--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -1945,7 +1945,7 @@
                 "rules": [
                     {
                         "rule": "hb.improvedigital.com/pbw/prebid/prebid-idhb-v8.51a.min.js",
-                        "domains": ["fun.chicagotribune.com"],
+                        "domains": ["chicagotribune.com"],
                         "reason": "https://github.com/duckduckgo/privacy-configuration/pull/3023"
                     }
                 ]


### PR DESCRIPTION
<!--
  ⚠️ ⚠️ IF YOU ARE MODIFYING `index.js` OR A FILE IN `features` ⚠️ ⚠️
  Please request a review and ping a DRI from the Config AOR or Breakage AOR.
  The quickest way to get attention for your PR is to ping the ~Breakage channel
  in MatterMost.

  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Consider adding an individual reviewer as well as the groups that are automatically added (this should create a review task in Asana for them specifically).
  Use the "merge when ready" button to automatically merge the PR as soon as it's reviewed.
-->

**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/1206670747178362/task/1210034193824226?focus=true

## Description
Broadens the existing exception to the whole domain.

### Site breakage mitigation process:

#### Brief explanation
- Reported URL: https://fun.chicagotribune.com/game/tca-jumble-daily
- Problems experienced: Previous exception not having an effect with the extension.
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [x] Extensions
- Tracker(s) being unblocked: N/A
- Feature being disabled: N/A


- [x] I have referenced the URL of this PR as the "reason" value for the exception (where applicable).
- [ ] This change is a speculative mitigation to fix reported breakage.

#### Reference

-   [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
-   [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
-   [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)
