### PR TITLE
Hide blank spaces on thekitchn.com

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -3295,6 +3295,15 @@
                 ]
             },
             {
+                "domain": "thekitchn.com",
+                "rules": [
+                    {
+                        "selector": ".Post__ad",
+                        "type": "hide"
+                    }
+                ]
+            },
+            {
                 "domain": "thetimes.co.uk",
                 "rules": [
                     {

--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -3299,7 +3299,23 @@
                 "rules": [
                     {
                         "selector": ".Post__ad",
-                        "type": "hide"
+                        "type": "hide-empty"
+                    },
+                    {
+                        "selector": ".PostDesktopStickyFooter",
+                        "type": "hide-empty"
+                    },
+                    {
+                        "selector": ".MobileStickyBanner",
+                        "type": "hide-empty"
+                    },
+                    {
+                        "selector": ".PostBundle__above",
+                        "type": "hide-empty"
+                    },
+                    {
+                        "selector": ".ProductGrid__adWrapper",
+                        "type": "hide-empty"
                     }
                 ]
             },


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/1205996472045435/task/1210665164782911?focus=true

## Description
Hide blank spaces on thekitchn.com due to tracker blocking.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL: https://www.thekitchn.com/serious-eats-french-onion-soup-22977747
- Problems experienced: Blank spaces where tracking ads were blocked.
- Platforms affected:
  - [X] iOS
  - [X] Android
  - [X] Windows
  - [X] MacOS
  - [X] Extensions
- Tracker(s) being unblocked: N/A
- Feature being disabled/modified: N/A
- [ ] This change is a speculative mitigation to fix reported breakage.
