### PR TITLE
Disables updatesWontAutomaticallyRestartTheApp

### DIFF
--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -786,7 +786,7 @@
             "state": "enabled"
         },
         "updatesWontAutomaticallyRestartApp": {
-            "state": "enabled",
+            "state": "disabled",
             "exceptions": [],
             "minSupportedVersion": "1.155.0"
         },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/task/1211209317228810?focus=true

## Description

Disables `updatesWontAutomaticallyRestartTheApp` until we can figure out what's causing trouble for it

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.
