### PR TITLE
SBT remove cpm and update elementhiding rules on nottinghampost-com

### DIFF
--- a/features/autoconsent.json
+++ b/features/autoconsent.json
@@ -662,6 +662,10 @@
         {
             "domain": "film.at",
             "reason": "https://github.com/duckduckgo/privacy-configuration/pull/3905"
+        },
+        {
+            "domain": "nottinghampost.com",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/pull/3909"
         }
     ],
     "settings": {

--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -2769,12 +2769,12 @@
                 "domain": "nottinghampost.com",
                 "rules": [
                     {
-                        "selector": "#auth-ui_one-tap-container",
+                        "selector": "div[data-tmdatatrack=\"non-content-unit\"]",
                         "type": "hide"
                     },
                     {
-                        "selector": "#comments-standalone-mpu",
-                        "type": "hide-empty"
+                        "selector": "div.vf-promo-gtag",
+                        "type": "closest-empty"
                     }
                 ]
             },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1206670747178362/task/1211606138498867?focus=true

## Description

### Site breakage mitigation process:
#### Brief explanation
- Reported URL: https://www.nottinghampost.com/news/local-news/end-era-nottinghams-house-fraser-10562668
- Problems experienced: blank space accross the article besides cookies need to be accepted to avoid fees
- Platforms affected:
  - [x ] iOS
  - [ x] Android
  - [ x] Windows
  - [x ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked: NA
- Feature being disabled/modified: autoconsent and elementHiding
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `nottinghampost.com` to autoconsent exceptions and updates its element-hiding selectors/rule types.
> 
> - **Autoconsent (`features/autoconsent.json`)**:
>   - Add exception for `nottinghampost.com`.
> - **Element Hiding (`features/element-hiding.json`)**:
>   - `nottinghampost.com` rules updated:
>     - Replace `#auth-ui_one-tap-container` hide with `div[data-tmdatatrack="non-content-unit"]` hide.
>     - Replace `#comments-standalone-mpu` hide-empty with `div.vf-promo-gtag` closest-empty.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bcddfa8d826b49bbc12a28f5919b7fd5671dab4d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->