### PR TITLE
Add toolbar upsell subfeature to Privacy Pro on macOS

### DIFF
--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -1235,6 +1235,9 @@
                 },
                 "privacyProFreeTrial": {
                     "state": "enabled"
+                },
+                "vpnToolbarUpsell": {
+                    "state": "disabled"
                 }
             }
         },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1210594645229050/task/1210614268287034?focus=true

## Description
Add Privacy Pro subfeature to control toolbar VPN upsell button visibility.
