### PR TITLE
Hide blank space when logged in on doodle.com

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -1330,6 +1330,10 @@
                         "type": "hide"
                     },
                     {
+                        "selector": ".jupiter-placement-middle-module_content__Z4Fc0",
+                        "type": "hide-empty"
+                    },
+                    {
                         "selector": ".jupiter-placement-middle_content__mxFQ3",
                         "type": "hide-empty"
                     },


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/1206670747178362/task/1211140456184575?focus=true

## Description
### Site breakage mitigation process:
#### Brief explanation
- Reported URL: Poll pages on https://doodle.com/
- Problems experienced: Blank space when logged in, caused by tracker blocking.
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [x] Windows
  - [x] MacOS
  - [x] Extensions
- Tracker(s) being unblocked: N/A
- Feature being disabled/modified: N/A
- [ ] This change is a speculative mitigation to fix reported breakage.
