### PR TITLE
Add browserComparisonPrompt in privacy config and remove reactivateUsersExperimentMay25

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -37749,50 +37749,16 @@
             "state": "enabled",
             "exceptions": [],
             "features": {
-                "reactivateUsersExperimentMay25": {
-                    "state": "enabled",
-                    "minSupportedVersion": 52361000,
-                    "targets": [
-                        {
-                            "localeLanguage": "en"
-                        }
-                    ],
+                "browserComparisonPrompt": {
+                    "state": "disabled",
+                    "minSupportedVersion": 52500000,
                     "rollout": {
                         "steps": [
                             {
                                 "percent": 5
-                            },
-                            {
-                                "percent": 15
-                            },
-                            {
-                                "percent": 30
-                            },
-                            {
-                                "percent": 50
-                            },
-                            {
-                                "percent": 80
-                            },
-                            {
-                                "percent": 100
                             }
                         ]
-                    },
-                    "cohorts": [
-                        {
-                            "name": "control",
-                            "weight": 0
-                        },
-                        {
-                            "name": "duckplayerPrompt",
-                            "weight": 0
-                        },
-                        {
-                            "name": "browserPrompt",
-                            "weight": 0
-                        }
-                    ]
+                    }
                 }
             }
         },


### PR DESCRIPTION

**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1200581511062568/task/1211317222307620?focus=true

## Description
<!-- 
  Please delete either or both process sections below.
-->
Added `browserComparisonPrompt` as disabled and removed `reactivateUsersExperimentMay25`.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.
