### PR TITLE
Add burnOnStartup and abortingBurn subfeatures for burn feature

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -704,7 +704,13 @@
                 },
                 "burnAnimationSettingVisibility": {
                     "state": "disabled"
-                }
+                },
+                "burnOnStartup": {
+                    "state": "enabled"
+                },
+                "abortingBurn": {
+                    "state": "enabled"
+                },
             }
         },
         "maliciousSiteProtection": {

--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -710,7 +710,7 @@
                 },
                 "abortingBurn": {
                     "state": "enabled"
-                },
+                }
             }
         },
         "maliciousSiteProtection": {


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/547792610048271/task/1210626336884855?focus=true

## Description
<!-- 
  Please delete either or both process sections below.
-->
* Add `burn.burnOnStartup` Windows subfeature. When disabled, it disables burn-on-startup functionality. Default: `enabled`.
* Add `burn.abortingBurn` Windows subfeature. When enabled, it enables aborting burn from burn progress popup. Default: `enabled`.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [x] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.
