### PR TITLE
Exclude shreddit-comments-page-ad from C-S-S Duck.ai page context selector

### DIFF
--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -1701,6 +1701,15 @@
                 "additionalCheck": "disabled",
                 "maxContentLength": 9500,
                 "mainContentSelector": "main, article, .content, .main, #content, #main",
+                "excludeSelectors": [
+                    ".ad",
+                    ".sidebar",
+                    ".footer",
+                    ".nav",
+                    ".header",
+                    ".banner",
+                    ".popup"
+                ],
                 "conditionalChanges": [
                     {
                         "condition": {

--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -1486,6 +1486,15 @@
             "settings": {
                 "additionalCheck": "disabled",
                 "maxContentLength": 9500,
+                "excludeSelectors": [
+                    ".ad",
+                    ".sidebar",
+                    ".footer",
+                    ".nav",
+                    ".header",
+                    ".banner",
+                    ".popup"
+                ],
                 "conditionalChanges": [
                     {
                         "condition": {


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1200681983164593/task/1211700139180710?focus=true

## Description

Adds `shreddit-comments-page-ad` to the list of excluded selectors for gathering Duck.ai page context on reddit.com.

To test:

- Set remote config URL to use this branch.
- Browse to https://www.reddit.com/r/worldnews/comments/1obh9g2/china_imports_no_us_soybeans_in_september_for/.
- Open the Duck.ai sidebar, attach page context, and Duck.ai ask a question.
- There should be no “message is too long” error.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [x] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds default page-context exclusion selectors and excludes `shreddit-comments-page-ad` on reddit.com for macOS and Windows.
> 
> - **Page Context**:
>   - **macOS** (`overrides/macos-override.json`):
>     - Add `settings.excludeSelectors` with common non-content selectors (e.g., `.ad`, `.sidebar`, `.footer`, `.nav`, `.header`, `.banner`, `.popup`).
>     - `conditionalChanges`: for `reddit.com`, append `shreddit-comments-page-ad` to `excludeSelectors`.
>   - **Windows** (`overrides/windows-override.json`):
>     - Add `settings.excludeSelectors` with the same common non-content selectors.
>     - `conditionalChanges`: for `reddit.com`, append `shreddit-comments-page-ad` to `excludeSelectors`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bde179f68592f40e7d1a6c791070f2df53d1fd1a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->