### PR TITLE
SBT-filmstarts-add-CPM-exception

### DIFF
--- a/features/autoconsent.json
+++ b/features/autoconsent.json
@@ -590,6 +590,10 @@
         {
             "domain": "mirror.co.uk",
             "reason": "https://github.com/duckduckgo/privacy-configuration/pull/3227"
+        },
+        {
+            "domain": "filmstarts.de",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/pull/3232"
         }
     ],
     "settings": {


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1206670747178362/task/1210365774215625?focus=true

## Description

### Site breakage mitigation process:
#### Brief explanation
- Reported URL: https://www.filmstarts.de/kritiken/270936/trailer/20618953.html
- Problems experienced: trailer video don't load, require to accept all cookies and thus to display the cookie banner; tested scenario on vanilla browsers
- Platforms affected:
  - [ x] iOS
  - [ ] Android
  - [x ] Windows
  - [ x] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked: NA
- Feature being disabled/modified: CPM
- [ ] This change is a speculative mitigation to fix reported breakage.
