### PR TITLE
Restrict auto respond workflow to people with write access

### DIFF
--- a/.github/workflows/auto-respond-pr.yml
+++ b/.github/workflows/auto-respond-pr.yml
@@ -28,48 +28,28 @@ jobs:
         runs-on: ubuntu-latest
 
         steps:
-            - name: Check team membership
+            - name: Check repository permissions
               uses: actions/github-script@v7
               with:
-                  github-token: ${{ secrets.GH_RO_PAT || secrets.GITHUB_TOKEN }}
+                  github-token: ${{ secrets.GITHUB_TOKEN }}
                   script: |
                       const username = context.payload.pull_request.user.login;
-                      
+
                       try {
-                          // First try to check team membership with the available token
-                          const response = await github.rest.teams.getMembershipForUserInOrg({
-                              org: 'duckduckgo',
-                              team_slug: 'core',
+                          const repoPermission = await github.rest.repos.getCollaboratorPermissionLevel({
+                              owner: context.repo.owner,
+                              repo: context.repo.repo,
                               username: username
                           });
                           
-                          if (response.data.state !== 'active') {
-                              core.setFailed(`User ${username} is not an active member of @duckduckgo/core team`);
-                              return;
+                          const permission = repoPermission.data.permission;
+                          if (permission === 'write' || permission === 'admin') {
+                              console.log(`✅ User authorized to use workflow`);
+                          } else {
+                              core.setFailed(`User does not have sufficient repository permissions to use this workflow`);
                           }
-                          
-                          console.log(`✅ User ${username} is a member of @duckduckgo/core team`);
                       } catch (error) {
-                          console.log(`Team membership check failed: ${error.message}`);
-                          
-                          // Fallback: Check if user has write access to the repository
-                          // This is a reasonable proxy for core team membership
-                          try {
-                              const repoPermission = await github.rest.repos.getCollaboratorPermissionLevel({
-                                  owner: context.repo.owner,
-                                  repo: context.repo.repo,
-                                  username: username
-                              });
-                              
-                              const permission = repoPermission.data.permission;
-                              if (permission === 'write' || permission === 'admin') {
-                                  console.log(`✅ User ${username} has ${permission} access to repository - allowing workflow`);
-                              } else {
-                                  core.setFailed(`User ${username} does not have sufficient repository permissions (${permission}) to use this workflow`);
-                              }
-                          } catch (fallbackError) {
-                              core.setFailed(`Unable to verify user permissions: ${fallbackError.message}`);
-                          }
+                          core.setFailed(`Unable to verify user permissions: ${error.message}`);
                       }
             - name: Create comment
               if: github.event.action == 'opened'

--- a/.github/workflows/auto-respond-pr.yml
+++ b/.github/workflows/auto-respond-pr.yml
@@ -49,7 +49,7 @@ jobs:
                               core.setFailed(`User does not have sufficient repository permissions to use this workflow`);
                           }
                       } catch (error) {
-                          core.setFailed(`Unable to verify user permissions: ${error.message}`);
+                          core.setFailed(`Unable to verify user permissions`);
                       }
             - name: Create comment
               if: github.event.action == 'opened'

--- a/.github/workflows/auto-respond-pr.yml
+++ b/.github/workflows/auto-respond-pr.yml
@@ -31,26 +31,44 @@ jobs:
             - name: Check team membership
               uses: actions/github-script@v7
               with:
-                  github-token: ${{ secrets.GITHUB_TOKEN }}
+                  github-token: ${{ secrets.GH_RO_PAT || secrets.GITHUB_TOKEN }}
                   script: |
+                      const username = context.payload.pull_request.user.login;
+                      
                       try {
+                          // First try to check team membership with the available token
                           const response = await github.rest.teams.getMembershipForUserInOrg({
                               org: 'duckduckgo',
                               team_slug: 'core',
-                              username: context.payload.pull_request.user.login
+                              username: username
                           });
                           
                           if (response.data.state !== 'active') {
-                              core.setFailed(`User ${context.payload.pull_request.user.login} is not an active member of @duckduckgo/core team`);
+                              core.setFailed(`User ${username} is not an active member of @duckduckgo/core team`);
                               return;
                           }
                           
-                          console.log(`✅ User ${context.payload.pull_request.user.login} is a member of @duckduckgo/core team`);
+                          console.log(`✅ User ${username} is a member of @duckduckgo/core team`);
                       } catch (error) {
-                          if (error.status === 404) {
-                              core.setFailed(`User ${context.payload.pull_request.user.login} is not a member of @duckduckgo/core team`);
-                          } else {
-                              core.setFailed(`Error checking team membership: ${error.message}`);
+                          console.log(`Team membership check failed: ${error.message}`);
+                          
+                          // Fallback: Check if user has write access to the repository
+                          // This is a reasonable proxy for core team membership
+                          try {
+                              const repoPermission = await github.rest.repos.getCollaboratorPermissionLevel({
+                                  owner: context.repo.owner,
+                                  repo: context.repo.repo,
+                                  username: username
+                              });
+                              
+                              const permission = repoPermission.data.permission;
+                              if (permission === 'write' || permission === 'admin') {
+                                  console.log(`✅ User ${username} has ${permission} access to repository - allowing workflow`);
+                              } else {
+                                  core.setFailed(`User ${username} does not have sufficient repository permissions (${permission}) to use this workflow`);
+                              }
+                          } catch (fallbackError) {
+                              core.setFailed(`Unable to verify user permissions: ${fallbackError.message}`);
                           }
                       }
             - name: Create comment

--- a/.github/workflows/auto-respond-pr.yml
+++ b/.github/workflows/auto-respond-pr.yml
@@ -28,6 +28,31 @@ jobs:
         runs-on: ubuntu-latest
 
         steps:
+            - name: Check team membership
+              uses: actions/github-script@v7
+              with:
+                  github-token: ${{ secrets.GITHUB_TOKEN }}
+                  script: |
+                      try {
+                          const response = await github.rest.teams.getMembershipForUserInOrg({
+                              org: 'duckduckgo',
+                              team_slug: 'core',
+                              username: context.payload.pull_request.user.login
+                          });
+                          
+                          if (response.data.state !== 'active') {
+                              core.setFailed(`User ${context.payload.pull_request.user.login} is not an active member of @duckduckgo/core team`);
+                              return;
+                          }
+                          
+                          console.log(`✅ User ${context.payload.pull_request.user.login} is a member of @duckduckgo/core team`);
+                      } catch (error) {
+                          if (error.status === 404) {
+                              core.setFailed(`User ${context.payload.pull_request.user.login} is not a member of @duckduckgo/core team`);
+                          } else {
+                              core.setFailed(`Error checking team membership: ${error.message}`);
+                          }
+                      }
             - name: Create comment
               if: github.event.action == 'opened'
               uses: peter-evans/create-or-update-comment@v4


### PR DESCRIPTION
**Asana Task/Github Issue:** N/A

## Description
This PR restricts the `auto-respond-pr.yml` GitHub workflow to only members of the `@duckduckgo/core` team. A new step has been added at the beginning of the workflow to check the pull request author's team membership. If the author is not an active member of the `@duckduckgo/core` team, the workflow will fail early, preventing further execution and providing clear feedback. This enhances access control and prevents unauthorized use of the automated workflow.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

---
<a href="https://cursor.com/background-agent?bcId=bc-57feef81-2210-4856-b73e-5b0bb0d3cedd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-57feef81-2210-4856-b73e-5b0bb0d3cedd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

