### PR TITLE
SBT allow users to access the site by adding cpm exception

### DIFF
--- a/features/autoconsent.json
+++ b/features/autoconsent.json
@@ -658,6 +658,10 @@
         {
             "domain": "mizuno.com",
             "reason": "https://github.com/duckduckgo/privacy-configuration/pull/3902"
+        },
+        {
+            "domain": "film.at",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/pull/3905"
         }
     ],
     "settings": {


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1206670747178362/task/1211595447919076?focus=true

## Description

### Site breakage mitigation process:
#### Brief explanation
- Reported URL: film.at
- Problems experienced: users can't access the site and need to be allowed to accept cookies
- Platforms affected:
  - [x ] iOS
  - [ x] Android
  - [ x] Windows
  - [x ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked: NA
- Feature being disabled/modified: autoconsent
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `film.at` to autoconsent exceptions to restore site access.
> 
> - **Config**: Update `features/autoconsent.json` to add `film.at` to the autoconsent exception list.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 96548f68c4a22fc6eaa6e569b38722093d2134ae. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->