### PR TITLE
Re-enable adsjs with no changes

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -36097,6 +36097,12 @@
                             "isPrivacyProEligible": true
                         }
                     ]
+                },
+                "updateScriptOnProtectionsChanged": {
+                    "state": "enabled"
+                },
+                "stopLoadingBeforeUpdatingScript": {
+                    "state": "disabled"
                 }
             }
         },
@@ -36116,6 +36122,32 @@
                                 "op": "add",
                                 "path": "/additionalCheck",
                                 "value": "disabled"
+                            }
+                        ]
+                    },
+                    {
+                        "condition": {
+                            "injectName": "android",
+                            "minSupportedVersion": 52530000
+                        },
+                        "patchSettings": [
+                            {
+                                "op": "add",
+                                "path": "/additionalCheck",
+                                "value": "enabled"
+                            }
+                        ]
+                    },
+                    {
+                        "condition": {
+                            "injectName": "android-adsjs",
+                            "minSupportedVersion": 52530000
+                        },
+                        "patchSettings": [
+                            {
+                                "op": "add",
+                                "path": "/additionalCheck",
+                                "value": "enabled"
                             }
                         ]
                     }
@@ -36959,7 +36991,18 @@
             "state": "enabled",
             "features": {
                 "useNewWebCompatApis": {
-                    "state": "disabled"
+                    "state": "enabled",
+                    "minSupportedVersion": 52530000,
+                    "rollout": {
+                        "steps": [
+                            {
+                                "percent": 50
+                            }
+                        ]
+                    }
+                },
+                "useWebMessageListener": {
+                    "state": "enabled"
                 }
             },
             "exceptions": []


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/72649045549333/task/1211371112177598?focus=true

## Description
Re-enable adsjs with no additional changes

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [x] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables new web compat APIs (50% rollout), adds version-gated breakage-reporting checks for Android/adsjs, and updates script handling when protections change.
> 
> - **Android overrides (`overrides/android-override.json`)**:
>   - **Script update behavior**:
>     - Enable `updateScriptOnProtectionsChanged`.
>     - Disable `stopLoadingBeforeUpdatingScript`.
>   - **Breakage reporting**:
>     - Add `additionalCheck: enabled` for `injectName: android` and `injectName: android-adsjs` when `minSupportedVersion >= 52530000`.
>     - Retain `additionalCheck: disabled` for legacy `injectName: android-adsjs`.
>   - **Client content features**:
>     - Enable `useNewWebCompatApis` with `minSupportedVersion: 52530000` and 50% rollout.
>     - Add and enable `useWebMessageListener`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bf427eac1f4d446e60b61819928ec8e7712a6014. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->