### PR TITLE
Relax feature file requirement

### DIFF
--- a/compatibility.js
+++ b/compatibility.js
@@ -90,6 +90,7 @@ export const compatFunctions = {
 
         // Replace reasons
         for (const key of Object.keys(unmodifiedConfig.features)) {
+            v3Config.features[key].exceptions = v3Config.features[key].exceptions || [];
             assignReasons(v3Config.features[key].exceptions, unmodifiedConfig?.features[key]?.exceptions);
 
             if (key === 'trackerAllowlist') {

--- a/util.js
+++ b/util.js
@@ -175,6 +175,9 @@ export function addHashToFeatures(config) {
  */
 export function stripReasons(config) {
     for (const key of Object.keys(config.features)) {
+        if (!config.features[key].exceptions) {
+            continue;
+        }
         for (const exception of config.features[key].exceptions) {
             delete exception.reason;
         }


### PR DESCRIPTION
**Asana Task/Github Issue:**

## Description

Relax the creation of feature files if they're not used in more than one platform. The intention here is to migrate feature files into being schemas eventually and also soon to remove features being defined on all platforms too (see: https://github.com/duckduckgo/privacy-configuration/pull/2940 - but holding out for a new config version just to remove them instead).

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.
