### PR TITLE
Hide blank spaces on digitaltrends.com

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -1269,6 +1269,19 @@
                 ]
             },
             {
+                "domain": "digitaltrends.com",
+                "rules": [
+                    {
+                        "selector": ".b-connatix",
+                        "type": "hide"
+                    },
+                    {
+                        "selector": ".dtads-location",
+                        "type": "hide-empty"
+                    }
+                ]
+            },
+            {
                 "domain": "doodle.com",
                 "rules": [
                     {


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/1205996472045435/task/1210694167679686?focus=true

## Description

### Site breakage mitigation process:
#### Brief explanation
- Reported URL: https://www.digitaltrends.com/computing/i-used-an-ai-browser-for-work-my-afternoons-became-boring-and-i-loved-it/
- Problems experienced: Blank spaces caused by blocking trackers.
- Platforms affected:
  - [x] iOS
  - [x] Android
  - [x] Windows
  - [x] MacOS
  - [x] Extensions
- Tracker(s) being unblocked: N/A
- Feature being disabled/modified: N/A
- [ ] This change is a speculative mitigation to fix reported breakage.
