### PR TITLE
Exception for Ikea to allow store lookup

### DIFF
--- a/features/autoconsent.json
+++ b/features/autoconsent.json
@@ -566,6 +566,10 @@
         {
             "domain": "ævognmand.dk",
             "reason": "https://github.com/duckduckgo/privacy-configuration/pull/3250"
+        },
+        {
+            "domain": "ikea.com",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/pull/3277"
         }
     ],
     "settings": {


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/1206670747178362/task/1210460591653956?focus=true

## Description
Disable cookie popup management (CPM) to enable the availability and store check feature.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL: https://www.ikea.com/us/en/p/torald-desk-white-90493955/
- Problems experienced: Cookie popup management (CPM) blocks the “Check availability” feature and makes the “In store” button unclickable.
- Platforms affected:
  - [X] iOS
  - [X] Android
  - [X] Windows
  - [X] MacOS
  - [X] Extensions
- Tracker(s) being unblocked: N/A
- Feature being disabled/modified: Cookie Popup Management (CPM)
- [ ] This change is a speculative mitigation to fix reported breakage.
