### PR TITLE
SBT - Updated styles to keep top banner fixed during page scroll

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -2775,7 +2775,7 @@
                     {
                         "selector": "div.vf-promo-gtag",
                         "type": "closest-empty"
-                    }, 
+                    },
                     {
                         "selector": ".kwUlOm.sticky ~ header",
                         "type": "modify-style",


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1206670747178362/task/1211606138498867?focus=true

## Description

### Site breakage mitigation process:
#### Brief explanation
- Reported URL: https://www.nottinghampost.com/news/local-news/end-era-nottinghams-house-fraser-10562668
- Problems experienced: Top banner moves with the page during scroll,
- Platforms affected:
  - [ x] iOS
  - [ x] Android
  - [x ] Windows
  - [ x] MacOS
  - [ x] Extensions
- Tracker(s) being unblocked: NA
- Feature being disabled/modified: element-hiding
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add a site-specific modify-style rule for `nottinghampost.com` to set the `header` `top: 0` when a sticky element is present, keeping the top banner/header fixed during scroll.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 015927dc315ab80a226c1b756fb3ca395d4225c3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->