### PR TITLE
Fix broken page interaction on caf.fr

### DIFF
--- a/features/autoconsent.json
+++ b/features/autoconsent.json
@@ -530,6 +530,10 @@
         {
             "domain": "telekom.de",
             "reason": "https://github.com/duckduckgo/privacy-configuration/pull/3039"
+        },
+        {
+            "domain": "caf.fr",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/pull/3052"
         }
     ],
     "settings": {


### PR DESCRIPTION
The Cookie Prompt Management (CPM) feature seems to clash with the caf.fr,
leaving the website in a broken state. When this happens, there's a grey overlay
and page interaction (e.g. clicking) doesn't work.
