### PR TITLE
Multiple mitigations for blank spaces

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -2216,6 +2216,10 @@
                     {
                         "selector": "#stickyFooterRoot",
                         "type": "hide"
+                    },
+                    {
+                        "selector": ".sc-toncsa-0",
+                        "type": "hide-empty"
                     }
                 ]
             },
@@ -2339,6 +2343,15 @@
                     },
                     {
                         "selector": "[class*='placeholder']",
+                        "type": "hide-empty"
+                    }
+                ]
+            },
+            {
+                "domain": "koreatimes.co.kr",
+                "rules": [
+                    {
+                        "selector": "[data-ad-position]",
                         "type": "hide-empty"
                     }
                 ]
@@ -3509,6 +3522,15 @@
                     },
                     {
                         "selector": ".Post__openWebSlot",
+                        "type": "hide-empty"
+                    }
+                ]
+            },
+            {
+                "domain": "theregister.com",
+                "rules": [
+                    {
+                        "selector": ".adun",
                         "type": "hide-empty"
                     }
                 ]


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/1206670747178362/task/1211531461090991?focus=true
https://app.asana.com/1/137249556945/project/1206670747178362/task/1211530293004398?focus=true
https://app.asana.com/1/137249556945/project/1206670747178362/task/1211531251052347?focus=true

## Description
### Site breakage mitigation process:
#### Brief explanation
- Reported URLs:
  - https://www.independent.co.uk/news/world/americas/msnbc-bloomberg-error-brian-williams-mara-gay-a9383741.html (mobile only)
  - https://www.koreatimes.co.kr/opinion/20250822/a-stealth-target-of-trumps-brazil-tariffs
  - https://www.theregister.com/2025/10/01/microsoft_consumer_copilot_corporate/
- Problems experienced: Blank spaces caused by trackers being blocked.
- Platforms affected:
  - [x] iOS
  - [x] Android
  - [x] Windows
  - [x] MacOS
  - [x] Extensions
- Tracker(s) being unblocked: N/A
- Feature being disabled/modified: N/A
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds element-hiding rules for `independent.co.uk`, `koreatimes.co.kr`, and `theregister.com` to remove blank ad spaces.
> 
> - **Element Hiding Rules**:
>   - `independent.co.uk`:
>     - Add `".sc-toncsa-0"` as `hide-empty`.
>   - `koreatimes.co.kr`:
>     - New domain entry with `[data-ad-position]` as `hide-empty`.
>   - `theregister.com`:
>     - New domain entry with `".adun"` as `hide-empty`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 213ee1411c2deaa7695a3c26cf70bf6064e8fb81. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->