### PR TITLE
Windows: add breakageReporting.includeOriginTrials subfeature

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -471,7 +471,12 @@
             "state": "enabled"
         },
         "breakageReporting": {
-            "state": "enabled"
+            "state": "enabled",
+            "features": {
+                "includeOriginTrials": {
+                    "state": "disabled"
+                }
+            }
         },
         "duckPlayer": {
             "state": "enabled",


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/72649045549333/task/1211092492872229?focus=true

## Description
Add disabled `breakageReporting.includeOriginTrials` feature.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [x] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.
