### PR TITLE
Enable autofillPopupReuse and set minSupportedVersion to 0.131.0

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -179,7 +179,8 @@
             "state": "enabled",
             "features": {
                 "autofillPopupReuse": {
-                    "state": "disabled"
+                    "state": "enabled",
+                    "minSupportedVersion": "0.131.0"
                 },
                 "deduplicateLoginsOnImport": {
                     "state": "enabled"


### PR DESCRIPTION
**Asana Task/Github Issue:**

## Description
Enable autofillPopupReuse and set minSupportedVersion to 0.131.0

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [X] I have tested this change locally in all supported browsers.
- [X] This code for the config change is ready to merge.
- [X] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [X] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.
