### PR TITLE
Simplify JSON report

### DIFF
--- a/.github/scripts/json-diff-directories.js
+++ b/.github/scripts/json-diff-directories.js
@@ -240,16 +240,21 @@ for (const [
         overallApprovalAnalysis.reasons.push(result.approvalAnalysis.reason);
     }
 
-    console.log(renderDetails(section, result.html, isOpen));
+    // Only show non-'latest' sections if 'latest' is empty
+    if (isOpen || Object.keys(sections.latest).length === 0) {
+        console.log(renderDetails(section, result.html, isOpen));
+    }
 }
 
 // Output overall approval status
 console.log('\n## 🎯 OVERALL APPROVAL STATUS');
 console.log(`**${overallApprovalAnalysis.shouldApprove ? '✅ AUTO-APPROVED' : '❌ MANUAL REVIEW REQUIRED'}**`);
 
+/* Skip for now duplicated
 if (overallApprovalAnalysis.reasons.length > 0) {
     console.log('\n**Reasons for manual review:**');
     overallApprovalAnalysis.reasons.forEach((reason) => {
         console.log(`- ${reason}`);
     });
 }
+*/

--- a/automation-utils.js
+++ b/automation-utils.js
@@ -159,20 +159,20 @@ export function analyzePatchesForApproval(patches) {
     }
 
     // Check if any changes are outside allowed paths
-    const disallowedPaths = new Set();
+    const disallowedPatches = [];
     for (const patch of patches) {
         const featurePath = AUTO_APPROVABLE_FEATURE_PATHS.find((feature) => patch.path.startsWith(feature));
         const isDisallowed = featurePath ? !isPathAllowedForFeature(patch.path, featurePath) : true;
         if (isDisallowed) {
-            disallowedPaths.add(patch.path);
+            disallowedPatches.push(patch);
         }
     }
 
-    if (disallowedPaths.size > 0) {
+    if (disallowedPatches.length > 0) {
         return {
             shouldApprove: false,
             reason: 'Manual review required: Changes to disallowed paths',
-            disallowedPaths,
+            disallowedPatches,
         };
     }
 

--- a/automation-utils.js
+++ b/automation-utils.js
@@ -141,7 +141,7 @@ export function isAllowedChangesOnly(patches) {
  * Analyzes patches to determine if they should be auto-approved
  * @param {Array} patches - Array of JSON patches from fast-json-patch
  * @returns {Object} Analysis result with approval status and reasoning
- */
+  */
 export function analyzePatchesForApproval(patches) {
     if (patches.length === 0) {
         return {
@@ -159,20 +159,20 @@ export function analyzePatchesForApproval(patches) {
     }
 
     // Check if any changes are outside allowed paths
-    const disallowedPaths = patches.filter((patch) => {
-        // Find which auto-approvable feature this patch belongs to
+    const disallowedPaths = new Set();
+    for (const patch of patches) {
         const featurePath = AUTO_APPROVABLE_FEATURE_PATHS.find((feature) => patch.path.startsWith(feature));
-
-        if (featurePath) {
-            return !isPathAllowedForFeature(patch.path, featurePath);
+        const isDisallowed = featurePath ? !isPathAllowedForFeature(patch.path, featurePath) : true;
+        if (isDisallowed) {
+            disallowedPaths.add(patch.path);
         }
-        return true; // Any non-auto-approvable feature changes are disallowed
-    });
+    }
 
-    if (disallowedPaths.length > 0) {
+    if (disallowedPaths.size > 0) {
         return {
             shouldApprove: false,
-            reason: `Manual review required: Changes to disallowed paths: ${disallowedPaths.map((p) => p.path).join(', ')}`,
+            reason: 'Manual review required: Changes to disallowed paths',
+            disallowedPaths,
         };
     }
 


### PR DESCRIPTION
**Asana Task/Github Issue:**

## Description

- Ignores outputting `legacy` files unless the latest is empty. (In most cases they should all match).
- Ignores duplicate paths that match different files.
- Removes the final "reasons for manual review" as already elsewhere.
- Simplify the computation of `disallowedPatches`

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.
