### PR TITLE
Disable burn.useExtensionBasedBurn subfeature on Windows

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -700,7 +700,7 @@
             "state": "enabled",
             "features": {
                 "useExtensionBasedBurn": {
-                    "state": "enabled"
+                    "state": "disabled"
                 },
                 "burnAnimationSettingVisibility": {
                     "state": "disabled"


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/547792610048271/task/1210626336884855?focus=true

## Description
<!-- 
  Please delete either or both process sections below.
-->
Disable `burn.useExtensionBasedBurn` subfeature on Windows

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.
