### PR TITLE
Hide blank ads in youtube.com feed

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -3902,6 +3902,10 @@
                     {
                         "selector": "ytm-promoted-sparkles-web-renderer",
                         "type": "hide"
+                    },
+                    {
+                        "selector": "ytd-in-feed-ad-layout-renderer",
+                        "type": "hide"
                     }
                 ]
             },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1206670747178362/task/1211146179032860?focus=true

### Site breakage mitigation process:
#### Brief explanation
- Reported URL: youtube.com
- Problems experienced: blank/gray ad spaces from blocking trackers
- Platforms affected:
  - [x] All
- Feature being disabled/modified: element-hiding
