### PR TITLE
Unbreak product videos on interdiscount.ch + bosch-diy.com, and expand translations exception to all sites

### DIFF
--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -2295,6 +2295,15 @@
                     }
                 ]
             },
+            "mycliplister.com": {
+                "rules": [
+                    {
+                        "rule": "mycliplister.com",
+                        "domains": ["bosch-diy.com", "interdiscount.ch"],
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/pull/3176"
+                    }
+                ]
+            },
             "myfonts.net": {
                 "rules": [
                     {
@@ -3324,8 +3333,8 @@
                 "rules": [
                     {
                         "rule": "j.wovn.io/1",
-                        "domains": ["tamashiiweb.com"],
-                        "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1574"
+                        "domains": ["<all>"],
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/pull/3176"
                     }
                 ]
             },

--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -2299,7 +2299,7 @@
                 "rules": [
                     {
                         "rule": "mycliplister.com",
-                        "domains": ["bosch-diy.com", "interdiscount.ch"],
+                        "domains": ["<all>"],
                         "reason": "https://github.com/duckduckgo/privacy-configuration/pull/3176"
                     }
                 ]


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1206670747178362/task/1210263717816781?focus=true
https://app.asana.com/1/137249556945/project/1206670747178362/task/1210263819527122?focus=true
https://app.asana.com/1/137249556945/project/1206670747178362/task/1210264154914641?focus=true
https://app.asana.com/1/137249556945/project/1206670747178362/task/1210264271547734?focus=true

### Site breakage mitigation process:
#### Brief explanation
- Reported URL: https://www.interdiscount.ch/de/product/bissell-spotclean-pro-750-w-ohne-beutel-0001434269, https://www.bosch-diy.com/de/de/p/advancedcut-18-06033b1300-v, https://jp.marugame.com/menu/tempura/, https://www.keikyu-bus.co.jp/en/airport/h-tokyo/

- Problems experienced: product videos won't load / translations don't work
- Platforms affected:
  - [x] All
- Tracker(s) being unblocked: `mycliplister.com` + `j.wovn.io/1` (expanded to `<all>` from previous Issue #1574)
