### PR TITLE
SBT-add-tracker-exception-for-form-display

### DIFF
--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -3008,6 +3008,15 @@
                     }
                 ]
             },
+            "salesforce-sites.com": {
+                "rules": [
+                    {
+                        "rule": "salesforce-sites.com/forms",
+                        "domains": ["greenworkstools.com"],
+                        "reason": ["greenworkstools.com - https://github.com/duckduckgo/privacy-configuration/pull/3247"]
+                    }
+                ]
+            },
             "sascdn.com": {
                 "rules": [
                     {


### PR DESCRIPTION
**Asana Task/Github Issue:**https://app.asana.com/1/137249556945/project/1206670747178362/task/1210386117845221?focus=true

## Description

### Site breakage mitigation process:
#### Brief explanation
- Reported URL: https://www.greenworkstools.com/pages/product-registration
- Problems experienced: The form doesn't display because trackers are being blocked.
- Platforms affected:
  - [ x] iOS
  - [ x] Android
  - [ x] Windows
  - [ x] MacOS
  - [x ] Extensions
- Tracker(s) being unblocked: salesforce-sites.com/forms
- Feature being disabled/modified: NA
- [ ] This change is a speculative mitigation to fix reported breakage.
