### PR TITLE
Disable autoconsent on inspirationaladventures.com

### DIFF
--- a/features/autoconsent.json
+++ b/features/autoconsent.json
@@ -578,6 +578,10 @@
         {
             "domain": "sofiebadet.dk",
             "reason": "https://github.com/duckduckgo/privacy-configuration/pull/3145"
+        },
+        {
+            "domain": "inspirationaladventures.com",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/pull/3202"
         }
     ],
     "settings": {


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1206670747178362/task/1210319809559239?focus=true

## Description
Site is blurred for a few seconds due to the active rule failing to opt-out. CMP is 'termsfeed' which fails because this popup version doesn't have a top-level reject all button.