### PR TITLE
Add patch settings for nba.com domain

### DIFF
--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -1693,6 +1693,7 @@
             "settings": {
                 "additionalCheck": "disabled",
                 "maxContentLength": 9500,
+                "mainContentSelector": "main, article, .content, .main, #content, #main",
                 "conditionalChanges": [
                     {
                         "condition": {


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/task/1211632579258684?focus=true

## Description

For now add a patch fix for nba.com
Intend to copy to Windows later.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a default `mainContentSelector` for page context and a domain-specific override for `nba.com`.
> 
> - **Config (macOS) — `features.pageContext.settings`**:
>   - Add default `mainContentSelector`: `main, article, .content, .main, #content, #main`.
>   - Extend `conditionalChanges` with domain rule for `nba.com` to set `mainContentSelector` to `main`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1c7d3c361eca2a947cb0fa1c4d7b671e12640348. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->