### PR TITLE
Remove mitigations for breakage due to (now disabled) Easylist

### DIFF
--- a/features/autoconsent.json
+++ b/features/autoconsent.json
@@ -356,38 +356,6 @@
             "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2661"
         },
         {
-            "domain": "vital-parts.co.uk",
-            "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2671"
-        },
-        {
-            "domain": "lta.org.uk",
-            "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2671"
-        },
-        {
-            "domain": "hobbyhall.fi",
-            "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2671"
-        },
-        {
-            "domain": "wienmobil.at",
-            "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2671"
-        },
-        {
-            "domain": "memsoft.fr",
-            "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2671"
-        },
-        {
-            "domain": "bafin.de",
-            "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2671"
-        },
-        {
-            "domain": "levi.pt",
-            "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2671"
-        },
-        {
-            "domain": "premiumegeszsegpenztar.hu",
-            "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2678"
-        },
-        {
             "domain": "mapquest.com",
             "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2679"
         },


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/task/1209197447337645?focus=true 
https://app.asana.com/1/137249556945/task/1209169165570691?focus=true 
https://app.asana.com/1/137249556945/task/1209211989362128?focus=true 
https://app.asana.com/1/137249556945/task/1209227491929061?focus=true 
https://app.asana.com/1/137249556945/task/1209212037717130?focus=true

## Description
Removes mitigations added in https://github.com/duckduckgo/privacy-configuration/pull/2671 and https://github.com/duckduckgo/privacy-configuration/pull/2678. The breakage being mitigated was caused by Easylist which has since been removed.

I tested using privacy-protections-debugger on macOS by visiting each site URL and confirming that a cookie popup banner is shown and that the site is not broken.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [x] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.
