### PR TITLE
Removed min version and the settings block

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -239,7 +239,6 @@
         },
         "duckPlayer": {
             "state": "enabled",
-            "minSupportedVersion": "0.109.7",
             "features": {
                 "pip": {
                     "state": "enabled"
@@ -262,85 +261,6 @@
                 "nativeUI": {
                     "state": "disabled"
                 }
-            },
-            "settings": {
-                "tryDuckPlayerLink": "https://www.youtube.com/watch?v=yKWIA-Pys4c",
-                "duckPlayerDisabledHelpPageLink": "https://duckduckgo.com/duckduckgo-help-pages/duck-player",
-                "youtubePath": "watch",
-                "youtubeEmbedUrl": "youtube-nocookie.com",
-                "youTubeUrl": "youtube.com",
-                "youTubeReferrerHeaders": ["Referer"],
-                "youTubeReferrerQueryParams": ["embeds_referring_euri"],
-                "youTubeVideoIDQueryParam": "v",
-                "overlays": {
-                    "youtube": {
-                        "state": "disabled",
-                        "selectors": {
-                            "thumbLink": "a[href^='/watch']",
-                            "excludedRegions": ["#playlist", "ytd-movie-renderer", "ytd-grid-movie-renderer"],
-                            "videoElement": "#player video",
-                            "videoElementContainer": "#player .html5-video-player",
-                            "hoverExcluded": [],
-                            "clickExcluded": ["ytd-thumbnail-overlay-toggle-button-renderer"],
-                            "allowedEventTargets": [
-                                ".ytp-inline-preview-scrim",
-                                ".ytd-video-preview",
-                                "#thumbnail-container",
-                                "#video-title-link",
-                                "#video-title",
-                                "video.video-stream.html5-main-video"
-                            ],
-                            "drawerContainer": "body"
-                        },
-                        "thumbnailOverlays": {
-                            "state": "enabled"
-                        },
-                        "clickInterception": {
-                            "state": "enabled"
-                        },
-                        "videoOverlays": {
-                            "state": "enabled"
-                        },
-                        "videoDrawer": {
-                            "state": "disabled"
-                        }
-                    },
-                    "serpProxy": {
-                        "state": "disabled"
-                    }
-                },
-                "domains": [
-                    {
-                        "domain": "www.youtube.com",
-                        "patchSettings": [
-                            {
-                                "op": "replace",
-                                "path": "/overlays/youtube/state",
-                                "value": "enabled"
-                            }
-                        ]
-                    },
-                    {
-                        "domain": "duckduckgo.com",
-                        "patchSettings": [
-                            {
-                                "op": "replace",
-                                "path": "/overlays/serpProxy/state",
-                                "value": "enabled"
-                            }
-                        ]
-                    },
-                    {
-                        "domain": "m.youtube.com",
-                        "patchSettings": [
-                            {
-                                "op": "replace",
-                                "path": "/overlays/youtube/state",
-                                "value": "enabled"
-                            }
-                        ]
-                    }
-                ]
             }
         },
         "elementHiding": {


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/task/1210252766883264?focus=true

## Description
Disabling DuckPlayer contingency mode for Windows versions older than 0.109.x.0. This involves:
- removing `minVersion...` from the windows config override
- reverting this [commit ](https://github.com/duckduckgo/privacy-configuration/commit/a376212134c39dee53d64bde513b7576a3528a42). During the incident I had to copy the settings session from the `duck-player.json` in order to modify the `duckPlayerDisabledHelpPageLink`. However, now that it's no longer needed, there is no need to keep the copied `settings` block so removed it. 
 
### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.
