### PR TITLE
Disable CPM for community.samsung.com

### DIFF
--- a/features/autoconsent.json
+++ b/features/autoconsent.json
@@ -610,6 +610,10 @@
         {
             "domain": "bahntickets.de",
             "reason": "https://github.com/duckduckgo/privacy-configuration/pull/3733"
+        },
+        {
+            "domain": "community.samsung.com",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/pull/3758"
         }
     ],
     "settings": {


### PR DESCRIPTION
It seems that occasionally, the cookie prompt on community.samsung.com will
still be visible after CPM finishes. Let's disable CPM for the website for now.

**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1206670747178362/task/1211352101458625?focus=true
