### PR TITLE
Enable partialFormSaves in windows-override.json

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -113,7 +113,7 @@
                     "minSupportedVersion": "0.98.0"
                 },
                 "partialFormSaves": {
-                    "state": "disabled"
+                    "state": "enabled"
                 },
                 "siteSpecificFixes": {
                     "state": "enabled",


### PR DESCRIPTION
**Asana Task/Github Issue:**

## Description
We temporarily disabled this feature flag while awaiting a fix rollout in WindowsBrowser. The fix has now fully rolled out, and we can safely re-enable the flag.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [x] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.
