### PR TITLE
Hide blank spaces on doodle.com

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -1328,6 +1328,14 @@
                     {
                         "selector": "#sticky-footer-ads",
                         "type": "hide"
+                    },
+                    {
+                        "selector": ".jupiter-placement-middle_content__mxFQ3",
+                        "type": "hide-empty"
+                    },
+                    {
+                        "selector": ".layout_sticky-slot-content__ExtEH",
+                        "type": "hide"
                     }
                 ]
             },


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/1206670747178362/task/1211140456184575?focus=true

## Description
### Site breakage mitigation process:
#### Brief explanation
- Reported URL: Poll pages on https://doodle.com
- Problems experienced: Blank spaces caused by tracker blocking.
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [x] Windows
  - [x] MacOS
  - [x] Extensions
- Tracker(s) being unblocked: N/A
- Feature being disabled/modified: N/A
- [ ] This change is a speculative mitigation to fix reported breakage.
