### PR TITLE
Hide blank space on gardenersworld.com

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -984,7 +984,7 @@
                         "type": "hide-empty"
                     },
                     {
-                        "selector": ".bioxContainer",
+                        "selector": ".bigBoxContainer",
                         "type": "hide-empty"
                     },
                     {
@@ -1626,7 +1626,7 @@
                 ]
             },
             {
-                "domain": "gaminible.com",
+                "domain": "gamingbible.com",
                 "rules": [
                     {
                         "selector": "[class*='Advert']",


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/1200277586140538/task/1210407556412359?focus=true

## Description
Hide blank space on gardenersworld.com

### Site breakage mitigation process:
#### Brief explanation
- Reported URL: https://www.gardenersworld.com/how-to/maintain-the-garden/small-garden-design-ideas/
- Problems experienced: Blank space because of hidden ad.
- Platforms affected:
  - [X] iOS
  - [X] Android
  - [X] Windows
  - [X] MacOS
  - [X] Extensions
- Tracker(s) being unblocked: None
- Feature being disabled/modified: None
- [ ] This change is a speculative mitigation to fix reported breakage.
