### PR TITLE
Enable unified URL predictor since 1.162.0 on macOS

### DIFF
--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -1683,7 +1683,8 @@
                     "state": "internal"
                 },
                 "unifiedURLPredictor": {
-                    "state": "internal"
+                    "state": "enabled",
+                    "minSupportedVersion": "1.162.0"
                 },
                 "appStoreUpdateFlow": {
                     "state": "enabled"


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/414235014887631/task/1211691913520561?focus=true

## Description
Re-enable unified URL predictor in the release that’s going out to public next Monday.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [x] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [x] This feature was covered by a tech design.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables macOS `unifiedURLPredictor` and requires app version >= 1.162.0.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bdc108efc9722ffbce55fbc693cf6ded13a1a949. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->