### PR TITLE
Added feature flags for new sync promos

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -590,10 +590,10 @@
                 "passwordManagerEmptyPasswords": {
                     "state": "internal"
                 },
-                "import-start": {
+                "importStart": {
                     "state": "internal"
                 },
-                "import-end": {
+                "importEnd": {
                     "state": "internal"
                 }
             }

--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -575,19 +575,19 @@
                 "passwords": {
                     "state": "enabled"
                 },
-                "bookmark-new": {
+                "bookmarkNew": {
                     "state": "internal"
                 },
-                "password-new": {
+                "passwordNew": {
                     "state": "internal"
                 },
-                "bookmark-manager-empty": {
+                "bookmarkManagerEmpty": {
                     "state": "internal"
                 },
-                "password-manager-empty-all-items": {
+                "passwordManagerEmptyAllItems": {
                     "state": "internal"
                 },
-                "password-manager-empty-passwords": {
+                "passwordManagerEmptyPasswords": {
                     "state": "internal"
                 },
                 "import-start": {

--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -574,6 +574,27 @@
                 },
                 "passwords": {
                     "state": "enabled"
+                },
+                "bookmark-new": {
+                    "state": "internal"
+                },
+                "password-new": {
+                    "state": "internal"
+                },
+                "bookmark-manager-empty": {
+                    "state": "internal"
+                },
+                "password-manager-empty-all-items": {
+                    "state": "internal"
+                },
+                "password-manager-empty-passwords": {
+                    "state": "internal"
+                },
+                "import-start": {
+                    "state": "internal"
+                },
+                "import-end": {
+                    "state": "internal"
                 }
             }
         },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/72649045549333/task/1210924534013844?focus=true

## Description
I'm creating 7 new sync promos. Added a feature flag for each of them under the pre-existing `syncPromos`.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.