### PR TITLE
CPM breakage on elindependiente.com

### DIFF
--- a/features/autoconsent.json
+++ b/features/autoconsent.json
@@ -33,7 +33,7 @@
         },
         {
             "domain": "elindependiente.com",
-            "reason": "site breakage"
+            "reason": "https://github.com/duckduckgo/privacy-configuration/pull/3924"
         },
         {
             "domain": "eurostar.com",


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/inbox/11472677167854/item/1211634252124445/story/1211637022679356

## Description
<!-- 
  Please delete either or both process sections below.
-->
CPM causing redirect on elindependiente.com

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `elindependiente.com` to autoconsent exceptions to mitigate CPM-related redirect breakage.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 48bef3db8e84d84e894b3ad25f7577076256ab7e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->