### PR TITLE
Speculative mitigation for reports of chatgpt data download 403 errors on Android

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -1061,6 +1061,10 @@
                 {
                     "domain": "youtube.com",
                     "reason": "https://github.com/duckduckgo/privacy-configuration/issues/557"
+                },
+                {
+                    "domain": "chatgpt.com",
+                    "reason": "https://github.com/duckduckgo/privacy-configuration/issues/3509"
                 }
             ]
         },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1200277586140538/task/1210894552952157?focus=true

### Site breakage mitigation process:
#### Brief explanation
- Reported URL: https://chatgpt.com/backend-api/estuary/content
- Problems experienced: users report being unable to download files from URL
- Platforms affected:
  - [ ] iOS
  - [x] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Feature being disabled/modified: `fingerprintingScreenSize`
- [x] This change is a speculative mitigation to fix un-reproduced reported breakage.
