### PR TITLE
Roll out Search + Duck.ai choice screen to 5% (Android)

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -271,15 +271,15 @@
                     "minSupportedVersion": 52440000
                 },
                 "showAIChatAddressBarChoiceScreen": {
-                  "state": "enabled",
-                  "minSupportedVersion": 52490000,
-                  "rollout": {
-                    "steps": [
-                      {
-                        "percent": 5
-                      }
-                    ]
-                  }
+                    "state": "enabled",
+                    "minSupportedVersion": 52490000,
+                    "rollout": {
+                        "steps": [
+                            {
+                                "percent": 5
+                            }
+                        ]
+                    }
                 }
             }
         },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/715106103902962/task/1211383346797389?focus=true

## Description
Rolls out the Search + Duck.ai choice screen to 5%

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [x] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.
