### PR TITLE
[Autofill] Set form type for accounts.google.com

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -35378,6 +35378,14 @@
                                         "path": "/formBoundarySelector",
                                         "op": "replace",
                                         "value": "c-wiz > main"
+                                    },
+                                    {
+                                        "path": "/formTypeSettings/-",
+                                        "op": "add",
+                                        "value": {
+                                            "selector": "c-wiz[data-p*=ServiceLogin] > main",
+                                            "type": "login"
+                                        }
                                     }
                                 ]
                             },

--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -768,6 +768,14 @@
                                         "path": "/formBoundarySelector",
                                         "op": "replace",
                                         "value": "c-wiz > main"
+                                    },
+                                    {
+                                        "path": "/formTypeSettings/-",
+                                        "op": "add",
+                                        "value": {
+                                            "selector": "c-wiz[data-p*=ServiceLogin] > main",
+                                            "type": "login"
+                                        }
                                     }
                                 ]
                             },

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -851,6 +851,14 @@
                                         "path": "/formBoundarySelector",
                                         "op": "replace",
                                         "value": "c-wiz > main"
+                                    },
+                                    {
+                                        "path": "/formTypeSettings/-",
+                                        "op": "add",
+                                        "value": {
+                                            "selector": "c-wiz[data-p*=ServiceLogin] > main",
+                                            "type": "login"
+                                        }
                                     }
                                 ]
                             },

--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -488,6 +488,14 @@
                                         "path": "/formBoundarySelector",
                                         "op": "replace",
                                         "value": "c-wiz > main"
+                                    },
+                                    {
+                                        "path": "/formTypeSettings/-",
+                                        "op": "add",
+                                        "value": {
+                                            "selector": "c-wiz[data-p*=ServiceLogin] > main",
+                                            "type": "login"
+                                        }
                                     }
                                 ]
                             },


### PR DESCRIPTION
**Asana Task/Github Issue:**

## Description
<!-- 
  Please delete either or both process sections below.
-->

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a site-specific autofill rule marking Google ServiceLogin pages as `login` on Android, iOS, macOS, and Windows.
> 
> - **Autofill — site-specific fixes**:
>   - `accounts.google.com`:
>     - Add `formTypeSettings` entry: selector `c-wiz[data-p*=ServiceLogin] > main` set to `login`.
>     - Retain `formBoundarySelector` override `c-wiz > main`.
>   - Platforms: `overrides/android-override.json`, `overrides/ios-override.json`, `overrides/macos-override.json`, `overrides/windows-override.json`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e3f6f50cb9ae4719e5a53696498fb65ec5384bc5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->