### PR TITLE
Add empty apple platform config features for failsafe toggles

### DIFF
--- a/features/ios-browser-config.json
+++ b/features/ios-browser-config.json
@@ -1,0 +1,7 @@
+{
+    "_meta": {
+        "description": "Parent flag for different features related to iOS browsing functionality.",
+        "sampleExcludeRecords": {}
+    },
+    "exceptions": []
+}

--- a/features/macos-browser-config.json
+++ b/features/macos-browser-config.json
@@ -1,0 +1,7 @@
+{
+    "_meta": {
+        "description": "Parent flag for different features related to macOS browsing functionality.",
+        "sampleExcludeRecords": {}
+    },
+    "exceptions": []
+}

--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -1089,8 +1089,7 @@
             }
         },
         "iOSBrowserConfig": {
-            "state": "enabled",
-            "exceptions": []
+            "state": "enabled"
         }
     },
     "unprotectedTemporary": []

--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -1087,6 +1087,9 @@
                     ]
                 }
             }
+        },
+        "iOSBrowserConfig": {
+            "state": "enabled"
         }
     },
     "unprotectedTemporary": []

--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -1089,7 +1089,8 @@
             }
         },
         "iOSBrowserConfig": {
-            "state": "enabled"
+            "state": "enabled",
+            "exceptions": []
         }
     },
     "unprotectedTemporary": []

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -1153,7 +1153,8 @@
             "state": "internal"
         },
         "macOSBrowserConfig": {
-            "state": "enabled"
+            "state": "enabled",
+            "exceptions": []
         }
     },
     "unprotectedTemporary": []

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -1151,6 +1151,9 @@
         },
         "delayedWebviewPresentation": {
             "state": "internal"
+        },
+        "macOSBrowserConfig": {
+            "state": "enabled"
         }
     },
     "unprotectedTemporary": []

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -1153,8 +1153,7 @@
             "state": "internal"
         },
         "macOSBrowserConfig": {
-            "state": "enabled",
-            "exceptions": []
+            "state": "enabled"
         }
     },
     "unprotectedTemporary": []


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/414235014887631/task/1210248783002400?focus=true

## Description

As discussed in [✓ Technical Design: Default values for native app feature flags](https://app.asana.com/1/137249556945/project/481882893211075/task/1209523442095784?focus=true), for all feature flags with a default local value of enabled  (AKA Failsafe feature flags) that don't belong in any other top-level feature of the [Privacy Remote Configuration](https://app.asana.com/1/137249556945/project/1200890834746050/list/1205111542165435), we should define them as children of respective macOSBrowserConfig or iOSBrowserConfig to avoid needing to add a new top-level feature every time we want to disable a feature of this kind.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [x] iOS
  - [ ] Android
  - [ ] Windows
  - [x] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.
