### PR TITLE
Add pageContext on macOS

### DIFF
--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -217,6 +217,9 @@
                 },
                 "globalToggle": {
                     "state": "internal"
+                },
+                "pageContext": {
+                    "state": "internal"
                 }
             },
             "settings": {


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/72649045549333/task/1211211991091697

## Description
This change makes pageContext feature flag available to internal users on macOS.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [x] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.
