### PR TITLE
Revert "Try a client brand hint override to address chatgpt download link reports"

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -86,12 +86,7 @@
             "minSupportedVersion": 51852000,
             "exceptions": [],
             "settings": {
-                "domains": [
-                    {
-                        "domain": "chatgpt.com",
-                        "brand": "CHROME"
-                    }
-                ]
+                "domains": []
             }
         },
         "contentBlocking": {


### PR DESCRIPTION
Reverts duckduckgo/privacy-configuration#3600 as it seems to be leading to crashes: https://app.asana.com/1/137249556945/project/414730916066338/task/1211100004323098?focus=true