### PR TITLE
AppTP: Remove Strava exception (issue fixed on app side)

### DIFF
--- a/features/app-tracker-protection.json
+++ b/features/app-tracker-protection.json
@@ -587,10 +587,6 @@
                     "reason": "Users report app issues with AppTP enabled"
                 },
                 {
-                    "packageName": "com.strava",
-                    "reason": "Users report app issues with AppTP enabled"
-                },
-                {
                     "packageName": "com.transsion.phoenix",
                     "reason": "App loads websites"
                 },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1200746877073315/task/1210026877524852?focus=true

## Description
<!-- 
  Please delete either or both process sections below.
-->

Removing our App Tracker Protection exception for Strava as they changed their DNS resolution method internally, which turned out to fix this issue.
