### PR TITLE
Hide blank spaces on cubbyathome.com

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -120,6 +120,10 @@
                 "type": "hide-empty"
             },
             {
+                "selector": ".Ad--empty",
+                "type": "hide-empty"
+            },
+            {
                 "selector": "[class^='ad-content']",
                 "type": "hide-empty"
             },
@@ -1199,6 +1203,15 @@
                                 "value": "3rem"
                             }
                         ]
+                    }
+                ]
+            },
+            {
+                "domain": "cubbyathome.com",
+                "rules": [
+                    {
+                        "selector": ".PostDesktopStickyFooter",
+                        "type": "hide-empty"
                     }
                 ]
             },


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/1200277586140538/task/1211355338604530?focus=true

## Description
### Site breakage mitigation process:
#### Brief explanation
- Reported URL: https://www.cubbyathome.com/boxed-cake-mix-sizes-have-shrunk-80045058
- Problems experienced: Blank spaces caused by blocked trackers.
- Platforms affected:
  - [x] iOS
  - [x] Android
  - [x] Windows
  - [x] MacOS
  - [x] Extensions
- Tracker(s) being unblocked: N/A
- Feature being disabled/modified: N/A
- [ ] This change is a speculative mitigation to fix reported breakage.
