### PR TITLE
Disable webview.allowRetriesForServiceWorkerTimeouts speculative fix to better understand the root cause

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -1165,10 +1165,10 @@
                     "state": "enabled"
                 },
                 "allowRetriesForServiceWorkerTimeouts": {
-                    "state": "preview"
+                    "state": "disabled"
                 },
                 "skipFetchForServiceWorkers": {
-                    "state": "disabled"
+                    "state": "preview"
                 },
                 "webViewSkipServiceWorkerAttachments": {
                     "state": "disabled",


### PR DESCRIPTION
**Asana Task/Github Issue:**

https://app.asana.com/1/137249556945/project/72649045549333/task/1210559041884443?focus=true

## Description

- Windows Browser: we previously enabled allowRetriesForServiceWorkerTimeouts and skipFetchForServiceWorkers speculative fixes on Preview
- This seems to have significantly improved the situation on the "Tabs sometimes not loading" issue on Windows.
- This change disable allowRetriesForServiceWorkerTimeouts to understand if it's skipFetchForServiceWorkers or allowRetriesForServiceWorkerTimeouts that has most impact in resolving the new tab timeouts

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> In `overrides/windows-override.json`, disable `webview.allowRetriesForServiceWorkerTimeouts` and set `webview.skipFetchForServiceWorkers` to `preview`.
> 
> - **Windows webview configuration** (`overrides/windows-override.json`):
>   - `webview.features.allowRetriesForServiceWorkerTimeouts`: `preview` → `disabled`.
>   - `webview.features.skipFetchForServiceWorkers`: `disabled` → `preview`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7a1601a3d39c9f7f0c0224481166a4520bc5937e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->