### PR TITLE
Hide empty space on thekitchn.com

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -3460,6 +3460,10 @@
                     {
                         "selector": ".ProductGrid__adWrapper",
                         "type": "hide-empty"
+                    },
+                    {
+                        "selector": ".Post__openWebSlot",
+                        "type": "hide-empty"
                     }
                 ]
             },


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/1200277586140538/task/1211368268176791?focus=true

## Description
### Site breakage mitigation process:
#### Brief explanation
- Reported URL: https://www.thekitchn.com/shortbread-cookie-recipe-showdown-23480965
- Problems experienced: Empty space due to tracker blocking.
- Platforms affected:
  - [x] iOS
  - [x] Android
  - [x] Windows
  - [x] MacOS
  - [x] Extensions
- Tracker(s) being unblocked: N/A
- Feature being disabled/modified: N/A
- [ ] This change is a speculative mitigation to fix reported breakage.
