### PR TITLE
Temporarily disable GPC on newyorker.com to resolve breakage

### DIFF
--- a/features/gpc.json
+++ b/features/gpc.json
@@ -71,6 +71,10 @@
         {
             "domain": "hopwtr.com",
             "reason": "https://github.com/duckduckgo/privacy-configuration/pull/3601"
+        },
+        {
+            "domain": "newyorker.com",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/pull/3664"
         }
     ],
     "settings": {


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1200277586140538/task/1211165826848371?focus=true

## Description
Temporarily disable GPC on newyorker.com due to a bug in their implementation that cause the first page load to go blank.

#### Brief explanation
- Reported URL: https://www.newyorker.com
- Problems experienced: First page load is blank when accessed from certain locations with privacy laws
- Platforms affected:
  - [x] iOS
  - [x] Android
  - [x] Windows
  - [x] MacOS
  - [x] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified: GPC
- [ ] This change is a speculative mitigation to fix reported breakage.
