### PR TITLE
Disable webview.skipFetchForServiceWorkers speculative fix to better understand the root cause

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -1164,7 +1164,7 @@
                     "state": "preview"
                 },
                 "skipFetchForServiceWorkers": {
-                    "state": "preview"
+                    "state": "disabled"
                 },
                 "webViewSkipServiceWorkerAttachments": {
                     "state": "disabled",


### PR DESCRIPTION
**Asana Task/Github Issue:**

https://app.asana.com/1/137249556945/project/72649045549333/task/1210559041884443?focus=true

## Description

- Windows Browser: we previously enabled allowRetriesForServiceWorkerTimeouts and skipFetchForServiceWorkers speculative fixes on Preview
- This seems to have significantly improved the situation on the "Tabs sometimes not loading" issue on Windows.
- This change disable skipFetchForServiceWorkers to udnerstand if it's skipFetchForServiceWorkers or allowRetriesForServiceWorkerTimeouts that has most impact in resolving the new tab timeouts

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Sets `webview` feature `skipFetchForServiceWorkers` from preview to disabled in `overrides/windows-override.json`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 252c05638ea75eeab3ee20de310e35fcaaf93508. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->