### PR TITLE
Android: Re-enable tab swiping

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -28277,11 +28277,11 @@
             }
         },
         "swipingTabs": {
-            "state": "disabled",
-            "minSupportedVersion": 52380000,
+            "state": "enabled",
+            "minSupportedVersion": 52390000,
             "features": {
                 "enabledForUsers": {
-                    "state": "disabled"
+                    "state": "enabled"
                 }
             }
         },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1207418217763355/task/1210580640372907?focus=true

## Description

This PR re-enables the tab swiping after the 2 issues related to the feature were fixed, which will be rolled out with version 5.239.0 (min. version for this feature flag).
