### PR TITLE
Add new flags in privacy config for postCtaExperience and onboardingHomeScreenWidget

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -37652,6 +37652,9 @@
             "state": "enabled",
             "exceptions": [],
             "features": {
+                "simpleSearchWidgetPrompt": {
+                  "state": "enabled"
+                },
                 "postCtaExperienceExperimentJun25": {
                     "state": "enabled",
                     "minSupportedVersion": 52400000,
@@ -37681,6 +37684,9 @@
             "state": "enabled",
             "exceptions": [],
             "features": {
+                "onboardingHomeScreenWidgetPrompt": {
+                    "state": "enabled"
+                },
                 "onboardingHomeScreenWidgetExperimentJun25": {
                     "state": "enabled",
                     "minSupportedVersion": 52400000,


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1200581511062568/task/1211313356974620?focus=true

## Description
<!-- 
  Please delete either or both process sections below.
-->
Added `simpleSearchWidgetPrompt` and `onboardingHomeScreenWidgetPrompt` features.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.
