### PR TITLE
Add canadiantire.ca to enumerateDevices domains in windows-override.json

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -1002,17 +1002,11 @@
                 "enumerateDevices": "enabled",
                 "domains": [
                     {
-                        "domain": "meet.google.com",
-                        "patchSettings": [
-                            {
-                                "op": "replace",
-                                "path": "/enumerateDevices",
-                                "value": "disabled"
-                            }
-                        ]
-                    },
-                    {
-                        "domain": "autotrader.com",
+                        "domain": [
+                            "meet.google.com",
+                            "autotrader.com",
+                            "canadiantire.ca"
+                        ],
                         "patchSettings": [
                             {
                                 "op": "replace",


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/task/1211484981184395?focus=true

## Description
<!-- 
  Please delete either or both process sections below.
-->

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds canadiantire.ca to the enumerateDevices-disabled list and consolidates meet.google.com and autotrader.com into a single domain array in overrides/windows-override.json.
> 
> - **Web Compat (Windows)** in `overrides/windows-override.json`:
>   - **enumerateDevices override** (`features.webCompat.settings.domains`):
>     - Add `canadiantire.ca` with `enumerateDevices` set to `disabled`.
>     - Consolidate `meet.google.com` and `autotrader.com` into a single entry using a `domain` array.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fc6cc10113806090e7bab1310e4ffd333ecf7f79. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->