### PR TITLE
Enable short history menu on Windows

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -690,6 +690,9 @@
             "state": "enabled",
             "minSupportedVersion": "0.105.0"
         },
+        "shortHistoryMenu": {
+            "state": "enabled"
+        },
         "addressBarTldNavOrSearch": {
             "state": "enabled",
             "minSupportedVersion": "0.100.0"


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1205491244064311/task/1210620507204467?focus=true

## Description
This change enables the short history menu option on Windows.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [x] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.