### PR TITLE
[iOS][Onboarding] Setup an experiment to show a PiP video tutorial when setting the default browser

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -27405,6 +27405,19 @@
                             "weight": 1
                         }
                     ]
+                },
+                "setAsDefaultBrowserPiPVideoExperiment": {
+                  "state": "enabled",
+                  "cohorts": [
+                    {
+                      "name": "control",
+                      "weight": 1
+                    },
+                    {
+                      "name": "treatment",
+                      "weight": 1
+                    }
+                  ]
                 }
             }
         },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/task/1210454186090902?focus=true

## Description

Setup an experiment to show a PiP video tutorial during the onboarding when the user chooses to change browser.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [x] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.
