### PR TITLE
Disable enumerateDevices on meet.google.com

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -721,6 +721,16 @@
                 "enumerateDevices": "enabled",
                 "domains": [
                     {
+                        "domain": "meet.google.com",
+                        "patchSettings": [
+                            {
+                                "op": "replace",
+                                "path": "/enumerateDevices",
+                                "value": "disabled"
+                            }
+                        ]
+                    },
+                    {
                         "domain": "asana.com",
                         "patchSettings": [
                             {


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1200277586140538/task/1210935005812527?focus=true

## Description

meet.google.com can't detect devices due to the fix we put in place for reduction of prompting.

Disabling whilst we investigate.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.
