### PR TITLE
Mitigate map suggestion breakage on Android

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -1142,9 +1142,14 @@
                     "yandex.ru": {
                         "rules": [
                             {
-                                "rule": "api-maps.yandex.ru/services/startup/v1",
-                                "domains": ["m.dzen.ru"],
-                                "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1627"
+                                "rule": "api-maps.yandex.ru",
+                                "domains": ["m.dzen.ru", "5ka.ru"],
+                                "reason": "https://github.com/duckduckgo/privacy-configuration/pull/3153"
+                            },
+                            {
+                                "rule": "suggest-maps.yandex.ru",
+                                "domains": ["5ka.ru"],
+                                "reason": "https://github.com/duckduckgo/privacy-configuration/pull/3153"
                             }
                         ]
                     }


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1206670747178362/task/1210222736614017?focus=true

## Description
### Site breakage mitigation process:
#### Brief explanation
- Reported URL: 5ka.ru
- Problems experienced: map/locale suggestions don't auto-populate
- Platforms affected:
  - [ ] iOS
  - [x] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked: `api-maps.yandex.ru` + `suggest-maps.yandex.ru`
