### PR TITLE
Add Mac hang reporting feature flag (internal)

### DIFF
--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -36412,6 +36412,9 @@
             "features": {
                 "willSoonDropBigSurSupport": {
                     "state": "enabled"
+                },
+                "hangReporting": {
+                    "state": "internal"
                 }
             }
         },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1211264967278501/task/1211260525640632?focus=true

Adds a feature flag for reporting hangs in the Mac browser
