### PR TITLE
Hide blank spaces on Japanese blogs

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -4067,6 +4067,32 @@
                         "type": "hide-empty"
                     }
                 ]
+            },
+            {
+                "domain": "exblog.jp",
+                "rules": [
+                    {
+                        "selector": "#gpt_pc_blog_overlay",
+                        "type": "hide-empty"
+                    },
+                    {
+                        "selector": "#gpt_pc_blog_header",
+                        "type": "hide-empty"
+                    }
+                ]
+            },
+            {
+                "domain": "ameblo.jp",
+                "rules": [
+                    {
+                        "selector": ".subAdBannerArea",
+                        "type": "hide-empty"
+                    },
+                    {
+                        "selector": "._2dsoQeNf",
+                        "type": "hide-empty"
+                    }
+                ]
             }
         ]
     }


### PR DESCRIPTION
**Asana Task/Github Issue:**
- https://app.asana.com/1/137249556945/project/1205996472045435/task/1210898252319472?focus=true
- https://app.asana.com/1/137249556945/project/1200277586140538/task/1206778734806440?focus=true

## Description
### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
  - https://ameblo.jp/elmore11051108/entry-12869503601.html
  - https://sumus.exblog.jp/15854676/
- Problems experienced: Blank spaces caused by blocked trackers.
- Platforms affected:
  - [X] iOS
  - [X] Android
  - [X] Windows
  - [X] MacOS
  - [X] Extensions
- Tracker(s) being unblocked: N/A
- Feature being disabled/modified: N/A
- [ ] This change is a speculative mitigation to fix reported breakage.
