### PR TITLE
Disable `updatesWontAutomaticallyRestartApp`

### DIFF
--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -719,7 +719,7 @@
             "state": "enabled"
         },
         "updatesWontAutomaticallyRestartApp": {
-            "state": "enabled",
+            "state": "disabled",
             "exceptions": [],
             "minSupportedVersion": "1.149.0"
         },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/task/1211009191268623?focus=true

## Description
<!-- 
  Please delete either or both process sections below.
-->

This feature disables a flag that was enabled in 1.149.0 and is impacting the update process.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.
