### PR TITLE
Move browserMultiStepImport to a Dedicated Import Feature

### DIFF
--- a/features/import.json
+++ b/features/import.json
@@ -1,0 +1,19 @@
+{
+    "_meta": {
+        "description": "Controls import functionality and browser data import features"
+    },
+    "state": "enabled",
+    "features": {
+        "browserMultiStepImport": {
+            "state": "enabled",
+            "settings": {
+                "chrome": "enabled",
+                "brave": "disabled",
+                "edge": "disabled",
+                "vivaldi": "disabled"
+            }
+        }
+    },
+    "settings": {},
+    "exceptions": []
+}

--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -361,7 +361,7 @@
             "state": "enabled",
             "minSupportedVersion": "0.88.3"
         },
-        "import" : {
+        "import": {
             "state": "enabled",
             "features": {
                 "browserMultiStepImport": {

--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -197,15 +197,6 @@
                             }
                         ]
                     }
-                },
-                "browserMultiStepImport": {
-                    "state": "enabled",
-                    "settings": {
-                        "chrome": "enabled",
-                        "brave": "disabled",
-                        "edge": "disabled",
-                        "vivaldi": "disabled"
-                    }
                 }
             }
         },
@@ -369,6 +360,20 @@
         "fingerprintingBattery": {
             "state": "enabled",
             "minSupportedVersion": "0.88.3"
+        },
+        "import" : {
+            "state": "enabled",
+            "features": {
+                "browserMultiStepImport": {
+                    "state": "enabled",
+                    "settings": {
+                        "chrome": "enabled",
+                        "brave": "disabled",
+                        "edge": "disabled",
+                        "vivaldi": "disabled"
+                    }
+                }
+            }
         },
         "referrer": {
             "state": "enabled",

--- a/schema/config.ts
+++ b/schema/config.ts
@@ -5,6 +5,7 @@ import { TrackerAllowlistFeature } from './features/tracker-allowlist';
 import { WebCompatFeature } from './features/webcompat';
 import { DuckPlayerFeature } from './features/duckplayer';
 import { AutofillFeature } from './features/autofill';
+import { ImportFeature } from './features/import';
 import { MessageBridgeFeature } from './features/message-bridge';
 import { AndroidBrowserConfig } from './features/android-browser-config';
 import { APIModificationFeature } from './features/api-modification';
@@ -34,6 +35,7 @@ export type ConfigV4<VersionType> = {
         apiModification?: APIModificationFeature<VersionType>;
         autoconsent: AutoconsentFeature<VersionType>;
         autofill: AutofillFeature<VersionType>;
+        import: ImportFeature<VersionType>;
         cookie: CookieFeature<VersionType>;
         duckPlayer: DuckPlayerFeature<VersionType>;
         trackerAllowlist: TrackerAllowlistFeature<VersionType>;

--- a/schema/features/import.ts
+++ b/schema/features/import.ts
@@ -1,9 +1,7 @@
 import { Feature, SubFeature } from '../feature';
 
-// Type of the feature `settings` object
-type SettingsType = undefined;
+type SettingsType = Record<string, never>;
 
-// Any subfeatures that have typed `settings` should be defined here.
 type SubFeatures<VersionType> = {
     browserMultiStepImport?: SubFeature<
         VersionType,

--- a/schema/features/import.ts
+++ b/schema/features/import.ts
@@ -1,0 +1,23 @@
+import { Feature, SubFeature } from '../feature';
+
+// Type of the feature `settings` object
+type SettingsType = undefined;
+
+// Any subfeatures that have typed `settings` should be defined here.
+type SubFeatures<VersionType> = {
+    browserMultiStepImport?: SubFeature<
+        VersionType,
+        {
+            chrome: 'enabled' | 'disabled';
+            brave: 'enabled' | 'disabled';
+            edge: 'enabled' | 'disabled';
+            vivaldi: 'enabled' | 'disabled';
+        }
+    >;
+};
+
+export type ImportFeature<VersionType> = Feature<
+    SettingsType,
+    VersionType,
+    SubFeatures<VersionType> & Record<string, SubFeature<VersionType>>
+>;


### PR DESCRIPTION
**Asana Task/Github Issue:** [Implement Individual Feature Flags](https://app.asana.com/1/137249556945/task/1210169807341854?focus=true)

## Description
Move browserMultiStepImport to a Dedicated Import Feature

This PR moves the browserMultiStepImport functionality from being a subfeature of autofill to its own top-level feature called "import". This change:

- Creates a new dedicated "import" feature to better organize import-related functionality
- Moves browserMultiStepImport settings from autofill to this new feature
- Adds proper type definitions and schema support for the new feature
- Maintains the same configuration settings and functionality

This refactoring improves the organization of our feature configuration, allowing import-related features to be managed independently from autofill, which will make it easier to add more import capabilities in the future.

### Feature change process:

- [x] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [x] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [x] This feature was covered by a tech design.
