### PR TITLE
[Windows] Add windowsReleaseNotesFromCDN feature

### DIFF
--- a/features/release-notes.json
+++ b/features/release-notes.json
@@ -1,0 +1,7 @@
+{
+    "_meta": {
+        "description": "Release notes functionality in our browsers"
+    },
+    "state": "enabled",
+    "exceptions": []
+}

--- a/features/windows-release-notes-from-cdn.json
+++ b/features/windows-release-notes-from-cdn.json
@@ -1,6 +1,0 @@
-{
-    "_meta": {
-        "description": "Enables downloading of release notes from CDN in Windows Browser"
-    },
-    "exceptions": []
-}

--- a/features/windows-release-notes-from-cdn.json
+++ b/features/windows-release-notes-from-cdn.json
@@ -1,0 +1,6 @@
+{
+    "_meta": {
+        "description": "Enables downloading of release notes from CDN in Windows Browser"
+    },
+    "exceptions": []
+}

--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -636,6 +636,9 @@
         "quickNavTldLookup": {
             "state": "enabled",
             "minSupportedVersion": "0.111.0"
+        },
+        "windowsReleaseNotesFromCDN": {
+            "state": "disabled"
         }
     },
     "unprotectedTemporary": []

--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -638,7 +638,8 @@
             "minSupportedVersion": "0.111.0"
         },
         "windowsReleaseNotesFromCDN": {
-            "state": "disabled"
+            "state": "disabled",
+            "exceptions": []
         }
     },
     "unprotectedTemporary": []

--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -637,9 +637,13 @@
             "state": "enabled",
             "minSupportedVersion": "0.111.0"
         },
-        "windowsReleaseNotesFromCDN": {
-            "state": "disabled",
-            "exceptions": []
+        "releaseNotes": {
+            "state": "enabled",
+            "features": {
+                "windowsReleaseNotesFromCDN": {
+                    "state": "disabled"
+                }
+            }
         }
     },
     "unprotectedTemporary": []

--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -640,7 +640,7 @@
         "releaseNotes": {
             "state": "enabled",
             "features": {
-                "windowsReleaseNotesFromCDN": {
+                "releaseNotesFromCDN": {
                     "state": "disabled"
                 }
             }


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/72649045549333/task/1203858942586367?focus=true

## Description
Add a new `windowsReleaseNotesFromCDN` feature that controls if release notes are downloaded from CDN. The current state is disabled, there will be another PR that enables it when we're ready.

<!-- 
  Please delete either or both process sections below.
-->

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210239308907247