### PR TITLE
Disable Duck Player on Windows and enable contingency mode in the UI

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -148,7 +148,7 @@
             "state": "enabled"
         },
         "duckPlayer": {
-            "state": "enabled",
+            "state": "disabled",
             "features": {
                 "pip": {
                     "state": "enabled"
@@ -171,6 +171,9 @@
                 "nativeUI": {
                     "state": "disabled"
                 }
+            },
+            "settings": {
+                "duckPlayerDisabledHelpPageLink": "https://duckduckgo.com/duckduckgo-help-pages/duck-player"
             }
         },
         "elementHiding": {

--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -148,7 +148,7 @@
             "state": "enabled"
         },
         "duckPlayer": {
-            "state": "disabled",
+            "state": "enabled",
             "features": {
                 "pip": {
                     "state": "enabled"
@@ -173,7 +173,83 @@
                 }
             },
             "settings": {
-                "duckPlayerDisabledHelpPageLink": "https://duckduckgo.com/duckduckgo-help-pages/duck-player"
+                "tryDuckPlayerLink": "https://www.youtube.com/watch?v=yKWIA-Pys4c",
+                "duckPlayerDisabledHelpPageLink": "https://duckduckgo.com/duckduckgo-help-pages/duck-player",
+                "youtubePath": "watch",
+                "youtubeEmbedUrl": "youtube-nocookie.com",
+                "youTubeUrl": "youtube.com",
+                "youTubeReferrerHeaders": ["Referer"],
+                "youTubeReferrerQueryParams": ["embeds_referring_euri"],
+                "youTubeVideoIDQueryParam": "v",
+                "overlays": {
+                    "youtube": {
+                        "state": "disabled",
+                        "selectors": {
+                            "thumbLink": "a[href^='/watch']",
+                            "excludedRegions": ["#playlist", "ytd-movie-renderer", "ytd-grid-movie-renderer"],
+                            "videoElement": "#player video",
+                            "videoElementContainer": "#player .html5-video-player",
+                            "hoverExcluded": [],
+                            "clickExcluded": ["ytd-thumbnail-overlay-toggle-button-renderer"],
+                            "allowedEventTargets": [
+                                ".ytp-inline-preview-scrim",
+                                ".ytd-video-preview",
+                                "#thumbnail-container",
+                                "#video-title-link",
+                                "#video-title",
+                                "video.video-stream.html5-main-video"
+                            ],
+                            "drawerContainer": "body"
+                        },
+                        "thumbnailOverlays": {
+                            "state": "enabled"
+                        },
+                        "clickInterception": {
+                            "state": "enabled"
+                        },
+                        "videoOverlays": {
+                            "state": "enabled"
+                        },
+                        "videoDrawer": {
+                            "state": "disabled"
+                        }
+                    },
+                    "serpProxy": {
+                        "state": "disabled"
+                    }
+                },
+                "domains": [
+                    {
+                        "domain": "www.youtube.com",
+                        "patchSettings": [
+                            {
+                                "op": "replace",
+                                "path": "/overlays/youtube/state",
+                                "value": "enabled"
+                            }
+                        ]
+                    },
+                    {
+                        "domain": "duckduckgo.com",
+                        "patchSettings": [
+                            {
+                                "op": "replace",
+                                "path": "/overlays/serpProxy/state",
+                                "value": "enabled"
+                            }
+                        ]
+                    },
+                    {
+                        "domain": "m.youtube.com",
+                        "patchSettings": [
+                            {
+                                "op": "replace",
+                                "path": "/overlays/youtube/state",
+                                "value": "enabled"
+                            }
+                        ]
+                    }
+                ]
             }
         },
         "elementHiding": {


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1201048563534612/task/1210195688400433?focus=true

## Description
There is an incident on DuckPlayer on Windows https://app.asana.com/1/137249556945/project/1201048563534612/task/1210193580444984?focus=true 

We are disabling DuckPlayer and adding the help page URL which will appear in the custom UI. 

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ x] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.
