### PR TITLE
Revert "Exception for clientBrandHint on ee.co.uk"

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -665,13 +665,7 @@
             "state": "disabled"
         },
         "clientBrandHint": {
-            "state": "enabled",
-            "exceptions": [
-                {
-                    "domain": "ee.co.uk",
-                    "reason": "https://github.com/duckduckgo/privacy-configuration/pull/3041"
-                }
-            ]
+            "state": "enabled"
         },
         "privacyPro": {
             "state": "enabled",


### PR DESCRIPTION
Reverts duckduckgo/privacy-configuration#3041

Currently unsupported so reverting.