### PR TITLE
SBT-add-tracker-exception-for-email-signup

### DIFF
--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -2338,6 +2338,11 @@
                         "rule": "listrakbi.com",
                         "domains": ["fsastore.com"],
                         "reason": ["fsastore.com - https://github.com/duckduckgo/privacy-configuration/issues/2114"]
+                    },
+                    {
+                        "rule": "oc.listrakbi.com/subscribestatus",
+                        "domains": ["ninjakitchen.com"],
+                        "reason": ["ninjakitchen.com - https://github.com/duckduckgo/privacy-configuration/pull/3728"]
                     }
                 ]
             },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1206670747178362/task/1211283306315932?focus=true

### Site breakage mitigation process:
#### Brief explanation
- Reported URL: https://www.ninjakitchen.com/
- Problems experienced: user can't sign up for emails; the email submission button is unresponsive because we're blocking a tracker.
- Platforms affected:
  - [ ] iOS
  - [ x] Android
  - [ x] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked: oc.listrakbi.com/subscribestatus
- Feature being disabled/modified: NA
- [ ] This change is a speculative mitigation to fix reported breakage.
