### PR TITLE
Mitigate adblock wall on sfchronicle.com

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -3873,7 +3873,7 @@
                         "selector": "[class*='belowMastheadWrapper']",
                         "type": "hide-empty"
                     }
-              ]
+                ]
             }
         ]
     }

--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -3858,6 +3858,22 @@
                         "type": "hide-empty"
                     }
                 ]
+            },
+            {
+                "domain": "sfchronicle.com",
+                "rules": [
+                    {
+                        "type": "disable-default"
+                    },
+                    {
+                        "selector": "[data-block-type='ad']",
+                        "type": "hide-empty"
+                    },
+                    {
+                        "selector": "[class*='belowMastheadWrapper']",
+                        "type": "hide-empty"
+                    }
+              ]
             }
         ]
     }


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1206670747178362/task/1210349029781417?focus=true

## Description
The default element-hiding rules trigger an adblock wall here. We can mitigate this by disabling them and just enabling specific rules.