### PR TITLE
AppTP: Unhide Google Calendar app

### DIFF
--- a/features/app-tracker-protection.json
+++ b/features/app-tracker-protection.json
@@ -744,6 +744,7 @@
                 "com.google.android.apps.walletnfcrel",
                 "com.google.android.apps.youtube.kids",
                 "com.google.android.apps.youtube.music",
+                "com.google.android.calendar",
                 "com.google.android.deskclock",
                 "com.google.android.gm",
                 "com.google.android.gm.lite",


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1114857721287938/task/1210071181480897

## Description
We got a user report from someone confused about why Google Calendar wasn't visible in the AppTP app list.
