### PR TITLE
[Autofill] Add failsafe to autofill/siteSpecificFixes

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -417,7 +417,20 @@
                         "formTypeSettings": [],
                         "inputTypeSettings": [],
                         "formBoundarySelector": "",
+                        "failsafeSettings": {},
                         "domains": [
+                            {
+                                "domain": ["coolors.co"],
+                                "patchSettings": [
+                                    {
+                                        "path": "/failsafeSettings",
+                                        "op": "replace",
+                                        "value": {
+                                            "maxInputsPerPage": 110
+                                        }
+                                    }
+                                ]
+                            },
                             {
                                 "domain": ["areaclientes.orange.es"],
                                 "patchSettings": [

--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -423,11 +423,9 @@
                                 "domain": ["coolors.co"],
                                 "patchSettings": [
                                     {
-                                        "path": "/failsafeSettings",
-                                        "op": "replace",
-                                        "value": {
-                                            "maxInputsPerPage": 110
-                                        }
+                                        "path": "/failsafeSettings/maxInputsPerPage",
+                                        "op": "add",
+                                        "value": 110
                                     }
                                 ]
                             },

--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -455,7 +455,20 @@
                         "formTypeSettings": [],
                         "inputTypeSettings": [],
                         "formBoundarySelector": "",
+                        "failsafeSettings": {},
                         "domains": [
+                            {
+                                "domain": ["coolors.co"],
+                                "patchSettings": [
+                                    {
+                                        "path": "/failsafeSettings",
+                                        "op": "replace",
+                                        "value": {
+                                            "maxInputsPerPage": 110
+                                        }
+                                    }
+                                ]
+                            },
                             {
                                 "domain": ["areaclientes.orange.es"],
                                 "patchSettings": [

--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -461,11 +461,9 @@
                                 "domain": ["coolors.co"],
                                 "patchSettings": [
                                     {
-                                        "path": "/failsafeSettings",
-                                        "op": "replace",
-                                        "value": {
-                                            "maxInputsPerPage": 110
-                                        }
+                                        "path": "/failsafeSettings/maxInputsPerPage",
+                                        "op": "add",
+                                        "value": 110
                                     }
                                 ]
                             },

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -487,7 +487,20 @@
                         "formTypeSettings": [],
                         "inputTypeSettings": [],
                         "formBoundarySelector": "",
+                        "failsafeSettings": {},
                         "domains": [
+                            {
+                                "domain": ["coolors.co"],
+                                "patchSettings": [
+                                    {
+                                        "path": "/failsafeSettings",
+                                        "op": "replace",
+                                        "value": {
+                                            "maxInputsPerPage": 110
+                                        }
+                                    }
+                                ]
+                            },
                             {
                                 "domain": ["areaclientes.orange.es"],
                                 "patchSettings": [

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -493,11 +493,9 @@
                                 "domain": ["coolors.co"],
                                 "patchSettings": [
                                     {
-                                        "path": "/failsafeSettings",
-                                        "op": "replace",
-                                        "value": {
-                                            "maxInputsPerPage": 110
-                                        }
+                                        "path": "/failsafeSettings/maxInputsPerPage",
+                                        "op": "add",
+                                        "value": 110
                                     }
                                 ]
                             },

--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -137,7 +137,20 @@
                         "formTypeSettings": [],
                         "inputTypeSettings": [],
                         "formBoundarySelector": "",
+                        "failsafeSettings": {},
                         "domains": [
+                            {
+                                "domain": ["coolors.co"],
+                                "patchSettings": [
+                                    {
+                                        "path": "/failsafeSettings",
+                                        "op": "replace",
+                                        "value": {
+                                            "maxInputsPerPage": 110
+                                        }
+                                    }
+                                ]
+                            },
                             {
                                 "domain": ["areaclientes.orange.es"],
                                 "patchSettings": [

--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -143,11 +143,9 @@
                                 "domain": ["coolors.co"],
                                 "patchSettings": [
                                     {
-                                        "path": "/failsafeSettings",
-                                        "op": "replace",
-                                        "value": {
-                                            "maxInputsPerPage": 110
-                                        }
+                                        "path": "/failsafeSettings/maxInputsPerPage",
+                                        "op": "add",
+                                        "value": 110
                                     }
                                 ]
                             },

--- a/schema/features/autofill.ts
+++ b/schema/features/autofill.ts
@@ -27,12 +27,19 @@ export type InputTypeSetting = {
     type: string;
 };
 
+export type FailsafeSettings = {
+    maxInputsPerPage?: number;
+    maxInputsPerForm?: number;
+    maxFormsPerPage?: number;
+};
+
 export type FormBoundarySelector = string;
 
 export type SiteSpecificFixes = {
     formBoundarySelector?: FormBoundarySelector;
     formTypeSettings?: FormTypeSetting[];
     inputTypeSettings?: InputTypeSetting[];
+    failsafeSettings?: FailsafeSettings;
 };
 
 // Any subfeatures that have typed `settings` should be defined here.


### PR DESCRIPTION
**Asana Task/Github Issue:** 

## Description
Adding failsafe setting to `autofill/siteSpecificFixes`: https://github.com/duckduckgo/duckduckgo-autofill/pull/832

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.
