### PR TITLE
Enable the newSyncEntryPoints for internal builds

### DIFF
--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -1058,6 +1058,9 @@
                 },
                 "syncSetupBarcodeIsUrlBased": {
                     "state": "enabled"
+                },
+                "newSyncEntryPoints": {
+                    "state": "internal"
                 }
             }
         },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/72649045549333/task/1211243813509187?focus=true

## Description
We're adding a bunch of new entry points to sync. This was going to be shipped enabled by default, but we had some scaling issues on the backend when Windows launched. As such, this will now be rolled out remotely.

Before we do that, it will need to be tested internally. This change promotes that flag to `internal`

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [x] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [x] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.
