### PR TITLE
Hide blank spaces on Windows forums

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -3973,6 +3973,33 @@
                         "type": "hide-empty"
                     }
                 ]
+            },
+            {
+                "domain": "tenforums.com",
+                "rules": [
+                    {
+                        "selector": ".chill",
+                        "type": "hide-empty"
+                    }
+                ]
+            },
+            {
+                "domain": "elevenforum.com",
+                "rules": [
+                    {
+                        "selector": ".gads",
+                        "type": "hide-empty"
+                    }
+                ]
+            },
+            {
+                "domain": "windowsforum.com",
+                "rules": [
+                    {
+                        "selector": "#adsense-wrapper",
+                        "type": "hide-empty"
+                    }
+                ]
             }
         ]
     }


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/1200277586140538/task/1210691677492111?focus=true

## Description
Hides blank spaces on Windows forums.

### Site breakage mitigation process:
#### Brief explanation
- Reported URLs:
  - https://www.tenforums.com/tutorials/75294-view-reliability-history-windows-10-a.html
  - https://www.elevenforum.com/t/view-reliability-history-in-windows-11.5791/
  - https://windowsforum.com/threads/unlocking-windows-reliability-monitor-your-guide-to-diagnosing-windows-11-issues.369595/
- Problems experienced: Blank spaces after blocking trackers.
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [X] Windows
  - [X] MacOS
  - [X] Extensions
- Tracker(s) being unblocked: N/A
- Feature being disabled/modified: N/A
- [ ] This change is a speculative mitigation to fix reported breakage.
