### PR TITLE
SBT prevent page to reload

### DIFF
--- a/features/autoconsent.json
+++ b/features/autoconsent.json
@@ -578,6 +578,10 @@
         {
             "domain": "telenor.no",
             "reason": "https://github.com/duckduckgo/privacy-configuration/pull/3306"
+        },
+        {
+            "domain": "telenor.no",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/pull/3367"
         }
     ],
     "settings": {

--- a/features/autoconsent.json
+++ b/features/autoconsent.json
@@ -580,7 +580,7 @@
             "reason": "https://github.com/duckduckgo/privacy-configuration/pull/3306"
         },
         {
-            "domain": "telenor.no",
+            "domain": "dwp.gov.uk",
             "reason": "https://github.com/duckduckgo/privacy-configuration/pull/3367"
         }
     ],


### PR DESCRIPTION
**Asana Task/Github Issue:**

## Description

### Site breakage mitigation process:
#### Brief explanation
- Reported URL: https://apply-for-attendance-allowance.dwp.gov.uk/attall-apply-ui/claim-type
- Problems experienced: page reloads
- Platforms affected:
  - [x ] iOS
  - [x ] Android
  - [ x] Windows
  - [x ] MacOS
  - [x ] Extensions
- Tracker(s) being unblocked: NA
- Feature being disabled/modified: autoconsent
- [ ] This change is a speculative mitigation to fix reported breakage.
