### PR TITLE
Include theater mode in video element queries

### DIFF
--- a/features/duck-player-native.json
+++ b/features/duck-player-native.json
@@ -10,8 +10,8 @@
             "adShowing": ".html5-video-player.ad-showing",
             "errorContainer": "body",
             "signInRequiredError": "[href*=\"//support.google.com/youtube/answer/3037019\"]",
-            "videoElement": "#player video, video",
-            "videoElementContainer": "#player-container-id",
+            "videoElement": "[full-bleed-player] #player-full-bleed-container video, #player video, video",
+            "videoElementContainer": "#player-container-id, [full-bleed-player] #player-full-bleed-container .html5-video-player, #player .html5-video-player",
             "youtubeError": ".ytp-error"
         },
         "domains": []

--- a/features/duck-player.json
+++ b/features/duck-player.json
@@ -40,8 +40,8 @@
                         "ytd-movie-renderer",
                         "ytd-grid-movie-renderer"
                     ],
-                    "videoElement": "#player video",
-                    "videoElementContainer": "#player .html5-video-player",
+                    "videoElement": "[full-bleed-player] #player-full-bleed-container video, #player video",
+                    "videoElementContainer": "[full-bleed-player] #player-full-bleed-container .html5-video-player, #player .html5-video-player",
                     "hoverExcluded": [],
                     "clickExcluded": ["ytd-thumbnail-overlay-toggle-button-renderer"],
                     "allowedEventTargets": [

--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -842,8 +842,8 @@
                                 "ytd-movie-renderer",
                                 "ytd-grid-movie-renderer"
                             ],
-                            "videoElement": "#player video",
-                            "videoElementContainer": "#player .html5-video-player",
+                            "videoElement": "[full-bleed-player] #player-full-bleed-container video, #player video",
+                            "videoElementContainer": "[full-bleed-player] #player-full-bleed-container .html5-video-player, #player .html5-video-player",
                             "hoverExcluded": [],
                             "clickExcluded": ["ytd-thumbnail-overlay-toggle-button-renderer"],
                             "allowedEventTargets": [

--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -183,8 +183,8 @@
                                 "ytd-movie-renderer",
                                 "ytd-grid-movie-renderer"
                             ],
-                            "videoElement": "#player video",
-                            "videoElementContainer": "#player .html5-video-player",
+                            "videoElement": "[full-bleed-player] #player-full-bleed-container video, #player video",
+                            "videoElementContainer": "[full-bleed-player] #player-full-bleed-container .html5-video-player, #player .html5-video-player",
                             "hoverExcluded": [],
                             "clickExcluded": ["ytd-thumbnail-overlay-toggle-button-renderer"],
                             "allowedEventTargets": [


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1207252092703676/task/1207272414708529?focus=true

## Description

**Testing instructions in the [task description here](https://app.asana.com/1/137249556945/project/1207252092703676/task/1207272414708529?focus=true).** This test can be done on a production version of the DDG app.

- **Why this change?**

    YouTube keeps two playback containers in the DOM at all times: `#player-full-bleed-container` for theater mode, and the standard `#player`. When switching to theater mode, YouTube moves the video element into that container and plays from there.

    By adding these selectors, we allow the Duck Player overlay to target the correct player in each mode. 

- **Why change both `videoElement` and `videoElementContainer`?**

    The first is used for video playback control, the second for inserting the overlay. When in theater mode, we need to make sure both targets are children of `#player-full-bleed-container`, otherwise the overlay may be placed in `#player` and obscured by the full bleed video.

- **Why place `#player-full-bleed-container` ahead of `#player`?**

    In theater mode, the `#player` div is still present, just not used for video playback. By targetting `#player-full-bleed-container` first, we ensure that the overlay will be inserted in the correct container. We also ensure that `#player-full-bleed-container` is not going to be targeted in standard mode by adding the `[full-bleed-player]` selector.

- **Why not target a parent of both (e.g. `#content`) so that we can keep the selector to one predicate?**

    That could lead to the elements in `#player `being selected before the ones `#player-full-bleed-container` in theater mode, which is exactly what we're trying to fix. 
 

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.
