### PR TITLE
SBT - add correct tracker exception to outsideonline-com

### DIFF
--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -385,15 +385,14 @@
                         "reason": ["https://github.com/duckduckgo/privacy-configuration/pull/3276"]
                     },
                     {
+                        "rule": "flag.lab.amplitude.com/sdk/",
+                        "domains": ["outsideonline.com"],
+                        "reason": ["outsideonline.com - https://github.com/duckduckgo/privacy-configuration/pull/3741"]
+                    },
+                    {
                         "rule": "flag.lab.eu.amplitude.com/sdk/",
-                        "domains": [
-                            "bluelightcard.co.uk",
-                            "outsideonline.com"
-                        ],
-                        "reason": [
-                            "bluelightcard.co.uk - https://github.com/duckduckgo/privacy-configuration/pull/2779",
-                            "outsideonline.com - https://github.com/duckduckgo/privacy-configuration/pull/3730"
-                        ]
+                        "domains": ["bluelightcard.co.uk"],
+                        "reason": ["bluelightcard.co.uk - https://github.com/duckduckgo/privacy-configuration/pull/2779"]
                     },
                     {
                         "rule": "api.lab.amplitude.com/sdk",


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/inbox/1201534009031797/item/1211275831135468/story/1211321444297744?focus=true

### Site breakage mitigation process:
#### Brief explanation
- Reported URL: https://watch.outsideonline.com/series/beat-monday/UkYMNqEb-Sg3dmWsy
- Problems experienced: video not loading/playing
- Platforms affected:
  - [ x] iOS
  - [x ] Android
  - [ x] Windows
  - [x ] MacOS
  - [ x] Extensions
- Tracker(s) being unblocked: flag.lab.amplitude.com/sdk
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.
