### PR TITLE
Add remote feature flag for open window by default

### DIFF
--- a/features/open-fire-window-by-default.json
+++ b/features/open-fire-window-by-default.json
@@ -1,0 +1,7 @@
+{
+    "_meta": {
+        "description": "Controls the new settings for opening fire windows by default (either startup or in general) for desktop browsers"
+    },
+    "state": "disabled",
+    "exceptions": []
+}

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -761,6 +761,9 @@
         "disableFireAnimation": {
             "state": "enabled"
         },
+        "openFireWindowByDefault": {
+            "state": "enabled"
+        },
         "feedbackForm": {
             "state": "enabled"
         },


### PR DESCRIPTION
**Asana Task/Github Issue:**  https://app.asana.com/1/137249556945/project/1204006570077678/task/1211090698913956?focus=true

## Description
We are introducing a new feature to our desktop browsers, allowing users to open fire windows by default. We would like to have this behind a remote feature flag, in case we need to turn it off if we see a problem (fire actions are core to privacy)

### Feature change process:

- [x] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [x] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.
