### PR TITLE
Exception to enable video on time.com

### DIFF
--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -1212,6 +1212,15 @@
                     }
                 ]
             },
+            "doubleverify.com": {
+                "rules": [
+                    {
+                        "rule": "pub.doubleverify.com/dvtag/",
+                        "domains": ["time.com"],
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/pull/3271"
+                    }
+                ]
+            },
             "driftt.com": {
                 "rules": [
                     {


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/1206670747178362/task/1210457836963010?focus=true

## Description
Allowing pub.doubleverify.com so that embedded videos will play.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL: https://time.com/7277608/demis-hassabis-interview-time100-2025/
- Problems experienced: The video was not playable – just an endless spinner.
- Platforms affected:
  - [X] iOS
  - [X] Android
  - [X] Windows
  - [X] MacOS
  - [X] Extensions
- Tracker(s) being unblocked: pub.doubleverify.com
- Feature being disabled/modified: N/A
- [ ] This change is a speculative mitigation to fix reported breakage.
