### PR TITLE
Adding local storage keys to duckAiDataClearing windows override

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -162,7 +162,14 @@
         },
         "duckAiDataClearing": {
             "exceptions": [],
-            "state": "disabled"
+            "state": "disabled",
+            "settings": {
+                "chatsLocalStorageKeys": ["savedAIChats"],
+                "chatImagesIndexDbNameObjectStoreNamePairs": [[
+                        "savedAIChatData",
+                        "chat-images"
+                    ]]
+            }
         },
         "dbp": {
             "state": "enabled",


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/72649045549333/task/1211560432543255?focus=true

## Description
Adding local storage keys to duckAiDataClearing windows override, used for clearing AI chats from LocalStorage and IndexedDB.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds LocalStorage and IndexedDB key settings to `duckAiDataClearing` in `overrides/windows-override.json` for clearing saved AI chats and images.
> 
> - **Windows override (`overrides/windows-override.json`)**:
>   - **`duckAiDataClearing`**:
>     - Add `settings` with:
>       - `chatsLocalStorageKeys`: `["savedAIChats"]`
>       - `chatImagesIndexDbNameObjectStoreNamePairs`: `[["savedAIChatData", "chat-images"]]`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cd11c8754f431841ae06d9e94f63ca93b20ed845. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->