### PR TITLE
Enable credit cards on Windows

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -124,6 +124,12 @@
                 "partialFormSaves": {
                     "state": "enabled"
                 },
+                "autofillCreditCards": {
+                    "state": "enabled"
+                },
+                "autofillCreditCardsOnByDefault": {
+                    "state": "enabled"
+                },
                 "siteSpecificFixes": {
                     "state": "enabled",
                     "settings": {


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1203709236521659/task/1206531758082926?focus=true

## Description
Enables the credit cards feature on Windows and sets the default setting for "Ask to save and autofill credit cards" to enabled. 
The feature is not yet released, so existing versions are not affected.
