### PR TITLE
Simplify naming and add chromium as provider as well

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -308,13 +308,14 @@
                         "vivaldi": "disabled"
                     }
                 },
-                "chromiumAppBoundDecryption": {
+                "appBoundDecryption": {
                     "state": "disabled",
                     "settings": {
                         "chrome": "disabled",
                         "brave": "disabled",
                         "edge": "disabled",
-                        "vivaldi": "disabled"
+                        "vivaldi": "disabled",
+                        "chromium": "disabled"
                     }
                 }
             }


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/task/1210080795227920?focus=true

## Description
<!-- 
  Please delete either or both process sections below.
-->

Simplified the name of the chromiumAppBoundDecryption to appBoundDecryption to avoid confusion and treat Chromium as another browser provider.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.
