### PR TITLE
Site Breakage: Blank space and adblock warning on sciencenews.org

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -2988,6 +2988,21 @@
                 ]
             },
             {
+                "domain": "sciencenews.org",
+                "rules": [
+                    {
+                        "selector": "[class*='ad-block']",
+                        "type": "modify-style",
+                        "values": [
+                            {
+                                "property": "display",
+                                "value": "none"
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
                 "domain": "scmp.com",
                 "rules": [
                     {

--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -2992,13 +2992,7 @@
                 "rules": [
                     {
                         "selector": "[class*='ad-block']",
-                        "type": "modify-style",
-                        "values": [
-                            {
-                                "property": "display",
-                                "value": "none"
-                            }
-                        ]
+                        "type": "hide-empty"
                     }
                 ]
             },

--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -2893,6 +2893,7 @@
                         "domains": [
                             "boingboing.net",
                             "signupgenius.com",
+                            "sciencenews.org",
                             "smithsonianmag.com",
                             "stockcharts.com",
                             "titantv.com",
@@ -2903,6 +2904,7 @@
                             "newrepublic.com - https://github.com/duckduckgo/privacy-configuration/pull/2807",
                             "boingboing.net - https://github.com/duckduckgo/privacy-configuration/pull/2574",
                             "signupgenius.com - https://github.com/duckduckgo/privacy-configuration/pull/2234",
+                            "sciencenews.org - https://github.com/duckduckgo/privacy-configuration/pull/3326",
                             "smithsonianmag.com - https://github.com/duckduckgo/privacy-configuration/pull/2346",
                             "stockcharts.com - https://github.com/duckduckgo/privacy-configuration/pull/2478",
                             "titantv.com - https://github.com/duckduckgo/privacy-configuration/issues/1925",


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/246491496396031/task/1210583742367444

## Description

### Site breakage mitigation process:
#### Brief explanation
- Reported URL: https://www.sciencenews.org/article/scopes-trial-anniversary-science-attack
- Problems experienced: Large blank space at the top banner
- Platforms affected:
  - [ x] iOS
  - [x ] Android
  - [ x] Windows
  - [x ] MacOS
  - [x ] Extensions
- Tracker(s) being unblocked: NA
- Feature being disabled/modified: ElementHiding
- [ ] This change is a speculative mitigation to fix reported breakage.
