### PR TITLE
Add disabled feature flag for autofill | autofillPopupReuse

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -98,6 +98,9 @@
         "autofill": {
             "state": "enabled",
             "features": {
+                "autofillPopupReuse": {
+                    "state": "disabled"
+                },
                 "deduplicateLoginsOnImport": {
                     "state": "enabled"
                 },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/task/1210460664610406?focus=true

## Description
Added a new feature flag `autofillPopupReuse` to control autofill popup reuse on Windows. The minimum supported version will be set once the flag is enabled.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [X] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.
