### PR TITLE
privacyProAuthV2 enabled on iOS for 5%

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -828,8 +828,15 @@
                     "minSupportedVersion": "7.148.0"
                 },
                 "privacyProAuthV2": {
-                    "state": "internal",
-                    "minSupportedVersion": "7.164.0"
+                    "state": "enabled",
+                    "rollout": {
+                        "steps": [
+                            {
+                                "percent": 5
+                            }
+                        ]
+                    },
+                    "minSupportedVersion": "7.167.0"
                 },
                 "privacyProFreeTrialJan25": {
                     "state": "enabled",


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1205842942115003/task/1209283428785611?focus=true

## Description

privacyProAuthV2 release at 5% for iOS

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [x] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [x] This feature was covered by a tech design.