### PR TITLE
Enabling allowRetriesForServiceWorkerTimeouts fix on Windows Stable

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -1171,10 +1171,17 @@
                     "state": "enabled"
                 },
                 "allowRetriesForServiceWorkerTimeouts": {
-                    "state": "disabled"
+                    "state": "enabled",
+                    "rollout": {
+                        "steps": [
+                            {
+                                "percent": 50.0
+                            }
+                        ]
+                    }
                 },
                 "skipFetchForServiceWorkers": {
-                    "state": "preview"
+                    "state": "disabled"
                 },
                 "webViewSkipServiceWorkerAttachments": {
                     "state": "disabled",


### PR DESCRIPTION
**Asana Task/Github Issue:**

https://app.asana.com/1/137249556945/project/72649045549333/task/1210559041884443?focus=true

## Description

- Enabling allowRetriesForServiceWorkerTimeouts fix on Windows Stable, now that Preview has indicated it works

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enable service worker timeout retries with a 50% rollout and disable skip-fetch for service workers in Windows webview.
> 
> - **Webview**:
>   - `features.allowRetriesForServiceWorkerTimeouts`: set to `enabled` with a 50% rollout.
>   - `features.skipFetchForServiceWorkers`: set to `disabled` (from `preview`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3260307b8a1d65837d30bd74977e59e1fb085e42. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->