### PR TITLE
PIR Email confirmation decoupling: Incremental rollout for macOS

### DIFF
--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -310,18 +310,6 @@
                         "steps": [
                             {
                                 "percent": 5
-                            },
-                            {
-                                "percent": 10
-                            },
-                            {
-                                "percent": 25
-                            },
-                            {
-                                "percent": 50
-                            },
-                            {
-                                "percent": 100
                             }
                         ]
                     }

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -304,8 +304,27 @@
                     "minSupportedVersion": "1.140.0"
                 },
                 "emailConfirmationDecoupling": {
-                    "state": "internal",
-                    "minSupportedVersion": "1.158.0"
+                    "state": "enabled",
+                    "minSupportedVersion": "1.158.0",
+                    "rollout": {
+                        "steps": [
+                            {
+                                "percent": 5
+                            },
+                            {
+                                "percent": 10
+                            },
+                            {
+                                "percent": 25
+                            },
+                            {
+                                "percent": 50
+                            },
+                            {
+                                "percent": 100
+                            }
+                        ]
+                    }
                 }
             },
             "minSupportedVersion": "1.70.0"


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1205591970852438/task/1211524231183389?focus=true

## Description
<!-- 
  Please delete either or both process sections below.
-->

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables `dbp.emailConfirmationDecoupling` on macOS and introduces an initial 5% rollout (minSupportedVersion 1.158.0).
> 
> - **macOS overrides (`overrides/macos-override.json`)**:
>   - **`dbp` > `emailConfirmationDecoupling`**:
>     - Set `state` to `enabled` (from `internal`).
>     - Added `rollout` with a 5% step.
>     - Retains `minSupportedVersion` `1.158.0`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3b26ea094af80493b3b772412c92c5af907c8240. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->