### PR TITLE
[iOS] Add Provisional Push Notification Remote Override Config

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -1382,6 +1382,16 @@
             "features": {
                 "widgetReporting": {
                     "state": "enabled"
+                },
+                "inactivityNotification": {
+                    "state": "disabled",
+                    "description": "Local inactivity provisional notifications delivered to Notification Center.",
+                    "targets": [ 
+                        { "localeLanguage": "en", "localeCountry": "US" }
+                    ],
+                    "settings": {
+                        "daysInactive": 7
+                    }
                 }
             }
         },

--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -1389,7 +1389,7 @@
                     "targets": [
                         { "localeLanguage": "en", "localeCountry": "US" }],
                     "settings": {
-                        "daysInactive": 7
+                        "daysInactive": "7"
                     }
                 }
             }

--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -1386,9 +1386,8 @@
                 "inactivityNotification": {
                     "state": "disabled",
                     "description": "Local inactivity provisional notifications delivered to Notification Center.",
-                    "targets": [ 
-                        { "localeLanguage": "en", "localeCountry": "US" }
-                    ],
+                    "targets": [
+                        { "localeLanguage": "en", "localeCountry": "US" }],
                     "settings": {
                         "daysInactive": 7
                     }


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/task/1211003501974970?focus=true

## Description

Introduced a remote feature override for provisional push notifications on iOS to allow enabling/disabling the feature remotely for internal testing and rollout control.

**Follow-up:** https://github.com/duckduckgo/apple-browsers/pull/1742

### Feature change process:

- [x] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [x] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [x] This feature was covered by a tech design.
