### PR TITLE
SBT - add autoconsent exception to display payment options

### DIFF
--- a/features/autoconsent.json
+++ b/features/autoconsent.json
@@ -646,6 +646,10 @@
         {
             "domain": "redlionchelwood.co.uk",
             "reason": "https://github.com/duckduckgo/privacy-configuration/pull/3848"
+        },
+        {
+            "domain": "sweetgreen.com",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/pull/3886"
         }
     ],
     "settings": {


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1206670747178362/task/1211578468778752?focus=true

## Description

### Site breakage mitigation process:
#### Brief explanation
- Reported URL: order.sweetgreen.com
- Problems experienced: payment options not showing
- Platforms affected:
  - [ x] iOS
  - [ x] Android
  - [x ] Windows
  - [x ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked: NA
- Feature being disabled/modified: autoconsent
- [ ] This change is a speculative mitigation to fix reported breakage.
