### PR TITLE
Update videoElementContainer on Duck Player Native

### DIFF
--- a/features/duck-player-native.json
+++ b/features/duck-player-native.json
@@ -7,13 +7,12 @@
     "exceptions": [],
     "settings": {
         "selectors": {
-            "adShowing": ".html5-video-player.ad-showing",
             "errorContainer": "body",
-            "playerControlsContainer": "#player-control-container",
             "signInRequiredError": "[href*=\"//support.google.com/youtube/answer/3037019\"]",
             "videoElement": "#player video, video",
             "videoElementContainer": "#player .html5-video-player",
-            "youtubeError": ".ytp-error"
+            "youtubeError": ".ytp-error",
+            "adShowing": ".html5-video-player.ad-showing"
         },
         "domains": []
     }

--- a/features/duck-player-native.json
+++ b/features/duck-player-native.json
@@ -7,12 +7,12 @@
     "exceptions": [],
     "settings": {
         "selectors": {
+            "adShowing": ".html5-video-player.ad-showing",
             "errorContainer": "body",
             "signInRequiredError": "[href*=\"//support.google.com/youtube/answer/3037019\"]",
             "videoElement": "#player video, video",
-            "videoElementContainer": "#player .html5-video-player",
-            "youtubeError": ".ytp-error",
-            "adShowing": ".html5-video-player.ad-showing"
+            "videoElementContainer": "#player-container-id",
+            "youtubeError": ".ytp-error"
         },
         "domains": []
     }

--- a/features/duck-player-native.json
+++ b/features/duck-player-native.json
@@ -7,12 +7,13 @@
     "exceptions": [],
     "settings": {
         "selectors": {
+            "adShowing": ".html5-video-player.ad-showing",
             "errorContainer": "body",
+            "playerControlsContainer": "#player-control-container",
             "signInRequiredError": "[href*=\"//support.google.com/youtube/answer/3037019\"]",
             "videoElement": "#player video, video",
             "videoElementContainer": "#player .html5-video-player",
-            "youtubeError": ".ytp-error",
-            "adShowing": ".html5-video-player.ad-showing"
+            "youtubeError": ".ytp-error"
         },
         "domains": []
     }

--- a/schema/features/duckplayer-native.ts
+++ b/schema/features/duckplayer-native.ts
@@ -2,13 +2,12 @@ import { Feature, CSSInjectFeatureSettings } from '../feature';
 
 export type DuckPlayerNativeSettings = CSSInjectFeatureSettings<{
     selectors: {
-        adShowing: string;
         errorContainer: string;
-        playerControlsContainer: string;
         signInRequiredError: string;
         videoElement: string;
         videoElementContainer: string;
         youtubeError: string;
+        adShowing: string;
     };
 }>;
 

--- a/schema/features/duckplayer-native.ts
+++ b/schema/features/duckplayer-native.ts
@@ -2,12 +2,13 @@ import { Feature, CSSInjectFeatureSettings } from '../feature';
 
 export type DuckPlayerNativeSettings = CSSInjectFeatureSettings<{
     selectors: {
+        adShowing: string;
         errorContainer: string;
+        playerControlsContainer: string;
         signInRequiredError: string;
         videoElement: string;
         videoElementContainer: string;
         youtubeError: string;
-        adShowing: string;
     };
 }>;
 


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1207252092703676/task/1210278123329112?focus=true

## Description

- Sets default videoElementContainer for Duck Player Native to be one level higher. Part of the fix to the pausing bug in the task above
- Changes were tested locally on iOS. Since this part of the feature hasn't shipped yet, there's little risk in releasing this change.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.
