### PR TITLE
Enable syncSetupBarcodeIsUrlBased feature

### DIFF
--- a/features/sync.json
+++ b/features/sync.json
@@ -19,6 +19,9 @@
         },
         "exchangeKeysToSyncWithAnotherDevice": {
             "state": "enabled"
+        },
+        "syncSetupBarcodeIsUrlBased": {
+            "state": "enabled"
         }
     },
     "exceptions": []

--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -26897,6 +26897,9 @@
                 },
                 "exchangeKeysToSyncWithAnotherDevice": {
                     "state": "enabled"
+                },
+                "syncSetupBarcodeIsUrlBased": {
+                    "state": "enabled"
                 }
             }
         },

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -27049,6 +27049,9 @@
                 },
                 "exchangeKeysToSyncWithAnotherDevice": {
                     "state": "enabled"
+                },
+                "syncSetupBarcodeIsUrlBased": {
+                    "state": "enabled"
                 }
             }
         },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/72649045549333/task/1210401935213541?focus=true

## Description
Enables the `syncSetupBarcodeIsUrlBased ` feature flag on all platforms.
- This flag is used to gate whether the sync setup barcodes are URL-based or not. 
- More info: [Spec: Update sync setup barcodes to be URL-based (all platforms)](https://app.asana.com/1/137249556945/task/1209921184459921?focus=true)

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

