### PR TITLE
Enable windowsWebviewFailures.crashAutoRecovery since 0.114.0

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -655,7 +655,8 @@
                     "state": "enabled"
                 },
                 "crashAutoRecovery": {
-                    "state": "disabled"
+                    "state": "enabled",
+                    "minSupportedVersion": "0.114.0"
                 }
             }
         },


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/1201048563534612/task/1209828379009709?focus=true

## Description
Enable `windowsWebviewFailures.crashAutoRecovery` subfeature since version 0.114.0.

<!-- 
  Please delete either or both process sections below.
-->

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.