### PR TITLE
Enable the serpSettings feature on Android

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -36277,6 +36277,7 @@
             "settings": {
                 "aiChat": "disabled",
                 "subscriptions": "disabled",
+                "serpSettings": "disabled",
                 "domains": [
                     {
                         "domain": [
@@ -36292,6 +36293,11 @@
                             {
                                 "op": "replace",
                                 "path": "/subscriptions",
+                                "value": "enabled"
+                            },
+                            {
+                                "op": "replace",
+                                "path": "/serpSettings",
                                 "value": "enabled"
                             }
                         ]


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/715106103902962/task/1211437038701612?focus=true

## Description

This PR enables the `serpSettings` feature for Android.
See related PR -> https://github.com/duckduckgo/privacy-configuration/pull/3497

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [x] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.
