### PR TITLE
Enable Sense Of Protection Experiment

### DIFF
--- a/features/sense-of-protection.json
+++ b/features/sense-of-protection.json
@@ -1,0 +1,7 @@
+{
+    "_meta": {
+        "description": "Controls the Sense Of Protection experiment."
+    },
+    "state": "disabled",
+    "exceptions": []
+}

--- a/features/tile-switcher-animation.json
+++ b/features/tile-switcher-animation.json
@@ -1,0 +1,7 @@
+{
+    "_meta": {
+        "description": "A feature flag that determines whether the tile switcher info panel animation is enabled.",
+        "sampleExcludeRecords": {}
+    },
+    "exceptions": []
+}

--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -2092,6 +2092,54 @@
                     ]
                 }
             }
+        },
+        "tileSwitcherAnimation": {
+            "state": "enabled",
+            "minSupportedVersion": 52320000
+        },
+        "senseOfProtection": {
+            "state": "enabled",
+            "exceptions": [],
+            "minSupportedVersion": 52320000,
+            "features": {
+                "senseOfProtectionNewUserExperimentApr25": {
+                    "state": "enabled",
+                    "target" : {
+                        "isReturningUser" : false
+                    },
+                    "cohorts": [
+                        {
+                            "name": "modifiedControl",
+                            "weight": 1
+                        },
+                        {
+                            "name": "variant1",
+                            "weight": 1
+                        },
+                        {
+                            "name": "variant2",
+                            "weight": 1
+                        }
+                    ]
+                },
+                "senseOfProtectionExistingUserExperimentApr25": {
+                    "state": "enabled",
+                    "cohorts": [
+                        {
+                            "name": "modifiedControl",
+                            "weight": 1
+                        },
+                        {
+                            "name": "variant1",
+                            "weight": 1
+                        },
+                        {
+                            "name": "variant2",
+                            "weight": 1
+                        }
+                    ]
+                }
+            }
         }
     },
     "unprotectedTemporary": [],


### PR DESCRIPTION
**Asana Task/Github Issue:**https://app.asana.com/1/137249556945/project/1174433894299346/task/1210140711789469?focus=true

## Description
<!-- 
  Please delete either or both process sections below.
—>
Enables the Sense Of Protection experiment for O-10

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.
