### PR TITLE
Revert unifiedURLPredictor back to internal

### DIFF
--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -1683,8 +1683,7 @@
                     "state": "internal"
                 },
                 "unifiedURLPredictor": {
-                    "state": "enabled",
-                    "minSupportedVersion": "1.161.0"
+                    "state": "internal"
                 },
                 "appStoreUpdateFlow": {
                     "state": "enabled"


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/414235014887631/task/1211691913520561?focus=true

## Description
Revert to internal until we’ve fixed the suggestions bug.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [x] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [x] This feature was covered by a tech design.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Sets `macOSBrowserConfig.features.unifiedURLPredictor` to `internal` and removes its `minSupportedVersion`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 98de874b01e38ea9fe6055c26a6e2a2d390cdd7f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->