### PR TITLE
Element hiding: Resolve overlapping ads in content on iltalehti.fi

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -2031,17 +2031,8 @@
                 "domain": "iltalehti.fi",
                 "rules": [
                     {
-                        "type": "disable-default"
-                    },
-                    {
-                        "selector": ".ad",
-                        "type": "modify-style",
-                        "values": [
-                            {
-                                "property": "overflow",
-                                "value": "hidden"
-                            }
-                        ]
+                        "type": "override",
+                        "selector": ".ad"
                     }
                 ]
             },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1206670747178362/task/1210608277284783?focus=true

## Description


### Site breakage mitigation process:
#### Brief explanation
- Reported URL: https://www.iltalehti.fi/kotimaa/a/981005e4-a47b-4026-beb4-2b74e4f5277a
- Problems experienced: ad overflows into the text
- Platforms affected:
  - [ x] iOS
  - [x ] Android
  - [x ] Windows
  - [ x] MacOS
  - [x ] Extensions
- Tracker(s) being unblocked: na
- Feature being disabled/modified: elementHiding
- [ ] This change is a speculative mitigation to fix reported breakage.
