### PR TITLE
Enable unified URL prediction logic on macOS

### DIFF
--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -1697,7 +1697,8 @@
                     "state": "internal"
                 },
                 "unifiedURLPredictor": {
-                    "state": "internal"
+                    "state": "enabled",
+                    "minSupportedVersion": "1.161.0"
                 },
                 "appStoreUpdateFlow": {
                     "state": "enabled"


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/72649045549333/task/1211625198099881?focus=true

## Description
This change enables unified URL prediction logic for all users on 1.161.0 and above (i.e. available next week).

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [x] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [x] This feature was covered by a tech design.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables the unified URL predictor on macOS for app versions 1.161.0 and above.
> 
> - **macOS config**:
>   - Enable `macOSBrowserConfig.features.unifiedURLPredictor` and set `minSupportedVersion` to `1.161.0`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7d53f48482c0f6e1446bd8dc1aaf01b5664e165f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->