### PR TITLE
Remove tracker exception for pc-builds.com

### DIFF
--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -1930,7 +1930,6 @@
                             "newschannel20.com",
                             "newschannel9.com",
                             "okcfox.com",
-                            "pc-builds.com",
                             "pointstreaksites.com",
                             "post-gazette.com",
                             "raleighcw.com",
@@ -1979,8 +1978,7 @@
                             "pointstreaksites.com - https://github.com/duckduckgo/privacy-configuration/issues/2197",
                             "signupgenius.com - https://github.com/duckduckgo/privacy-configuration/pull/2234",
                             "stockcharts.com - https://github.com/duckduckgo/privacy-configuration/pull/2478",
-                            "mlb.com - https://github.com/duckduckgo/privacy-configuration/pull/2345",
-                            "pc-builds.com - https://github.com/duckduckgo/privacy-configuration/pull/3573"
+                            "mlb.com - https://github.com/duckduckgo/privacy-configuration/pull/2345"
                         ]
                     }
                 ]
@@ -2958,11 +2956,6 @@
                         "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1689"
                     },
                     {
-                        "rule": "a.pub.network/core/imgs/1.png",
-                        "domains": ["pc-builds.com"],
-                        "reason": "https://github.com/duckduckgo/privacy-configuration/pull/3573"
-                    },
-                    {
                         "rule": "a.pub.network/core/prebid-universal-creative.js",
                         "domains": [
                             "boingboing.net",
@@ -2972,8 +2965,7 @@
                             "stockcharts.com",
                             "titantv.com",
                             "newrepublic.com",
-                            "thenation.com",
-                            "pc-builds.com"
+                            "thenation.com"
                         ],
                         "reason": [
                             "newrepublic.com - https://github.com/duckduckgo/privacy-configuration/pull/2807",
@@ -2983,8 +2975,7 @@
                             "smithsonianmag.com - https://github.com/duckduckgo/privacy-configuration/pull/2346",
                             "stockcharts.com - https://github.com/duckduckgo/privacy-configuration/pull/2478",
                             "titantv.com - https://github.com/duckduckgo/privacy-configuration/issues/1925",
-                            "thenation.com - https://github.com/duckduckgo/privacy-configuration/pull/2846",
-                            "pc-builds.com - https://github.com/duckduckgo/privacy-configuration/pull/3573"
+                            "thenation.com - https://github.com/duckduckgo/privacy-configuration/pull/2846"
                         ]
                     },
                     {


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/1206670747178362/task/1211017302977607?focus=true

## Description
### Site breakage mitigation process:
#### Brief explanation
- Reported URL: https://pc-builds.com
- Problems experienced: Adblock wall but has a “Continue without supporting us” link.
- Platforms affected:
  - [x] iOS
  - [x] Android
  - [x] Windows
  - [x] MacOS
  - [x] Extensions
- Tracker(s) being unblocked: N/A
- Feature being disabled/modified: N/A
- [ ] This change is a speculative mitigation to fix reported breakage.
