### PR TITLE
Disable Windows WebView2 crash auto-recovery

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -656,8 +656,7 @@
                     "state": "enabled"
                 },
                 "crashAutoRecovery": {
-                    "state": "enabled",
-                    "minSupportedVersion": "0.114.0"
+                    "state": "disabled"
                 }
             }
         },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1201048563534612/task/1209828379009709?focus=true

## Description
<!-- 
  Please delete either or both process sections below.
-->
Disabled Windows WebView crash auto-recovery.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.
