### PR TITLE
[TSC] Remove unused imports

### DIFF
--- a/schema/features/broker-protection.ts
+++ b/schema/features/broker-protection.ts
@@ -1,3 +1,3 @@
-import { Feature, FeatureState } from '../feature';
+import { Feature } from '../feature';
 
 export type BrokerProtectionFeature<VersionType> = Feature<never, VersionType>;

--- a/schema/features/fingerprinting-canvas.ts
+++ b/schema/features/fingerprinting-canvas.ts
@@ -1,4 +1,4 @@
-import { Feature, CSSInjectFeatureSettings, CSSConfigSetting, FeatureState } from '../feature';
+import { Feature, CSSInjectFeatureSettings, FeatureState } from '../feature';
 
 type FullFingerprintingCanvasOptions = CSSInjectFeatureSettings<{
     // Codebase change

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,7 @@
         "esModuleInterop": true,
         "forceConsistentCasingInFileNames": true,
         "strict": true,
+        "noUnusedLocals": true,
         "skipLibCheck": true
     },
     "include": ["schema"]


### PR DESCRIPTION
**Asana Task/Github Issue:**

## Description
There are a few unused imports in these package. These can cause issues in packages pulling it as a dependency (e.g autofill). Typically we should share these rules, but we're not there yet.

- [x] Remove unused import
- [x] Add `noUnusedLocals` rule to `tsConfig.json`

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes unused imports in feature schemas and enables TypeScript noUnusedLocals for stricter checks.
> 
> - **Schema**:
>   - `schema/features/broker-protection.ts`: remove unused `FeatureState` import.
>   - `schema/features/fingerprinting-canvas.ts`: remove unused `CSSConfigSetting` import.
> - **Tooling**:
>   - `tsconfig.json`: enable `noUnusedLocals`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 544bd7054f25127759c7b73257987ec0e52bbf0e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->