### PR TITLE
Add webViewProviderPreviewOptInFallbackToDefault

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -840,6 +840,9 @@
             "features": {
                 "webViewProviderPreviewOptIn": {
                     "state": "disabled"
+                },
+                "webViewProviderPreviewOptInFallbackToDefault": {
+                    "state": "disabled"
                 }
             },
             "exceptions": []


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/72649045549333/task/1211008971469490?focus=true

## Description
<!-- 
  Please delete either or both process sections below.
-->

Follow up on https://github.com/duckduckgo/privacy-configuration/pull/3636 and adds a separate flag to force fallback to default provider.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.