### PR TITLE
Enable releaseNotesFromCDN on Windows

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -757,7 +757,8 @@
             "state": "enabled",
             "features": {
                 "releaseNotesFromCDN": {
-                    "state": "disabled"
+                    "state": "enabled",
+                    "minSupportedVersion": "0.120.0"
                 }
             }
         },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1205044477659400/task/1210239308907245

## Description
On Windows, enable `releaseNotesFromCDN `with minimum supported version of `0.120.0`

