### PR TITLE
SBT-add-mirror-cpm-exception

### DIFF
--- a/features/autoconsent.json
+++ b/features/autoconsent.json
@@ -586,6 +586,10 @@
         {
             "domain": "servus.com",
             "reason": "https://github.com/duckduckgo/privacy-configuration/pull/3206"
+        },
+        {
+            "domain": "mirror.co.uk",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/pull/3227"
         }
     ],
     "settings": {


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1206670747178362/task/1210378331303934?focus=true

## Description

### Site breakage mitigation process:
#### Brief explanation
- Reported URL: mirror.co.uk
- Problems experienced: site has now a paywall cookie banner and requires a cpm exception to ease site browsing and access
- Platforms affected:
  - [ x] iOS
  - [ ] Android
  - [ x] Windows
  - [x ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked: NA
- Feature being disabled/modified: CPM
- [ ] This change is a speculative mitigation to fix reported breakage.
