### PR TITLE
Add canvas experiment to the extension

### DIFF
--- a/.cursor/rules/content-scope-experiments.mdc
+++ b/.cursor/rules/content-scope-experiments.mdc
@@ -1,0 +1,115 @@
+---
+description: Guide for adding content scope experiments (C-S-S experiments) to privacy-remote-configuration override files. Use this when you need to test features with a subset of users before full deployment.
+alwaysApply: false
+---
+# Content Scope Experiments Configuration
+
+## Description
+Guide for adding content scope experiments (C-S-S experiments) to privacy-remote-configuration override files. Use this when you need to test features with a subset of users before full deployment.
+
+## When to Use
+- Testing new features with limited user exposure
+- A/B testing feature variations
+- Gradual rollout of potentially breaking changes
+- Validating feature behavior before full deployment
+
+## Implementation Pattern
+
+### 1. Define Experiment in contentScopeExperiments
+```json
+"contentScopeExperiments": {
+    "state": "enabled",
+    "features": {
+        "yourExperimentName": {
+            "state": "enabled",
+            "rollout": {
+                "steps": [
+                    {
+                        "percent": 10
+                    }
+                ]
+            },
+            "cohorts": [
+                { "name": "control", "weight": 1 },
+                { "name": "treatment", "weight": 1 }
+            ]
+        }
+    }
+}
+```
+
+### 2. Add Conditional Changes to Target Feature
+```json
+"targetFeature": {
+    "state": "enabled",
+    "settings": {
+        "conditionalChanges": [
+            {
+                "condition": {
+                    "experiment": { 
+                        "experimentName": "yourExperimentName", 
+                        "cohort": "treatment" 
+                    }
+                },
+                "patchSettings": [
+                    {
+                        "op": "replace",
+                        "path": "/settingName",
+                        "value": true
+                    }
+                ]
+            }
+        ]
+    }
+}
+```
+
+## Key Rules
+- Never add `patchSettings` to the experiment definition in `contentScopeExperiments`
+- Always use `conditionalChanges` in the target feature's settings
+- Use JSON Patch operations (`replace`, `add`, `remove`)
+- Use JSON Pointer format for paths (e.g., `/settingName`)
+- Start with small rollout percentages (5-10%)
+- Test with a small rollout before expanding
+
+## Example: Fingerprinting Canvas
+```json
+// Experiment definition
+"contentScopeExperiments": {
+    "state": "enabled",
+    "features": {
+        "fingerprintingCanvasAdditionalEnabledCheck": {
+            "state": "enabled",
+            "rollout": { "steps": [{ "percent": 10 }] },
+            "cohorts": [
+                { "name": "control", "weight": 1 },
+                { "name": "treatment", "weight": 1 }
+            ]
+        }
+    }
+}
+
+// Feature modification
+"fingerprintingCanvas": {
+    "state": "enabled",
+    "settings": {
+        "conditionalChanges": [
+            {
+                "condition": {
+                    "experiment": { 
+                        "experimentName": "fingerprintingCanvasAdditionalEnabledCheck", 
+                        "cohort": "treatment" 
+                    }
+                },
+                "patchSettings": [
+                    {
+                        "op": "replace",
+                        "path": "/additionalEnabledCheck",
+                        "value": true
+                    }
+                ]
+            }
+        ]
+    }
+}
+```

--- a/.cursor/rules/feature-schema.mdc
+++ b/.cursor/rules/feature-schema.mdc
@@ -1,0 +1,66 @@
+---
+description: Guide for creating new feature schema files in the privacy-remote-configuration system. Use this when adding new features that need TypeScript type definitions and validation.
+
+alwaysApply: false
+---
+# Feature Schema Creation
+
+## Description
+Guide for creating new feature schema files in the privacy-remote-configuration system. Use this when adding new features that need TypeScript type definitions and validation.
+
+## When to Use
+- Adding new features to privacy-remote-configuration
+- Features that need conditional changes or experiment support
+- Features that will be used across multiple platforms
+- Features requiring type safety and validation
+
+## Implementation Pattern
+
+### 1. Create Schema File
+Create a new file in `schema/features/feature-name.ts`:
+
+```typescript
+import { Feature, CSSInjectFeatureSettings, CSSConfigSetting, FeatureState } from '../feature';
+
+type FullFeatureNameOptions = CSSInjectFeatureSettings<{
+    // Boolean/state settings
+    settingName?: FeatureState;
+    
+    // Array settings
+    arraySetting?: string[];
+    
+    // Complex settings (use CSSConfigSetting)
+    complexSetting?: CSSConfigSetting;
+}>;
+
+export type FeatureNameFeature<VersionType> = Feature<Partial<FullFeatureNameOptions>, VersionType>;
+```
+
+### 2. Add to Config
+Import and add to `schema/config.ts`:
+
+```typescript
+// Add import
+import { FeatureNameFeature } from './features/feature-name';
+
+// Add to ConfigV5 type
+export type ConfigV5<VersionType> = {
+    // ... existing code ...
+    features: Record<string, Feature<any, VersionType>> & {
+        // ... existing features ...
+        featureName?: FeatureNameFeature<VersionType>;
+    };
+};
+```
+
+## Key Rules
+
+- **Use CSSInjectFeatureSettings**: If this is a C-S-S feature, provides built-in support for conditional changes and experiments.
+- **FeatureState for booleans**: Use `FeatureState` for enabled/disabled settings
+- **Arrays for lists**: Use `string[]` for method lists, domain lists, etc.
+- **CSSConfigSetting for complex**: Use for complex objects that need type/function definitions
+- **Partial wrapper**: Always wrap options in `Partial<>` for flexibility
+- **VersionType generic**: Include `<VersionType>` for version compatibility
+- **Testing**: Run `npm run test` to validate the output and also `npm lint` to check the formatting.
+
+When writing these rules, check against `features/` and `overrides/` for it's current usage. 

--- a/overrides/extension-override.json
+++ b/overrides/extension-override.json
@@ -71,6 +71,7 @@
             "state": "enabled",
             "settings": {
                 "webGl": "enabled",
+                "additionalEnabledCheck": "disabled",
                 "conditionalChanges": [
                     {
                         "condition": {

--- a/overrides/extension-override.json
+++ b/overrides/extension-override.json
@@ -181,6 +181,7 @@
             "features": {
                 "fingerprintingCanvasAdditionalEnabledCheck": {
                     "state": "enabled",
+                    "minSupportedVersion": "2025.7.23",
                     "rollout": {
                         "steps": [
                             {

--- a/overrides/extension-override.json
+++ b/overrides/extension-override.json
@@ -81,7 +81,7 @@
                             {
                                 "op": "replace",
                                 "path": "/additionalEnabledCheck",
-                                "value": true
+                                "value": "enabled"
                             }
                         ]
                     }

--- a/overrides/extension-override.json
+++ b/overrides/extension-override.json
@@ -68,7 +68,24 @@
             "state": "enabled"
         },
         "fingerprintingCanvas": {
-            "state": "disabled"
+            "state": "enabled",
+            "settings": {
+                "webGl": "enabled",
+                "conditionalChanges": [
+                    {
+                        "condition": {
+                            "experiment": { "experimentName": "fingerprintingCanvasAdditionalEnabledCheck", "cohort": "treatment" }
+                        },
+                        "patchSettings": [
+                            {
+                                "op": "replace",
+                                "path": "/additionalEnabledCheck",
+                                "value": true
+                            }
+                        ]
+                    }
+                ]
+            }
         },
         "fingerprintingAudio": {
             "state": "disabled"
@@ -157,6 +174,25 @@
         },
         "webCompat": {
             "state": "disabled"
+        },
+        "contentScopeExperiments": {
+            "state": "enabled",
+            "features": {
+                "fingerprintingCanvasAdditionalEnabledCheck": {
+                    "state": "enabled",
+                    "rollout": {
+                        "steps": [
+                            {
+                                "percent": 10
+                            }
+                        ]
+                    },
+                    "cohorts": [
+                        { "name": "control", "weight": 1 },
+                        { "name": "treatment", "weight": 1 }
+                    ]
+                }
+            }
         }
     },
     "unprotectedTemporary": [

--- a/schema/config.ts
+++ b/schema/config.ts
@@ -11,6 +11,7 @@ import { MessageBridgeFeature } from './features/message-bridge';
 import { AndroidBrowserConfig } from './features/android-browser-config';
 import { APIManipulationFeature } from './features/api-manipulation';
 import { FingerprintingHardwareFeature } from './features/fingerprinting-hardware';
+import { FingerprintingCanvasFeature } from './features/fingerprinting-canvas';
 import { FingerprintingScreenSizeFeature } from './features/fingerprinting-screen-size';
 import { NetworkProtection } from './features/network-protection';
 import { AiChatConfig } from './features/ai-chat';
@@ -50,6 +51,7 @@ export type ConfigV5<VersionType> = {
         messageBridge?: MessageBridgeFeature<VersionType>;
         androidBrowserConfig?: AndroidBrowserConfig<VersionType>;
         fingerprintingHardware?: FingerprintingHardwareFeature<VersionType>;
+        fingerprintingCanvas?: FingerprintingCanvasFeature<VersionType>;
         fingerpringtingScreenSize?: FingerprintingScreenSizeFeature<VersionType>;
         networkProtection?: NetworkProtection<VersionType>;
         scriptlets?: ScriptletsFeature<VersionType>;

--- a/schema/features/fingerprinting-canvas.ts
+++ b/schema/features/fingerprinting-canvas.ts
@@ -1,0 +1,12 @@
+import { Feature, CSSInjectFeatureSettings, CSSConfigSetting, FeatureState } from '../feature';
+
+type FullFingerprintingCanvasOptions = CSSInjectFeatureSettings<{
+    additionalEnabledCheck?: FeatureState;
+    webGl?: FeatureState;
+    safeMethods?: string[];
+    unsafeMethods?: string[];
+    unsafeGlMethods?: string[];
+    canvasMethods?: string[];
+}>;
+
+export type FingerprintingCanvasFeature<VersionType> = Feature<Partial<FullFingerprintingCanvasOptions>, VersionType>;


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1208889145294658/task/1210933442930111?focus=true

## Description

Simple experiment to validate breakage from Canvas on desktop.
Adds some basic cursor rules to draft these experiments more easily.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.
