### PR TITLE
Android: Preserve IndexedDB entries for duckduckgo.com + fireproofed sites

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -663,7 +663,7 @@
                     "state": "enabled"
                 },
                 "indexedDB": {
-                    "state": "internal",
+                    "state": "enabled",
                     "settings": {
                         "domains": ["duckduckgo.com"]
                     }

--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -662,6 +662,12 @@
                 "fireproofedWebLocalStorage": {
                     "state": "enabled"
                 },
+                "indexedDB": {
+                    "state": "internal",
+                    "settings": {
+                        "domains": ["duckduckgo.com"]
+                    }
+                },
                 "enableMaliciousSiteProtection": {
                     "state": "enabled",
                     "minSupportedVersion": 52301000

--- a/schema/features/android-browser-config.ts
+++ b/schema/features/android-browser-config.ts
@@ -26,7 +26,7 @@ type SubFeatures<VersionType> = {
             versions: AppVersionConfig[];
         }
     >;
-    // This subfeature allowlists web local storage when the fire button is pressed
+    // This subfeature allowlists web local storage when the fire button is pressed.
     webLocalStorage?: SubFeature<
         VersionType,
         {
@@ -34,6 +34,14 @@ type SubFeatures<VersionType> = {
             domains: string[];
             // Patterns to be matched in the WebView's LevelDB
             matchingRegex: string[];
+        }
+    >;
+    // This subfeature allowlists IndexedDB entries when the fire button is pressed.
+    indexedDB?: SubFeature<
+        VersionType,
+        {
+            // Domains to be allowlisted
+            domains: string[];
         }
     >;
     // This sets the omnibar's change bounds duration, tension and icon fade duration.


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1202552961248957/task/1210392634102859

## Description
Preserves IndexedDB entries for duckduckgo.com and fireproofed sites.

### Feature change process:

- [x] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [x] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [x] This feature was covered by a tech design.
