### PR TITLE
Add subfeature and settings for inactive users

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -1363,12 +1363,17 @@
             "settings": {
                 "firstModalDelayDays": 1,
                 "secondModalDelayDays": 4,
-                "subsequentModalRepeatIntervalDays": 14
+                "subsequentModalRepeatIntervalDays": 14,
+                "inactiveModalNumberOfDaysSinceInstall": 28,
+                "inactiveModalNumberOfInactiveDays": 7
             },
             "features": {
                 "scheduledDefaultBrowserPrompts": {
                     "state": "enabled",
                     "minSupportedVersion": "7.177.0"
+                },
+                "scheduledDefaultBrowserPromptsInactiveUser": {
+                    "state": "enabled"
                 }
             }
         },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1206329551987282/task/1210716032146079?focus=true

## Description

Adds an iOS subfeature + settings to enable/disable default browser prompt for inactive users. 

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [x] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.
