### PR TITLE
Remove disableDeviceEnumeration as no longer used

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -931,8 +931,6 @@
                     "state": "enabled",
                     "changes": []
                 },
-                "disableDeviceEnumerationFrames": "disabled",
-                "disableDeviceEnumeration": "disabled",
                 "enumerateDevices": "enabled",
                 "domains": [
                     {

--- a/schema/features/webcompat.ts
+++ b/schema/features/webcompat.ts
@@ -52,8 +52,6 @@ type FullWebCompatOptions = CSSInjectFeatureSettings<{
             domain?: string;
         }[];
     };
-    disableDeviceEnumeration: StateToggle;
-    disableDeviceEnumerationFrames: StateToggle;
     enumerateDevices: StateToggle;
     additionalCheck?: FeatureState;
 }>;


### PR DESCRIPTION
**Asana Task/Github Issue:**  https://app.asana.com/1/137249556945/project/1201614831475344/task/1211341363480704?focus=true

## Description
Cleans up config that we no longer use.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.
