### PR TITLE
Try to enable unclickable links on 1und1.de

### DIFF
--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -3295,6 +3295,7 @@
                         "domains": ["1und1.de"],
                         "reason": "https://github.com/duckduckgo/privacy-configuration/issues/3393"
                     }
+                ]
             },
             "techlab-cdn.com": {
                 "rules": [

--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -3289,8 +3289,12 @@
                         "rule": "visitor-service-us-east-1.tealiumiq.com/asics/main/",
                         "domains": ["asics.com"],
                         "reason": "https://github.com/duckduckgo/privacy-configuration/issues/379"
+                    },
+                    {
+                        "rule": "visitor-service.tealiumiq.com/",
+                        "domains": ["1und1.de"],
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/issues/3393"
                     }
-                ]
             },
             "techlab-cdn.com": {
                 "rules": [


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/1200277586140538/task/1210667755517358?focus=true

## Description
Speculative mitigation to make links within account area clickable.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL: https://control-center.1und1.de/unlimited-highspeed
- Problems experienced: Links within account area are not clickable, according to user report.
- Platforms affected:
  - [ ] iOS
  - [X] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked: visitor-service.tealiumiq.com
- Feature being disabled/modified: N/A
- [X] This change is a speculative mitigation to fix reported breakage.
