### PR TITLE
Add serpSettings privacy config

### DIFF
--- a/features/message-bridge.json
+++ b/features/message-bridge.json
@@ -7,6 +7,7 @@
     "settings": {
         "aiChat": "disabled",
         "subscriptions": "disabled",
+        "serpSettings": "disabled",
         "domains": []
     }
 }

--- a/features/serp-settings.json
+++ b/features/serp-settings.json
@@ -1,8 +1,0 @@
-{
-    "_meta": {
-        "description": "Sync SERP settings to the browser",
-        "sampleExcludeRecords": {}
-    },
-    "state": "disabled",
-    "exceptions": []
-}

--- a/features/serp-settings.json
+++ b/features/serp-settings.json
@@ -1,0 +1,8 @@
+{
+    "_meta": {
+        "description": "Sync SERP settings to the browser",
+        "sampleExcludeRecords": {}
+    },
+    "state": "disabled",
+    "exceptions": []
+}

--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -72,7 +72,6 @@
             "settings": {
                 "aiChat": "disabled",
                 "subscriptions": "disabled",
-                "serpSettings": "disabled",
                 "domains": [
                     {
                         "domain": [

--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -72,13 +72,12 @@
             "settings": {
                 "aiChat": "disabled",
                 "subscriptions": "disabled",
-                "serpSettings": "enabled",
+                "serpSettings": "disabled",
                 "domains": [
                     {
                         "domain": [
                             "duckduckgo.com",
-                            "duck.co",
-                            "bhall.duck.co"
+                            "duck.co"
                         ],
                         "patchSettings": [
                             {
@@ -89,6 +88,11 @@
                             {
                                 "op": "replace",
                                 "path": "/subscriptions",
+                                "value": "enabled"
+                            },
+                            {
+                                "op": "add",
+                                "path": "/serpSettings",
                                 "value": "enabled"
                             }
                         ]
@@ -3129,9 +3133,6 @@
                     }
                 ]
             }
-        },
-        "serpSettings": {
-            "state": "enabled"
         }
     },
 

--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -72,11 +72,13 @@
             "settings": {
                 "aiChat": "disabled",
                 "subscriptions": "disabled",
+                "serpSettings": "enabled",
                 "domains": [
                     {
                         "domain": [
                             "duckduckgo.com",
-                            "duck.co"
+                            "duck.co",
+                            "bhall.duck.co"
                         ],
                         "patchSettings": [
                             {
@@ -3127,6 +3129,9 @@
                     }
                 ]
             }
+        },
+        "serpSettings": {
+            "state": "enabled"
         }
     },
 

--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -72,6 +72,7 @@
             "settings": {
                 "aiChat": "disabled",
                 "subscriptions": "disabled",
+                "serpSettings": "disabled",
                 "domains": [
                     {
                         "domain": [

--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -90,7 +90,7 @@
                                 "value": "enabled"
                             },
                             {
-                                "op": "add",
+                                "op": "replace",
                                 "path": "/serpSettings",
                                 "value": "enabled"
                             }

--- a/schema/features/message-bridge.ts
+++ b/schema/features/message-bridge.ts
@@ -4,6 +4,7 @@ export type MessageBridgeSettings = CSSInjectFeatureSettings<{
     aiChat: FeatureState;
     subscriptions?: FeatureState;
     subscriptionPages?: FeatureState;
+    serpSettings?: FeatureState;
 }>;
 
 export type MessageBridgeFeature<VersionType> = Feature<MessageBridgeSettings, VersionType>;


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/task/1210889796974442?focus=true

## Description
Adds the serpSetting change to the privacy config (disabled by default)

### Feature change process:

- [x] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [x] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [x] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.
