### PR TITLE
[macOS] Add new configuration for the scheduled SAD/ATT prompts

### DIFF
--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -277,14 +277,14 @@
         },
         "setAsDefaultAndAddToDock": {
             "state": "enabled",
+            "settings": {
+                "firstPopoverDelayDays": 14,
+                "bannerAfterPopoverDelayDays": 14,
+                "bannerRepeatIntervalDays": 14
+            },
             "features": {
                 "scheduledDefaultBrowserAndDockPrompts": {
-                    "state": "enabled",
-                    "settings": {
-                        "firstPopoverDelayDays": 14,
-                        "bannerAfterPopoverDelayDays": 14,
-                        "bannerRepeatIntervalDays": 14
-                    }
+                    "state": "enabled"
                 }
             }
         },

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -302,7 +302,8 @@
                     ]
                 },
                 "scheduledDefaultBrowserAndDockPrompts": {
-                    "state": "enabled"
+                    "state": "enabled",
+                    "minSupportedVersion": "1.143.0"
                 }
             }
         },

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -277,24 +277,14 @@
         },
         "setAsDefaultAndAddToDock": {
             "state": "enabled",
-            "minSupportedVersion": "1.130.0",
             "features": {
-                "popoverVsBannerExperiment": {
-                    "state": "disabled",
-                    "cohorts": [
-                        {
-                            "name": "control",
-                            "weight": 1
-                        },
-                        {
-                            "name": "popover",
-                            "weight": 1
-                        },
-                        {
-                            "name": "banner",
-                            "weight": 1
-                        }
-                    ]
+                "scheduledDefaultBrowserAndDockPrompts": {
+                    "state": "enabled",
+                    "settings": {
+                        "firstPopoverDelayDays": 14,
+                        "bannerAfterPopoverDelayDays": 14,
+                        "bannerRepeatIntervalDays": 14
+                    }
                 }
             }
         },

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -277,12 +277,30 @@
         },
         "setAsDefaultAndAddToDock": {
             "state": "enabled",
+            "minSupportedVersion": "1.130.0",
             "settings": {
                 "firstPopoverDelayDays": 14,
                 "bannerAfterPopoverDelayDays": 14,
                 "bannerRepeatIntervalDays": 14
             },
             "features": {
+                "popoverVsBannerExperiment": {
+                    "state": "disabled",
+                    "cohorts": [
+                        {
+                            "name": "control",
+                            "weight": 1
+                        },
+                        {
+                            "name": "popover",
+                            "weight": 1
+                        },
+                        {
+                            "name": "banner",
+                            "weight": 1
+                        }
+                    ]
+                },
                 "scheduledDefaultBrowserAndDockPrompts": {
                     "state": "enabled"
                 }


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1206329551987282/task/1210257533397816

## Description
Add a new subfeature for the scheduled SAD/ATT prompts for macOS

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [x] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.
