### PR TITLE
Allow CDN-hosted jQuery on qwen.ai

### DIFF
--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -290,6 +290,11 @@
                             "qwenlm.ai - https://github.com/duckduckgo/privacy-configuration/pull/2700",
                             "qwen.ai - https://github.com/duckduckgo/privacy-configuration/pull/2809"
                         ]
+                    },
+                    {
+                        "rule": "o.alicdn.com/frontend-lib/common-lib/jquery.min.js",
+                        "domains": ["chat.qwen.ai"],
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/pull/3243"
                     }
                 ]
             },


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/1206670747178362/task/1210192885114810?focus=true

## Description
Fixing a "The current content is empty, please regenerate.” error message.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL: https://chat.qwen.ai/
- Problems experienced: Getting an error when trying to send prompts.
- Platforms affected:
  - [X] iOS
  - [X] Android
  - [X] Windows
  - [X] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked: CDN-hosted jQuery
- Feature being disabled/modified: None
- [ ] This change is a speculative mitigation to fix reported breakage.
