### PR TITLE
Disable element-hiding on airlive.net

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -10,6 +10,10 @@
         {
             "domain": "duckduckgo.com",
             "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1236"
+        },
+        {
+            "domain": "airlive.net",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/issues/3208"
         }
     ],
     "settings": {


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1206670747178362/task/1210277365867272?focus=true

## Description
Element hiding is triggering an adblock wall here.
