### PR TITLE
Clean up a couple typos, remove conflicting rule to restore mitigation for Sinclair news sites

### DIFF
--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -930,11 +930,6 @@
                         "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2410"
                     },
                     {
-                        "rule": "securepubads.g.doubleclick.net",
-                        "domains": ["xataka.com"],
-                        "reason": ["xataka.com - https://github.com/duckduckgo/privacy-configuration/pull/2507"]
-                    },
-                    {
                         "rule": "securepubads.g.doubleclick.net/gampad/ads",
                         "domains": [
                             "ah.nl",
@@ -1249,7 +1244,7 @@
                         ]
                     },
                     {
-                        "rule": "https://googleads.g.doubleclick.net/ads/preferences/naioptout",
+                        "rule": "googleads.g.doubleclick.net/ads/preferences/naioptout",
                         "domains": ["zojirushi.com"],
                         "reason": "https://github.com/duckduckgo/privacy-configuration/issues/2021"
                     }
@@ -2711,7 +2706,7 @@
                         "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1904"
                     },
                     {
-                        "rule": "https://cdn.optimizely.com/js/271989291.js",
+                        "rule": "cdn.optimizely.com/js/271989291.js",
                         "domains": ["my.zipcar.com"],
                         "reason": "https://github.com/duckduckgo/privacy-configuration/issues/916"
                     },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1201870266890790/task/1210934810002068?focus=true

### Site breakage mitigation process:
#### Brief explanation
- Reported URL: all Sinclair news sites (e.g., wlos.com, komonews.com, etc.)
- Problems experienced: 500 error w/ greyed-out background
- Platforms affected:
  - [x] iOS
  - [ ] Android
  - [ ] Windows
  - [x] MacOS
  - [x] MV2 Extension
- Tracker(s) being RE-unblocked: `securepubads.g.doubleclick.net/tag/js/gpt.js`
