### PR TITLE
Windows: enable open fire windows by default for internal users

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -1247,6 +1247,9 @@
                     }
                 ]
             }
+        },
+        "openFireWindowByDefault": {
+            "state": "internal"
         }
     },
     "unprotectedTemporary": []


### PR DESCRIPTION
**Asana Task/Github Issue:**

## Description
For Windows, enable the Open Fire Windows by default feature for internal users
This feature flag was introduced here: https://github.com/duckduckgo/privacy-configuration/pull/3676

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [x] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

