### PR TITLE
Do not pretty print generated output JSON

### DIFF
--- a/index.js
+++ b/index.js
@@ -72,7 +72,7 @@ function writeConfigToDisk(platform, config) {
         addHashToFeatures(compatConfig);
 
         compatibility.removeEolFeatures(compatConfig, i);
-        fs.writeFileSync(`${GENERATED_DIR}/${version}/${configName}-config.json`, JSON.stringify(compatConfig, null, 4));
+        fs.writeFileSync(`${GENERATED_DIR}/${version}/${configName}-config.json`, JSON.stringify(compatConfig));
     }
 }
 


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/0/task/1210142069641181

## Description
Outputs in the `generated` folder are currently 'pretty printed' with 4-space tab width. Given that this data is only consumed by JSON parsers, this is unnecessary, and just bloats the amount of data to transfer, parsed and store. We should just output this without whitespace, and benefit from a size reduction from 492k (Android config) to 154k.

I've tested this on all platforms, so don't expect an issue from making this change.