### PR TITLE
Hide blank spaces on dailymotion.com

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -1290,6 +1290,15 @@
                 ]
             },
             {
+                "domain": "dailymotion.com",
+                "rules": [
+                    {
+                        "selector": "[class^='DisplayAd']",
+                        "type": "hide-empty"
+                    }
+                ]
+            },
+            {
                 "domain": "dallasnews.com",
                 "rules": [
                     {


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/1206670747178362/task/1211491198848179?focus=true

## Description
### Site breakage mitigation process:
#### Brief explanation
- Reported URL: https://www.dailymotion.com/video/x3nureq
- Problems experienced: Blank spaces where trackers are blocked.
- Platforms affected:
  - [x] iOS
  - [x] Android
  - [x] Windows
  - [x] MacOS
  - [x] Extensions
- Tracker(s) being unblocked: N/A
- Feature being disabled/modified: N/A
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a site-specific rule for dailymotion.com to hide empty `DisplayAd*` elements and remove blank ad spaces.
> 
> - **Element-hiding config**:
>   - **`dailymotion.com`**: Add rule `hide-empty` for `[class^='DisplayAd']` to remove empty ad placeholders.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c99d042ffbb06cb085b93cd86736b78f8b684d68. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->