### PR TITLE
Add duck.co special-casing for internal testing

### DIFF
--- a/features/duck-player.json
+++ b/features/duck-player.json
@@ -83,7 +83,7 @@
                 ]
             },
             {
-                "domain": "duckduckgo.com",
+                "domain": ["duckduckgo.com", "duck.co"],
                 "patchSettings": [
                     {
                         "op": "replace",

--- a/features/duck-player.json
+++ b/features/duck-player.json
@@ -83,7 +83,10 @@
                 ]
             },
             {
-                "domain": ["duckduckgo.com", "duck.co"],
+                "domain": [
+                    "duckduckgo.com",
+                    "duck.co"
+                ],
                 "patchSettings": [
                     {
                         "op": "replace",

--- a/features/navigator-interface.json
+++ b/features/navigator-interface.json
@@ -11,6 +11,9 @@
         "privilegedDomains": [
             {
                 "domain": "duckduckgo.com"
+            },
+            {
+                "domain": "duck.co"
             }
         ]
     }

--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -27122,7 +27122,10 @@
                         ]
                     },
                     {
-                        "domain": ["duckduckgo.com", "duck.co"],
+                        "domain": [
+                            "duckduckgo.com",
+                            "duck.co"
+                        ],
                         "patchSettings": [
                             {
                                 "op": "replace",
@@ -27236,7 +27239,10 @@
                 "aiChat": "disabled",
                 "domains": [
                     {
-                        "domain": ["duckduckgo.com", "duck.co"],
+                        "domain": [
+                            "duckduckgo.com",
+                            "duck.co"
+                        ],
                         "patchSettings": [
                             {
                                 "op": "replace",

--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -26979,6 +26979,10 @@
                     {
                         "domain": "duck.it",
                         "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1959"
+                    },
+                    {
+                        "domain": "duck.co",
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1959"
                     }
                 ],
                 "ddgFixedUserAgent": {
@@ -27118,7 +27122,7 @@
                         ]
                     },
                     {
-                        "domain": "duckduckgo.com",
+                        "domain": ["duckduckgo.com", "duck.co"],
                         "patchSettings": [
                             {
                                 "op": "replace",
@@ -27232,7 +27236,7 @@
                 "aiChat": "disabled",
                 "domains": [
                     {
-                        "domain": "duckduckgo.com",
+                        "domain": ["duckduckgo.com", "duck.co"],
                         "patchSettings": [
                             {
                                 "op": "replace",

--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -67,7 +67,7 @@
                 "aiChat": "disabled",
                 "domains": [
                     {
-                        "domain": "duckduckgo.com",
+                        "domain": ["duckduckgo.com", "duck.co"],
                         "patchSettings": [
                             {
                                 "op": "replace",

--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -67,7 +67,10 @@
                 "aiChat": "disabled",
                 "domains": [
                     {
-                        "domain": ["duckduckgo.com", "duck.co"],
+                        "domain": [
+                            "duckduckgo.com",
+                            "duck.co"
+                        ],
                         "patchSettings": [
                             {
                                 "op": "replace",

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -134,7 +134,7 @@
                 "aiChat": "disabled",
                 "domains": [
                     {
-                        "domain": "duckduckgo.com",
+                        "domain": ["duckduckgo.com", "duck.co"],
                         "patchSettings": [
                             {
                                 "op": "replace",

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -134,7 +134,10 @@
                 "aiChat": "disabled",
                 "domains": [
                     {
-                        "domain": ["duckduckgo.com", "duck.co"],
+                        "domain": [
+                            "duckduckgo.com",
+                            "duck.co"
+                        ],
                         "patchSettings": [
                             {
                                 "op": "replace",

--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -332,7 +332,7 @@
                 "aiChat": "disabled",
                 "domains": [
                     {
-                        "domain": "duckduckgo.com",
+                        "domain": ["duckduckgo.com", "duck.co"],
                         "patchSettings": [
                             {
                                 "op": "replace",

--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -332,7 +332,10 @@
                 "aiChat": "disabled",
                 "domains": [
                     {
-                        "domain": ["duckduckgo.com", "duck.co"],
+                        "domain": [
+                            "duckduckgo.com",
+                            "duck.co"
+                        ],
                         "patchSettings": [
                             {
                                 "op": "replace",


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1201614831475344/task/1210571946743989?focus=true

## Description

Add special-casing to handle duck.co to be different for internal testing.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.
