### PR TITLE
[Google password import] Add export confirm settings

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -35565,6 +35565,13 @@
                                                         "Export"
                                                     ]
                                                 },
+                                                "exportConfirmButton": {
+                                                    "shouldAutotap": true,
+                                                    "path": "/options",
+                                                    "selectors": [
+                                                        "button[data-mdc-dialog-action='ok']"
+                                                    ]
+                                                },
                                                 "signInButton": {
                                                     "shouldAutotap": true,
                                                     "path": "/intro",

--- a/schema/features/autofill.ts
+++ b/schema/features/autofill.ts
@@ -8,13 +8,14 @@ type ButtonConfig = {
     shouldAutotap: boolean;
     path: string;
     selectors: string[];
-    labelTexts: string[];
+    labelTexts?: string[];
 };
 
 type ImportFromGooglePasswordManager = {
     settingsButton: ButtonConfig;
     exportButton: ButtonConfig;
     signInButton: ButtonConfig;
+    exportConfirmButton: ButtonConfig;
 };
 
 export type FormTypeSetting = {


### PR DESCRIPTION
**Asana Task/Github Issue:**

## Description
<!-- 
  Please delete either or both process sections below.
-->
This config can be merged with the code that consumes it https://github.com/duckduckgo/content-scope-scripts/pull/1933

We want to (near future) allow auto-tapping of export confirmation element on google password import.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.
