### PR TITLE
Disable CPM on leanpaul.com

### DIFF
--- a/features/autoconsent.json
+++ b/features/autoconsent.json
@@ -602,6 +602,10 @@
         {
             "domain": "tuttoandroid.net",
             "reason": "https://github.com/duckduckgo/privacy-configuration/pull/3606"
+        },
+        {
+            "domain": "leonpaul.com",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/pull/3628"
         }
     ],
     "settings": {


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1206670747178362/task/1211072368791640?focus=true

## Description
Popup with no reject button is hidden by CPM, however the overlay is left, leaving the page unusable.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.
