### PR TITLE
SBT-Reuters-Hide-Blank-Space

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -2955,7 +2955,7 @@
                 "domain": "reuters.com",
                 "rules": [
                     {
-                        "selector": "[testid='ResponsiveAdSlot']",
+                        "selector": "[data-testid='ResponsiveAdSlot']",
                         "type": "hide-empty"
                     }
                 ]


### PR DESCRIPTION
**Asana Task/Github Issue:**

## Description


### Site breakage mitigation process:
#### Brief explanation
- Reported URL: https://www.reuters.com/business/healthcare-pharmaceuticals/pandemic-behind-largest-backslide-childhood-vaccination-generation-un-2022-07-15/
- Problems experienced: Few blank spaces
- Platforms affected:
  - [ x] iOS
  - [x ] Android
  - [x ] Windows
  - [x ] MacOS
  - [x ] Extensions
- Tracker(s) being unblocked: NA
- Feature being disabled/modified: Element-Hiding
- [ ] This change is a speculative mitigation to fix reported breakage.
