### PR TITLE
Hide empty .ad-frame elements

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -280,6 +280,10 @@
                 "type": "hide-empty"
             },
             {
+                "selector": ".ad-frame",
+                "type": "hide-empty"
+            },
+            {
                 "selector": ".advertisement",
                 "type": "closest-empty"
             },


### PR DESCRIPTION
<!--
  ⚠️ ⚠️ IF YOU ARE MODIFYING `index.js` OR A FILE IN `features` ⚠️ ⚠️
  Please request a review and ping a DRI from the Config AOR or Breakage AOR.
  The quickest way to get attention for your PR is to ping the ~Breakage channel
  in MatterMost.

  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Consider adding an individual reviewer as well as the groups that are automatically added (this should create a review task in Asana for them specifically).
  Use the "merge when ready" button to automatically merge the PR as soon as it's reviewed.
-->

**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/1204912272578138/task/1210069268246862?focus=true

## Description
Hides empty space at the top of nativime.co.jp

### Site breakage mitigation process:

#### Brief explanation
- Reported URL: https://www.navitime.co.jp/transfer/?from=top&gaCategory=&gaLabel=%E4%B9%97%E6%8F%9B%E6%A1%88%E5%86%85
- Problems experienced: Blank space at top of page.
- Platforms affected:
  - [x] iOS
  - [x] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked: N/A
- Feature being disabled: N/A


- [ ] I have referenced the URL of this PR as the "reason" value for the exception (where applicable).
- [ ] This change is a speculative mitigation to fix reported breakage.

#### Reference

-   [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
-   [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
-   [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)
