### PR TITLE
Element hiding: remove cyclingtips.com, address empty spaces on outsideonline.com

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -1127,15 +1127,6 @@
                 ]
             },
             {
-                "domain": "cyclingtips.com",
-                "rules": [
-                    {
-                        "selector": "[data-block-name='ads']",
-                        "type": "closest-empty"
-                    }
-                ]
-            },
-            {
                 "domain": "dailyboulder.com",
                 "rules": [
                     {

--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -2631,6 +2631,25 @@
                 ]
             },
             {
+                "domain": "outsideonline.com",
+                "rules": [
+                    {
+                        "selector": ".o-ad",
+                        "type": "hide-empty"
+                    },
+                    {
+                        "selector": ".l-main",
+                        "type": "modify-style",
+                        "values": [
+                            {
+                                "property": "margin-top",
+                                "value": "0vh"
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
                 "domain": "paypal.com",
                 "rules": [
                     {


### PR DESCRIPTION
Site now redirects to https://velo.outsideonline.com/ which has it's own banners but they're using CSS margins rather than elements.

**Asana Task/Github Issue:**

## Description
<!-- 
  Please delete either or both process sections below.
-->

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.
