### PR TITLE
Bump downloadManager minSupportedVersion to 0.112

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -707,7 +707,7 @@
         },
         "downloadManager": {
             "state": "enabled",
-            "minSupportedVersion": "0.111.0",
+            "minSupportedVersion": "0.112.0",
             "features": {
                 "alwaysAskWhereToSaveFiles": {
                     "state": "enabled",


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/1200695233846578/task/1210252184838636?focus=true

## Description
* Bumps minSupportedVersion for DownloadManager to v0.112

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.