### PR TITLE
Try a client brand hint override to address chatgpt download link reports

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -89,7 +89,7 @@
                 "domains": [
                     {
                         "domain": "chatgpt.com",
-                        "brand": "Chrome"
+                        "brand": "CHROME"
                     }
                 ]
             }


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1200277586140538/task/1210894552952157?focus=true

### Site breakage mitigation process:
#### Brief explanation
- Reported URL: `https://chatgpt.com/backend-api/estuary/content`
- Problems experienced: file download issues/403 errors
- Platforms affected:
  - [ ] iOS
  - [x] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Feature being disabled/modified: `clientbrandhint`
- [x] This change is a speculative mitigation to fix reported breakage.
