### PR TITLE
Add win-back offer subfeature for macOS and iOS

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -1361,6 +1361,9 @@
                 "paidAIChat": {
                     "state": "enabled",
                     "minSupportedVersion": "7.181.0"
+                },
+                "winBackOffer": {
+                    "state": "disabled"
                 }
             }
         },

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -1516,6 +1516,9 @@
                 "paidAIChat": {
                     "state": "enabled",
                     "minSupportedVersion": "1.153.0"
+                },
+                "winBackOffer": {
+                    "state": "disabled"
                 }
             }
         },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1210594645229050/task/1211494295271901?focus=true

## Description
I have added a Privacy Pro subfeature to control the availability of the win-back offer on Apple platforms.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a disabled `privacyPro.winBackOffer` feature flag to `overrides/ios-override.json` and `overrides/macos-override.json`.
> 
> - **Privacy Pro**
>   - **iOS (`overrides/ios-override.json`)**: Add `features.winBackOffer` subfeature (state: `disabled`).
>   - **macOS (`overrides/macos-override.json`)**: Add `features.winBackOffer` subfeature (state: `disabled`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ac0625fe9a3b657fc65932325747a61f07e46e0f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->