### PR TITLE
localVpnControllerDns from internal to enabled

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -910,7 +910,7 @@
             "state": "enabled",
             "features": {
                 "localVpnControllerDns": {
-                    "state": "internal"
+                    "state": "enabled"
                 },
                 "allowDnsBlockMalware": {
                     "state": "enabled"


### PR DESCRIPTION
**Asana Task/Github Issue:**https://app.asana.com/1/137249556945/task/1209940115509909?focus=true

## Description

Enable the `localVpnControllerDns` feature flag. The flag controls a VPN in-app DNS that resolves our VPN controller.

We first enabled it for internal users to test in production internal build. Now that we've tested that, enable to all users

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change
- [x] I have tested this change locally
- [x] This code for the config change is ready to merge
- [x] This feature was covered by a tech design (https://app.asana.com/1/137249556945/project/481882893211075/task/1209634295831199?focus=true)

#### Additional info:
- [x] I have tested this change locally in all supported browsers
- [x] This change will be visible to users
- [x] This code for the config change is ready
- [ ] This change was covered by a ship review

### Site breakage mitigation process:

#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [x] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled:


- [ ] I have referenced the URL of this PR as the "reason" value for the exception (where applicable).
- [ ] This change is a speculative mitigation to fix reported breakage.

