### PR TITLE
Remove fingerprinting hardware exceptions as well after webcompat fix

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -36392,16 +36392,7 @@
                     }
                 ]
             },
-            "exceptions": [
-                {
-                    "domain": "crocs.com",
-                    "reason": "https://github.com/duckduckgo/privacy-configuration/issues/567"
-                },
-                {
-                    "domain": "realtor.com",
-                    "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2855"
-                }
-            ]
+            "exceptions": []
         },
         "fingerprintingScreenSize": {
             "state": "enabled",


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/1206670747178362/task/1211264455407109?focus=true

## Description
Missed out these extra mitigations that appear to have been related (fixing the notification shim appears to also obviate the need for excepting fingerprinting hardware on those sites) to those removed in PR #3930. (Testing them works fine w/o.)
