### PR TITLE
macOS: Enable duckAiDataClearing feature

### DIFF
--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -275,21 +275,6 @@
             "exceptions": [],
             "state": "enabled",
             "settings": {
-                "additionalCheck": "disabled",
-                "conditionalChanges": [
-                    {
-                        "condition": {
-                            "internal": true
-                        },
-                        "patchSettings": [
-                            {
-                                "op": "replace",
-                                "path": "/additionalCheck",
-                                "value": "enabled"
-                            }
-                        ]
-                    }
-                ],
                 "chatsLocalStorageKeys": ["savedAIChats"],
                 "chatImagesIndexDbNameObjectStoreNamePairs": [[
                         "savedAIChatData",


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1209825025475019/task/1211651246255776?focus=true

## Description
<!-- 
  Please delete either or both process sections below.
-->

This enables the feature to clear Duck.ai chat history on macOS (removing the internal user check). Note: The feature is not yet merged on macOS but can be tested with the build and testing steps from https://github.com/duckduckgo/apple-browsers/pull/2195, which is using this remote feature flag.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [x] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes the `additionalCheck` and its `conditionalChanges` from `features.duckAiDataClearing.settings` in `overrides/macos-override.json`, enabling AI chat data clearing without internal checks.
> 
> - **macOS overrides** (`overrides/macos-override.json`):
>   - **duckAiDataClearing**:
>     - Remove `settings.additionalCheck` and related `conditionalChanges` gating.
>     - Retain data-clearing targets: `chatsLocalStorageKeys` and `chatImagesIndexDbNameObjectStoreNamePairs`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9fcfee30b557cc0b868ce99d55a5ec4bcda96aca. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->