### PR TITLE
Speculative mitigation for athena.io report surge

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -920,6 +920,10 @@
                     {
                         "domain": "arcteryx.com",
                         "reason": "https://github.com/duckduckgo/privacy-configuration/pull/3701"
+                    },
+                    {
+                        "domain": "messaginganalytics.athena.io",
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/pull/3900"
                     }
                 ],
                 "ddgDefaultSites": [
@@ -955,6 +959,10 @@
                     {
                         "domain": "arcteryx.com",
                         "reason": "https://github.com/duckduckgo/privacy-configuration/pull/3701"
+                    },
+                    {
+                        "domain": "messaginganalytics.athena.io",
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/pull/3900"
                     }
                 ],
                 "omitVersionSites": []


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1200277586140538/task/1211573250320293?focus=true

### Site breakage mitigation process:
#### Brief explanation
- Reported URL: messaginganalytics.athena.io
- Problems experienced: reports of messaging section not loading on mobile
- Platforms affected:
  - [x] iOS
  - [x] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Feature being disabled/modified: user agent
- [x] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `messaginganalytics.athena.io` to iOS `customUserAgent` `ddgFixedSites` and `omitApplicationSites`.
> 
> - **iOS customUserAgent** (`overrides/ios-override.json`):
>   - Add `messaginganalytics.athena.io` to `settings.ddgFixedSites`.
>   - Add `messaginganalytics.athena.io` to `settings.omitApplicationSites`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6c816d7b3f0492d87bcd85fb0a983fce645492f9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->