### PR TITLE
[iOS]Toggle on inactivityNotification internally

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -1442,7 +1442,7 @@
                     "state": "disabled"
                 },
                 "inactivityNotification": {
-                    "state": "disabled",
+                    "state": "internal",
                     "description": "Local inactivity provisional notifications delivered to Notification Center.",
                     "targets": [
                         { "localeLanguage": "en", "localeCountry": "US" }],


### PR DESCRIPTION
## Description

After https://github.com/duckduckgo/apple-browsers/pull/1794 we are ready to toggle it on internally

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [x] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [x] This feature was covered by a tech design.