### PR TITLE
Re-enable adsjs with no messaging

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -36097,6 +36097,12 @@
                             "isPrivacyProEligible": true
                         }
                     ]
+                },
+                "updateScriptOnProtectionsChanged": {
+                    "state": "enabled"
+                },
+                "stopLoadingBeforeUpdatingScript": {
+                    "state": "disabled"
                 }
             }
         },
@@ -36116,6 +36122,19 @@
                                 "op": "add",
                                 "path": "/additionalCheck",
                                 "value": "disabled"
+                            }
+                        ]
+                    },
+                    {
+                        "condition": {
+                            "injectName": "android",
+                            "minSupportedVersion": 52530000
+                        },
+                        "patchSettings": [
+                            {
+                                "op": "add",
+                                "path": "/additionalCheck",
+                                "value": "enabled"
                             }
                         ]
                     }
@@ -36959,6 +36978,17 @@
             "state": "enabled",
             "features": {
                 "useNewWebCompatApis": {
+                    "state": "enabled",
+                    "minSupportedVersion": 52530000,
+                    "rollout": {
+                        "steps": [
+                            {
+                                "percent": 50
+                            }
+                        ]
+                    }
+                },
+                "useWebMessageListener": {
                     "state": "disabled"
                 }
             },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/72649045549333/task/1211371112177598?focus=true

## Description
Re-enable adsjs with no messaging

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [x] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables new web compat APIs with a 50% rollout (>=52530000), adds script update flags, adjusts breakage reporting checks, and keeps web message listener disabled.
> 
> - **Android overrides (`overrides/android-override.json`)**:
>   - **Client content features**:
>     - Enable `useNewWebCompatApis` with `minSupportedVersion` `52530000` and 50% rollout.
>     - Add `useWebMessageListener` (state: `disabled`).
>   - **Breakage reporting**:
>     - Add conditional change for `injectName` `android` (min version `52530000`) to set `/additionalCheck` to `enabled`.
>     - Retain adsjs-specific `/additionalCheck` override and add it explicitly for `android-adsjs` as `disabled`.
>   - **Script update behavior**:
>     - Add `updateScriptOnProtectionsChanged` (enabled) and `stopLoadingBeforeUpdatingScript` (disabled).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 957e2c7c8495b0609a07b386194c38e311832c52. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->