### PR TITLE
SBT add tracker exception to allow video play on bbc-com

### DIFF
--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -1250,8 +1250,14 @@
                 "rules": [
                     {
                         "rule": "pub.doubleverify.com/dvtag/",
-                        "domains": ["time.com"],
-                        "reason": "https://github.com/duckduckgo/privacy-configuration/pull/3271"
+                        "domains": [
+                            "time.com",
+                            "bbc.com"
+                        ],
+                        "reason": [
+                            "time.com - https://github.com/duckduckgo/privacy-configuration/pull/3271",
+                            "bbc.com - https://github.com/duckduckgo/privacy-configuration/issues/3507"
+                        ]
                     }
                 ]
             },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1206670747178362/task/1210894249074678?focus=true

## Description

### Site breakage mitigation process:
#### Brief explanation
- Reported URL: https://www.bbc.com/news/videos/c0k7l3p6vdno
- Problems experienced: no video is playing
- Platforms affected:
  - [x ] iOS
  - [ x] Android
  - [x ] Windows
  - [x ] MacOS
  - [x ] Extensions
- Tracker(s) being unblocked: pub.doubleverify.com/dvtag
- Feature being disabled/modified: NA
- [ ] This change is a speculative mitigation to fix reported breakage.
