### PR TITLE
Hiding empty elements on techrepublic.com

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -3193,6 +3193,23 @@
                 ]
             },
             {
+                "domain": "techrepublic.com",
+                "rules": [
+                    {
+                        "selector": "#nav-ad",
+                        "type": "hide-empty"
+                    },
+                    {
+                        "selector": "#leader-plus-top",
+                        "type": "hide-empty"
+                    },
+                    {
+                        "selector": "#sticky-bottom",
+                        "type": "hide-empty"
+                    }
+                ]
+            },
+            {
                 "domain": "techwalla.com",
                 "rules": [
                     {


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/1205996472045435/task/1210548795217255?focus=true

## Description
Hides empty elements on the page.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL: https://www.techrepublic.com/article/news-outages-google-cloud-openai-shopify-cloudflare/
- Problems experienced: Big blank spaces at the top and bottom of the page.
- Platforms affected: 
  - [X] iOS
  - [X] Android
  - [X] Windows
  - [X] MacOS
  - [X] Extensions
- Tracker(s) being unblocked: N/A
- Feature being disabled/modified: N/A
- [ ] This change is a speculative mitigation to fix reported breakage.
