### PR TITLE
SBT-Resy-com tracker exclusion to allow page to load

### DIFF
--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -840,8 +840,14 @@
                     },
                     {
                         "rule": "datadoghq-browser-agent.com",
-                        "domains": ["indeed.com"],
-                        "reason": "https://github.com/duckduckgo/privacy-configuration/issues/2163"
+                        "domains": [
+                            "indeed.com",
+                            "resy.com"
+                        ],
+                        "reason": [
+                            "indeed.com - https://github.com/duckduckgo/privacy-configuration/issues/2163",
+                            "resy.com - https://github.com/duckduckgo/privacy-configuration/pull/3370"
+                        ]
                     }
                 ]
             },

--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -840,14 +840,8 @@
                     },
                     {
                         "rule": "datadoghq-browser-agent.com",
-                        "domains": [
-                            "indeed.com",
-                            "resy.com"
-                        ],
-                        "reason": [
-                            "indeed.com - https://github.com/duckduckgo/privacy-configuration/issues/2163",
-                            "resy.com - https://github.com/duckduckgo/privacy-configuration/pull/3370"
-                        ]
+                        "domains": ["indeed.com"],
+                        "reason": "indeed.com - https://github.com/duckduckgo/privacy-configuration/issues/2163"
                     }
                 ]
             },

--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -1203,6 +1203,15 @@
                             }
                         ]
                     },
+                    "datadoghq-browser-agent.com": {
+                        "rules": [
+                            {
+                                "rule": "datadoghq-browser-agent.com",
+                                "domains": ["resy.com"],
+                                "reason": "resy.com - https://github.com/duckduckgo/privacy-configuration/pull/3370"
+                            }
+                        ]
+                    },
                     "yandex.ru": {
                         "rules": [
                             {

--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -823,6 +823,15 @@
                             }
                         ]
                     },
+                    "datadoghq-browser-agent.com": {
+                        "rules": [
+                            {
+                                "rule": "datadoghq-browser-agent.com",
+                                "domains": ["resy.com"],
+                                "reason": "resy.com - https://github.com/duckduckgo/privacy-configuration/pull/3370"
+                            }
+                        ]
+                    },
                     "skimresources.com": {
                         "rules": [
                             {


### PR DESCRIPTION
**Asana Task/Github Issue:**

## Description

### Site breakage mitigation process:
#### Brief explanation
- Reported URL: resy.com 
- Problems experienced: log in page does not load
- Platforms affected:
  - [x ] iOS
  - [x ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked: datadoghq-browser-agent.com
- Feature being disabled/modified: NA
- [ ] This change is a speculative mitigation to fix reported breakage.
