### PR TITLE
Disable CPM on wheeloffortune.com

### DIFF
--- a/features/autoconsent.json
+++ b/features/autoconsent.json
@@ -614,6 +614,10 @@
         {
             "domain": "community.samsung.com",
             "reason": "https://github.com/duckduckgo/privacy-configuration/pull/3758"
+        },
+        {
+            "domain": "wheeloffortune.com",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/pull/3776"
         }
     ],
     "settings": {


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/1206670747178362/task/1211379686881993?focus=true

## Description
### Site breakage mitigation process:
#### Brief explanation
- Reported URL: https://www.wheeloffortune.com/
- Problems experienced: Big blank space left behind when cookie popup is removed.
- Platforms affected:
  - [x] iOS
  - [x] Android
  - [x] Windows
  - [x] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked: N/A
- Feature being disabled/modified: Cookie popup management (CPM)
- [ ] This change is a speculative mitigation to fix reported breakage.
