### PR TITLE
Re-enable sync promos on Windows with minimum version 0.129 and gradual rollout

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -685,7 +685,7 @@
             "features": {
                 "bookmarkNew": {
                     "state": "enabled",
-                    "minSupportedVersion": "0.129.0",
+                    "minSupportedVersion": "0.128.3",
                     "rollout": {
                         "steps": [
                             { "percent": 10 }]
@@ -693,7 +693,7 @@
                 },
                 "bookmarksBarEmpty": {
                     "state": "enabled",
-                    "minSupportedVersion": "0.129.0",
+                    "minSupportedVersion": "0.128.3",
                     "rollout": {
                         "steps": [
                             { "percent": 10 }]
@@ -701,7 +701,7 @@
                 },
                 "bookmarksBarNonEmpty": {
                     "state": "enabled",
-                    "minSupportedVersion": "0.129.0",
+                    "minSupportedVersion": "0.128.3",
                     "rollout": {
                         "steps": [
                             { "percent": 10 }]
@@ -709,7 +709,7 @@
                 },
                 "bookmarks": {
                     "state": "enabled",
-                    "minSupportedVersion": "0.129.0",
+                    "minSupportedVersion": "0.128.3",
                     "rollout": {
                         "steps": [
                             { "percent": 10 }]
@@ -717,7 +717,7 @@
                 },
                 "bookmarkManagerEmpty": {
                     "state": "enabled",
-                    "minSupportedVersion": "0.129.0",
+                    "minSupportedVersion": "0.128.3",
                     "rollout": {
                         "steps": [
                             { "percent": 10 }]
@@ -728,7 +728,7 @@
                 },
                 "passwords": {
                     "state": "enabled",
-                    "minSupportedVersion": "0.129.0",
+                    "minSupportedVersion": "0.128.3",
                     "rollout": {
                         "steps": [
                             { "percent": 10 }]
@@ -736,7 +736,7 @@
                 },
                 "passwordManagerEmptyAllItems": {
                     "state": "enabled",
-                    "minSupportedVersion": "0.129.0",
+                    "minSupportedVersion": "0.128.3",
                     "rollout": {
                         "steps": [
                             { "percent": 10 }]
@@ -744,7 +744,7 @@
                 },
                 "passwordManagerEmptyPasswords": {
                     "state": "enabled",
-                    "minSupportedVersion": "0.129.0",
+                    "minSupportedVersion": "0.128.3",
                     "rollout": {
                         "steps": [
                             { "percent": 10 }]
@@ -752,7 +752,7 @@
                 },
                 "bookmarksAndPasswordsBannersOpenSyncSetupDialog": {
                     "state": "enabled",
-                    "minSupportedVersion": "0.129.0",
+                    "minSupportedVersion": "0.128.3",
                     "rollout": {
                         "steps": [
                             { "percent": 10 }]
@@ -760,7 +760,7 @@
                 },
                 "importStart": {
                     "state": "enabled",
-                    "minSupportedVersion": "0.129.0",
+                    "minSupportedVersion": "0.128.3",
                     "rollout": {
                         "steps": [
                             { "percent": 10 }]
@@ -768,7 +768,7 @@
                 },
                 "importEnd": {
                     "state": "enabled",
-                    "minSupportedVersion": "0.129.0",
+                    "minSupportedVersion": "0.128.3",
                     "rollout": {
                         "steps": [
                             { "percent": 10 }]

--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -681,52 +681,98 @@
             "state": "enabled"
         },
         "syncPromotion": {
-            "state": "disabled",
+            "state": "enabled",
             "features": {
                 "bookmarkNew": {
                     "state": "enabled",
-                    "minSupportedVersion": "0.126.0"
+                    "minSupportedVersion": "0.129.0",
+                    "rollout": {
+                        "steps": [
+                            { "percent": 10 }]
+                    }
                 },
                 "bookmarksBarEmpty": {
                     "state": "enabled",
-                    "minSupportedVersion": "0.126.0"
+                    "minSupportedVersion": "0.129.0",
+                    "rollout": {
+                        "steps": [
+                            { "percent": 10 }]
+                    }
                 },
                 "bookmarksBarNonEmpty": {
                     "state": "enabled",
-                    "minSupportedVersion": "0.126.0"
+                    "minSupportedVersion": "0.129.0",
+                    "rollout": {
+                        "steps": [
+                            { "percent": 10 }]
+                    }
                 },
                 "bookmarks": {
-                    "state": "enabled"
+                    "state": "enabled",
+                    "minSupportedVersion": "0.129.0",
+                    "rollout": {
+                        "steps": [
+                            { "percent": 10 }]
+                    }
                 },
                 "bookmarkManagerEmpty": {
                     "state": "enabled",
-                    "minSupportedVersion": "0.126.0"
+                    "minSupportedVersion": "0.129.0",
+                    "rollout": {
+                        "steps": [
+                            { "percent": 10 }]
+                    }
                 },
                 "passwordNew": {
                     "state": "disabled"
                 },
                 "passwords": {
-                    "state": "enabled"
+                    "state": "enabled",
+                    "minSupportedVersion": "0.129.0",
+                    "rollout": {
+                        "steps": [
+                            { "percent": 10 }]
+                    }
                 },
                 "passwordManagerEmptyAllItems": {
                     "state": "enabled",
-                    "minSupportedVersion": "0.126.0"
+                    "minSupportedVersion": "0.129.0",
+                    "rollout": {
+                        "steps": [
+                            { "percent": 10 }]
+                    }
                 },
                 "passwordManagerEmptyPasswords": {
                     "state": "enabled",
-                    "minSupportedVersion": "0.126.0"
+                    "minSupportedVersion": "0.129.0",
+                    "rollout": {
+                        "steps": [
+                            { "percent": 10 }]
+                    }
                 },
                 "bookmarksAndPasswordsBannersOpenSyncSetupDialog": {
                     "state": "enabled",
-                    "minSupportedVersion": "0.126.0"
+                    "minSupportedVersion": "0.129.0",
+                    "rollout": {
+                        "steps": [
+                            { "percent": 10 }]
+                    }
                 },
                 "importStart": {
                     "state": "enabled",
-                    "minSupportedVersion": "0.126.0"
+                    "minSupportedVersion": "0.129.0",
+                    "rollout": {
+                        "steps": [
+                            { "percent": 10 }]
+                    }
                 },
                 "importEnd": {
                     "state": "enabled",
-                    "minSupportedVersion": "0.126.0"
+                    "minSupportedVersion": "0.129.0",
+                    "rollout": {
+                        "steps": [
+                            { "percent": 10 }]
+                    }
                 }
             }
         },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1203709236521659/task/1211217546356321?focus=true

## Description
The issue that necessitated the disabling of the sync promos was fixed and will release in 0.129: https://app.asana.com/1/137249556945/project/1203709236521659/task/1211217979519721?focus=true

Re-enabling the sync promos with min version 0.129 and gradual rollout.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.