### PR TITLE
Windows: Disable autofillPopupReuse flag

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -113,8 +113,7 @@
             "state": "enabled",
             "features": {
                 "autofillPopupReuse": {
-                    "state": "enabled",
-                    "minSupportedVersion": "0.122.0"
+                    "state": "disabled"
                 },
                 "deduplicateLoginsOnImport": {
                     "state": "enabled"


### PR DESCRIPTION
**Asana Task/Github Issue:**

## Description
We identified UI issues with the autofill popup reuse feature, so we are disabling the flag until these issues are resolved.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.
