### PR TITLE
Revert client brand hint domain (Android)

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -86,12 +86,7 @@
             "minSupportedVersion": 51852000,
             "exceptions": [],
             "settings": {
-                "domains": [
-                    {
-                        "domain": "chatgpt.com",
-                        "reason": "https://github.com/duckduckgo/privacy-configuration/pull/3509"
-                    }
-                ]
+                "domains": []
             }
         },
         "contentBlocking": {


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1200204095367872/task/1210939806484676?focus=true

## Description
The domain added [here](https://github.com/duckduckgo/privacy-configuration/pull/3520) is causing parsing issues on Android, reverting.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [x] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced: Config parsing failing
- Platforms affected:
  - [ ] iOS
  - [x] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.
