### PR TITLE
Add Default Browser prompt subfeature to iOS

### DIFF
--- a/features/set-as-default-and-add-to-dock.json
+++ b/features/set-as-default-and-add-to-dock.json
@@ -4,10 +4,5 @@
         "sampleExcludeRecords": {}
     },
     "state": "disabled",
-    "exceptions": [],
-    "features": {
-        "popoverVsBannerExperiment": {
-            "state": "disabled"
-        }
-    }
+    "exceptions": []
 }

--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -1215,6 +1215,20 @@
                 }
             }
         },
+        "setAsDefaultAndAddToDock": {
+            "state": "enabled",
+            "settings": {
+                "firstModalDelayDays": 1,
+                "secondModalDelayDays": 4,
+                "subsequentModalRepeatIntervalDays": 14
+            },
+            "features": {
+                "scheduledDefaultBrowserPrompts": {
+                    "state": "enabled",
+                    "minSupportedVersion": "7.176.0"
+                }
+            }
+        },
         "iOSBrowserConfig": {
             "state": "enabled"
         }

--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -1225,7 +1225,7 @@
             "features": {
                 "scheduledDefaultBrowserPrompts": {
                     "state": "enabled",
-                    "minSupportedVersion": "7.176.0"
+                    "minSupportedVersion": "7.177.0"
                 }
             }
         },


### PR DESCRIPTION
**Asana Task/Github Issue:**  https://app.asana.com/1/137249556945/project/1206329551987282/task/1210713642171960?focus=true

## Description
Add a subfeature to show default browser prompt in iOS

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.
