### PR TITLE
hide empty drive ad

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -3779,6 +3779,15 @@
                         "type": "hide-empty"
                     }
                 ]
+            },
+            {
+                "domain": "thedrive.com",
+                "rules": [
+                    {
+                        "selector": "#pw-top-right-sidebar-aib",
+                        "type": "hide-empty"
+                    }
+                ]
             }
         ]
     }


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/inbox/11472677167854/item/1210154005474191/story/1210154046976696

## Description
<!-- 
  Please delete either or both process sections below.
-->
hide empty sidebar ad
### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.
