### PR TITLE
disable widget reporting

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -1381,7 +1381,7 @@
             "state": "enabled",
             "features": {
                 "widgetReporting": {
-                    "state": "enabled"
+                    "state": "disabled"
                 },
                 "inactivityNotification": {
                     "state": "disabled",


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/414235014887631/task/1211138493415452?focus=true

## Description
Disables widget data collection pixel.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.
