### PR TITLE
Clean up defaultBrowserPrompts remote config feature and add the new flag for defaultBrowserPrompts25

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -37326,7 +37326,7 @@
             "features": {
                 "defaultBrowserPrompts25": {
                     "state": "enabled",
-                    "minSupportedVersion": 52450000,
+                    "minSupportedVersion": 52451000,
                     "rollout": {
                         "steps": [
                             {


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1142021229838617/task/1209626585877656?focus=true

## Description
<!-- 
  Please delete either or both process sections below.
-->
Cleaned up `defaultBrowserPrompts` and added `defaultBrowserPrompts25`.
Both are enabled, rollout set to 5%, min version for `defaultBrowserPrompts25` is next Android version `5.245.0`.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.
