### PR TITLE
Remove sundancecatalog unprotected-temporary.json

### DIFF
--- a/features/unprotected-temporary.json
+++ b/features/unprotected-temporary.json
@@ -12,10 +12,6 @@
             "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1194"
         },
         {
-            "domain": "sundancecatalog.com",
-            "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1420"
-        },
-        {
             "domain": "noaprints.com",
             "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2143"
         },


### PR DESCRIPTION
Domain redirects to sundanceliving.com

**Asana Task/Github Issue:**

## Description
Domain redirects to sundanceliving.com

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.
