### PR TITLE
Enable set as default prompts feature on windows

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -791,9 +791,13 @@
                 },
                 "scheduledPinToTaskbarPrompts": {
                     "state": "enabled"
+                },
+                "popoverVsBannerExperiment": {
+                    "state": "disabled"
                 }
             }
         }
     },
     "unprotectedTemporary": []
 }
+

--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -800,4 +800,3 @@
     },
     "unprotectedTemporary": []
 }
-

--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -775,6 +775,24 @@
                     }
                 }
             }
+        },
+        "setAsDefaultAndAddToDock": {
+            "state": "enabled",
+            "minSupportedVersion": "0.118.0",
+            "settings": {
+                "firstPopoverDelayDays": 14,
+                "bannerAfterPopoverDelayDays": 14,
+                "bannerRepeatIntervalDays": 14
+            },
+            "features": {
+                "scheduledDefaultBrowserAndTaskbarPrompts": {
+                    "state": "enabled",
+                    "minSupportedVersion": "0.118.0"
+                },
+                "scheduledPinToTaskbarPrompts": {
+                    "state": "enabled"
+                }
+            }
         }
     },
     "unprotectedTemporary": []


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1209753985157325/task/1210640020260241?focus=true

## Description

This PR enables the `setAsDefaultAndAddToDock` feature on Windows.

Additionally, it introduces the `scheduledPinToTaskbarPrompts` sub-feature to control taskbar pinning prompts separately, as the pin-to-taskbar functionality is currently unstable on Windows.