### PR TITLE
Mitigate CPM breakage on telenor.no + delayrepaycompensation.com

### DIFF
--- a/features/autoconsent.json
+++ b/features/autoconsent.json
@@ -574,6 +574,14 @@
         {
             "domain": "ikea.com",
             "reason": "https://github.com/duckduckgo/privacy-configuration/pull/3277"
+        },
+        {
+            "domain": "delayrepaycompensation.com",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/pull/3306"
+        },
+        {
+            "domain": "telenor.no",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/pull/3306"
         }
     ],
     "settings": {


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1206670747178362/task/1210490412581558?focus=true
https://app.asana.com/1/137249556945/project/1206670747178362/task/1210490444269021?focus=true

## Description
### Site breakage mitigation process:
#### Brief explanation
- Reported URL: greateranglia.delayrepaycompensation.com/index.cfm + www.telenor.no/kundeservice/faktura/forklaring/
- Problems experienced: dark overlay remains after autoconsent runs
- Platforms affected:
  - [x] iOS
  - [x] Android
  - [x] Windows
  - [x] MacOS
  - [ ] Extensions
- Feature being disabled/modified: CPM
