### PR TITLE
Revert GPC exclusion for npr.org

### DIFF
--- a/features/gpc.json
+++ b/features/gpc.json
@@ -45,10 +45,6 @@
             "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2122"
         },
         {
-            "domain": "npr.org",
-            "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2160"
-        },
-        {
             "domain": "norton.com",
             "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2240"
         },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1206670747178362/task/1207848824036080?focus=true

## Description
NPR was not showing a donation modal when detecting the GPC flag, but not adjusting the layout to account for that, which disabled clicks for users. Seems to be fixed on their end now, so rolling back the exclusion.