### PR TITLE
Disable windowsWebviewFailures.crashAutoRecovery subfeature for DDG-WebView

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -1175,6 +1175,33 @@
                 }
             }
         },
+        "windowsWebviewFailures_DDGWV": {
+            "state": "enabled",
+            "exceptions": [],
+            "features": {
+                "enableTabUnresponsivePopup": {
+                    "state": "enabled"
+                },
+                "enableOutOfMemoryView": {
+                    "state": "enabled"
+                },
+                "preserveCrashedTabAttributes": {
+                    "state": "enabled"
+                },
+                "crashAutoRecovery": {
+                    "state": "disabled",
+                    "minSupportedVersion": "0.125.0",
+                    "settings": {
+                        "autoRecoveryBrowserEngine": true,
+                        "autoRecoveryTab": true,
+                        "autoRecoveryTabOutOfMemory": false
+                    }
+                },
+                "ignoreInvalidCastExceptionOnDisposal": {
+                    "state": "enabled"
+                }
+            }
+        },
         "webview": {
             "state": "enabled",
             "features": {

--- a/schema/config.ts
+++ b/schema/config.ts
@@ -65,6 +65,7 @@ export type ConfigV5<VersionType> = {
         networkProtection?: NetworkProtection<VersionType>;
         scriptlets?: ScriptletsFeature<VersionType>;
         windowsWebviewFailures?: WindowsWebViewFailures<VersionType>;
+        windowsWebviewFailures_DDGWV?: WindowsWebViewFailures<VersionType>;
         customUserAgent?: CustomUserAgentFeature<VersionType>;
         elementHiding?: ElementHidingFeature<VersionType>;
     };


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1208490749815560/task/1211650922171522?focus=true

## Description
Tab crash auto recovery doesn't work properly with DDG-WV, the sub-feature needs to be disabled until the issue is fixed.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a DDG-WebView-specific `windowsWebviewFailures_DDGWV` feature with `crashAutoRecovery` disabled and updates the schema to support it.
> 
> - **Windows Config (`overrides/windows-override.json`)**:
>   - **New Variant**: Adds `windowsWebviewFailures_DDGWV`.
>     - Enables `enableTabUnresponsivePopup`, `enableOutOfMemoryView`, `preserveCrashedTabAttributes`, `ignoreInvalidCastExceptionOnDisposal`.
>     - Disables `crashAutoRecovery` (with existing recovery settings retained, `minSupportedVersion: "0.125.0"`).
> - **Schema (`schema/config.ts`)**:
>   - Adds optional `windowsWebviewFailures_DDGWV?: WindowsWebViewFailures<VersionType>` to `ConfigV5.features`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e9ed726f8c302fdaffde8f4c6ad19806e6a9a311. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->