### PR TITLE
Enable "showDownloadPopup" from v0.129.0

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -1083,6 +1083,10 @@
                 "alwaysAskWhereToSaveFiles": {
                     "state": "enabled",
                     "minSupportedVersion": "0.112.0"
+                },
+                "showDownloadPopup": {
+                    "state": "enabled",
+                    "minSupportedVersion": "0.129.0"
                 }
             }
         },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1200695233846578/task/1210444616087564?focus=true

## Description
* Enables the `showDownloadPopup` from version 0.129.0

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [x] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.
