### PR TITLE
Temporarily revert skipFetchForServiceWorkers until UI tests fixed

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -1122,12 +1122,6 @@
                 "certificateTransparency": {
                     "state": "enabled"
                 },
-                "allowRetriesForServiceWorkerTimeouts": {
-                    "state": "preview"
-                },
-                "skipFetchForServiceWorkers": {
-                    "state": "preview"
-                },
                 "webViewSkipServiceWorkerAttachments": {
                     "state": "disabled",
                     "rollout": {


### PR DESCRIPTION
**Asana Task/Github Issue:**

## Description
<!-- 
  Please delete either or both process sections below.
-->

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes `allowRetriesForServiceWorkerTimeouts` and `skipFetchForServiceWorkers` preview flags from Windows `webview` overrides.
> 
> - **Windows overrides** (`overrides/windows-override.json`):
>   - **Webview features**:
>     - Remove `allowRetriesForServiceWorkerTimeouts` (preview)
>     - Remove `skipFetchForServiceWorkers` (preview)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 36eaede50213c4477e455fff15b79d7f3ac0c20d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->