### PR TITLE
Default DuckPlayer Native to “Disabled"

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -106,7 +106,7 @@
                     }
                 },
                 "nativeUI": {
-                    "state": "internal"
+                    "state": "disabled"
                 }
             },
             "settings": {


### PR DESCRIPTION
**Asana Task/Github Issue:**

## Description
Changes DuckPlayer `nativeUI` override to 'disabled' by default in preparation for upcoming release
