### PR TITLE
Disable newTabPagePerTab

### DIFF
--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -853,8 +853,7 @@
                     "minSupportedVersion": "1.157.0"
                 },
                 "newTabPagePerTab": {
-                    "state": "enabled",
-                    "minSupportedVersion": "1.157.0"
+                    "state": "disabled"
                 }
             }
         },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1148564399326804/task/1211542533273111?focus=true

## Description
We are disabling newTabPagePerTab because of increase tab crashes

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Disables `htmlNewTabPage.features.newTabPagePerTab` in `overrides/macos-override.json` (removes `minSupportedVersion`).
> 
> - **macOS overrides** (`overrides/macos-override.json`):
>   - **HTML New Tab Page**:
>     - Disable `features.newTabPagePerTab` (previously enabled with `minSupportedVersion: 1.157.0`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 318a272bba83b62c37d397dbe18d8a39303a19e3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->