### PR TITLE
Disable sense of protection experiments

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -2182,7 +2182,7 @@
             "exceptions": [],
             "features": {
                 "senseOfProtectionNewUserExperimentApr25": {
-                    "state": "enabled",
+                    "state": "disabled",
                     "targets": [
                         {
                             "isReturningUser": false
@@ -2204,7 +2204,7 @@
                     ]
                 },
                 "senseOfProtectionExistingUserExperimentApr25": {
-                    "state": "enabled",
+                    "state": "disabled",
                     "cohorts": [
                         {
                             "name": "modifiedControl",

--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -2191,15 +2191,15 @@
                     "cohorts": [
                         {
                             "name": "modifiedControl",
-                            "weight": 1
+                            "weight": 0
                         },
                         {
                             "name": "variant1",
-                            "weight": 1
+                            "weight": 0
                         },
                         {
                             "name": "variant2",
-                            "weight": 1
+                            "weight": 0
                         }
                     ]
                 },


### PR DESCRIPTION
We're going to add a new experiments so turning this off for now

**Asana Task/Github Issue:**

## Description

Disables sense of protection experiments as we're going to be using new ones soon.
<!-- 
  Please delete either or both process sections below.
-->

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.
