### PR TITLE
add feature flag for app bound decryption on windows

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -375,6 +375,15 @@
                         "edge": "disabled",
                         "vivaldi": "disabled"
                     }
+                },
+                "chromiumAppBoundDecryption": {
+                    "state": "disabled",
+                    "settings": {
+                        "chrome": "disabled",
+                        "brave": "disabled",
+                        "edge": "disabled",
+                        "vivaldi": "disabled"
+                    }
                 }
             }
         },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/72649045549333/task/1210225650558161?focus=true

## Description
<!-- 
  Please delete either or both process sections below.
-->

Feature flag to control whether app bound decryption can be used or not on Windows.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [x] This feature was covered by a tech design.