### PR TITLE
Enable Duck.ai keepSession on Android for 25%

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -223,7 +223,8 @@
                     "!duckai"
                 ],
                 "aiChatBangRegex": "^(?!({bangs})$)(?=.*({bangs})(?=$|\\s)).+$",
-                "addressBarEntryPoint": true
+                "addressBarEntryPoint": true,
+                "sessionTimeoutMinutes": 60
             },
             "minSupportedVersion": 52250000,
             "exceptions": [],
@@ -241,6 +242,17 @@
                             },
                             {
                                 "percent": 25
+                            }
+                        ]
+                    }
+                },
+                "keepSession": {
+                    "state": "enabled",
+                    "minSupportedVersion": 52400000,
+                    "rollout": {
+                        "steps": [
+                            {
+                                "percent": 5
                             }
                         ]
                     }

--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -252,7 +252,7 @@
                     "rollout": {
                         "steps": [
                             {
-                                "percent": 5
+                                "percent": 25
                             }
                         ]
                     }

--- a/schema/features/ai-chat.ts
+++ b/schema/features/ai-chat.ts
@@ -10,6 +10,7 @@ type SettingsType = {
     aiChatBangs?: string[];
     aiChatBangRegex?: string;
     addressBarEntryPoint?: boolean;
+    sessionTimeoutMinutes?: number;
 };
 
 // Any subfeatures that have typed `settings` should be defined here.


### PR DESCRIPTION
**Asana Task/Github Issue:**https://app.asana.com/1/137249556945/project/1174433894299346/task/1210658163190303?focus=true

## Description
Rollout keepAlive flag for DuckChat to 25%