### PR TITLE
Remove deviceEnumeration mitigations

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -696,34 +696,6 @@
                 "enumerateDevices": "enabled",
                 "domains": [
                     {
-                        "domain": [
-                            "microsoft.com",
-                            "nytimes.com",
-                            "gmail.com",
-                            "reuters.com",
-                            "etsy.com",
-                            "aliexpress.com",
-                            "walmart.com",
-                            "bestbuy.com",
-                            "www.youtube.com",
-                            "yelp.com",
-                            "linkedin.com",
-                            "schwab.com"
-                        ],
-                        "patchSettings": [
-                            {
-                                "op": "add",
-                                "path": "/disableDeviceEnumerationFrames",
-                                "value": "enabled"
-                            },
-                            {
-                                "op": "add",
-                                "path": "/disableDeviceEnumeration",
-                                "value": "enabled"
-                            }
-                        ]
-                    },
-                    {
                         "domain": "asana.com",
                         "patchSettings": [
                             {


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/72649045549333/task/1210500918264539

## Description
Removed deviceEnumeration exceptions now that we have a proper fix about to go to 100% in v0.121.3

### Site breakage mitigation process:
#### Brief explanation
- Reported URL: schwab.com amongst others
- Problems experienced: deviceEnumeration calls fail
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [x] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked: -
- Feature being disabled/modified: we're rolling back the mitigation now that we have a fix
- [ ] This change is a speculative mitigation to fix reported breakage.
