### PR TITLE
Add 'contentScopeScripts' to handlerStrategies

### DIFF
--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -504,6 +504,7 @@
                     "state": "disabled",
                     "handlerStrategies": {
                         "reflect": [
+                            "contentScopeScripts",
                             "trackerDetectedMessage",
                             "printHandler",
                             "specialPages"


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/72649045549333/task/1211552912534476?focus=true

## Description

This adds support for contentScopeScripts handler for sites that require the message proxy, explained better here https://github.com/duckduckgo/macos-browser/pull/1411

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `contentScopeScripts` to the `reflect` handler strategy under `features.webCompat.settings.messageHandlers.handlerStrategies` in `overrides/macos-override.json`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b8e8c86df884c886f8892e66bd38bd3cad9ddb7a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->