### PR TITLE
Hide empty spaces on yahoo.com

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -3837,6 +3837,14 @@
                     {
                         "selector": "[id*='rrvkqH1']",
                         "type": "hide-empty"
+                    },
+                    {
+                        "selector": ".ad-container",
+                        "type": "hide-empty"
+                    },
+                    {
+                        "selector": "ul.flex > li.relative",
+                        "type": "hide-empty"
                     }
                 ]
             },


### PR DESCRIPTION
The (US) homepage for Yahoo.com has some empty white-space, presumably left over
from tracker blocking. Let's hide that now.

**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1206670747178362/task/1211352850569624?focus=true
