### PR TITLE
Windows: Rollout burn.useExtensionBasedBurn feature to Stable@20%

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -873,8 +873,15 @@
             "state": "enabled",
             "features": {
                 "useExtensionBasedBurn": {
-                    "state": "preview",
-                    "minSupportedVersion": "0.124.0"
+                    "state": "enabled",
+                    "minSupportedVersion": "0.124.0",
+                    "rollout": {
+                        "steps": [
+                            {
+                                "percent": 20.0
+                            }
+                        ]
+                    }
                 },
                 "burnAnimationSettingVisibility": {
                     "state": "enabled",


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/72649045549333/task/1210688190916893?focus=true

## Description
Windows: Rollout `burn.useExtensionBasedBurn` feature to Stable@20%.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.
