### PR TITLE
SBT hide blank space

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -1458,10 +1458,21 @@
                 ]
             },
             {
-                "domain": "ebay-kleinanzeigen.de",
+                "domain": [
+                    "ebay-kleinanzeigen.de",
+                    "kleinanzeigen.de"
+                ],
                 "rules": [
                     {
                         "selector": "[data-liberty-position-name]",
+                        "type": "hide"
+                    },
+                    {
+                        "selector": ".bannerplacement-fullwidth",
+                        "type": "hide-empty"
+                    },
+                    {
+                        "selector": ".bannerplacement-sticky",
                         "type": "hide-empty"
                     }
                 ]


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1206670747178362/task/1211584600997350?focus=true

## Description

### Site breakage mitigation process:
#### Brief explanation
- Reported URL: https://www.kleinanzeigen.de/s-autos/opel-combo/k0c216
- Problems experienced: ad blank space
- Platforms affected:
  - [ x] iOS
  - [x ] Android
  - [x ] Windows
  - [ x] MacOS
  - [ x] Extensions
- Tracker(s) being unblocked: NA
- Feature being disabled/modified: elementHiding
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Expands coverage to kleinanzeigen.de and tightens element-hiding on ad placeholders, adding rules for fullwidth and sticky banners.
> 
> - **Element Hiding Config (features/element-hiding.json)**:
>   - **Domains**: Expand `ebay-kleinanzeigen.de` to `["ebay-kleinanzeigen.de", "kleinanzeigen.de"]`.
>   - **Rules**:
>     - Change `"[data-liberty-position-name]"` from `hide-empty` to `hide`.
>     - Add `".bannerplacement-fullwidth"` → `hide-empty`.
>     - Add `".bannerplacement-sticky"` → `hide-empty`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d75fe97c8cb58359bbd6b98fcec22c0f5fe52173. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->