### PR TITLE
Disable setAsDefaultAndAddToDock feature for windows

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -868,7 +868,7 @@
             }
         },
         "setAsDefaultAndAddToDock": {
-            "state": "enabled",
+            "state": "disabled",
             "minSupportedVersion": "0.118.0",
             "settings": {
                 "firstPopoverDelayDays": 14,


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1209753985157325/task/1210863243965615?focus=true

## Description
Disables setAsDefaultAndAddToDock feature for windows

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.
