### PR TITLE
Add user agent override for www.msn.com

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -610,7 +610,12 @@
             "settings": {
                 "omitApplicationSites": [],
                 "omitVersionSites": [],
-                "userAgentOverrides": [],
+                "userAgentOverrides": [
+                    {
+                      "domain": "www.msn.com",
+                      "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36"
+                    }
+                ],
                 "omitClientHintMutations": []
             },
             "exceptions": [],

--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -612,8 +612,8 @@
                 "omitVersionSites": [],
                 "userAgentOverrides": [
                     {
-                      "domain": "www.msn.com",
-                      "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36"
+                        "domain": "www.msn.com",
+                        "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36"
                     }
                 ],
                 "omitClientHintMutations": []

--- a/schema/config.ts
+++ b/schema/config.ts
@@ -17,6 +17,7 @@ import { NetworkProtection } from './features/network-protection';
 import { AiChatConfig } from './features/ai-chat';
 import { ScriptletsFeature } from './features/scriptlets';
 import { WindowsWebViewFailures } from './features/windows-webview-failures';
+import { CustomUserAgentFeature } from './features/custom-user-agent';
 
 export { WebCompatSettings } from './features/webcompat';
 export { DuckPlayerSettings } from './features/duckplayer';
@@ -57,6 +58,7 @@ export type ConfigV5<VersionType> = {
         networkProtection?: NetworkProtection<VersionType>;
         scriptlets?: ScriptletsFeature<VersionType>;
         windowsWebviewFailures?: WindowsWebViewFailures<VersionType>;
+        customUserAgent?: CustomUserAgentFeature<VersionType>;
     };
     unprotectedTemporary: SiteException[];
 };

--- a/schema/features/custom-user-agent.ts
+++ b/schema/features/custom-user-agent.ts
@@ -1,4 +1,4 @@
-import { Feature, CSSInjectFeatureSettings } from '../feature';
+import { Feature } from '../feature';
 
 type UserAgentOverride = {
     domain: string;
@@ -23,7 +23,7 @@ type VersionsOnly = {
     versions: string[];
 };
 
-type FullCustomUserAgentOptions = CSSInjectFeatureSettings<{
+type CustomUserAgentSettings = {
     // Windows properties
     userAgentOverrides?: UserAgentOverride[];
     omitClientHintMutations?: string[];
@@ -42,8 +42,6 @@ type FullCustomUserAgentOptions = CSSInjectFeatureSettings<{
     // iOS/Android specific user agent configs
     closestUserAgent?: UserAgentConfig | VersionsOnly;
     ddgFixedUserAgent?: UserAgentConfig;
-}>;
-
-export type CustomUserAgentSettings = Partial<FullCustomUserAgentOptions>;
+};
 
 export type CustomUserAgentFeature<VersionType> = Feature<CustomUserAgentSettings, VersionType>;

--- a/schema/features/custom-user-agent.ts
+++ b/schema/features/custom-user-agent.ts
@@ -1,0 +1,49 @@
+import { Feature, CSSInjectFeatureSettings } from '../feature';
+
+type UserAgentOverride = {
+    domain: string;
+    userAgent: string;
+};
+
+type DomainWithReason = {
+    domain: string;
+    reason: string;
+};
+
+type DomainOnly = {
+    domain: string;
+};
+
+type UserAgentConfig = {
+    state?: string;
+    versions?: string[];
+};
+
+type VersionsOnly = {
+    versions: string[];
+};
+
+type FullCustomUserAgentOptions = CSSInjectFeatureSettings<{
+    // Windows properties
+    userAgentOverrides?: UserAgentOverride[];
+    omitClientHintMutations?: string[];
+
+    // Common properties (can be strings for Windows or objects for mobile platforms)
+    omitApplicationSites?: string[] | DomainOnly[];
+    omitVersionSites?: string[] | DomainOnly[];
+
+    // macOS/iOS/Android properties
+    defaultPolicy?: 'brand' | 'closest' | string;
+    defaultSites?: DomainWithReason[];
+    ddgFixedSites?: DomainWithReason[];
+    ddgDefaultSites?: DomainWithReason[];
+    webViewDefault?: DomainWithReason[];
+
+    // iOS/Android specific user agent configs
+    closestUserAgent?: UserAgentConfig | VersionsOnly;
+    ddgFixedUserAgent?: UserAgentConfig;
+}>;
+
+export type CustomUserAgentSettings = Partial<FullCustomUserAgentOptions>;
+
+export type CustomUserAgentFeature<VersionType> = Feature<CustomUserAgentSettings, VersionType>;


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1207686573307971/task/1210591342674337?focus=true

## Description

1. Make UA Chrome to prevent missing sign in button (it's part of Edge UI to have account).
2. Adds a best effort schema to prevent issues. (May not be perfect but is better than no guardrails, it enshrines the current use of config rather than trying to get all supported fields).

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.
