### PR TITLE
Add schwab.com as exception

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -708,7 +708,8 @@
                             "bestbuy.com",
                             "www.youtube.com",
                             "yelp.com",
-                            "linkedin.com"
+                            "linkedin.com",
+                            "schwab.com"
                         ],
                         "patchSettings": [
                             {


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1210407179200832/task/1210877822921681?focus=true

## Description
Add schwab.com as an exception to work around issue with enumerateDevices API

### Site breakage mitigation process:
#### Brief explanation
- Reported URL: schwab.com
- Problems experienced: cannot log in because it hangs because the webcam approval request never pops up
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [x] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked: -
- Feature being disabled/modified: disableDeviceEnumeration, disableDeviceEnumerationFrames
- [ ] This change is a speculative mitigation to fix reported breakage.
