### PR TITLE
Disable updating script on page finished

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -36047,6 +36047,9 @@
                         "tension": 1
                     }
                 },
+                "updateScriptOnPageFinished": {
+                    "state": "disabled"
+                },
                 "vpnMenuItem": {
                     "state": "enabled",
                     "targets": [


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1202552961248957/task/1211559945961347?focus=true

## Description
Disable `updateScriptOnPageFinished` to see if it has an impact on native crashes

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [x] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [x] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Disables `updateScriptOnPageFinished` in `overrides/android-override.json` for Android.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 510cc10dc13dcafd13fd5c5c5f77660f7d76c610. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->