### PR TITLE
Mitigate map breakage on 5ka.ru

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -1341,9 +1341,12 @@
                     "yandex.ru": {
                         "rules": [
                             {
-                                "rule": "api-maps.yandex.ru/services/startup/v1",
-                                "domains": ["m.dzen.ru"],
-                                "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1627"
+                                "rule": "api-maps.yandex.ru",
+                                "domains": [
+                                    "m.dzen.ru",
+                                    "5ka.ru"
+                                ],
+                                "reason": "https://github.com/duckduckgo/privacy-configuration/pull/3536"
                             }
                         ]
                     }


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1206670747178362/task/1210222736614017?focus=true

### Site breakage mitigation process:
#### Brief explanation
- Reported URL: 5ka.ru
- Problems experienced: maps don't load, address completion doesn't work
- Platforms affected:
  - [ ] iOS
  - [x] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked: `api-maps.yandex.ru` (scripts from this subdomain shouldn't be blocked, but Android doesn't seem to be getting the type from the request and is therefore blocking)
