### PR TITLE
Refactor and corrections made to element-hiding.ts

### DIFF
--- a/schema/features/element-hiding.ts
+++ b/schema/features/element-hiding.ts
@@ -1,32 +1,41 @@
 import { Feature } from '../feature';
 
-export type ElementHidingFeature<VersionType> = Feature<
-    {
-        useStrictHideStyleTag?: boolean;
-        rules: Array<{
-            selector?: string;
-            type: 'hide-empty' | 'hide' | 'closest-empty' | 'override' | 'modify-style' | 'modify-attr' | 'disable-default';
-            values?: Array<{
-                property: string;
-                value: string;
-            }>;
-        }>;
-        domains: Array<{
-            domain: string | string[];
-            rules: Array<{
-                selector?: string;
-                type: 'hide-empty' | 'hide' | 'closest-empty' | 'override' | 'modify-style' | 'modify-attr' | 'disable-default';
-                values?: Array<{
-                    property: string;
-                    value: string;
-                }>;
-            }>;
-        }>;
-        hideTimeouts?: number[];
-        unhideTimeouts?: number[];
-        mediaAndFormSelectors?: string;
-        adLabelStrings?: string[];
-        [key: string]: any;
-    },
-    VersionType
->;
+type ElementHidingValue = {
+    property: string;
+    value: string;
+};
+
+type ElementHidingRuleWithSelector = {
+    selector: string;
+    type: 'hide-empty' | 'hide' | 'closest-empty' | 'override' | 'modify-style' | 'modify-attr';
+    values?: ElementHidingValue[];
+};
+
+type ElementHidingRuleWithoutSelector = {
+    type: 'disable-default';
+};
+
+type ElementHidingRule = ElementHidingRuleWithSelector | ElementHidingRuleWithoutSelector;
+
+type ElementHidingDomain = {
+    domain: string | string[];
+    rules: ElementHidingRule[];
+};
+
+type StyleTagException = {
+    domain: string;
+    reason: string;
+};
+
+interface ElementHidingConfiguration {
+    useStrictHideStyleTag?: boolean;
+    rules: ElementHidingRule[];
+    domains: ElementHidingDomain[];
+    hideTimeouts?: number[];
+    unhideTimeouts?: number[];
+    mediaAndFormSelectors?: string;
+    adLabelStrings?: string[];
+    styleTagExceptions?: StyleTagException[];
+}
+
+export type ElementHidingFeature<VersionType> = Feature<ElementHidingConfiguration, VersionType>;


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/72649045549333/task/1211479926220518?focus=true

## Description


### Feature change process:

- [x ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refactors element-hiding schema with stricter rule typing and adds styleTagExceptions to configuration.
> 
> - **Schema: `schema/features/element-hiding.ts`**
>   - **New config**: Add `styleTagExceptions: { domain, reason }[]`.
>   - **Rule typing**: Split `disable-default` into a selector-less rule; other rule types now require `selector`.
>   - **Refactor**: Extract `ElementHidingValue`, `ElementHidingRule*`, `ElementHidingDomain`, and `ElementHidingConfiguration`; remove index signature and update `ElementHidingFeature` to `Feature<ElementHidingConfiguration, VersionType>`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1fa6b5c5a7b1137a75f4efe723b136aff5454283. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->