### PR TITLE
Duck.ai entry point settings updates

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -138,6 +138,15 @@
                 },
                 "pageContext": {
                     "state": "internal"
+                },
+                "improvements": {
+                    "state": "internal"
+                },
+                "keepSession": {
+                    "state": "internal",
+                    "settings": {
+                        "sessionTimeoutMinutes": 60
+                    }
                 }
             },
             "minSupportedVersion": "0.100.0",


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1210132634900450/task/1211333196670334?focus=true

This is the same as the macOS change: #3799

## Description

- `aiChat.improvements` enables the changes for:
    -  [✓ 2B Remove setting option for shortcuts in browser menus - 1d](https://app.asana.com/1/137249556945/project/1210132634900450/task/1211508044571129)
    - [1C Allow Summarize/Translate with Duck.ai to use sidebar despite it being disabled in settings - 1d](https://app.asana.com/1/137249556945/project/1210132634900450/task/1211508044571128)
    - [2C Add a separate setting option for address bar when typing - 2d](https://app.asana.com/1/137249556945/project/1210132634900450/task/1211508044571130)
- `aiChat.keepSession` enables and set the configuration for 
     - [1B Reopen most recent Duck.ai conversation in tab's sidebar for 60 mins - 3 days](https://app.asana.com/1/137249556945/project/1210132634900450/task/1211508044571127) 

These are equivalent to the already existing macOS feature flags:
https://github.com/duckduckgo/privacy-configuration/blob/main/overrides/macos-override.json#L253-#L261

### Feature change process:

- [x] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change. (added by macOS team beforehand)
https://github.com/duckduckgo/privacy-configuration/blob/968a57adbfe9e8afe55b6d33ab69b635c5d57c2a/schema/features/ai-chat.ts#L13C5-L13C26
- [x] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge. (partial)
- [ ] This feature was covered by a tech design.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `aiChat` feature flags `improvements` and `keepSession` (with 60‑minute session timeout) to `overrides/windows-override.json`.
> 
> - **Windows config (`overrides/windows-override.json`)**:
>   - **`aiChat`**:
>     - Adds `improvements` feature (`state: "internal"`).
>     - Adds `keepSession` feature (`state: "internal"`) with `settings.sessionTimeoutMinutes: 60`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit af13b08bd636e6da8196c64a43808a42b8a0c56f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->