### PR TITLE
Broaden crunchyroll.com exception to all platforms, narrow permitted requests

### DIFF
--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -9,6 +9,19 @@
     "state": "enabled",
     "settings": {
         "allowlistedTrackers": {
+            "2mdn.net": {
+                "rules": [
+                    {
+                        "rule": "gcdn.2mdn.net/videoplayback/id/",
+                        "domains": ["crunchyroll.com"],
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/pull/3334"
+                    {
+                        "rule": "s0.2mdn.net/instream/video/client.js",
+                        "domains": ["crunchyroll.com"],
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/pull/3334"
+                    }
+                ]
+            },
             "3lift.com": {
                 "rules": [
                     {

--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -15,6 +15,7 @@
                         "rule": "gcdn.2mdn.net/videoplayback/id/",
                         "domains": ["crunchyroll.com"],
                         "reason": "https://github.com/duckduckgo/privacy-configuration/pull/3334"
+                    },
                     {
                         "rule": "s0.2mdn.net/instream/video/client.js",
                         "domains": ["crunchyroll.com"],

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -27086,15 +27086,6 @@
         "trackerAllowlist": {
             "settings": {
                 "allowlistedTrackers": {
-                    "2mdn.net": {
-                        "rules": [
-                            {
-                                "rule": "2mdn.net",
-                                "domains": ["crunchyroll.com"],
-                                "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1888"
-                            }
-                        ]
-                    },
                     "appboycdn.com": {
                         "rules": [
                             {


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1206670747178362/task/1210568873649925?focus=true

### Site breakage mitigation process:
#### Brief explanation
- Reported URL: crunchyroll.com
- Problems experienced: video playback blocked, "Oops! Something went wrong." message
- Root cause: tracker blocking
- Platforms affected:
  - [ ] iOS
  - [x] Android
  - [x] Windows
  - [x] MacOS
  - [x] Extensions
- Tracker(s) being unblocked: `gcdn.2mdn.net/videoplayback/id/`, `s0.2mdn.net/instream/video/client.js`
