### PR TITLE
Hiding blank space on nature.com

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -2436,6 +2436,15 @@
                 ]
             },
             {
+                "domain": "nature.com",
+                "rules": [
+                    {
+                        "selector": ".c-ad",
+                        "type": "hide"
+                    }
+                ]
+            },
+            {
                 "domain": "nbcsports.com",
                 "rules": [
                     {


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/1205996472045435/task/1210616347709327?focus=true

## Description
Using `hide` rather than `hide-empty` because the area contains text.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL: https://www.nature.com/articles/d41586-025-01835-0
- Problems experienced: Blank space above the page header.
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [x] Windows
  - [x] MacOS
  - [x] Extensions
- Tracker(s) being unblocked: N/A
- Feature being disabled/modified: N/A
- [ ] This change is a speculative mitigation to fix reported breakage.
