### PR TITLE
Remove overlay on lalanalu.com

### DIFF
--- a/features/autoconsent.json
+++ b/features/autoconsent.json
@@ -590,6 +590,10 @@
         {
             "domain": "leonpaul.com",
             "reason": "https://github.com/duckduckgo/privacy-configuration/pull/3628"
+        },
+        {
+            "domain": "lalanalu.com",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/pull/3698"
         }
     ],
     "settings": {


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/1206670747178362/task/1211240932253985?focus=true

## Description
### Site breakage mitigation process:
#### Brief explanation
- Reported URL: https://www.lalanalu.com/bcgarn/1149-6932-lino-de-bcgarn-9168274075276.html
- Problems experienced: Dark overlay caused by CPM.
- Platforms affected:
  - [x] iOS
  - [x] Android
  - [x] Windows
  - [x] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked: N/A
- Feature being disabled/modified: Cookie Popup Management (CPM)
- [ ] This change is a speculative mitigation to fix reported breakage.
