### PR TITLE
Enable `downloadDeletion` and `downloadContextMenu` from v0.131.0

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -1172,10 +1172,12 @@
                     "minSupportedVersion": "0.129.0"
                 },
                 "downloadDeletion": {
-                    "state": "internal"
+                    "state": "enabled",
+                    "minSupportedVersion": "0.131.0"
                 },
                 "downloadContextMenu": {
-                    "state": "internal"
+                    "state": "enabled",
+                    "minSupportedVersion": "0.131.0"
                 }
             }
         },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/72649045549333/task/1211247123207977?focus=true

## Description
* Makes `downloadDeletion` & `downloadContextMenu` available as of [Windows Release v0.131.0](https://app.asana.com/1/137249556945/project/1201522530643637/task/1211427658000107?focus=true)

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [*] I have tested this change locally in all supported browsers.
- [*] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.
