### PR TITLE
Change iOS and macOS syncCreditCards and identities to internal only

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -1003,7 +1003,7 @@
                     "state": "enabled"
                 },
                 "syncCreditCards": {
-                    "state": "enabled"
+                    "state": "internal"
                 }
             }
         },

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -1236,10 +1236,10 @@
                     }
                 },
                 "syncCreditCards": {
-                    "state": "enabled"
+                    "state": "internal"
                 },
                 "syncIdentities": {
-                    "state": "enabled"
+                    "state": "internal"
                 }
             }
         },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/414709148257752/task/1211663416720269?focus=true

## Description

There was a crash on the internal build when autofill accesses credit cards. I think I've found a fix for it, but it's too late to get it into the next build in time as we're submitting today. Therefore I need to disabled `syncCreditCards` on iOS and macOS as they both rely on the problematic code.

I've also disabled `syncIdentities` too as it's weird to just have them syncable on macOS and no other platform. See the task for more context.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [x] iOS
  - [ ] Android
  - [ ] Windows
  - [x] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Set `syncCreditCards` to `internal` on iOS; set `syncCreditCards` and `syncIdentities` to `internal` on macOS.
> 
> - **Sync configuration**:
>   - **iOS (`overrides/ios-override.json`)**:
>     - `sync.features.syncCreditCards` state changed from `enabled` to `internal`.
>   - **macOS (`overrides/macos-override.json`)**:
>     - `sync.features.syncCreditCards` state changed from `enabled` to `internal`.
>     - `sync.features.syncIdentities` state changed from `enabled` to `internal`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f60d3e96eca190605cf8c5bed08f4021d05b5a7f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->