### PR TITLE
Hide blank space on doodle.com

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -1304,6 +1304,10 @@
                     {
                         "selector": "[data-testid*='ads-layout-placement']",
                         "type": "hide"
+                    },
+                    {
+                        "selector": "#sticky-footer-ads",
+                        "type": "hide"
                     }
                 ]
             },


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/1200277586140538/task/1210943621712021?focus=true

## Description
### Site breakage mitigation process:
#### Brief explanation
- Reported URL: Any poll page on https://doodle.com
- Problems experienced: Blank space at the bottom of the page.
- Platforms affected:
  - [x] iOS
  - [x] Android
  - [x] Windows
  - [x] MacOS
  - [x] Extensions
- Tracker(s) being unblocked: N/A
- Feature being disabled/modified: N/A
- [ ] This change is a speculative mitigation to fix reported breakage.
