### PR TITLE
Fix broken cookie prompt on newatlas.com

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -2620,6 +2620,9 @@
                 "domain": "newatlas.com",
                 "rules": [
                     {
+                        "type": "disable-default"
+                    },
+                    {
                         "selector": ".OcelotAdModule",
                         "type": "hide-empty"
                     },

--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -721,6 +721,20 @@
                     }
                 ]
             },
+            "criteo.net": {
+                "rules": [
+                    {
+                        "rule": "static.criteo.net/js/ld/publishertag.prebid.js",
+                        "domains": ["newatlas.com"],
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/pull/3766"
+                    },
+                    {
+                        "rule": "static.criteo.net/images/pixel.gif",
+                        "domains": ["newatlas.com"],
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/pull/3766"
+                    }
+                ]
+            },
             "computerworld.com": {
                 "rules": [
                     {


### PR DESCRIPTION
Clicking the "Learn more and customize" button in the cookie prompt wasn't
working, since a

    this.rootNode.getElementsByClassName("google-additional-consent-btn")[0].onclick
      = function() { ... }`

call was failing, with the element in question being undefined. Workaround that
here.

**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1206670747178362/task/1211356343673897?focus=true
