### PR TITLE
David/enable visual designs for internal

### DIFF
--- a/features/experimental-ui-theming.json
+++ b/features/experimental-ui-theming.json
@@ -1,0 +1,7 @@
+{
+    "_meta": {
+        "description": "A feature flag that determines if the visual design experiments should be enabled.",
+        "sampleExcludeRecords": {}
+    },
+    "exceptions": []
+}

--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -2278,13 +2278,13 @@
         }
     },
     "experimentalUITheming": {
-      "state": "internal",
-      "exceptions": [],
-      "features": {
-        "visualUpdatesFeature": {
-          "state": "internal"
+        "state": "internal",
+        "exceptions": [],
+        "features": {
+            "visualUpdatesFeature": {
+                "state": "internal"
+            }
         }
-      }
     },
     "unprotectedTemporary": [],
     "experimentalVariants": {

--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -2277,6 +2277,15 @@
             }
         }
     },
+    "experimentalUITheming": {
+      "state": "internal",
+      "exceptions": [],
+      "features": {
+        "visualUpdatesFeature": {
+          "state": "internal"
+        }
+      }
+    },
     "unprotectedTemporary": [],
     "experimentalVariants": {
         "variants": [


### PR DESCRIPTION
**Asana Task/Github Issue:**https://app.asana.com/1/137249556945/task/1210364308838769

## Description
Enable the Visual Design on Android for internal users

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.