### PR TITLE
Disable the Set As Default PiP video experiment

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -1248,7 +1248,7 @@
                     ]
                 },
                 "setAsDefaultBrowserPiPVideoExperiment": {
-                    "state": "enabled",
+                    "state": "disabled",
                     "cohorts": [
                         {
                             "name": "control",


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1206329551987282/task/1210816708333861?focus=true

## Description

Disable the PiP video experiment for Set As Default Browser iOS

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.
