### PR TITLE
Revert CPM mitigation for prairiemoon.com

### DIFF
--- a/features/autoconsent.json
+++ b/features/autoconsent.json
@@ -596,10 +596,6 @@
             "reason": "https://github.com/duckduckgo/privacy-configuration/pull/3545"
         },
         {
-            "domain": "prairiemoon.com",
-            "reason": "https://github.com/duckduckgo/privacy-configuration/pull/3551"
-        },
-        {
             "domain": "mypremiercreditcard.com",
             "reason": "https://github.com/duckduckgo/privacy-configuration/pull/3554"
         }


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/1206670747178362/task/1210960685637407?focus=true

## Description
### Site breakage mitigation process:
#### Brief explanation
- Reported URL: https://www.prairiemoon.com/actaea-pachypoda-dolls-eyes
- Problems experienced: Credit card form fields were not display but seems OK now.
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [x] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked: N/A
- Feature being disabled/modified: Cookie popup management (CPM)
- [ ] This change is a speculative mitigation to fix reported breakage.
