### PR TITLE
SBT add tracker exception to allow video to play on cc-com

### DIFF
--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -975,7 +975,7 @@
                             "cc.com"
                         ],
                         "reason": [
-                            "cc.com - https://github.com/duckduckgo/privacy-configuration/issues/3508"
+                            "cc.com - https://github.com/duckduckgo/privacy-configuration/pull/3508"
                         ]
                     },
                     {


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1206670747178362/task/1210894524866299?focus=true

## Description

### Site breakage mitigation process: 
#### Brief explanation
- Reported URL: https://southpark.cc.com/video-clips/ft9rdy/south-park-relax-guy
- Problems experienced: blocking a tracker prevents video to play
- Platforms affected:
  - [x ] iOS
  - [ x] Android
  - [x ] Windows
  - [x ] MacOS
  - [x ] Extensions
- Tracker(s) being unblocked: https://pubads.g.doubleclick.net/ondemand/hls/content
- Feature being disabled/modified: NA
- [ ] This change is a speculative mitigation to fix reported breakage.
