### PR TITLE
wfb blank ad space

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -3792,6 +3792,15 @@
                         "type": "hide-empty"
                     }
                 ]
+            },
+            {
+                "domain": "worldfootball.net",
+                "rules": [
+                    {
+                        "selector": ".wfb-ad",
+                        "type": "hide-empty"
+                    }
+                ]
             }
         ]
     }


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/11472677167855/task/1210183047654141

## Description
<!-- 
  Please delete either or both process sections below.
-->
blank ad space at top

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.
