### PR TITLE
[Autofill] Set Spotify input type to unknown

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -35535,6 +35535,21 @@
                                         "value": ".loginSelectUnit.slctInputUnit"
                                     }
                                 ]
+                            },
+                            {
+                                "domain": [
+                                    "challenge.spotify.com"
+                                ],
+                                "patchSettings": [
+                                    {
+                                        "path": "/inputTypeSettings/-",
+                                        "op": "add",
+                                        "value": {
+                                            "selector": "input[inputmode=\"numeric\"]",
+                                            "type": "unknown"
+                                        }
+                                    }
+                                ]
                             }
                         ]
                     }

--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -719,6 +719,21 @@
                                         "value": "c-wiz > main"
                                     }
                                 ]
+                            },
+                            {
+                                "domain": [
+                                    "challenge.spotify.com"
+                                ],
+                                "patchSettings": [
+                                    {
+                                        "path": "/inputTypeSettings/-",
+                                        "op": "add",
+                                        "value": {
+                                            "selector": "input[inputmode=\"numeric\"]",
+                                            "type": "unknown"
+                                        }
+                                    }
+                                ]
                             }
                         ]
                     }

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -35637,6 +35637,21 @@
                                         "value": "c-wiz > main"
                                     }
                                 ]
+                            },
+                            {
+                                "domain": [
+                                    "challenge.spotify.com"
+                                ],
+                                "patchSettings": [
+                                    {
+                                        "path": "/inputTypeSettings/-",
+                                        "op": "add",
+                                        "value": {
+                                            "selector": "input[inputmode=\"numeric\"]",
+                                            "type": "unknown"
+                                        }
+                                    }
+                                ]
                             }
                         ]
                     }

--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -439,6 +439,21 @@
                                         "value": "c-wiz > main"
                                     }
                                 ]
+                            },
+                            {
+                                "domain": [
+                                    "challenge.spotify.com"
+                                ],
+                                "patchSettings": [
+                                    {
+                                        "path": "/inputTypeSettings/-",
+                                        "op": "add",
+                                        "value": {
+                                            "selector": "input[inputmode=\"numeric\"]",
+                                            "type": "unknown"
+                                        }
+                                    }
+                                ]
                             }
                         ]
                     }


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1200930669568058/task/1210955471693663?focus=true

## Description
<!-- 
  Please delete either or both process sections below
-->
Set Spotify OTP input type to unknown, otherwise it is recognized as a username
<img width="514" height="289" alt="Screenshot 2025-09-22 at 15 28 58" src="https://github.com/user-attachments/assets/811e13eb-1b57-4844-9c3e-226055f17405" />


### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.
