### PR TITLE
Turn on feature flag for keep session

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -94,7 +94,7 @@
                     "minSupportedVersion": "7.155.0"
                 },
                 "keepSession": {
-                    "state": "internal",
+                    "state": "enabled",
                     "settings": {
                         "sessionTimeoutMinutes": 60
                     }


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/1201011656765697/task/1210487101950245?focus=true

## Description
Enable 60 min session for duck.ai on iOS

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [x] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [x] This feature was covered by a tech design.
