### PR TITLE
Styles to hid gap at top of cricbuzz.com on mobile

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -1135,11 +1135,22 @@
                 "domain": "cricbuzz.com",
                 "rules": [
                     {
-                        "selector": "#loaderCon",
+                        "selector": "#main-header.top-12",
                         "type": "modify-style",
                         "values": [
                             {
-                                "opacity": "1"
+                                "property": "top",
+                                "value": "0rem"
+                            }
+                        ]
+                    },
+                    {
+                        "selector": "#main-nav.top-24",
+                        "type": "modify-style",
+                        "values": [
+                            {
+                                "property": "top",
+                                "value": "3rem"
                             }
                         ]
                     }


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/1206670747178362/task/1210436283075504?focus=true

## Description
Styles to hid gap at top of cricbuzz.com on mobile.
Also removed an unused selector.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL: https://m.cricbuzz.com/live-cricket-scorecard/105820/eng-vs-wi-2nd-odi-west-indies-tour-of-england-2025
- Problems experienced: A transparent gap was above the top header.
- Platforms affected:
  - [X] iOS
  - [X] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked: N/A
- Feature being disabled/modified: N/A
- [ ] This change is a speculative mitigation to fix reported breakage.
