### PR TITLE
Android browserComparisonPrompt rollout 5%

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -37832,8 +37832,8 @@
             "exceptions": [],
             "features": {
                 "browserComparisonPrompt": {
-                    "state": "disabled",
-                    "minSupportedVersion": 52500000,
+                    "state": "enabled",
+                    "minSupportedVersion": 52510000,
                     "rollout": {
                         "steps": [
                             {


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1200581511062568/task/1211394266245406?focus=true

## Description
<!-- 
  Please delete either or both process sections below.
-->
Enable `browserComparisonPrompt` in privacy config and start rollout with 5%.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.
