### PR TITLE
Remove inspirationaladventures.com mitigation

### DIFF
--- a/features/autoconsent.json
+++ b/features/autoconsent.json
@@ -580,10 +580,6 @@
             "reason": "https://github.com/duckduckgo/privacy-configuration/pull/3145"
         },
         {
-            "domain": "inspirationaladventures.com",
-            "reason": "https://github.com/duckduckgo/privacy-configuration/pull/3202"
-        },
-        {
             "domain": "servus.com",
             "reason": "https://github.com/duckduckgo/privacy-configuration/pull/3206"
         },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1209121419454298/task/1210331336303768?focus=true

## Description
Removes the mitigation added in https://github.com/duckduckgo/privacy-configuration/pull/3202. The mitigated issue was fixed in https://github.com/duckduckgo/autoconsent/pull/750.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [x] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.
