### PR TITLE
SBT remove blank space by adding css selector - theepochtimes-com

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -3302,6 +3302,15 @@
                 ]
             },
             {
+                "domain": "theepochtimes.com",
+                "rules": [
+                    {
+                        "selector": ".eet-ad",
+                        "type": "hide-empty"
+                    }
+                ]
+            },
+            {
                 "domain": "thegatewaypundit.com",
                 "rules": [
                     {


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1206670747178362/task/1210924343110476?focus=true

## Description

### Site breakage mitigation process:
#### Brief explanation
- Reported URL: https://www.theepochtimes.com/article/the-9-supreme-court-cases-to-watch-next-term-5891600
- Problems experienced: ad blank space in the middle of the article. Hiding-empty a selector to remove the placeholder.
- Platforms affected:
  - [ x] iOS
  - [x ] Android
  - [x ] Windows
  - [x ] MacOS
  - [x ] Extensions
- Tracker(s) being unblocked: NA
- Feature being disabled/modified: elementHiding
- [ ] This change is a speculative mitigation to fix reported breakage.
