### PR TITLE
Update Windows burn config

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -826,16 +826,14 @@
             "state": "enabled",
             "features": {
                 "useExtensionBasedBurn": {
-                    "state": "disabled"
+                    "state": "preview",
+                    "minSupportedVersion": "0.124.0"
                 },
                 "burnAnimationSettingVisibility": {
                     "state": "enabled",
                     "minSupportedVersion": "0.120.0"
                 },
                 "burnOnStartup": {
-                    "state": "enabled"
-                },
-                "abortingBurn": {
                     "state": "enabled"
                 }
             }


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/72649045549333/task/1210688190916893?focus=true

## Description
<!-- 
  Please delete either or both process sections below.
-->
* Remove an unused Windows-only feature `burn.abortingBurn`. It was added during an incident, but was not used.
* Enable `burn.useExtensionBasedBurn` Windows-only feature in Preview builds >= 0.124.0

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [x] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.
