### PR TITLE
Enable hang reporting on macOS

### DIFF
--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -1680,7 +1680,8 @@
                     "state": "enabled"
                 },
                 "hangReporting": {
-                    "state": "internal"
+                    "state": "enabled",
+                    "minSupportedVersion": "1.161.0"
                 },
                 "unifiedURLPredictor": {
                     "state": "enabled",


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1211264967278501/task/1211708368679025?focus=true

## Description

In this PR, I’m simply enabling the hang reporting feature in 1.161.0 of the Mac browser.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables `macOSBrowserConfig.features.hangReporting` and sets `minSupportedVersion` to `1.161.0`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4b372d0eda3bcea6b61eb5f3da0ad0c99f198096. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->