### PR TITLE
Omnibar set to internal for macOS + new newTabPagePerTab subfeature

### DIFF
--- a/features/html-new-tab-page.json
+++ b/features/html-new-tab-page.json
@@ -14,6 +14,9 @@
         },
         "omnibar": {
             "state": "disabled"
+        },
+        "newTabPagePerTab": {
+            "state": "disabled"
         }
     }
 }

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -709,7 +709,10 @@
                     "state": "disabled"
                 },
                 "omnibar": {
-                    "state": "disabled"
+                    "state": "internal"
+                },
+                "newTabPagePerTab": {
+                    "state": "internal"
                 }
             }
         },

--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -856,6 +856,9 @@
                 },
                 "omnibar": {
                     "state": "internal"
+                },
+                "newTabPagePerTab": {
+                    "state": "disabled"
                 }
             },
             "minSupportedVersion": "0.100.0"


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1148564399326804/task/1211123676044316?focus=true

## Description

1. Omnibar subfeature set to internal for macOS
2. New subfeature for independent New Tab Page instance per tab

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [x] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [x] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.
