### PR TITLE
Re-enables updatesWontAutomaticallyRestartApp

### DIFF
--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -955,7 +955,7 @@
         "updatesWontAutomaticallyRestartApp": {
             "state": "internal",
             "exceptions": [],
-            "minSupportedVersion": "1.155.0"
+            "minSupportedVersion": "1.161.0"
         },
         "incontextSignup": {
             "state": "enabled"


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1211647254502910/task/1211661187706202?focus=true

## Description

Re-enables updatesWontAutomaticallyRestartApp

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> In `overrides/macos-override.json`, sets `updatesWontAutomaticallyRestartApp` state to `internal` and increases `minSupportedVersion` to `1.161.0`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 98cf8d03e9fe43924ca353ee6f16795513682eac. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->