### PR TITLE
Add shortHistoryMenu feature flag

### DIFF
--- a/features/short-history-menu.json
+++ b/features/short-history-menu.json
@@ -1,0 +1,8 @@
+{
+    "_meta": {
+        "description": "Controls the display of the daily history entries groupings in History Menu in desktop browsers.",
+        "sampleExcludeRecords": {}
+    },
+    "state": "disabled",
+    "exceptions": []
+}

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -26788,6 +26788,9 @@
                 }
             }
         },
+        "shortHistoryMenu": {
+            "state": "enabled"
+        },
         "incontextSignup": {
             "state": "enabled"
         },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1142021229838617/task/1210519540757012?focus=true

## Description
This change adds a new feature flag to control the display of the daily history entries groupings
in the History Menu in desktop browsers.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [x] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.
