### PR TITLE
Temporarily disable GPC on mazdausa.com to avoid redirect-loop

### DIFF
--- a/features/gpc.json
+++ b/features/gpc.json
@@ -75,6 +75,10 @@
         {
             "domain": "newyorker.com",
             "reason": "https://github.com/duckduckgo/privacy-configuration/pull/3664"
+        },
+        {
+            "domain": "mazdausa.com",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/pull/3760"
         }
     ],
     "settings": {


### PR DESCRIPTION
It seems that when the GPC header is sent when loading
https://www.mazdausa.com (at least the mobile view), the website sometimes gets
stuck in a redirect-loop for a while. Let's avoid that by temporarily stopping
sending the header.

**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1206670747178362/task/1211351998267925?focus=true
