### PR TITLE
Enable email confirmation decoupling for internal users

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -1606,7 +1606,8 @@
                     "minSupportedVersion": "7.180.0"
                 },
                 "emailConfirmationDecoupling": {
-                    "state": "disabled"
+                    "state": "internal",
+                    "minSupportedVersion": "7.190.0"
                 }
             },
             "minSupportedVersion": "7.180.0"


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/72649045549333/task/1211699456572832?focus=true

## Description
<!-- 
  Please delete either or both process sections below.
—>

Enables email confirmation decoupling for internal users.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches `dbp.features.emailConfirmationDecoupling` to `internal` and adds `minSupportedVersion: 7.190.0` in `overrides/ios-override.json`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e76a222519672b0b082cec558f56b8e601eb7444. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->