### PR TITLE
SBT-add-selector-tracker-exception-cookingclassy-com

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -1119,6 +1119,15 @@
                 ]
             },
             {
+                "domain": "cookingclassy.com",
+                "rules": [
+                    {
+                        "selector": ".adthrive",
+                        "type": "override"
+                    }
+                ]
+            },
+            {
                 "domain": "corriere.it",
                 "rules": [
                     {

--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -161,9 +161,13 @@
                         "domains": [
                             "gardeningknowhow.com",
                             "adamtheautomator.com",
-                            "packhacker.com"
+                            "packhacker.com",
+                            "cookingclassy.com"
                         ],
-                        "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1122"
+                        "reason": [
+                            "gardeningknowhow.com, adamtheautomator.com, packhacker.com - https://github.com/duckduckgo/privacy-configuration/issues/1122",
+                            "cookingclassy.com - https://github.com/duckduckgo/privacy-configuration/pull/3325 "
+                        ]
                     }
                 ]
             },


### PR DESCRIPTION
**Asana Task/Github Issue:**

## Description

### Site breakage mitigation process:
#### Brief explanation
- Reported URL: https://www.cookingclassy.com/white-chicken-chili/#jump-to-recipe
- Problems experienced: A combination of element hiding and tracker blocking is preventing the video player from displaying. On all platforms, the video takes time to load due to ads playing before the main content, but the video does eventually play.
- Platforms affected:
  - [x ] iOS
  - [x] Android
  - [x ] Windows
  - [x ] MacOS
  - [ x] Extensions
- Tracker(s) being unblocked: adthrive.com 
- Feature being disabled/modified: elementHiding
- [ ] This change is a speculative mitigation to fix reported breakage.
