### PR TITLE
Add feature flag for VPN in-app DNS

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -909,6 +909,9 @@
         "networkProtection": {
             "state": "enabled",
             "features": {
+                "localVpnControllerDns": {
+                    "state": "internal"
+                },
                 "allowDnsBlockMalware": {
                     "state": "enabled"
                 },


### PR DESCRIPTION
**Asana Task/Github Issue:**https://app.asana.com/1/137249556945/task/1209940115509909?focus=true

## Description

Add the `localVpnControllerDns` (and enable it). The flag controls a VPN in-app DNS that resolves our VPN controller.

EVen thought this change is tested, enabling for `internal` users only for now to re-test it again in the internal build after going through app updates etc.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change
- [x] I have tested this change locally
- [x] This code for the config change is ready to merge
- [x] This feature was covered by a tech design (https://app.asana.com/1/137249556945/project/481882893211075/task/1209634295831199?focus=true)

#### Additional info:
- [x] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [x] This code for the config change is ready
- [ ] This change was covered by a ship review

### Site breakage mitigation process:

#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [x] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled:


- [ ] I have referenced the URL of this PR as the "reason" value for the exception (where applicable).
- [ ] This change is a speculative mitigation to fix reported breakage.

