### PR TITLE
Windows: Add import.importShortcuts subfeature

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -573,6 +573,15 @@
                 },
                 "multiImportWindow": {
                     "state": "internal"
+                },
+                "importShortcuts": {
+                    "state": "disabled",
+                    "settings": {
+                        "chrome": "enabled",
+                        "brave": "enabled",
+                        "edge": "enabled",
+                        "firefox": "enabled"
+                    }
                 }
             }
         },

--- a/schema/features/import.ts
+++ b/schema/features/import.ts
@@ -12,6 +12,15 @@ type SubFeatures<VersionType> = {
             vivaldi: 'enabled' | 'disabled';
         }
     >;
+    importShortcuts?: SubFeature<
+        VersionType,
+        {
+            chrome: 'enabled' | 'disabled';
+            brave: 'enabled' | 'disabled';
+            edge: 'enabled' | 'disabled';
+            firefox: 'enabled' | 'disabled';
+        }
+    >;
 };
 
 export type ImportFeature<VersionType> = Feature<


### PR DESCRIPTION
**Asana Task/Github Issue:** [Add feature flag](https://app.asana.com/1/137249556945/project/1211150617965544/task/1210789732616809?focus=true)

## Description
Add a disabled `import.importShortcuts` feature for Windows that will be used to control the behavior of [Improve the ordering of Bookmarks/Favourites when importing from other browsers](https://app.asana.com/1/137249556945/project/1211150617965544/task/1210789830980414?focus=true).

### Feature change process:

- [x] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.
