### PR TITLE
Windows: enable open fire windows by default from version 0.130.0

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -1298,7 +1298,8 @@
             }
         },
         "openFireWindowByDefault": {
-            "state": "internal"
+            "state": "enabled",
+            "minSupportedVersion": "0.130.0"
         }
     },
     "unprotectedTemporary": []


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/1205044477659400/task/1210449591533866?focus=true

## Description
For Windows, enable the Open Fire Windows by default feature from [version 0.130.0](https://app.asana.com/1/137249556945/project/1201522530643637/task/1211358333562595?focus=true)
This feature flag was introduced here: https://github.com/duckduckgo/privacy-configuration/pull/3676

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [x] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

