### PR TITLE
Add new feature for Picture in Picture video tutorial

### DIFF
--- a/features/system-settings-pip-video-tutorial.json
+++ b/features/system-settings-pip-video-tutorial.json
@@ -1,0 +1,7 @@
+{
+    "_meta": {
+        "description": "Master flag for PiP video tutorials shown in the system settings.",
+        "sampleExcludeRecords": {}
+    },
+    "exceptions": []
+}

--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -1250,6 +1250,14 @@
             },
             "exceptions": []
         },
+        "systemSettingsPiPVideoTutorial": {
+            "state": "enabled",
+            "features": {
+                "defaultBrowserTutorial": {
+                    "state": "enabled"
+                }
+            }
+        },
         "backgroundAgentPixelTest": {
             "state": "enabled",
             "features": {


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1206329551987282/task/1210806442029218?focus=true

## Description
Add a new feature to show Picture in Picture video for iOS when deeplinking to the system settings.
Add a subfeature fore showing Picture in Picture video when setting the browser as default.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [x] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.
