### PR TITLE
Disable Sense of Protection Existing Users May - Enable Visual Design for Internal

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -2250,7 +2250,7 @@
                     ]
                 },
                 "senseOfProtectionExistingUserExperimentMay25": {
-                    "state": "enabled",
+                    "state": "disabled",
                     "minSupportedVersion": 52342000,
                     "rollout": {
                         "steps": [
@@ -2262,27 +2262,27 @@
                     "cohorts": [
                         {
                             "name": "modifiedControl",
-                            "weight": 1
+                            "weight": 0
                         },
                         {
                             "name": "variant1",
-                            "weight": 1
+                            "weight": 0
                         },
                         {
                             "name": "variant2",
-                            "weight": 1
+                            "weight": 0
                         }
                     ]
                 }
             }
-        }
-    },
-    "experimentalUITheming": {
-        "state": "internal",
-        "exceptions": [],
-        "features": {
-            "visualUpdatesFeature": {
-                "state": "internal"
+        },
+        "experimentalUITheming": {
+            "state": "internal",
+            "exceptions": [],
+            "features": {
+                "visualUpdatesFeature": {
+                    "state": "internal"
+                }
             }
         }
     },


### PR DESCRIPTION
**Asana Task/Github Issue:**https://app.asana.com/1/137249556945/project/1174433894299346/task/1210378253868121?focus=true

## Description

- Disable Sense of Protection Experiment because it doesn’t respect rollout
- Move Experimental UI inside the Feature object
