### PR TITLE
Hide empty spaces on drivespark.com

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -4115,6 +4115,15 @@
                         "type": "hide-empty"
                     }
                 ]
+            },
+            {
+                "domain": "drivespark.com",
+                "rules": [
+                    {
+                        "selector": ".oiad",
+                        "type": "hide"
+                    }
+                ]
             }
         ]
     }

--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -4122,6 +4122,18 @@
                     {
                         "selector": ".oiad",
                         "type": "hide"
+                    },
+                    {
+                        "selector": "[class^='headerMain-ad']",
+                        "type": "hide-empty"
+                    },
+                    {
+                        "selector": ".oi-adblock",
+                        "type": "hide-empty"
+                    },
+                    {
+                        "selector": ".vuukle-ads",
+                        "type": "hide-empty"
                     }
                 ]
             }


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/1205996472045435/task/1210956979775347?focus=true

## Description
### Site breakage mitigation process:
#### Brief explanation
- Reported URL: https://www.drivespark.com/four-wheelers/2025/mazda-july-2025-sales-results-report-011-74385.html
- Problems experienced: Blank spaces due to blocked trackers.
- Platforms affected:
  - [x] iOS
  - [x] Android
  - [x] Windows
  - [x] MacOS
  - [x] Extensions
- Tracker(s) being unblocked: N/A
- Feature being disabled/modified: N/A
- [ ] This change is a speculative mitigation to fix reported breakage.
