### PR TITLE
Enables webKitPerformanceReporting

### DIFF
--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -1689,6 +1689,9 @@
                 },
                 "appStoreUpdateFlow": {
                     "state": "enabled"
+                },
+                "webKitPerformanceReporting": {
+                    "state": "enabled"
                 }
             }
         },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/72649045549333/task/1211647254053246?focus=true

## Description

Enables WebKit performance reporting - which enables a pixel with site loading performance data for macOS.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables `webKitPerformanceReporting` (state: `enabled`) in `overrides/macos-override.json` under `features.macOSBrowserConfig.features`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f56148d31010286df76bb4a31935e71d6a827bdf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->