### PR TITLE
Disable onboarding design experiment (Oct25)

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -37909,29 +37909,29 @@
             }
         },
         "onboardingDesignExperiment": {
-            "state": "enabled",
+            "state": "disabled",
             "exceptions": [],
             "features": {
                 "onboardingDesignExperimentOct25": {
-                    "state": "enabled",
+                    "state": "disabled",
                     "minSupportedVersion": 52510000,
                     "cohorts": [
                         {
                             "name": "modifiedControl",
-                            "weight": 1
+                            "weight": 0
                         },
                         {
                             "name": "bb",
-                            "weight": 1
+                            "weight": 0
                         },
                         {
                             "name": "buck",
-                            "weight": 1
+                            "weight": 0
                         }
                     ]
                 },
                 "waitForLocalPrivacyConfig": {
-                    "state": "enabled",
+                    "state": "disabled",
                     "minSupportedVersion": 52510000
                 }
             }


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1207908166761516/task/1211422384382179?focus=true

## Description
<!-- 
  Please delete either or both process sections below.
-->

Turns off the onboardingDesignExperiment for Oct25

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Disables `onboardingDesignExperiment` (Oct25) and `waitForLocalPrivacyConfig` in `overrides/android-override.json`, setting all experiment cohort weights to 0.
> 
> - **Android config (`overrides/android-override.json`)**:
>   - **Onboarding Design Experiment (Oct25)**:
>     - Set `onboardingDesignExperiment` and `onboardingDesignExperimentOct25` to `disabled`.
>     - Set cohort weights (`modifiedControl`, `bb`, `buck`) to `0`.
>   - **Related Feature**:
>     - Set `waitForLocalPrivacyConfig` to `disabled`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0a61f87250abb97afd98b3f05cb381bf90adb3a4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->