### PR TITLE
Remove improvedErrorPixels, won't be needed after all

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -376,9 +376,6 @@
                 },
                 "bulkBookmarksImport": {
                     "state": "enabled"
-                },
-                "improvedErrorPixels": {
-                    "state": "internal"
                 }
             }
         },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1210407179200832/task/1210708587243975?focus=true

## Description
I planned to put my project behind this feature flag during its Ship Review, but it turns out a Ship Review won't be needed for this project after all.

### Feature change process:

- [x] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [x] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [x] This feature was covered by a tech design.