### PR TITLE
Delayed WebView Presentation feature

### DIFF
--- a/features/delayed-webview-presentation.json
+++ b/features/delayed-webview-presentation.json
@@ -1,0 +1,8 @@
+{
+    "_meta": {
+        "description": "A feature toggle for the delayed webview presentation when switching from an internal site to the web content",
+        "sampleExcludeRecords": {}
+    },
+    "state": "disabled",
+    "exceptions": []
+}

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -1079,6 +1079,9 @@
         "tabCrashRecovery": {
             "state": "enabled",
             "minSupportedVersion": "1.137.0"
+        },
+        "delayedWebviewPresentation": {
+            "state": "internal"
         }
     },
     "unprotectedTemporary": []


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/1148564399326804/task/1209499005452053?focus=true

## Description
Feature flag for delayed webview presentation when switching from internal site to web content

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [x] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.
