### PR TITLE
Enable videos on modernhoney.com

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -2543,6 +2543,15 @@
                 ]
             },
             {
+                "domain": "modernhoney.com",
+                "rules": [
+                    {
+                        "selector": ".adthrive",
+                        "type": "override"
+                    }
+                ]
+            },
+            {
                 "domain": "motortrend.com",
                 "rules": [
                     {

--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -176,11 +176,13 @@
                             "gardeningknowhow.com",
                             "adamtheautomator.com",
                             "packhacker.com",
-                            "cookingclassy.com"
+                            "cookingclassy.com",
+                            "modernhoney.com"
                         ],
                         "reason": [
                             "gardeningknowhow.com, adamtheautomator.com, packhacker.com - https://github.com/duckduckgo/privacy-configuration/issues/1122",
-                            "cookingclassy.com - https://github.com/duckduckgo/privacy-configuration/pull/3325 "
+                            "cookingclassy.com - https://github.com/duckduckgo/privacy-configuration/pull/3325",
+                            "modernhoney.com - https://github.com/duckduckgo/privacy-configuration/pull/3851"
                         ]
                     }
                 ]


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/1206670747178362/task/1211531480905366?focus=true

## Description
Similar to https://github.com/duckduckgo/privacy-configuration/pull/3325

### Site breakage mitigation process:
#### Brief explanation
- Reported URL: https://www.modernhoney.com/the-best-chocolate-chip-cookies/#wprm-recipe-container-14504
- Problems experienced: Videos not playing.
- Platforms affected:
  - [x] iOS
  - [x] Android
  - [x] Windows
  - [x] MacOS
  - [x] Extensions
- Tracker(s) being unblocked: Adthrive
- Feature being disabled/modified: N/A
- [ ] This change is a speculative mitigation to fix reported breakage.
