### PR TITLE
[iOS][Malicious Site Protection] Increase Hash prefix update frequency to 8 hours

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -2298,7 +2298,7 @@
                 }
             },
             "settings": {
-                "hashPrefixUpdateFrequency": 20,
+                "hashPrefixUpdateFrequency": 480,
                 "filterSetUpdateFrequency": 720
             },
             "exceptions": []


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/414709148257752/task/1211645814224499?focus=true

## Description

Reduce high disk writes / energy consumption due to frequent updates of malicious site protection hash prefix
<img width="2560" height="1278" alt="Screenshot 2025-10-15 at 6 32 39 pm" src="https://github.com/user-attachments/assets/0687483e-b9a0-4af3-ad40-28efdb284875" />

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [x] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates `maliciousSiteProtection` hash prefix update frequency from `20` to `480` minutes in `overrides/ios-override.json`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 436b86ae61565c58514a6bcbea3be7911097bd87. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->