### PR TITLE
Element hiding: hide new switch to chrome nags

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -1901,6 +1901,10 @@
                         "type": "hide"
                     },
                     {
+                        "selector": "div:has(> [aria-labelledby='promo_label_id'])",
+                        "type": "hide"
+                    },
+                    {
                         "selector": "div[role='banner']:has(div > a[href='https://support.google.com/a/answer/33864'])",
                         "type": "hide"
                     }


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/246491496396031/task/1210750872289704?focus=true

## Description
New element hiding rule to address the switch to chrome pop-ups that are appearing on iOS.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [x] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
