### PR TITLE
CPM exception for eastmidlandsrailway.co.uk

### DIFF
--- a/features/autoconsent.json
+++ b/features/autoconsent.json
@@ -626,6 +626,10 @@
         {
             "domain": "musiciansfriend.com",
             "reason": "https://github.com/duckduckgo/privacy-configuration/pull/3516"
+        },
+        {
+            "domain": "delayrepay.eastmidlandsrailway.co.uk",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/pull/3532"
         }
     ],
     "settings": {


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/1200277586140538/task/1210946345859442?focus=true

## Description
### Site breakage mitigation process:
#### Brief explanation
- Reported URL: delayrepay.eastmidlandsrailway.co.uk
- Problems experienced: Dark overlay
- Platforms affected:
  - [x] iOS
  - [x] Android
  - [x] Windows
  - [x] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked: N/A
- Feature being disabled/modified: Cookie popup management (CPM)
- [ ] This change is a speculative mitigation to fix reported breakage.
