### PR TITLE
Mitigate video playback on paramountplus.com

### DIFF
--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -927,10 +927,7 @@
                             "cbs.com",
                             "paramountplus.com"
                         ],
-                        "reason": [
-                            "cbs - https://github.com/duckduckgo/privacy-configuration/pull/2410",
-                            "paramount - https://github.com/duckduckgo/privacy-configuration/pull/3534"
-                        ]
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2410"
                     },
                     {
                         "rule": "securepubads.g.doubleclick.net/gampad/ads",
@@ -974,7 +971,8 @@
                             "paramountplus.com"
                         ],
                         "reason": [
-                            "cc.com - https://github.com/duckduckgo/privacy-configuration/pull/3508"
+                            "cc.com - https://github.com/duckduckgo/privacy-configuration/pull/3508",
+                            "paramount - https://github.com/duckduckgo/privacy-configuration/pull/3534"
                         ]
                     },
                     {


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1206670747178362/task/1210946344807802?focus=true

### Site breakage mitigation process:
#### Brief explanation
- Reported URL: paramountplus.com
- Problems experienced: video won't play
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [x] Windows
  - [x] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked: `pubads.g.doubleclick.net/ondemand/hls/content`
