### PR TITLE
[iOS][App Shortcut] Add App Shortcut Remote Override

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -1431,6 +1431,12 @@
                     "settings": {
                         "daysInactive": "7"
                     }
+                },
+                "appShortcut": {
+                    "state": "disabled",
+                    "description": "iOS App Shortcuts for quick actions",
+                    "targets": [
+                        { "localeLanguage": "en", "localeCountry": "US" }]
                 }
             }
         },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/task/1211152077380451?focus=true

## Description

Introduces a remote override for App Shortcuts on iOS. The goal is to allow enable/disable of App Shortcuts (SearchInAppIntent, AIChatIntent, etc.) via privacy-config. This enables us to quickly disable a shortcut if it causes unintended behavior. 

For context on App Shortcut, see parent task: https://app.asana.com/1/137249556945/project/276630244458377/task/1211107420315000?focus=true

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [x] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.
