### PR TITLE
Windows: Enable credit card and identity sync for internal users

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -718,12 +718,30 @@
         "sync": {
             "state": "enabled",
             "features": {
+                "level0ShowSync": {
+                  "state": "enabled"
+                },
+                "level1AllowDataSyncing": {
+                  "state": "enabled"
+                },
+                "level2AllowSetupFlows": {
+                  "state": "enabled"
+                },
+                "level3AllowCreateAccount": {
+                  "state": "enabled"
+                },
+                "exchangeKeysToSyncWithAnotherDevice": {
+                  "state": "enabled"
+                },
+                "syncSetupBarcodeIsUrlBased": {
+                  "state": "enabled"
+                },
                 "syncCreditCards": {
                     "state": "internal"
-                    },
+                },
                 "syncIdentities": {
                     "state": "internal"
-                    }
+                }
             }
         },
         "syncPromotion": {

--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -716,7 +716,15 @@
             "exceptions": []
         },
         "sync": {
-            "state": "enabled"
+            "state": "enabled",
+            "features": {
+                "syncCreditCards": {
+                    "state": "internal"
+                    },
+                "syncIdentities": {
+                    "state": "internal"
+                    }
+            }
         },
         "syncPromotion": {
             "state": "enabled",

--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -719,22 +719,22 @@
             "state": "enabled",
             "features": {
                 "level0ShowSync": {
-                  "state": "enabled"
+                    "state": "enabled"
                 },
                 "level1AllowDataSyncing": {
-                  "state": "enabled"
+                    "state": "enabled"
                 },
                 "level2AllowSetupFlows": {
-                  "state": "enabled"
+                    "state": "enabled"
                 },
                 "level3AllowCreateAccount": {
-                  "state": "enabled"
+                    "state": "enabled"
                 },
                 "exchangeKeysToSyncWithAnotherDevice": {
-                  "state": "enabled"
+                    "state": "enabled"
                 },
                 "syncSetupBarcodeIsUrlBased": {
-                  "state": "enabled"
+                    "state": "enabled"
                 },
                 "syncCreditCards": {
                     "state": "internal"


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/1209272522976873/task/1211160811951792?focus=true

## Description
Adds to subfeatures to the `sync` feature and enables them for internal users on Windows:
- `syncCreditCards`
- `syncIdentities`
