### PR TITLE
Enable [Android Experiment] Re-activate users by prompting after absence

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -2222,6 +2222,42 @@
                 }
             }
         },
+        "reactivateUsers": {
+            "state": "enabled",
+            "exceptions": [],
+            "features": {
+                "reactivateUsersExperimentMay25": {
+                    "state": "enabled",
+                    "minSupportedVersion": 52360000,
+                    "targets": [
+                        {
+                            "localeLanguage": "en"
+                        }
+                    ],
+                    "rollout": {
+                        "steps": [
+                            {
+                                "percent": 5
+                            }
+                        ]
+                    },
+                    "cohorts": [
+                        {
+                            "name": "control",
+                            "weight": 1
+                        },
+                        {
+                            "name": "duckplayer_prompt",
+                            "weight": 1
+                        },
+                        {
+                            "name": "browser_prompt",
+                            "weight": 1
+                        }
+                    ]
+                }
+            }
+        },
         "experimentalUITheming": {
             "state": "internal",
             "exceptions": [],


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/72649045549333/task/1210386893025132?focus=true

## Description
<!-- 
  Please delete either or both process sections below.
-->
Enabled `reactivateUsers` and `reactivateUsersExperimentMay25` - 5%.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.
