### PR TITLE
Enabling omnibar widget for Windows internal users

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -811,7 +811,7 @@
                     "state": "enabled"
                 },
                 "omnibar": {
-                    "state": "disabled"
+                    "state": "internal"
                 }
             },
             "minSupportedVersion": "0.100.0"


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/1209825025247378/task/1210625492570365?focus=true

## Description
Enabling omnibar widget for Windows internal users only.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.
