### PR TITLE
SBT-add-tracker-exception-to-play-videos

### DIFF
--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -386,8 +386,19 @@
                     },
                     {
                         "rule": "flag.lab.eu.amplitude.com/sdk/",
-                        "domains": ["bluelightcard.co.uk"],
-                        "reason": ["https://github.com/duckduckgo/privacy-configuration/pull/2779"]
+                        "domains": [
+                            "bluelightcard.co.uk",
+                            "outsideonline.com"
+                        ],
+                        "reason": [
+                            "bluelightcard.co.uk - https://github.com/duckduckgo/privacy-configuration/pull/2779",
+                            "outsideonline.com - https://github.com/duckduckgo/privacy-configuration/pull/3730"
+                        ]
+                    },
+                    {
+                        "rule": "api.lab.amplitude.com/sdk",
+                        "domains": ["outsideonline.com"],
+                        "reason": ["outsideonline.com - https://github.com/duckduckgo/privacy-configuration/pull/3730"]
                     }
                 ]
             },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1206670747178362/task/1211275831135468?focus=true

## Description

### Site breakage mitigation process: 
#### Brief explanation
- Reported URL: https://watch.outsideonline.com/series/beat-monday/UkYMNqEb-Sg3dmWsy
- Problems experienced: videos would not play because of two blocked trackers
- Platforms affected:
  - [x ] iOS
  - [x ] Android
  - [ x] Windows
  - [x ] MacOS
  - [ x] Extensions
- Tracker(s) being unblocked: api.lab.amplitude.com/sdk & flag.lab.amplitude.com/sdk
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.
