### PR TITLE
Re-enable DownloadManager and enable `alwaysAskWheretoSaveFiles`

### DIFF
--- a/features/download-manager.json
+++ b/features/download-manager.json
@@ -7,5 +7,10 @@
         }
     },
     "state": "disabled",
-    "exceptions": []
+    "exceptions": [],
+    "features": {
+        "alwaysAskWhereToSaveFiles": {
+            "state": "disabled"
+        }
+    }
 }

--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -618,8 +618,14 @@
             "state": "enabled"
         },
         "downloadManager": {
-            "state": "disabled",
-            "minSupportedVersion": "0.111.0"
+            "state": "enabled",
+            "minSupportedVersion": "0.111.0",
+            "features": {
+                "alwaysAskWhereToSaveFiles": {
+                    "state": "enabled",
+                    "minSupportedVersion": "0.112.0"
+                }
+            }
         },
         "quickNavTldLookup": {
             "state": "enabled",


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/72649045549333/task/1210095850963933?focus=true

## Description
* DownloadManager was temporarily disabled to address some localization issues. This commit re-enables the download manager in the current preview release (0.111.0)
* A new "alwaysAskWhereToSaveFiles` sub-feature has been added for release in the next preview (0.112.0)

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [x] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.
