### PR TITLE
SBT - add tracker exception-webmd

### DIFF
--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -3327,6 +3327,15 @@
                     }
                 ]
             },
+            "syndicatedsearch.goog": {
+                "rules": [
+                    {
+                        "rule": "syndicatedsearch.goog/adsense/search/ads.js",
+                        "domains": ["webmd.com"],
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/pull/3720"
+                    }
+                ]
+            },
             "taboola.com": {
                 "rules": [
                     {


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1206670747178362/task/1211287368093583?focus=true

### Site breakage mitigation process:
#### Brief explanation
- Reported URL: https://www.webmd.com/search
- Problems experienced: Search results don't load due to a tracker being blocked. Only happening on desktop apps.
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [x] Windows
  - [x] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked: syndicatedsearch.goog/adsense/search/ads.js
- Feature being disabled/modified: NA
- [ ] This change is a speculative mitigation to fix reported breakage.
