### PR TITLE
Windows: Disable Duck Player in v0.109.6 and older

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -158,7 +158,7 @@
         },
         "duckPlayer": {
             "state": "enabled",
-            "minSupportedVersion": "0.109.7"
+            "minSupportedVersion": "0.109.7",
             "features": {
                 "pip": {
                     "state": "enabled"

--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -158,6 +158,7 @@
         },
         "duckPlayer": {
             "state": "enabled",
+            "minSupportedVersion": "0.109.7"
             "features": {
                 "pip": {
                     "state": "enabled"


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1201048563534612/task/1210193580444984?focus=true

## Description
Disables Duck Player in Windows Browser v0.109.6 and older.
Since `duckPlayerDisabledHelpPageLink` is still set, the contingency message will be displayed in the Settings for versions with disabled Duck Player.
