### PR TITLE
Revert "Enable videos on modernhoney.com"

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -2543,15 +2543,6 @@
                 ]
             },
             {
-                "domain": "modernhoney.com",
-                "rules": [
-                    {
-                        "selector": ".adthrive",
-                        "type": "override"
-                    }
-                ]
-            },
-            {
                 "domain": "motortrend.com",
                 "rules": [
                     {

--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -176,13 +176,11 @@
                             "gardeningknowhow.com",
                             "adamtheautomator.com",
                             "packhacker.com",
-                            "cookingclassy.com",
-                            "modernhoney.com"
+                            "cookingclassy.com"
                         ],
                         "reason": [
                             "gardeningknowhow.com, adamtheautomator.com, packhacker.com - https://github.com/duckduckgo/privacy-configuration/issues/1122",
-                            "cookingclassy.com - https://github.com/duckduckgo/privacy-configuration/pull/3325",
-                            "modernhoney.com - https://github.com/duckduckgo/privacy-configuration/pull/3851"
+                            "cookingclassy.com - https://github.com/duckduckgo/privacy-configuration/pull/3325 "
                         ]
                     }
                 ]


### PR DESCRIPTION
Reverts duckduckgo/privacy-configuration#3851

Task: https://app.asana.com/1/137249556945/project/414709148257752/task/1211538392803623?focus=true

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes modernhoney.com-specific allowances by deleting the `adthrive.com` allowlist entry for the domain and its `.adthrive` element-hiding override.
> 
> - **Config**:
>   - **Element Hiding (`features/element-hiding.json`)**:
>     - Remove domain rules for `modernhoney.com` that overrode `.adthrive`.
>   - **Tracker Allowlist (`features/tracker-allowlist.json`)**:
>     - Remove `modernhoney.com` from `adthrive.com` allowlisted domains and its associated reason; keep `cookingclassy.com`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f76b925a0b421289a78072f5c37636832a2adb78. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->