### PR TITLE
Update list of `gpcHeaderEnabledSites`

### DIFF
--- a/features/gpc.json
+++ b/features/gpc.json
@@ -71,6 +71,8 @@
             "globalprivacycontrol.org",
             "washingtonpost.com",
             "nytimes.com",
+            "privacytests.org",
+            "privacytests2.org",
             "privacy-test-pages.site"
         ]
     }


### PR DESCRIPTION
<!--
  ⚠️ ⚠️ IF YOU ARE MODIFYING `index.js` OR A FILE IN `features` ⚠️ ⚠️
  Please request a review and ping a DRI from the Config AOR or Breakage AOR.
  The quickest way to get attention for your PR is to ping the ~Breakage channel
  in MatterMost.

  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Consider adding an individual reviewer as well as the groups that are automatically added (this should create a review task in Asana for them specifically).
  Use the "merge when ready" button to automatically merge the PR as soon as it's reviewed.
-->

**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1205680387402877/task/1208304772216267?focus=true

## Description
Add privacy tests domains to list of `gpcHeaderEnabledSites`.
