### PR TITLE
Add GHA to check invalid config for contentScopeExperiments (Android)

### DIFF
--- a/.github/workflows/check-android-content-scope-experiments.yml
+++ b/.github/workflows/check-android-content-scope-experiments.yml
@@ -1,0 +1,126 @@
+name: Check Latest Content Scope Experiment State
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'features/content-scope-experiments.json'
+      - 'overrides/android-override.json'
+  pull_request:
+    paths:
+      - 'features/content-scope-experiments.json'
+      - 'overrides/android-override.json'
+
+jobs:
+  check-experiment-state:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Use Node.js 20
+        uses: actions/setup-node@v4
+        with:
+            node-version: 20.x
+            cache: 'npm'
+      - name: Install dependencies
+        run: npm ci
+      - uses: ./
+      - name: Build
+        run: npm run build
+
+      - name: Analyze Experiments
+        id: analyze
+        run: |
+          # --- Phase 1: Data Gathering ---
+          URL="https://raw.githubusercontent.com/duckduckgo/Android/feature/cris/css-experiments/pre-allocate-experiments/content-scope-scripts/content-scope-scripts-impl/src/main/java/com/duckduckgo/contentscopescripts/impl/features/contentscopeexperiments/ContentScopeExperimentsFeature.kt"
+          ALL_REMOTE_EXPERIMENTS=$(curl -sL "$URL" | grep -o 'contentScopeExperiment[0-9]*' | sort -u)
+          
+          if [ -z "$ALL_REMOTE_EXPERIMENTS" ]; then
+            echo "::error::Could not fetch remote experiments from $URL. Failing workflow."
+            exit 1
+          fi
+
+          CONFIG_FILE="generated/v5/android-config.json"
+          ENABLED_LOCAL_EXPERIMENTS=$(jq -r 'if .features.contentScopeExperiments.features then .features.contentScopeExperiments.features | to_entries[] | select(.value.state == "enabled") | .key else empty end' "$CONFIG_FILE")
+          
+          # --- Phase 2: Analysis & Individual Outputs ---
+          invalid_local_experiments_found='false'
+          recently_added_enabled_found='false'
+
+          LATEST_10_EXPERIMENT_NUMS=$(echo "$ALL_REMOTE_EXPERIMENTS" | sed 's/contentScopeExperiment//' | sort -n | tail -n 10)
+          
+          INVALID_EXPERIMENTS=$(comm -13 <(echo "$ALL_REMOTE_EXPERIMENTS" | sort) <(echo "$ENABLED_LOCAL_EXPERIMENTS" | sort))
+          if [ -n "$INVALID_EXPERIMENTS" ]; then
+            invalid_local_experiments_found='true'
+            { echo 'invalid_experiments<<EOF'; echo "$INVALID_EXPERIMENTS"; echo 'EOF'; } >> "$GITHUB_OUTPUT"
+          fi
+          
+          ENABLED_RECENT_EXPERIMENTS=""
+          if [ -n "$LATEST_10_EXPERIMENT_NUMS" ]; then
+            LATEST_10_EXPERIMENTS=$(for n in $LATEST_10_EXPERIMENT_NUMS; do echo "contentScopeExperiment$n"; done)
+            ENABLED_RECENT_EXPERIMENTS=$(comm -12 <(echo "$LATEST_10_EXPERIMENTS" | sort) <(echo "$ENABLED_LOCAL_EXPERIMENTS" | sort))
+          fi
+          if [ -n "$ENABLED_RECENT_EXPERIMENTS" ]; then
+            recently_added_enabled_found='true'
+            { echo 'enabled_recent_experiments<<EOF'; echo "$ENABLED_RECENT_EXPERIMENTS"; echo 'EOF'; } >> "$GITHUB_OUTPUT"
+          fi
+
+          # --- Phase 3: Set Summary Outputs ---
+          if [ "$invalid_local_experiments_found" == 'true' ]; then
+            echo "errors_found=true" >> $GITHUB_OUTPUT
+          else
+            echo "errors_found=false" >> $GITHUB_OUTPUT
+          fi
+          
+          if [ "$recently_added_enabled_found" == 'true' ]; then
+            echo "warnings_found=true" >> $GITHUB_OUTPUT
+          else
+            echo "warnings_found=false" >> $GITHUB_OUTPUT
+          fi
+
+          # Also pass through detailed findings for the Asana task
+          echo "invalid_local_experiments_found=$invalid_local_experiments_found" >> $GITHUB_OUTPUT
+          echo "recently_added_enabled_found=$recently_added_enabled_found" >> $GITHUB_OUTPUT
+
+      - name: Prepare Asana Task
+        if: steps.analyze.outputs.errors_found == 'true' || steps.analyze.outputs.warnings_found == 'true'
+        id: asana_content
+        run: |
+          if [ "${{ steps.analyze.outputs.errors_found }}" == 'true' ]; then
+            echo "task_name=GH Workflow Failure - Content Scope Experiment Check Failed" >> $GITHUB_OUTPUT
+          else
+            echo "task_name=GH Workflow Warning - Content Scope Experiment Check" >> $GITHUB_OUTPUT
+          fi
+
+          DESCRIPTION=""
+          if [ "${{ steps.analyze.outputs.invalid_local_experiments_found }}" == 'true' ]; then
+            DESCRIPTION="${DESCRIPTION}**ERROR: \nAn enabled experiment is not defined in the Android codebase. Please add it to ContentScopeExperimentsFeature.kt.\n"
+            DESCRIPTION="${DESCRIPTION}Failing experiments: ${{ steps.analyze.outputs.invalid_experiments }}\n\n"
+          fi
+          if [ "${{ steps.analyze.outputs.recently_added_enabled_found }}" == 'true' ]; then
+            DESCRIPTION="${DESCRIPTION}**WARNING: About to run out of allocated experiments, please pre-allocate more experiments in ContentScopeExperimentsFeature.kt.\n\n"
+          fi
+          
+          {
+            echo 'task_description<<EOF'
+            echo -e "$DESCRIPTION"
+            echo 'EOF'
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Create Asana Task
+        if: steps.asana_content.outcome == 'success'
+        uses: honeycombio/gha-create-asana-task@main
+        with:
+          asana-secret: ${{ secrets.ASANA_ACCESS_TOKEN }}
+          asana-workspace-id: ${{ secrets.GH_ASANA_WORKSPACE_ID }}
+          asana-project: ${{ vars.GH_ANDROID_APP_PROJECT_ID }}
+          asana-section: ${{ vars.GH_ANDROID_APP_INCOMING_SECTION_ID }}
+          asana-task-name: ${{ steps.asana_content.outputs.task_name }}
+          asana-task-description: |
+            ${{ steps.asana_content.outputs.task_description }}
+            Workflow run: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+      
+      - name: Fail workflow if errors were found
+        if: steps.analyze.outputs.errors_found == 'true'
+        run: exit 1


### PR DESCRIPTION


**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/task/1210674581657609?focus=true

## Description
Add a GitHub action that will
* Fail and create a task if a new experiment is added and enabled in contentScopeExperiments and enabled for Android and ContentScopeExperimentsFeature on the Android codebase doesn't have it defined
* Pass and create a task if less than 10 of the pre-allocated experiments for contentScopeExperiments in the Android codebase are left