### PR TITLE
Enable sync entry points in prod

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -593,41 +593,50 @@
         "syncPromotion": {
             "state": "enabled",
             "features": {
+                "bookmarkNew": {
+                    "state": "enabled",
+                    "minSupportedVersion": "0.126.0"
+                },
+                "bookmarksBarEmpty": {
+                    "state": "enabled",
+                    "minSupportedVersion": "0.126.0"
+                },
+                "bookmarksBarNonEmpty": {
+                    "state": "enabled",
+                    "minSupportedVersion": "0.126.0"
+                },
                 "bookmarks": {
                     "state": "enabled"
+                },
+                "bookmarkManagerEmpty": {
+                    "state": "enabled",
+                    "minSupportedVersion": "0.126.0"
+                },
+                "passwordNew": {
+                    "state": "disabled"
                 },
                 "passwords": {
                     "state": "enabled"
                 },
-                "bookmarksAndPasswordsBannersOpenSyncSetupDialog": {
-                    "state": "internal"
-                },
-                "bookmarkNew": {
-                    "state": "internal"
-                },
-                "passwordNew": {
-                    "state": "internal"
-                },
-                "bookmarkManagerEmpty": {
-                    "state": "internal"
-                },
                 "passwordManagerEmptyAllItems": {
-                    "state": "internal"
+                    "state": "enabled",
+                    "minSupportedVersion": "0.126.0"
                 },
                 "passwordManagerEmptyPasswords": {
-                    "state": "internal"
+                    "state": "enabled",
+                    "minSupportedVersion": "0.126.0"
+                },
+                "bookmarksAndPasswordsBannersOpenSyncSetupDialog": {
+                    "state": "enabled",
+                    "minSupportedVersion": "0.126.0"
                 },
                 "importStart": {
-                    "state": "internal"
+                    "state": "enabled",
+                    "minSupportedVersion": "0.126.0"
                 },
                 "importEnd": {
-                    "state": "internal"
-                },
-                "bookmarksBarEmpty": {
-                    "state": "internal"
-                },
-                "bookmarksBarNonEmpty": {
-                    "state": "internal"
+                    "state": "enabled",
+                    "minSupportedVersion": "0.126.0"
                 }
             }
         },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1210407179200832/task/1210974462396112?focus=true

## Description
[Ship Review](https://app.asana.com/1/137249556945/project/1210407179200832/task/1210785627677175?focus=true) is passed so enabling new sync entry points in prod, beginning with next week's 0.126 release. The final code is already merged.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.