### PR TITLE
Setup and enable widget as a protection remote flag 

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -2140,9 +2140,11 @@
                             }
                         ]
                     }
+                },
+                "widgetAsProtection": {
+                    "state": "enabled"
                 }
-            }
-        },
+            },
         "defaultBrowserPrompts": {
             "state": "disabled",
             "exceptions": [],

--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -2144,7 +2144,8 @@
                 "widgetAsProtection": {
                     "state": "enabled"
                 }
-            },
+            }
+        },
         "defaultBrowserPrompts": {
             "state": "disabled",
             "exceptions": [],

--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -2142,6 +2142,7 @@
                     }
                 },
                 "widgetAsProtection": {
+                    "minSupportedVersion": 52410000,
                     "state": "enabled"
                 }
             }

--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -2142,7 +2142,7 @@
                     }
                 },
                 "widgetAsProtection": {
-                    "minSupportedVersion": 52410000,
+                    "minSupportedVersion": 52400000,
                     "state": "enabled"
                 }
             }


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1200581511062568/task/1210403485354656?focus=true

## Description
<!-- 
  Please delete either or both process sections below.
-->
Added `widgetAsProtection` and enabled it.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205830065348221