### PR TITLE
Exception for youngliving.com

### DIFF
--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -348,6 +348,11 @@
             "amplitude.com": {
                 "rules": [
                     {
+                        "rule": "cdn.amplitude.com/script/",
+                        "domains": ["youngliving.com"],
+                        "reason": ["https://github.com/duckduckgo/privacy-configuration/pull/3276"]
+                    },
+                    {
                         "rule": "flag.lab.eu.amplitude.com/sdk/",
                         "domains": ["bluelightcard.co.uk"],
                         "reason": ["https://github.com/duckduckgo/privacy-configuration/pull/2779"]


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/1206670747178362/task/1210461468672910?focus=true

## Description
Need to make an exception for a CDN to enable page display.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL: https://www.youngliving.com/us/en
- Problems experienced: Page not displaying.
- Platforms affected:
  - [X] iOS
  - [X] Android
  - [X] Windows
  - [X] MacOS
  - [X] Extensions
- Tracker(s) being unblocked: cdn.amplitude.com
- Feature being disabled/modified: N/A
- [ ] This change is a speculative mitigation to fix reported breakage.
