### PR TITLE
Enabled message bridge feature on windows from 0.115.0 onwards

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -323,7 +323,7 @@
         "messageBridge": {
             "exceptions": [],
             "settings": {
-                "aiChat": "enabled",
+                "aiChat": "disabled",
                 "domains": [
                     {
                         "domain": "duckduckgo.com",

--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -338,7 +338,7 @@
                 ]
             },
             "state": "enabled",
-			"minSupportedVersion": "0.115.0"
+            "minSupportedVersion": "0.115.0"
         },
         "referrer": {
             "state": "enabled",

--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -320,6 +320,26 @@
                 }
             }
         },
+        "messageBridge": {
+            "exceptions": [],
+            "settings": {
+                "aiChat": "enabled",
+                "domains": [
+                    {
+                        "domain": "duckduckgo.com",
+                        "patchSettings": [
+                            {
+                                "op": "replace",
+                                "path": "/aiChat",
+                                "value": "enabled"
+                            }
+                        ]
+                    }
+                ]
+            },
+            "state": "enabled",
+			"minSupportedVersion": "0.115.0",
+        },
         "referrer": {
             "state": "enabled",
             "minSupportedVersion": "0.93.0"

--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -338,7 +338,7 @@
                 ]
             },
             "state": "enabled",
-			"minSupportedVersion": "0.115.0",
+			"minSupportedVersion": "0.115.0"
         },
         "referrer": {
             "state": "enabled",


### PR DESCRIPTION
https://app.asana.com/1/137249556945/project/72649045549333/task/1209556560924114?

## Description
This PR enables the `Message Bridge` feature for windows. The first (and currently only) feature that uses this will be released in v0.115.0.

### Feature change process:

- [x] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [x] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [x] This feature was covered by a tech design.

