### PR TITLE
Start ignoring WebView2 invalid cast exceptions on disposal.

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -657,6 +657,9 @@
                 },
                 "crashAutoRecovery": {
                     "state": "disabled"
+                },
+                "ignoreInvalidCastExceptionOnDisposal": {
+                    "state": "enabled"
                 }
             }
         },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/949243614371883/task/1210678266999121?focus=true

## Description
<!-- 
  Please delete either or both process sections below.
-->
Enables `windowsWebviewFailures|ignoreInvalidCastExceptionOnDisposal`

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [x] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.
