### PR TITLE
Disable Cookie Prompt Management (CPM) for gegen-hartz.de

### DIFF
--- a/features/autoconsent.json
+++ b/features/autoconsent.json
@@ -674,6 +674,10 @@
         {
             "domain": "nottinghampost.com",
             "reason": "https://github.com/duckduckgo/privacy-configuration/pull/3909"
+        },
+        {
+            "domain": "gegen-hartz.de",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/pull/3959"
         }
     ],
     "settings": {


### PR DESCRIPTION
There is an issue where after the cookie prompt is automatically managed, the
user can't scroll down to view the full page content. Let's disable CPM for now,
while we look into it what's happening.

**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1206670747178362/task/1211692063404367?focus=true

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `gegen-hartz.de` to `features/autoconsent.json` exceptions to disable Cookie Prompt Management.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d340f008a66809542976ebdcaefc400e9faf47b7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->