### PR TITLE
Disable onboarding design experiment and related features

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -37629,29 +37629,29 @@
             }
         },
         "onboardingDesignExperiment": {
-            "state": "enabled",
+            "state": "disabled",
             "exceptions": [],
             "features": {
                 "onboardingDesignExperimentAug25": {
-                    "state": "enabled",
+                    "state": "disabled",
                     "minSupportedVersion": 52450000,
                     "cohorts": [
                         {
                             "name": "modifiedControl",
-                            "weight": 1
+                            "weight": 0
                         },
                         {
                             "name": "bb",
-                            "weight": 1
+                            "weight": 0
                         },
                         {
                             "name": "buck",
-                            "weight": 1
+                            "weight": 0
                         }
                     ]
                 },
                 "waitForLocalPrivacyConfig": {
-                    "state": "enabled",
+                    "state": "disabled",
                     "minSupportedVersion": 52450000
                 }
             }


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/72649045549333/task/1208579588904210?focus=true

## Description
<!-- 
  Please delete either or both process sections below.
-->

Disables and stops enrolment into the Onboarding Design Experiment

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.
