### PR TITLE
Revert "Renable adsjs"

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -36076,32 +36076,6 @@
                                 "value": "disabled"
                             }
                         ]
-                    },
-                    {
-                        "condition": {
-                            "injectName": "android",
-                            "minSupportedVersion": 52511000
-                        },
-                        "patchSettings": [
-                            {
-                                "op": "add",
-                                "path": "/additionalCheck",
-                                "value": "enabled"
-                            }
-                        ]
-                    },
-                    {
-                        "condition": {
-                            "injectName": "android-adsjs",
-                            "minSupportedVersion": 52511000
-                        },
-                        "patchSettings": [
-                            {
-                                "op": "add",
-                                "path": "/additionalCheck",
-                                "value": "enabled"
-                            }
-                        ]
                     }
                 ]
             }
@@ -37000,15 +36974,7 @@
             "state": "enabled",
             "features": {
                 "useNewWebCompatApis": {
-                    "state": "enabled",
-                    "minSupportedVersion": 52511000,
-                    "rollout": {
-                        "steps": [
-                            {
-                                "percent": 50
-                            }
-                        ]
-                    }
+                    "state": "disabled"
                 }
             },
             "exceptions": []


### PR DESCRIPTION
Reverts duckduckgo/privacy-configuration#3863

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes version-gated additionalCheck enablement for android/android-adsjs and disables useNewWebCompatApis in Android overrides.
> 
> - **Android overrides (`overrides/android-override.json`)**:
>   - **Ads/patch behavior**: Remove version-gated patches that set `additionalCheck: enabled` for `android` and `android-adsjs`.
>   - **Client content features**: Disable `useNewWebCompatApis` (was partially rolled out with `minSupportedVersion`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 646e6c14ee7dc12a1bfe11c5b6667cec16f1da56. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->