### PR TITLE
disable FB CTL on Pinterest due to login button optics

### DIFF
--- a/features/click-to-load.json
+++ b/features/click-to-load.json
@@ -894,7 +894,191 @@
         {
             "domain": "vinted.sk",
             "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2174"
-        }
+        },
+       {
+            "domain": "pin.it",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/issues/TBD"
+       },
+       {
+            "domain": "pinterest.at",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/issues/TBD"
+       },
+       {
+            "domain": "pinterest.be",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/issues/TBD"
+       },
+       {
+            "domain": "pinterest.ca",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/issues/TBD"
+       },
+       {
+            "domain": "pinterest.ch",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/issues/TBD"
+       },
+       {
+            "domain": "pinterest.cl",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/issues/TBD"
+       },
+       {
+            "domain": "pinterest.co",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/issues/TBD"
+       },
+       {
+            "domain": "pinterest.co.at",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/issues/TBD"
+       },
+       {
+            "domain": "pinterest.co.in",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/issues/TBD"
+       },
+       {
+            "domain": "pinterest.co.kr",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/issues/TBD"
+       },
+       {
+            "domain": "pinterest.co.nz",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/issues/TBD"
+       },
+       {
+            "domain": "pinterest.co.uk",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/issues/TBD"
+       },
+       {
+            "domain": "pinterest.com",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/issues/TBD"
+       },
+       {
+            "domain": "pinterest.com.au",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/issues/TBD"
+       },
+       {
+            "domain": "pinterest.com.bo",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/issues/TBD"
+       },
+       {
+            "domain": "pinterest.com.ec",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/issues/TBD"
+       },
+       {
+            "domain": "pinterest.com.mx",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/issues/TBD"
+       },
+       {
+            "domain": "pinterest.com.pe",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/issues/TBD"
+       },
+       {
+            "domain": "pinterest.com.py",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/issues/TBD"
+       },
+       {
+            "domain": "pinterest.com.uy",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/issues/TBD"
+       },
+       {
+            "domain": "pinterest.com.vn",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/issues/TBD"
+       },
+       {
+            "domain": "pinterest.de",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/issues/TBD"
+       },
+       {
+            "domain": "pinterest.dk",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/issues/TBD"
+       },
+       {
+            "domain": "pinterest.ec",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/issues/TBD"
+       },
+       {
+            "domain": "pinterest.es",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/issues/TBD"
+       },
+       {
+            "domain": "pinterest.fr",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/issues/TBD"
+       },
+       {
+            "domain": "pinterest.hu",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/issues/TBD"
+       },
+       {
+            "domain": "pinterest.id",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/issues/TBD"
+       },
+       {
+            "domain": "pinterest.ie",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/issues/TBD"
+       },
+       {
+            "domain": "pinterest.in",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/issues/TBD"
+       },
+       {
+            "domain": "pinterest.info",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/issues/TBD"
+       },
+       {
+            "domain": "pinterest.it",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/issues/TBD"
+       },
+       {
+            "domain": "pinterest.jp",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/issues/TBD"
+       },
+       {
+            "domain": "pinterest.kr",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/issues/TBD"
+       },
+       {
+            "domain": "pinterest.mx",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/issues/TBD"
+       },
+       {
+            "domain": "pinterest.nl",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/issues/TBD"
+       },
+       {
+            "domain": "pinterest.nz",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/issues/TBD"
+       },
+       {
+            "domain": "pinterest.pe",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/issues/TBD"
+       },
+       {
+            "domain": "pinterest.ph",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/issues/TBD"
+       },
+       {
+            "domain": "pinterest.pt",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/issues/TBD"
+       },
+       {
+            "domain": "pinterest.ru",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/issues/TBD"
+       },
+       {
+            "domain": "pinterest.se",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/issues/TBD"
+       },
+       {
+            "domain": "pinterest.th",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/issues/TBD"
+       },
+       {
+            "domain": "pinterest.tw",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/issues/TBD"
+       },
+       {
+            "domain": "pinterest.uk",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/issues/TBD"
+       },
+       {
+            "domain": "pinterest.vn",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/issues/TBD"
+       }
     ],
     "settings": {
         "Facebook, Inc.": {


### PR DESCRIPTION
**Asana Task/Github Issue:** 
https://app.asana.com/1/137249556945/project/1163321984198618/task/1210406513386493?focus=true

## Description
<!-- 
  Please delete either or both process sections below.
-->

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL: *.pinterest.com
- Problems experienced: Layout issues with FB login button overlay
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified: FB CTL for Pinterest 
- [x] This change is a speculative mitigation to fix reported breakage.
