### PR TITLE
Android: Remove privacyProFreeTrialJan25 experiment sub-feature

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -37429,23 +37429,6 @@
                     "state": "enabled",
                     "minSupportedVersion": 52451000
                 },
-                "privacyProFreeTrialJan25": {
-                    "state": "enabled",
-                    "minSupportedVersion": 52280000,
-                    "description": "Privacy Pro free trial experiment",
-                    "targets": [
-                        {
-                            "localeCountry": "us",
-                            "isPrivacyProEligible": true
-                        }
-                    ],
-                    "cohorts": [
-                        {
-                            "name": "treatment",
-                            "weight": 1
-                        }
-                    ]
-                },
                 "subscriptionRebranding": {
                     "state": "enabled"
                 },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/task/1210510700371847?focus=true

## Description
Remove the previous experiment sub-feature now that the real Free Trials feature is widely adopted by users

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [x] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.
