### PR TITLE
Windows: Add disabled burn.fireproofSettingsVisibility subfeature

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -1290,6 +1290,9 @@
                 },
                 "burnOnStartup": {
                     "state": "enabled"
+                },
+                "fireproofSettingsVisibility": {
+                    "state": "disabled"
                 }
             }
         },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/72649045549333/task/1211649536657102?focus=true

## Description
Add a disabled `burn.fireproofSettingsVisibility` feature for Windows that will be used to control the visibility of a new Fireproof Sites section in Data Clearing settings. This is for this project: [Desktop Browsers: Windows - Fireproof UI consistency with macOS](https://app.asana.com/1/137249556945/project/72649045549333/task/1210416778703286?focus=true).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds disabled `burn.fireproofSettingsVisibility` subfeature to Windows overrides.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b92646d510c2622fdf41bf37ea5357bb39fe1c8c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->