### PR TITLE
Clear outdated WebCompat exceptions

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -36779,28 +36779,7 @@
         },
         "webCompat": {
             "state": "enabled",
-            "exceptions": [
-                {
-                    "domain": "chewy.com",
-                    "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2154"
-                },
-                {
-                    "domain": "wsj.com",
-                    "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2162"
-                },
-                {
-                    "domain": "instagram.com",
-                    "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2182"
-                },
-                {
-                    "domain": "skechers.com",
-                    "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2827"
-                },
-                {
-                    "domain": "realtor.com",
-                    "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2855"
-                }
-            ],
+            "exceptions": [],
             "settings": {
                 "conditionalChanges": [
                     {
@@ -36875,30 +36854,6 @@
                                     "key": "keyToBeDeleted",
                                     "action": "delete"
                                 }
-                            }
-                        ]
-                    },
-                    {
-                        "condition": {
-                            "domain": "realestate.com.au"
-                        },
-                        "patchSettings": [
-                            {
-                                "op": "replace",
-                                "path": "/notification/state",
-                                "value": "disabled"
-                            }
-                        ]
-                    },
-                    {
-                        "condition": {
-                            "domain": "hyatt.com"
-                        },
-                        "patchSettings": [
-                            {
-                                "op": "replace",
-                                "path": "/notification/state",
-                                "value": "disabled"
                             }
                         ]
                     }


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/1201870266890790/task/1211264455407109?focus=true

### Site breakage mitigation process:
We've fixed the underlying webcompat features (notification shim + viewport adjustments) so that these mitigations should no longer be necessary 🎉 💥 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes outdated WebCompat domain exceptions and deletes domain-specific notification overrides in `overrides/android-override.json`.
> 
> - **Android overrides (`overrides/android-override.json`)**:
>   - **WebCompat**:
>     - Remove domain exceptions list (e.g., `chewy.com`, `wsj.com`, `instagram.com`, `skechers.com`, `realtor.com`).
>     - Delete `conditionalChanges` entries that disabled `notification` for `realestate.com.au` and `hyatt.com`.
>     - Keep `notification` and `permissions` states enabled; other settings unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cb9c9d57a4d13d2604a2a0b9a51fceb40d1ae50a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->