### PR TITLE
macOS: Enable newSyncEntryPoints at 10 percent

### DIFF
--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -1089,6 +1089,7 @@
                 },
                 "newSyncEntryPoints": {
                     "state": "enabled",
+                    "minSupportedVersion": "1.156.0",
                     "rollout": {
                         "steps": [
                             {

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -1088,7 +1088,14 @@
                     "state": "enabled"
                 },
                 "newSyncEntryPoints": {
-                    "state": "internal"
+                    "state": "enabled",
+                    "rollout": {
+                        "steps": [
+                            {
+                                "percent": 10.0
+                            }
+                        ]
+                    }
                 }
             }
         },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/72649045549333/task/1211357274473830?focus=true

## Description
This enables and rolls out the [new Sync entry points](https://app.asana.com/1/137249556945/project/72649045549333/task/1210785627677162?focus=true) on macOS to 10% of 1.156.0 users. This was already enabled internally here: https://github.com/duckduckgo/privacy-configuration/pull/3705

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.
