### PR TITLE
Enabling allowRetriesForServiceWorkerTimeouts and skipFetchForServiceWorkers speculative fixes on Preview

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -1122,6 +1122,12 @@
                 "certificateTransparency": {
                     "state": "enabled"
                 },
+                "allowRetriesForServiceWorkerTimeouts": {
+                    "state": "preview"
+                },
+                "skipFetchForServiceWorkers": {
+                    "state": "preview"
+                },
                 "webViewSkipServiceWorkerAttachments": {
                     "state": "disabled",
                     "rollout": {


### PR DESCRIPTION
**Asana Task/Github Issue:**

https://app.asana.com/1/137249556945/project/72649045549333/task/1210559041884443?focus=true

## Description

- Windows Browser: Enabling allowRetriesForServiceWorkerTimeouts and skipFetchForServiceWorkers speculative fixes on Preview
- Used to validate an approach to resolve the "Tabs sometimes not loading" issue on Windows.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `allowRetriesForServiceWorkerTimeouts` and `skipFetchForServiceWorkers` webview features in `overrides/windows-override.json`, both set to preview.
> 
> - **Webview (Windows override)**:
>   - Add `allowRetriesForServiceWorkerTimeouts` feature with state `preview` in `features.webview.features`.
>   - Add `skipFetchForServiceWorkers` feature with state `preview` in `features.webview.features`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6e34bf3db72605b80b252f4da52072594527253d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->