### PR TITLE
Add new Sense of Protection experiments

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -2177,11 +2177,10 @@
         },
         "tabSwitcherAnimation": {
             "state": "enabled",
-            "minSupportedVersion": 52320000
+            "minSupportedVersion": 52340000
         },
         "senseOfProtection": {
             "state": "enabled",
-            "minSupportedVersion": 52320000,
             "exceptions": [],
             "features": {
                 "senseOfProtectionNewUserExperimentApr25": {
@@ -2208,6 +2207,54 @@
                 },
                 "senseOfProtectionExistingUserExperimentApr25": {
                     "state": "disabled",
+                    "cohorts": [
+                        {
+                            "name": "modifiedControl",
+                            "weight": 0
+                        },
+                        {
+                            "name": "variant1",
+                            "weight": 0
+                        },
+                        {
+                            "name": "variant2",
+                            "weight": 0
+                        }
+                    ]
+                },
+                "senseOfProtectionNewUserExperimentMay25": {
+                    "state": "disabled",
+                    "minSupportedVersion": 52340000,
+                    "targets": [
+                        {
+                            "isReturningUser": false
+                        }
+                    ],
+                    "cohorts": [
+                        {
+                            "name": "modifiedControl",
+                            "weight": 0
+                        },
+                        {
+                            "name": "variant1",
+                            "weight": 0
+                        },
+                        {
+                            "name": "variant2",
+                            "weight": 0
+                        }
+                    ]
+                },
+                "senseOfProtectionExistingUserExperimentMay25": {
+                    "state": "disabled",
+                    "minSupportedVersion": 52340000,
+                    "rollout": {
+                        "steps": [
+                            {
+                                "percent": 5
+                            }
+                        ]
+                    },
                     "cohorts": [
                         {
                             "name": "modifiedControl",


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1207908166761516/task/1210235542874003

## Description

Adds new sense of protection experiments in anticipation of turning on for the next android release, ` 5.2334.0`. The experiments are not enabled and will be turned on at a later date.

Removed `minSupportedVersion` on `senseOfProtection` as it has no effect.

<!-- 
  Please delete either or both process sections below.
-->

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.
