### PR TITLE
Partially enable app bound decryption on Windows

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -309,13 +309,13 @@
                     }
                 },
                 "appBoundDecryption": {
-                    "state": "disabled",
+                    "state": "enabled",
                     "settings": {
-                        "chrome": "disabled",
-                        "brave": "disabled",
+                        "chrome": "enabled",
+                        "brave": "enabled",
                         "edge": "disabled",
                         "vivaldi": "disabled",
-                        "chromium": "disabled"
+                        "chromium": "enabled"
                     }
                 }
             }


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/72649045549333/task/1210483969190263?focus=true

## Description

Partially enables the app bound decryption on Windows.


### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [x] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [x] This feature was covered by a tech design.