### PR TITLE
Add mapping config for iOS to Safari strings

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -868,6 +868,11 @@
             "settings": {
                 "defaultPolicy": "brand",
                 "useUpdatedSafariVersions": true,
+                "safariVersionMappings": {
+                    "26": "18_6",
+                    "26.0": "18_6",
+                    "26.0.1": "18_7"
+                },
                 "ddgFixedSites": [
                     {
                         "domain": "chase.com",

--- a/schema/features/custom-user-agent.ts
+++ b/schema/features/custom-user-agent.ts
@@ -41,6 +41,7 @@ type CustomUserAgentSettings = {
 
     // iOS specific properties
     useUpdatedSafariVersions?: boolean;
+    safariVersionMappings?: Record<string, string>;
 
     // iOS/Android specific user agent configs
     closestUserAgent?: UserAgentConfig | VersionsOnly;


### PR DESCRIPTION
**Asana Task/Github Issue:**  https://app.asana.com/1/137249556945/project/414235014887631/task/1211472182542141?focus=true

## Description

Adds a mapping so that the code can use hard coded values to Safari strings.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds iOS Safari version mappings to `customUserAgent` settings and updates the schema to support the new mapping property.
> 
> - **iOS Overrides**:
>   - `overrides/ios-override.json`: Add `settings.safariVersionMappings` under `features.customUserAgent`, mapping `"26"`/`"26.0"` → `"18_6"` and `"26.0.1"` → `"18_7"`.
> - **Schema**:
>   - `schema/features/custom-user-agent.ts`: Add optional `safariVersionMappings?: Record<string, string>;` to `CustomUserAgentSettings`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b1e39c5744813345835d4c085ef8eea9b7e1220c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->