### PR TITLE
Android: Enable privacyProFreeTrial for ROW

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -28113,13 +28113,7 @@
                     "state": "disabled"
                 },
                 "privacyProFreeTrial": {
-                    "state": "enabled",
-                    "targets": [
-                        {
-                            "localeCountry": "us",
-                            "isPrivacyProEligible": true
-                        }
-                    ]
+                    "state": "enabled"
                 },
                 "privacyProFreeTrialJan25": {
                     "state": "enabled",


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1201807753394693/task/1210550804595006?focus=true

## Description
Remove targets for privacyProFreeTrial sub-feature so it is enabled for ROW

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [x] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [x] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.
