### PR TITLE
Enable emailConfirmationDecoupling for internal users

### DIFF
--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -304,7 +304,8 @@
                     "minSupportedVersion": "1.140.0"
                 },
                 "emailConfirmationDecoupling": {
-                    "state": "disabled"
+                    "state": "internal",
+                    "minSupportedVersion": "1.158.0"
                 }
             },
             "minSupportedVersion": "1.70.0"


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1205591970852438/task/1211461958042682?focus=true

## Description
<!-- 
  Please delete either or both process sections below.
-->

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates `features/dbp/emailConfirmationDecoupling` to `state: internal` and adds `minSupportedVersion: 1.158.0` in `overrides/macos-override.json`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ea766c4a033a876393a5100140f9732120f95d71. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->