### PR TITLE
Rename fire animation flag

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -699,7 +699,7 @@
                 "useExtensionBasedBurn": {
                     "state": "enabled"
                 },
-                "fireAnimationSettingVisibility": {
+                "burnAnimationSettingVisibility": {
                     "state": "disabled"
                 }
             }


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1210369001783739/task/1210568779796494

## Description

Rename fire animation flag since we don't use "fire" name for the animation anywhere. Use more generic "burn" instead.