### PR TITLE
Hide blank spaces on boardgamegeek.com

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -978,6 +978,31 @@
                 ]
             },
             {
+                "domain": "boardgamegeek.com",
+                "rules": [
+                    {
+                        "selector": "gg-home-leaderboard-ad",
+                        "type": "hide-empty"
+                    },
+                    {
+                        "selector": "gg-leaderboard-lg-ad",
+                        "type": "hide-empty"
+                    },
+                    {
+                        "selector": "gg-support-leaderboard-ad",
+                        "type": "hide-empty"
+                    },
+                    {
+                        "selector": "gg-post-inline-ad",
+                        "type": "hide-empty"
+                    },
+                    {
+                        "selector": "[hide-ad-block]",
+                        "type": "hide-empty"
+                    }
+                ]
+            },
+            {
                 "domain": "bostonglobe.com",
                 "rules": [
                     {


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/1206670747178362/task/1211504904109706?focus=true

## Description
### Site breakage mitigation process:
#### Brief explanation
- Reported URL: https://boardgamegeek.com/
- Problems experienced: Blocked trackers have left empty spaces.
- Platforms affected:
  - [x] iOS
  - [x] Android
  - [x] Windows
  - [x] MacOS
  - [x] Extensions
- Tracker(s) being unblocked: N/A
- Feature being disabled/modified: N/A
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add site-specific rules to hide empty ad placeholders on `boardgamegeek.com`.
> 
> - **Domains**:
>   - `boardgamegeek.com`:
>     - Add `hide-empty` for `gg-home-leaderboard-ad`, `gg-leaderboard-lg-ad`, `gg-support-leaderboard-ad`, `gg-post-inline-ad`, and `[hide-ad-block]`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1c3e9b47d6d104ab140137e40fb42c53561f8126. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->