### PR TITLE
Set Auth v2 rollout on Windows to 1%

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -568,7 +568,15 @@
                     "state": "enabled"
                 },
                 "authApiV2": {
-                    "state": "disabled"
+                    "state": "enabled",
+                    "rollout": {
+                        "steps": [
+                            {
+                                "percent": 1
+                            }
+                        ]
+                    },
+                    "minSupportedVersion": "0.116.5"
                 }
             },
             "settings": {


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1205044477659400/task/1210622836877619

## Description
Set Auth v2 rollout on Windows to 1% with minimum supported version of [0.116.5](https://app.asana.com/1/137249556945/project/1201522530643637/task/1210609420666282)

