### PR TITLE
Android: Re-enable tab swiping

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -2008,10 +2008,10 @@
         },
         "swipingTabs": {
             "state": "enabled",
-            "minSupportedVersion": 52340000,
+            "minSupportedVersion": 52380000,
             "features": {
                 "enabledForUsers": {
-                    "state": "disabled"
+                    "state": "enabled"
                 }
             }
         },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/72649045549333/task/1210496460794399?focus=true

## Description

This PR re-enables the tab swiping after addressing an issue with initial tab loading. The PR sets the min. version to `5.238.0`, which contains the fix.