### PR TITLE
Remove additional params for intlannouncement origin

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -39,7 +39,7 @@
             "state": "enabled",
             "exceptions": [],
             "settings": {
-                "origins": ["funnel_newtab_android_intlannouncement"]
+                "origins": []
             },
             "minSupportedVersion": 52100000
         },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/task/1209945776683478?focus=true

## Description

Removes `intlannouncement` origin from additional pixel parameters

#### Reference

-   [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
-   [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
-   [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)