### PR TITLE
Make download deletion available internally

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -1118,14 +1118,20 @@
             "state": "enabled",
             "minSupportedVersion": "0.112.0",
             "features": {
-                "alwaysAskWhereToSaveFiles": {
-                    "state": "enabled",
-                    "minSupportedVersion": "0.112.0"
-                },
-                "showDownloadPopup": {
-                    "state": "enabled",
-                    "minSupportedVersion": "0.129.0"
-                }
+              "alwaysAskWhereToSaveFiles": {
+                "state": "enabled",
+                "minSupportedVersion": "0.112.0"
+              },
+              "showDownloadPopup": {
+                "state": "enabled",
+                "minSupportedVersion": "0.129.0"
+              },
+              "downloadDeletion": {
+                "state": "internal"
+              },
+              "downloadContextMenu": {
+                "state": "internal"
+              }
             }
         },
         "quickNavTldLookup": {

--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -1118,20 +1118,20 @@
             "state": "enabled",
             "minSupportedVersion": "0.112.0",
             "features": {
-              "alwaysAskWhereToSaveFiles": {
-                "state": "enabled",
-                "minSupportedVersion": "0.112.0"
-              },
-              "showDownloadPopup": {
-                "state": "enabled",
-                "minSupportedVersion": "0.129.0"
-              },
-              "downloadDeletion": {
-                "state": "internal"
-              },
-              "downloadContextMenu": {
-                "state": "internal"
-              }
+                "alwaysAskWhereToSaveFiles": {
+                    "state": "enabled",
+                    "minSupportedVersion": "0.112.0"
+                },
+                "showDownloadPopup": {
+                    "state": "enabled",
+                    "minSupportedVersion": "0.129.0"
+                },
+                "downloadDeletion": {
+                    "state": "internal"
+                },
+                "downloadContextMenu": {
+                    "state": "internal"
+                }
             }
         },
         "quickNavTldLookup": {


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1200695233846578/task/1210726966913338?focus=true

## Description
* Marks the `downloadDeletion` and `downloadContextMenu` subfeatures of `downloadManager` as `internal` ahead of ship review.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [x] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.
