### PR TITLE
Fix Malicious Site Protection Duplicate PRs

### DIFF
--- a/.github/workflows/msp-filter-stale.yml
+++ b/.github/workflows/msp-filter-stale.yml
@@ -1,24 +1,8 @@
 name: Remove stale exceptions from malicious site protection feature.
 
 on:
-    workflow_dispatch:
-        inputs:
-            run:
-                description: 'Run the workflow'
-                required: true
-                default: 'yes'
-                type: choice
-                options:
-                    - yes
-                    - no
     schedule:
         - cron: '0 0 * * 0' # Every Sunday at midnight UTC
-
-    push:
-        branches:
-            - main
-            - tespach/test-pr-creation
-            - tespach/fix-malsite-duplicates
 
 jobs:
     update_data:
@@ -29,7 +13,6 @@ jobs:
               with:
                   repository: duckduckgo/privacy-configuration
                   path: privacy-configuration/
-                  ref: tespach/test-pr-creation
             - name: Execute Update Script
               run: |
                   cd ./privacy-configuration/

--- a/.github/workflows/msp-filter-stale.yml
+++ b/.github/workflows/msp-filter-stale.yml
@@ -1,8 +1,12 @@
 name: Remove stale exceptions from malicious site protection feature.
 
 on:
-    schedule:
-        - cron: '0 0 * * *' # Run every day at midnight UTC
+    commit:
+        branches:
+            - tespach/fix-malsite-duplicates
+    # schedule:
+    #     - cron: '0 0 * * *' # Run every day at midnight UTC
+
 
 jobs:
     update_data:
@@ -13,6 +17,7 @@ jobs:
               with:
                   repository: duckduckgo/privacy-configuration
                   path: privacy-configuration/
+                  ref: tespach/test-pr-creation
             - name: Execute Update Script
               run: |
                   cd ./privacy-configuration/

--- a/.github/workflows/msp-filter-stale.yml
+++ b/.github/workflows/msp-filter-stale.yml
@@ -1,9 +1,23 @@
 name: Remove stale exceptions from malicious site protection feature.
 
 on:
-    pull_request:
-        types: [opened, synchronize, reopened]
+    workflow_dispatch:
+        inputs:
+            run:
+                description: 'Run the workflow'
+                required: true
+                default: 'yes'
+                type: choice
+                options:
+                    - yes
+                    - no
+    schedule:
+        - cron: '0 0 * * 0' # Every Sunday at midnight UTC
+
+    push:
         branches:
+            - main
+            - tespach/test-pr-creation
             - tespach/fix-malsite-duplicates
 
 jobs:

--- a/.github/workflows/msp-filter-stale.yml
+++ b/.github/workflows/msp-filter-stale.yml
@@ -29,40 +29,11 @@ jobs:
                   echo "TEMPLATE=$TEMPLATE" >> $GITHUB_ENV
                   PR_BODY="${TEMPLATE//\{\{date\}\}/$DATE}"
                   PR_BODY="${PR_BODY//\\n/$'\n'}" # Replace escaped newlines with actual newlines
+                  PR_ID="$(echo "$PR_BODY" | grep 'PR ID: ' | cut -d' ' -f3)"
                   echo "PR_BODY<<EOF" >> $GITHUB_ENV
                   echo "$PR_BODY" >> $GITHUB_ENV
                   echo "EOF" >> $GITHUB_ENV
                   npm run lint-fix
-
-            - name: Find potential duplicate PRs for this entry
-              id: find-duplicates
-              run: |
-                  cd ./privacy-configuration/
-                  # Get the list of open PRs
-                  OPEN_PRS=$(gh pr list --state open --json number,title,body,createdAt,updatedAt,headRefName --jq '.[] | select(.title | contains("Remove stale exemptions from malicious site protection")) | .headRefName')
-                  # Check if the body of the PR contains the same template as the current one
-                  for pr in $OPEN_PRS; do
-                      # Get the body of the PR
-                      PR_BODY=$(gh pr view $pr --json body --jq '.body')
-                      # Check if the body contains the same template
-                      if [[ "$PR_BODY" == *"$TEMPLATE"* ]]; then
-                          echo "Duplicate PR found: $pr"
-                          echo "duplicate_pr=$pr" >> $GITHUB_ENV
-                          exit 0
-                      fi
-                  done
-                  echo "No duplicate PR found."
-
-            - name: Check for duplicate PR
-              if: steps.find-duplicates.outputs.duplicate_pr == ''
-              run: |
-                  echo "No duplicate PR found. Proceeding to create a new PR."
-            
-            - name: Handle duplicate PR
-              if: steps.find-duplicates.outputs.duplicate_pr != ''
-              run: |
-                  echo "Duplicate PR found. Exiting with success."
-                  exit 0
             - name: Create PR with updated configs
               uses: peter-evans/create-pull-request@88bf0de51c7487d91e1abbb4899332e602c58bbf
               id: create-pr

--- a/.github/workflows/msp-filter-stale.yml
+++ b/.github/workflows/msp-filter-stale.yml
@@ -53,7 +53,7 @@ jobs:
                   echo "EOF" >> $GITHUB_ENV
                   npm run lint-fix
             - name: Create PR with updated configs
-              uses: peter-evans/create-pull-request@88bf0de51c7487d91e1abbb4899332e602c58bbf
+              uses: peter-evans/create-pull-request@889dce9eaba7900ce30494f5e1ac7220b27e5c81
               id: create-pr
               with:
                   github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/msp-filter-stale.yml
+++ b/.github/workflows/msp-filter-stale.yml
@@ -1,7 +1,8 @@
 name: Remove stale exceptions from malicious site protection feature.
 
 on:
-    commit:
+    pull_request:
+        types: [opened, synchronize, reopened]
         branches:
             - tespach/fix-malsite-duplicates
     # schedule:

--- a/.github/workflows/msp-filter-stale.yml
+++ b/.github/workflows/msp-filter-stale.yml
@@ -33,31 +33,36 @@ jobs:
                   echo "$PR_BODY" >> $GITHUB_ENV
                   echo "EOF" >> $GITHUB_ENV
                   npm run lint-fix
+
             - name: Find potential duplicate PRs for this entry
-                id: find-duplicates
-                run: |
-                    cd ./privacy-configuration/
-                    # Get the list of open PRs
-                    OPEN_PRS=$(gh pr list --state open --json number,title,body,createdAt,updatedAt,headRefName --jq '.[] | select(.title | contains("Remove stale exemptions from malicious site protection")) | .headRefName')
-                    # Check if the body of the PR contains the same template as the current one
-                    for pr in $OPEN_PRS; do
-                        # Get the body of the PR
-                        PR_BODY=$(gh pr view $pr --json body --jq '.body')
-                        # Check if the body contains the same template
-                        if [[ "$PR_BODY" == *"$TEMPLATE"* ]]; then
-                            echo "Duplicate PR found: $pr"
-                            echo "duplicate_pr=$pr" >> $GITHUB_ENV
-                            exit 0
-                        fi
-                    done
-                    echo "No duplicate PR found."
+              id: find-duplicates
+              run: |
+                  cd ./privacy-configuration/
+                  # Get the list of open PRs
+                  OPEN_PRS=$(gh pr list --state open --json number,title,body,createdAt,updatedAt,headRefName --jq '.[] | select(.title | contains("Remove stale exemptions from malicious site protection")) | .headRefName')
+                  # Check if the body of the PR contains the same template as the current one
+                  for pr in $OPEN_PRS; do
+                      # Get the body of the PR
+                      PR_BODY=$(gh pr view $pr --json body --jq '.body')
+                      # Check if the body contains the same template
+                      if [[ "$PR_BODY" == *"$TEMPLATE"* ]]; then
+                          echo "Duplicate PR found: $pr"
+                          echo "duplicate_pr=$pr" >> $GITHUB_ENV
+                          exit 0
+                      fi
+                  done
+                  echo "No duplicate PR found."
+
             - name: Check for duplicate PR
-                if: steps.find-duplicates.outputs.duplicate_pr == ''
-                run: |
-                    echo "No duplicate PR found. Proceeding to create a new PR."
-                else:
-                    echo "Duplicate PR found. Exiting with success."
-                    exit 0
+              if: steps.find-duplicates.outputs.duplicate_pr == ''
+              run: |
+                  echo "No duplicate PR found. Proceeding to create a new PR."
+            
+            - name: Handle duplicate PR
+              if: steps.find-duplicates.outputs.duplicate_pr != ''
+              run: |
+                  echo "Duplicate PR found. Exiting with success."
+                  exit 0
             - name: Create PR with updated configs
               uses: peter-evans/create-pull-request@88bf0de51c7487d91e1abbb4899332e602c58bbf
               id: create-pr

--- a/.github/workflows/msp-filter-stale.yml
+++ b/.github/workflows/msp-filter-stale.yml
@@ -2,7 +2,7 @@ name: Remove stale exceptions from malicious site protection feature.
 
 on:
     schedule:
-        - cron: '0 0 * * 0' # Every Sunday at midnight UTC
+        - cron: '0 0 * * *' # Run every day at midnight UTC
 
 jobs:
     update_data:

--- a/.github/workflows/msp-filter-stale.yml
+++ b/.github/workflows/msp-filter-stale.yml
@@ -30,6 +30,7 @@ jobs:
                   PR_BODY="${TEMPLATE//\{\{date\}\}/$DATE}"
                   PR_BODY="${PR_BODY//\\n/$'\n'}" # Replace escaped newlines with actual newlines
                   PR_ID="$(echo "$PR_BODY" | grep 'PR ID: ' | cut -d' ' -f3)"
+                  echo "PR_ID=$PR_ID" >> $GITHUB_ENV
                   echo "PR_BODY<<EOF" >> $GITHUB_ENV
                   echo "$PR_BODY" >> $GITHUB_ENV
                   echo "EOF" >> $GITHUB_ENV
@@ -44,7 +45,7 @@ jobs:
                       ./
                   commit-message: Remove stale exemptions from malicious site protection
                   assignees: not-a-rootkit
-                  branch: remove-stale-exemptions-${{ env.DATE }}
+                  branch: remove-stale-exemptions-${{ env.PR_ID }}
                   title: Remove stale exemptions from malicious site protection - ${{ env.DATE }}
                   body: |
                       ${{ env.PR_BODY }}

--- a/.github/workflows/msp-filter-stale.yml
+++ b/.github/workflows/msp-filter-stale.yml
@@ -5,9 +5,6 @@ on:
         types: [opened, synchronize, reopened]
         branches:
             - tespach/fix-malsite-duplicates
-    # schedule:
-    #     - cron: '0 0 * * *' # Run every day at midnight UTC
-
 
 jobs:
     update_data:

--- a/.github/workflows/msp-filter-stale.yml
+++ b/.github/workflows/msp-filter-stale.yml
@@ -33,6 +33,31 @@ jobs:
                   echo "$PR_BODY" >> $GITHUB_ENV
                   echo "EOF" >> $GITHUB_ENV
                   npm run lint-fix
+            - name: Find potential duplicate PRs for this entry
+                id: find-duplicates
+                run: |
+                    cd ./privacy-configuration/
+                    # Get the list of open PRs
+                    OPEN_PRS=$(gh pr list --state open --json number,title,body,createdAt,updatedAt,headRefName --jq '.[] | select(.title | contains("Remove stale exemptions from malicious site protection")) | .headRefName')
+                    # Check if the body of the PR contains the same template as the current one
+                    for pr in $OPEN_PRS; do
+                        # Get the body of the PR
+                        PR_BODY=$(gh pr view $pr --json body --jq '.body')
+                        # Check if the body contains the same template
+                        if [[ "$PR_BODY" == *"$TEMPLATE"* ]]; then
+                            echo "Duplicate PR found: $pr"
+                            echo "duplicate_pr=$pr" >> $GITHUB_ENV
+                            exit 0
+                        fi
+                    done
+                    echo "No duplicate PR found."
+            - name: Check for duplicate PR
+                if: steps.find-duplicates.outputs.duplicate_pr == ''
+                run: |
+                    echo "No duplicate PR found. Proceeding to create a new PR."
+                else:
+                    echo "Duplicate PR found. Exiting with success."
+                    exit 0
             - name: Create PR with updated configs
               uses: peter-evans/create-pull-request@88bf0de51c7487d91e1abbb4899332e602c58bbf
               id: create-pr

--- a/scripts/filter-malicious.js
+++ b/scripts/filter-malicious.js
@@ -6,7 +6,7 @@ const _ = require('lodash'); // Add this import
 
 // Rate limit fetch to 30 requests per second using a promise queue
 // https://thoughtspile.github.io/2018/07/07/rate-limit-promises/
-const resolveAfter = (ms) => new Promise((ok) => setTimeout(ok, ms));
+const resolveAfter = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
 function rateLimit1(fn, msPerOp) {
     let wait = Promise.resolve();


### PR DESCRIPTION
**Asana Task/Github Issue:**

## Description
<!-- 
  Please delete either or both process sections below.
-->
When domains are ready to be removed from our exceptions lists for malicious site protection we use this GitHub workflow to auto-create the removal PRs. Two bugs are fixed here:
1. To prevent duplication of PRs every night that the script runs, we generate a PR ID for the branch name which is a partial hash of the sorted domains. Now if the workflow runs again and the same domains are removed as an existing branch/PR it will fail to create the branch.
2. Our API client was getting blocked by the WAF for not respecting rate limits and not having a valid user agent set. We add a valid user agent that allows the traffic to be treated the same as our browsers, and ensure the rate limit is respected now using a promise queue.

Example generated PR: https://github.com/duckduckgo/privacy-configuration/pull/3140
Validation that multiple runs don't cause duplicate PRs anymore: https://github.com/duckduckgo/privacy-configuration/actions/runs/14977318428

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.
