### PR TITLE
Windows: rollout extension-based burn to 100%

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -1093,11 +1093,14 @@
                         "steps": [
                             {
                                 "percent": 20.0
+                            },
+                            {
+                                "percent": 100.0
                             }
                         ]
                     },
                     "settings": {
-                        "timeoutIntervalSeconds": 12
+                        "timeoutIntervalSeconds": 10
                     }
                 },
                 "burnAnimationSettingVisibility": {


### PR DESCRIPTION
**Asana Task/Github Issue:**

## Description
<!-- 
  Please delete either or both process sections below.
-->

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.
