### PR TITLE
Enable Duck.ai and FireWindow jumplist items from 0.125.0

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -818,7 +818,7 @@
         },
         "windowsFireWindow": {
             "state": "enabled",
-            "minSupportedVersion": "0.98.0",            
+            "minSupportedVersion": "0.98.0",
             "features": {
                 "fireWindowJumpListItem": {
                     "state": "enabled",

--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -69,6 +69,10 @@
                 "textSummarization": {
                     "state": "enabled",
                     "minSupportedVersion": "0.123.0"
+                },
+                "duckAiChatJumpListItem": {
+                    "state": "enabled",
+                    "minSupportedVersion": "0.125.0"
                 }
             },
             "minSupportedVersion": "0.100.0",
@@ -814,7 +818,13 @@
         },
         "windowsFireWindow": {
             "state": "enabled",
-            "minSupportedVersion": "0.98.0"
+            "minSupportedVersion": "0.98.0",            
+            "features": {
+                "fireWindowJumpListItem": {
+                    "state": "enabled",
+                    "minSupportedVersion": "0.125.0"
+                }
+            }
         },
         "windowsNewTabPageExperiment": {
             "state": "enabled",


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1200695233846578/task/1210509457021298?focus=true

## Description
* Adds "New Fire Window" and "New Duck.ai Window" jump list items the Windows taskbar from version 0.125.0

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [*] I have tested this change locally in all supported browsers.
- [*] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.
