### PR TITLE
Disable element-hiding on gmx.net

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -14,6 +14,10 @@
         {
             "domain": "duck.co",
             "reason": "Element hiding is targeting the ad badge on dev instances as they are not under the duckduckgo.com domain anymore"
+        },
+        {
+            "domain": "gmx.net",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/issues/3629"
         }
     ],
     "settings": {


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1206670747178362/task/1211109945204577?focus=true

## Description
Element hiding is triggering the adblock wall.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.
