### PR TITLE
Add settings to windowsWebviewFailures.crashAutoRecovery feature

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -783,7 +783,12 @@
                     "state": "enabled"
                 },
                 "crashAutoRecovery": {
-                    "state": "disabled"
+                    "state": "preview",
+                    "settings": {
+                        "autoRecoveryBrowserEngine": true,
+                        "autoRecoveryTab": true,
+                        "autoRecoveryTabOutOfMemory": false
+                    }
                 },
                 "ignoreInvalidCastExceptionOnDisposal": {
                     "state": "enabled"

--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -784,6 +784,7 @@
                 },
                 "crashAutoRecovery": {
                     "state": "preview",
+                    "minSupportedVersion": "0.125.0",
                     "settings": {
                         "autoRecoveryBrowserEngine": true,
                         "autoRecoveryTab": true,

--- a/schema/config.ts
+++ b/schema/config.ts
@@ -16,6 +16,7 @@ import { FingerprintingScreenSizeFeature } from './features/fingerprinting-scree
 import { NetworkProtection } from './features/network-protection';
 import { AiChatConfig } from './features/ai-chat';
 import { ScriptletsFeature } from './features/scriptlets';
+import { WindowsWebViewFailures } from './features/windows-webview-failures';
 
 export { WebCompatSettings } from './features/webcompat';
 export { DuckPlayerSettings } from './features/duckplayer';
@@ -55,6 +56,7 @@ export type ConfigV5<VersionType> = {
         fingerpringtingScreenSize?: FingerprintingScreenSizeFeature<VersionType>;
         networkProtection?: NetworkProtection<VersionType>;
         scriptlets?: ScriptletsFeature<VersionType>;
+        windowsWebviewFailures?: WindowsWebViewFailures<VersionType>;
     };
     unprotectedTemporary: SiteException[];
 };

--- a/schema/features/windows-webview-failures.ts
+++ b/schema/features/windows-webview-failures.ts
@@ -1,12 +1,15 @@
-﻿import {Feature, SubFeature} from "../feature";
+﻿import { Feature, SubFeature } from '../feature';
 
 type SubFeatures<VersionType> = {
-    crashAutoRecovery?: SubFeature<VersionType, {
-        autoRecoveryBrowserEngine: boolean,
-        autoRecoveryTab: boolean,
-        autoRecoveryTabOutOfMemory: boolean
-    }>;
-}
+    crashAutoRecovery?: SubFeature<
+        VersionType,
+        {
+            autoRecoveryBrowserEngine: boolean;
+            autoRecoveryTab: boolean;
+            autoRecoveryTabOutOfMemory: boolean;
+        }
+    >;
+};
 
 export type WindowsWebViewFailures<VersionType> = Feature<
     Record<string, never>,

--- a/schema/features/windows-webview-failures.ts
+++ b/schema/features/windows-webview-failures.ts
@@ -1,0 +1,15 @@
+﻿import {Feature, SubFeature} from "../feature";
+
+type SubFeatures<VersionType> = {
+    crashAutoRecovery?: SubFeature<VersionType, {
+        autoRecoveryBrowserEngine: boolean,
+        autoRecoveryTab: boolean,
+        autoRecoveryTabOutOfMemory: boolean
+    }>;
+}
+
+export type WindowsWebViewFailures<VersionType> = Feature<
+    Record<string, never>,
+    VersionType,
+    SubFeatures<VersionType> & Record<string, SubFeature<VersionType>>
+>;


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/1201048563534612/task/1210751069609386?focus=true

## Description
<!-- 
  Please delete either or both process sections below.
-->
* Enable `windowsWebviewFailures.crashAutoRecovery` subfeature in `preview` channel since version `0.125.0`.
* Add settings to this subfeature that disable autorecovery for OOM tab crashes.

### Feature change process:

- [x] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [x] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.
