### PR TITLE
SBT-add-UA-exception-to-play-videos

### DIFF
--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -780,6 +780,10 @@
                     {
                         "domain": "routenote.com",
                         "reason": "https://github.com/duckduckgo/privacy-configuration/pull/3055"
+                    },
+                    {
+                        "domain": "sfr.fr",
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/pull/3338"
                     }
                 ],
                 "webViewDefault": [


### PR DESCRIPTION
**Asana Task/Github Issue:**

## Description

### Site breakage mitigation process:
#### Brief explanation
- Reported URL: https://tv.sfr.fr/home
- Problems experienced: Videos are not playing
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ x] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked: NA
- Feature being disabled/modified: UA
- [ ] This change is a speculative mitigation to fix reported breakage.
