### PR TITLE
Disable cookie-notice and notice-cookie autoconsent rules

### DIFF
--- a/features/autoconsent.json
+++ b/features/autoconsent.json
@@ -670,7 +670,9 @@
     ],
     "settings": {
         "disabledCMPs": [
-            "healthline-media"
+            "healthline-media",
+            "cookie-notice",
+            "notice-cookie"
         ],
         "filterlistExceptions": [],
         "compactRuleList": {


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/task/1210595725302425?focus=true

## Description
Disabling two generic cosmetic rules to measure impact on breakage and coverage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `cookie-notice` and `notice-cookie` to `settings.disabledCMPs` in `features/autoconsent.json`.
> 
> - **Config**:
>   - Update `features/autoconsent.json` → `settings.disabledCMPs` to include `cookie-notice` and `notice-cookie`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5e97f091690f9cef860243952478982e73831ace. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->