### PR TITLE
Disable element hiding on Fairplay email login sites

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -14,6 +14,14 @@
         {
             "domain": "duck.co",
             "reason": "Element hiding is targeting the ad badge on dev instances as they are not under the duckduckgo.com domain anymore"
+        },
+        {
+            "domain": "gmx.net",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/pull/3638"
+        },
+        {
+            "domain": "web.de",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/pull/3638"
         }
     ],
     "settings": {


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1206670747178362/task/1210398033784022?focus=true

### Site breakage mitigation process:
#### Brief explanation
- Reported URL: web.de & gmx.net
- Problems experienced: Adblock disable nag (can still log in, but not as obvious w/o mitigation) based on CSS check
- Platforms affected:
  - [ ] All
- Feature being disabled/modified: element hiding
