### PR TITLE
SBT-another country-specific tracker exception for webmd-com

### DIFF
--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -1148,6 +1148,7 @@
                             "wcti12.com",
                             "wcyb.com",
                             "weartv.com",
+                            "webmd.com",
                             "wfgxtv.com",
                             "wfxl.com",
                             "wgme.com",
@@ -1185,7 +1186,8 @@
                             "lowes.com - https://github.com/duckduckgo/privacy-configuration/pull/2833",
                             "https://github.com/duckduckgo/privacy-configuration/pull/2869",
                             "https://github.com/duckduckgo/privacy-configuration/pull/2888",
-                            "krcrtv.com - https://github.com/duckduckgo/privacy-configuration/pull/3489"
+                            "krcrtv.com - https://github.com/duckduckgo/privacy-configuration/pull/3489",
+                            "webmd.com - https://github.com/duckduckgo/privacy-configuration/pull/3737"
                         ]
                     },
                     {


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1206670747178362/task/1211287368093583?focus=true

## Description

### Site breakage mitigation process:
#### Brief explanation
- Reported URL: webmd.com
- Problems experienced: Search results return empty in some countries. An additional tracker exception added to prevent this issue.
- Platforms affected:
  - [ x] iOS
  - [ x] Android
  - [ x] Windows
  - [ x] MacOS
  - [x ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.
