### PR TITLE
Disable CPM for paypal.com

### DIFF
--- a/features/autoconsent.json
+++ b/features/autoconsent.json
@@ -622,6 +622,10 @@
         {
             "domain": "philadelphiaunion.com",
             "reason": "https://github.com/duckduckgo/privacy-configuration/pull/3790"
+        },
+        {
+            "domain": "paypal.com",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/pull/3826"
         }
     ],
     "settings": {


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/1206670747178362/task/1211484270654847?focus=true

## Description
### Site breakage mitigation process:
#### Brief explanation
- Reported URL: https://www.paypal.com/myaccount/privacy/cookiePrefs?locale=en_US
- Problems experienced: The cookie popup re-opens each time it’s dismissed.
- Platforms affected:
  - [x] iOS
  - [x] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked: N/A
- Feature being disabled/modified: Cookie Popup Management (CPM)
- [ ] This change is a speculative mitigation to fix reported breakage.
