### PR TITLE
Windows Browser: Enabled webViewSkipServiceWorkerAttachments for 50% of users

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -1083,6 +1083,16 @@
                 },
                 "certificateTransparency": {
                     "state": "enabled"
+                },
+                "webViewSkipServiceWorkerAttachments": {
+                    "state": "enabled",
+                    "rollout": {
+                        "steps": [
+                            {
+                                "percent": 50
+                            }
+                        ]
+                    }
                 }
             },
             "exceptions": []


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/72649045549333/task/1210559041884443?focus=true

## Description

- Enables `webViewSkipServiceWorkerAttachments` feature for 50% of users. The feature is currently in Preview, and is expected to start hitting Stable tomorrow. 
- This is an attempted fix to stop tab loading failures.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables `webViewSkipServiceWorkerAttachments` in Windows webview config with a 50% rollout.
> 
> - **Windows config (`overrides/windows-override.json`)**:
>   - **`webview` feature**:
>     - Adds `webViewSkipServiceWorkerAttachments`: `enabled` with rollout step at 50%.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5bf8304fd410ba714d5eca1c7803e23782d6cbec. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->