### PR TITLE
Added UA string exception for doublelist.com

### DIFF
--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -933,6 +933,10 @@
                     {
                         "domain": "sfr.fr",
                         "reason": "https://github.com/duckduckgo/privacy-configuration/pull/3338"
+                    },
+                    {
+                        "domain": "doublelist.com",
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/pull/3539"
                     }
                 ],
                 "webViewDefault": [


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/1200277586140538/task/1210954461664063?focus=true

## Description
### Site breakage mitigation process:
#### Brief explanation
- Reported URL: https://doublelist.com
- Problems experienced: Can’t complete onboarding because of being detected as Firefox.
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [X] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked: N/A
- Feature being disabled/modified: UA string
- [ ] This change is a speculative mitigation to fix reported breakage.
