### PR TITLE
Add unifiedURLPredictor subfeature to macOSBrowserConfig

### DIFF
--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -36430,6 +36430,9 @@
                 },
                 "hangReporting": {
                     "state": "internal"
+                },
+                "unifiedURLPredictor": {
+                    "state": "internal"
                 }
             }
         },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/72649045549333/task/1211396583578253?focus=true

## Description
This change adds a new subfeature to control the state of unified URL predictor on macOS.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [x] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

