### PR TITLE
Release settings improvements and keepSession on macOS 1.161.0

### DIFF
--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -252,10 +252,12 @@
                     "minSupportedVersion": "1.157.0"
                 },
                 "improvements": {
-                    "state": "disabled"
+                    "state": "enabled",
+                    "minSupportedVersion": "1.161.0"
                 },
                 "keepSession": {
-                    "state": "disabled",
+                    "state": "enabled",
+                    "minSupportedVersion": "1.161.0",
                     "settings": {
                         "sessionTimeoutMinutes": 60
                     }


### PR DESCRIPTION
**Asana Task/Github Issue:** https://duckduckgo.zoom.us/my/michal.smaga 

## Description
Enable Duck.ai settings `improvements` and `keepSession` feature for this week's internal release on macOS.
### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables `aiChat.improvements` and `aiChat.keepSession` on macOS with minSupportedVersion 1.161.0.
> 
> - **macOS overrides** (`overrides/macos-override.json`):
>   - **`aiChat`**:
>     - Enable `improvements` and set `minSupportedVersion` to `1.161.0`.
>     - Enable `keepSession`, add `minSupportedVersion` `1.161.0` (keeps `sessionTimeoutMinutes: 60`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 41e95038ca7c7c6b06134c2eef82203c249f98c6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->