### PR TITLE
macOS: Add feature flag for new App Store update flow

### DIFF
--- a/features/app-store-update-flow.json
+++ b/features/app-store-update-flow.json
@@ -1,7 +1,0 @@
-{
-    "_meta": {
-        "description": "macOS specific feature flag to enable/disable the new App Store update flow"
-    },
-    "state": "disabled",
-    "exceptions": []
-}

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -875,9 +875,6 @@
         "openFireWindowByDefault": {
             "state": "enabled"
         },
-        "appStoreUpdateFlow": {
-            "state": "enabled"
-        },
         "feedbackForm": {
             "state": "enabled"
         },
@@ -1621,6 +1618,9 @@
                 },
                 "unifiedURLPredictor": {
                     "state": "internal"
+                },
+                "appStoreUpdateFlow": {
+                    "state": "enabled"
                 }
             }
         },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/72649045549333/task/1211563301906360?focus=true

## Description
This adds the feature flag for the new App Store update process flow we’ve introduced in the new macOS browser.

### Feature change process:

- [x] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [x] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [x] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `appStoreUpdateFlow` feature flag (enabled) under `macOSBrowserConfig.features` in `overrides/macos-override.json`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d2b95d8eafc49377936d94c5beb9a74ad36e6549. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->