### PR TITLE
macos-override for fireDialog and sitesSection

### DIFF
--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -929,17 +929,6 @@
                 }
             }
         },
-        "macOSBrowserConfig": {
-            "features": {
-                "fireDialog": {
-                    "state": "enabled",
-                    "minSupportedVersion": "1.162.0"
-                },
-                "fireDialogIndividualSitesLink": {
-                    "state": "enabled"
-                }
-            }
-        },
         "shortHistoryMenu": {
             "state": "enabled"
         },
@@ -1690,6 +1679,13 @@
         "macOSBrowserConfig": {
             "state": "enabled",
             "features": {
+                "fireDialog": {
+                    "state": "enabled",
+                    "minSupportedVersion": "1.162.0"
+                },
+                "fireDialogIndividualSitesLink": {
+                    "state": "enabled"
+                },
                 "willSoonDropBigSurSupport": {
                     "state": "enabled"
                 },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1202406491309510/task/1210417832822045

## Description
<!-- 
  Please delete either or both process sections below.
-->

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ *] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables `macOSBrowserConfig` `fireDialog` (+ min version) and `fireDialogIndividualSitesLink`, and adds `htmlHistoryPage` `sitesSection` (disabled).
> 
> - **macOS overrides**:
>   - **`macOSBrowserConfig`**:
>     - Enable `fireDialog` with `minSupportedVersion` `1.162.0`.
>     - Enable `fireDialogIndividualSitesLink`.
>   - **`htmlHistoryPage`**:
>     - Add `sitesSection` feature (state: `disabled`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2e50f442c8d116a8bec36173282af62f57d3a124. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->