### PR TITLE
GPC exclusion for musiciansfriend.com

### DIFF
--- a/features/gpc.json
+++ b/features/gpc.json
@@ -71,6 +71,10 @@
         {
             "domain": "delta.com",
             "reason": "https://github.com/duckduckgo/privacy-configuration/pull/3493"
+        },
+        {
+            "domain": "musiciansfriend.com",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/pull/3499"
         }
     ],
     "settings": {


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/1206670747178362/task/1210851805430104?focus=true

## Description
### Site breakage mitigation process:
#### Brief explanation
- Reported URL: https://www.musiciansfriend.com/guitars/fender-american-vintage-ii-1951-telecaster-electric-guitar/l95519000001000
- Problems experienced: Blank page showing at checkout.
- Platforms affected:
  - [X] iOS
  - [ ] Android
  - [ ] Windows
  - [X] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked: N/A
- Feature being disabled/modified: Global Privacy Control (GPC)
- [ ] This change is a speculative mitigation to fix reported breakage.
