### PR TITLE
Windows: include origin trials in breakage reports

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -491,7 +491,7 @@
             "state": "enabled",
             "features": {
                 "includeOriginTrials": {
-                    "state": "disabled"
+                    "state": "enabled"
                 }
             }
         },


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/task/1211469477640338

## Description
Windows: include origin trials in breakage report

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [x] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.
