### PR TITLE
Enable search on fastcompany.com

### DIFF
--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -3105,6 +3105,15 @@
                     }
                 ]
             },
+            "queryly.com": {
+                "rules": [
+                    {
+                        "rule": "api.queryly.com/v4/search.aspx",
+                        "domains": ["fastcompany.com"],
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/pull/3894"
+                    }
+                ]
+            },
             "reddit.com": {
                 "rules": [
                     {


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/1206670747178362/task/1211572161964851?focus=true

## Description
### Site breakage mitigation process:
#### Brief explanation
- Reported URL: https://www.fastcompany.com/3045676/tech-forecast/after-the-fracas-over-hello-barbie-toytalk-responds-to-its-critics
- Problems experienced: Search not working.
- Platforms affected:
  - [x] iOS
  - [x] Android
  - [x] Windows
  - [x] MacOS
  - [x] Extensions
- Tracker(s) being unblocked: api.queryly.com
- Feature being disabled/modified: N/A
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds an allowlist rule for `api.queryly.com/v4/search.aspx` on `fastcompany.com`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e6a3a78da8584a756c800f51dbc6e8daf5e11915. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->