### PR TITLE
Hide blank space on nytimes.com

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -2706,6 +2706,10 @@
                     {
                         "selector": ".pz-ad-box",
                         "type": "hide-empty"
+                    },
+                    {
+                        "selector": "[class*='Ad-module_adContainer__']",
+                        "type": "hide-empty"
                     }
                 ]
             },


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/1206670747178362/task/1211191407577302?focus=true

## Description
### Site breakage mitigation process:
#### Brief explanation
- Reported URL: https://www.nytimes.com/games/wordle/index.html
- Problems experienced: Blank space caused by tracker blocking.
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [x] Windows
  - [x] MacOS
  - [x] Extensions
- Tracker(s) being unblocked: N/A
- Feature being disabled/modified: N/A
- [ ] This change is a speculative mitigation to fix reported breakage.
