### PR TITLE
Disable "webview skip service-worker attachments" subfeature

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -1083,6 +1083,16 @@
                 },
                 "certificateTransparency": {
                     "state": "enabled"
+                },
+                "webViewSkipServiceWorkerAttachments": {
+                    "state": "disabled",
+                    "rollout": {
+                        "steps": [
+                            {
+                                "percent": 50
+                            }
+                        ]
+                    }
                 }
             },
             "exceptions": []

--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -1083,16 +1083,6 @@
                 },
                 "certificateTransparency": {
                     "state": "enabled"
-                },
-                "webViewSkipServiceWorkerAttachments": {
-                    "state": "enabled",
-                    "rollout": {
-                        "steps": [
-                            {
-                                "percent": 50
-                            }
-                        ]
-                    }
                 }
             },
             "exceptions": []


### PR DESCRIPTION
**Asana Task/Github Issue:**

## Description
<!-- 
  Please delete either or both process sections below.
-->

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Disables `webViewSkipServiceWorkerAttachments` in `overrides/windows-override.json` (was enabled, now disabled; rollout unchanged).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5499b29d392a964a7efc48a899e59c0d8b6623ee. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->