### PR TITLE
Added YouTube error selector to Duck Player custom error settings

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -799,7 +799,8 @@
                 "customError": {
                     "state": "enabled",
                     "settings": {
-                        "signInRequiredSelector": "[href*=\"//support.google.com/youtube/answer/3037019\"]"
+                        "signInRequiredSelector": "[href*=\"//support.google.com/youtube/answer/3037019\"]",
+                        "youtubeErrorSelector": ".ytp-error"
                     }
                 },
                 "nativeUI": {

--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -102,7 +102,8 @@
                     "state": "enabled",
                     "minSupportedVersion": "7.159.0",
                     "settings": {
-                        "signInRequiredSelector": "[href*=\"//support.google.com/youtube/answer/3037019\"]"
+                        "signInRequiredSelector": "[href*=\"//support.google.com/youtube/answer/3037019\"]",
+                        "youtubeErrorSelector": ".ytp-error"
                     }
                 },
                 "nativeUI": {

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -245,7 +245,8 @@
                     "state": "enabled",
                     "minSupportedVersion": "1.128.0",
                     "settings": {
-                        "signInRequiredSelector": "[href*=\"//support.google.com/youtube/answer/3037019\"]"
+                        "signInRequiredSelector": "[href*=\"//support.google.com/youtube/answer/3037019\"]",
+                        "youtubeErrorSelector": ".ytp-error"
                     }
                 },
                 "nativeUI": {

--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -257,7 +257,8 @@
                 "customError": {
                     "state": "enabled",
                     "settings": {
-                        "signInRequiredSelector": "[href*=\"//support.google.com/youtube/answer/3037019\"]"
+                        "signInRequiredSelector": "[href*=\"//support.google.com/youtube/answer/3037019\"]",
+                        "youtubeErrorSelector": ".ytp-error"
                     }
                 },
                 "nativeUI": {


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1203249713006009/task/1210483318529990?focus=true

## Description

- Added a new `youtubeErrorSelector` property to the custom error settings for Duck Player on all platforms. This will potentially allow a faster response in case YouTube changes how they render playback errors. 

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.
