### PR TITLE
remove yandex.cloud allowlist

### DIFF
--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -3619,11 +3619,6 @@
                         "reason": "https://github.com/duckduckgo/privacy-configuration/issues/366"
                     },
                     {
-                        "rule": "runtime.strm.yandex.ru/player/video/",
-                        "domains": ["yandex.cloud"],
-                        "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2481"
-                    },
-                    {
                         "rule": "strm.yandex.ru/vh-special-converted/vod-content/",
                         "domains": ["<all>"],
                         "reason": "https://github.com/duckduckgo/privacy-configuration/issues/366"


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/inbox/11472677167854/item/1208774974541469/story/1208774932295994

## Description
<!-- 
  Please delete either or both process sections below.
-->
Fixed with an entity update in the blocklist. 

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.
