### PR TITLE
Add autofillSkipAuthenticationIfVaultEmpty

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -148,6 +148,9 @@
                 "autofillIdentitiesOnByDefault": {
                     "state": "internal"
                 },
+                "autofillSkipAuthenticationIfVaultEmpty": {
+                    "state": "internal"
+                },
                 "siteSpecificFixes": {
                     "state": "enabled",
                     "settings": {


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1210407179200832/task/1210620156307507?focus=true

## Description
Add autofillSkipAuthenticationIfVaultEmpty flag. If this flag is true, the Autofill Popup will not request authentication if the vault is empty.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.