### PR TITLE
feat: enable onboarding design experiment and wait local privacy config

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -2686,6 +2686,33 @@
                     ]
                 }
             }
+        },
+        "onboardingDesignExperiment": {
+            "state": "enabled",
+            "features": {
+                "onboardingDesignExperimentAug25": {
+                    "state": "enabled",
+                    "minSupportedVersion": 52450000,
+                    "cohorts": [
+                        {
+                            "name": "modifiedControl",
+                            "weight": 1
+                        },
+                        {
+                            "name": "bb",
+                            "weight": 1
+                        },
+                        {
+                            "name": "buck",
+                            "weight": 1
+                        }
+                    ]
+                },
+                "waitForLocalPrivacyConfig" : {
+                    "state": "enabled",
+                    "minSupportedVersion": 52450000
+                }
+            }
         }
     },
     "unprotectedTemporary": [],


### PR DESCRIPTION
These are already enabled and bundled as part of local privacy config in the app as this is an experiment with onboarding

**Asana Task/Github Issue:**

## Description
<!-- 
  Please delete either or both process sections below.
-->

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.
