### PR TITLE
Fix issue with scrolling on homeoffice.gov.uk

### DIFF
--- a/features/autoconsent.json
+++ b/features/autoconsent.json
@@ -534,6 +534,10 @@
         {
             "domain": "caf.fr",
             "reason": "https://github.com/duckduckgo/privacy-configuration/pull/3052"
+        },
+        {
+            "domain": "homeoffice.gov.uk",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/pull/3056"
         }
     ],
     "settings": {


### PR DESCRIPTION
Scrolling seems to be broken for homeoffice.gov.uk when Cookie Prompt
Management (CPM) is enabled. The user is repeatedly jumped back to the page as
they attempt to scroll down.
