### PR TITLE
Fix broken page interaction on myavista.com

### DIFF
--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -3294,8 +3294,11 @@
                 "rules": [
                     {
                         "rule": "cdn.weglot.com/weglot.min.js",
-                        "domains": ["cherrycreekschools.org"],
-                        "reason": "https://github.com/duckduckgo/privacy-configuration/issues/2968"
+                        "domains": ["cherrycreekschools.org", "myavista.com"],
+                        "reason": [
+                            "cherrycreekschools.org - https://github.com/duckduckgo/privacy-configuration/issues/2968",
+                            "myavista.com - https://github.com/duckduckgo/privacy-configuration/pull/3057"
+                        ]
                     }
                 ]
             },


### PR DESCRIPTION
An AJAX spinner overlay was shown, preventing users from interacting with the
website.