### PR TITLE
hide blank spaces on presse-citron.net

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -4129,6 +4129,27 @@
                 ]
             },
             {
+                "domain": "drivespark.com",
+                "rules": [
+                    {
+                        "selector": ".oiad",
+                        "type": "hide"
+                    },
+                    {
+                        "selector": "[class^='headerMain-ad']",
+                        "type": "hide-empty"
+                    },
+                    {
+                        "selector": ".oi-adblock",
+                        "type": "hide-empty"
+                    },
+                    {
+                        "selector": ".vuukle-ads",
+                        "type": "hide-empty"
+                    }
+                ]
+            },
+            {
                 "domain": "presse-citron.net",
                 "rules": [
                     {

--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -4129,22 +4129,14 @@
                 ]
             },
             {
-                "domain": "drivespark.com",
+                "domain": "presse-citron.net",
                 "rules": [
                     {
-                        "selector": ".oiad",
-                        "type": "hide"
-                    },
-                    {
-                        "selector": "[class^='headerMain-ad']",
+                        "selector": ".od-wrapper",
                         "type": "hide-empty"
                     },
                     {
-                        "selector": ".oi-adblock",
-                        "type": "hide-empty"
-                    },
-                    {
-                        "selector": ".vuukle-ads",
+                        "selector": ".banner",
                         "type": "hide-empty"
                     }
                 ]


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/11472677167855/task/1210983288576613

## Description
<!-- 
  Please delete either or both process sections below.
-->
Hide empty ad spaces

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.
