### PR TITLE
Enables taskbar pinning for Windows 10

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -1425,7 +1425,7 @@
             "exceptions": [],
             "features": {
                 "win10Pinning": {
-                    "state": "internal",
+                    "state": "enabled",
                     "settings": {
                         "minWin10Build": 19045,
                         "minWin10Patch": 6159


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/task/1211575054199031?focus=true

## Description
* Makes taskbar pinning for Windows 10 publicly available

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches `features.taskbar.features.win10Pinning.state` from `internal` to `enabled` in `overrides/windows-override.json`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f449402de87bbcfb11df5c5dfdffe927f0b5719e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->