### PR TITLE
Re-enable adsjs with stopLoadingBeforeUpdatingScript

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -36097,6 +36097,12 @@
                             "isPrivacyProEligible": true
                         }
                     ]
+                },
+                "updateScriptOnProtectionsChanged": {
+                    "state": "enabled"
+                },
+                "stopLoadingBeforeUpdatingScript": {
+                    "state": "enabled"
                 }
             }
         },
@@ -36116,6 +36122,32 @@
                                 "op": "add",
                                 "path": "/additionalCheck",
                                 "value": "disabled"
+                            }
+                        ]
+                    },
+                    {
+                        "condition": {
+                            "injectName": "android",
+                            "minSupportedVersion": 52530000
+                        },
+                        "patchSettings": [
+                            {
+                                "op": "add",
+                                "path": "/additionalCheck",
+                                "value": "enabled"
+                            }
+                        ]
+                    },
+                    {
+                        "condition": {
+                            "injectName": "android-adsjs",
+                            "minSupportedVersion": 52530000
+                        },
+                        "patchSettings": [
+                            {
+                                "op": "add",
+                                "path": "/additionalCheck",
+                                "value": "enabled"
                             }
                         ]
                     }
@@ -36959,7 +36991,18 @@
             "state": "enabled",
             "features": {
                 "useNewWebCompatApis": {
-                    "state": "disabled"
+                    "state": "enabled",
+                    "minSupportedVersion": 52530000,
+                    "rollout": {
+                        "steps": [
+                            {
+                                "percent": 50
+                            }
+                        ]
+                    }
+                },
+                "useWebMessageListener": {
+                    "state": "enabled"
                 }
             },
             "exceptions": []


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/72649045549333/task/1211371112177598?focus=true

## Description
Re-enable adsjs with stopLoadingBeforeUpdatingScript

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [x] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables ads/script update behaviors, adds version-gated breakage-report checks, and rolls out new web compat APIs (50%) with WebMessage listener on Android.
> 
> - **Android overrides (`overrides/android-override.json`)**:
>   - **Ads/Script update behavior**:
>     - Enable `updateScriptOnProtectionsChanged` and `stopLoadingBeforeUpdatingScript`.
>   - **Breakage reporting**:
>     - Add `conditionalChanges` to set `additionalCheck` to `enabled` for `injectName` `android` and `android-adsjs` when `minSupportedVersion >= 52530000` (retain existing `disabled` case for legacy `android-adsjs`).
>   - **Client content features**:
>     - Enable `useNewWebCompatApis` with `minSupportedVersion: 52530000` and a 50% rollout.
>     - Add `useWebMessageListener` and enable it.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f4b32fe6208243b11df5c9215bd93c6f2a4f35dc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->