### PR TITLE
Set Auth v2 rollout on Windows to 5%

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -592,7 +592,8 @@
                         "steps": [
                             {
                                 "percent": 1
-                            }, {
+                            },
+                            {
                                 "percent": 5
                             }
                         ]


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1205044477659400/task/1210140669962427

## Description
Set Auth v2 rollout on Windows to 5% with minimum supported version of [0.118.4](https://app.asana.com/1/137249556945/project/1201522530643637/task/1210696641023066)

