### PR TITLE
doubleclick breaking videos on wunderground

### DIFF
--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -1124,8 +1124,11 @@
                     },
                     {
                         "rule": "doubleclick.net",
-                        "domains": ["rocketnews24.com"],
-                        "reason": "https://github.com/duckduckgo/privacy-configuration/issues/846"
+                        "domains": ["rocketnews24.com", "wunderground.com"],
+                        "reason": [
+                            "rocketnews24.com - https://github.com/duckduckgo/privacy-configuration/issues/846",
+                            "wunderground.com - https://github.com/duckduckgo/privacy-configuration/pull/3095"
+                        ]
                     },
                     {
                         "rule": "https://googleads.g.doubleclick.net/ads/preferences/naioptout",

--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -1127,7 +1127,7 @@
                         "domains": ["rocketnews24.com", "wunderground.com"],
                         "reason": [
                             "rocketnews24.com - https://github.com/duckduckgo/privacy-configuration/issues/846",
-                            "wunderground.com - https://github.com/duckduckgo/privacy-configuration/pull/3095"
+                            "wunderground.com - https://github.com/duckduckgo/privacy-configuration/pull/3096"
                         ]
                     },
                     {


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/11472677167855/task/1210170243253227

## Description
<!-- 
  Please delete either or both process sections below.
-->
Videos are broken on pages like https://www.wunderground.com/video/top-stories/lightning-starts-house-fire-in-colleyville-texas
### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.
