### PR TITLE
Add disabled feature flag for defaultBrowserExperience| toastNotifications

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -857,6 +857,15 @@
                 }
             }
         },
+        "defaultBrowserExperience": {
+            "state": "disabled",
+            "features": {
+                "toastNotifications": {
+                    "state": "disabled"
+                }
+            },
+            "exceptions": []
+        },
         "windowsNewTabPageExperiment": {
             "state": "enabled",
             "minSupportedVersion": "0.96.0"


### PR DESCRIPTION
**Asana Task/Github Issue:** [Create feature flag in privacy-configuration - 0.5 days](https://app.asana.com/1/137249556945/project/1209292120581622/task/1211138704507661?focus=true)

## Description
Added a new feature flag `defaultBrowserExperience| toastNotifications` to control whether we show system notifications as follow ups to the inline prompts. The minimum supported version will be set once the flag is enabled.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [X] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.
