### PR TITLE
Hide blank spaces on games.usatoday.com

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -3749,6 +3749,14 @@
                     {
                         "selector": ".gnt_flp",
                         "type": "hide-empty"
+                    },
+                    {
+                        "selector": "[class*='HomeCategory__adWrapper']",
+                        "type": "closest-empty"
+                    },
+                    {
+                        "selector": "[class^='HomeTemplate__afterCategoryAd']",
+                        "type": "closest-empty"
                     }
                 ]
             },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1206670747178362/task/1210781219031125?focus=true

### Site breakage mitigation process:
#### Brief explanation
- Reported URL: games.usatoday.com
- Problems experienced: white spaces between sections and in right gutter
- Platforms affected:
  - [x] All
- Feature being disabled/modified: element hiding