### PR TITLE
Tab swiping: Re-enable the tab swiping feature

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -2033,21 +2033,18 @@
             }
         },
         "swipingTabs": {
-            "state": "internal",
-            "minSupportedVersion": 52320000,
+            "state": "enabled",
+            "minSupportedVersion": 52340000,
             "features": {
                 "enabledForUsers": {
                     "state": "enabled",
                     "rollout": {
                         "steps": [
                             {
-                                "percent": 20
+                                "percent": 5
                             }
                         ]
                     }
-                },
-                "saveStateToDataStore": {
-                    "state": "enabled"
                 }
             }
         },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1207418217763355/task/1210271604455966?focus=true

## Description

This PR re-enables the tab swiping feature to 5% of prod users. The min. version is set to 5.324.0, when the latest crash fix was fixed.

`saveStateToDataStore` was removed as it's not needed anymore.
