### PR TITLE
Add browser-specific feature flags for multi-step import (Chrome, Brave, Edge, Vivaldi)

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -114,6 +114,15 @@
                 },
                 "partialFormSaves": {
                     "state": "disabled"
+                },
+                "browserMultiStepImport": {
+                    "state": "enabled",
+                    "settings": {
+                        "chrome": "enabled",
+                        "brave": "disabled",
+                        "edge": "disabled",
+                        "vivaldi": "disabled"
+                    }
                 }
             }
         },


### PR DESCRIPTION
**Asana Task/Github Issue:** [Implement Individual Feature Flags](https://app.asana.com/1/137249556945/project/1209292120581622/task/1210169807341854?focus=true)

## Description
This PR adds browser-specific feature flags under `autofill.browserMultiStepImport` to independently control the two-stage password import process for each Chromium-based browser.

Chrome recently introduced encryption changes that require users to export passwords via CSV files separately. By adding these flags, we can proactively enable or disable the multi-step import flow per browser, depending on whether other browsers adopt similar encryption methods in the future.

Currently, only Chrome is enabled by default; Brave, Edge, and Vivaldi remain disabled until needed.

### Feature change process:

- [ ] I have added a schema to validate this feature change.
- [x] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [x] This feature was covered by a tech design.