### PR TITLE
Android: disable Default Browser Prompts experiment

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -2144,11 +2144,11 @@
             }
         },
         "defaultBrowserPrompts": {
-            "state": "enabled",
+            "state": "disabled",
             "exceptions": [],
             "features": {
                 "defaultBrowserAdditionalPrompts202501": {
-                    "state": "enabled",
+                    "state": "disabled",
                     "minSupportedVersion": 52282000,
                     "settings": {
                         "activeDaysUntilStage1": "1",


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/task/1209375952679517?focus=true

## Description
<!-- 
  Please delete either or both process sections below.
-->
Disabled the Default Browser Prompts experiment on Android.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.
