### PR TITLE
Allowed cookie script for redlionchelwood.co.uk

### DIFF
--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -825,6 +825,15 @@
                     }
                 ]
             },
+            "cookie-script.com": {
+                "rules": [
+                    {
+                        "rule": "cdn.cookie-script.com",
+                        "domains": ["redlionchelwood.co.uk"],
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/issues/3892"
+                    }
+                ]
+            },
             "cquotient.com": {
                 "rules": [
                     {


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/1206670747178362/task/1211528101922635?focus=true

## Description
### Site breakage mitigation process:
#### Brief explanation
- Reported URL: https://www.redlionchelwood.co.uk/
- Problems experienced: Dark overlay.
- Platforms affected:
  - [x] iOS
  - [x] Android
  - [x] Windows
  - [x] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked: cdn.cookie-script.com
- Feature being disabled/modified: N/A
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `cookie-script.com` rule to allow `cdn.cookie-script.com` on `redlionchelwood.co.uk` in `features/tracker-allowlist.json`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 34eb4817f437f6a347ac3b994f8e228ff411a65c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->