### PR TITLE
Add bookmarksAndPasswordsOpenSyncSetupDialog flag

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -582,6 +582,9 @@
                 "passwords": {
                     "state": "enabled"
                 },
+                "bookmarksAndPasswordsBannersOpenSyncSetupDialog": {
+                    "state": "internal"
+                },
                 "bookmarkNew": {
                     "state": "internal"
                 },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/task/1210924534013848?focus=true

## Description
Added the `bookmarksAndPasswordsBannersOpenSyncSetupDialog` flag. If it is enabled, the bookmarks and passwords sync setup promo banners will open the Sync Setup dialog instead of the Settings page.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.