### PR TITLE
[Android] remove singleOmnibarFeature rollout param

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -2482,13 +2482,6 @@
                 "singleOmnibarFeature": {
                     "state": "internal",
                     "minSupportedVersion": 52410000,
-                    "rollout": {
-                        "steps": [
-                            {
-                                "percent": 5
-                            }
-                        ]
-                    },
                     "cohorts": [
                         {
                             "name": "control",


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1202552961248957/task/1210708421106332?focus=true

## Description
Disabling the rollout as we're intending to make the feature available to all internal users.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.
