### PR TITLE
Enable remote broker delivery for macOS 1.140.0

### DIFF
--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -174,8 +174,8 @@
                     "minSupportedVersion": "1.114.0"
                 },
                 "remoteBrokerDelivery": {
-                    "state": "internal",
-                    "minSupportedVersion": "1.139.0"
+                    "state": "enabled",
+                    "minSupportedVersion": "1.140.0"
                 }
             },
             "minSupportedVersion": "1.70.0"


### PR DESCRIPTION
**Asana Task/Github Issue:**

https://app.asana.com/1/137249556945/project/72649045549333/task/1205508328452434?focus=true

## Description
<!-- 
  Please delete either or both process sections below.
—>

Changes the `remoteBrokerDelivery` flag from internal to prod.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.
