### PR TITLE
Enable Auth API V2 for Preview users on Windows

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -600,7 +600,7 @@
                 }
             },
             "settings": {
-                "authApiV2NonStableRollout": false
+                "authApiV2NonStableRollout": true
             }
         },
         "webCompat": {


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1205044477659400/task/1210339285939344?focus=true

## Description
Enable rollout of Auth API V2 to non-stable builds - Canary and Preview users on Windows.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [x] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [x] This feature was covered by a tech design.

