### PR TITLE
Enable toast notifications for default browser in Windows

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -1156,7 +1156,8 @@
                     "state": "disabled"
                 },
                 "toastNotifications": {
-                    "state": "disabled"
+                    "state": "enabled",
+                    "minSupportedVersion": "0.129.0"
                 }
             }
         },


### PR DESCRIPTION
**Asana Task/Github Issue:** [Windows: Improve set as default rate with Windows instruction prompt](https://app.asana.com/1/137249556945/project/1209292120581622/task/1210758756109894?focus=true)

## Description
The system notifications have been implemented and released in version 0.129.0, so it is now safe to enable the feature flag.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [x] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [x] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [x] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.
