### PR TITLE
Temporarily disabling Duck Player on Windows while we fix an incident.

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -148,7 +148,7 @@
             "state": "enabled"
         },
         "duckPlayer": {
-            "state": "enabled",
+            "state": "disabled",
             "features": {
                 "pip": {
                     "state": "enabled"


### PR DESCRIPTION
**Asana Task/Github Issue:**

## Description
Temporarily disabling Duck Player on Windows while we fix an incident.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.
