### PR TITLE
Enable viewport legacy fix

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -36914,6 +36914,7 @@
                 "mediaSession": "enabled",
                 "presentation": "disabled",
                 "viewportWidth": "enabled",
+                "viewportWidthLegacy": "enabled",
                 "webShare": "enabled",
                 "screenLock": "enabled",
                 "plainTextViewPort": "enabled",

--- a/schema/features/webcompat.ts
+++ b/schema/features/webcompat.ts
@@ -34,6 +34,7 @@ type FullWebCompatOptions = CSSInjectFeatureSettings<{
               forcedDesktopValue: string;
               forcedMobileValue: string;
           };
+    viewportWidthLegacy: StateToggle;
     screenLock: StateToggle;
     plainTextViewPort: StateToggle;
     modifyLocalStorage: {


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1206777341262243/task/1211383592263201?focus=true

## Description
<!-- 
  Please delete either or both process sections below.
-->

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a new `viewportWidthLegacy` toggle to the webcompat schema and enables it in `overrides/android-override.json`.
> 
> - **Schema**:
>   - Add `viewportWidthLegacy: StateToggle` to `schema/features/webcompat.ts`.
> - **Android Overrides**:
>   - Enable `viewportWidthLegacy` in `overrides/android-override.json`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d5c9a1b670a1f876b05b12d95af85458263fda4c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->