### PR TITLE
Add vpnMenuItem sub-feature on iOS

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -1417,12 +1417,10 @@
                     "state": "disabled",
                     "targets": [
                         {
-                            "localeCountry": "gb",
-                            "isPrivacyProEligible": true
+                            "localeCountry": "GB"
                         },
                         {
-                            "localeCountry": "us",
-                            "isPrivacyProEligible": true
+                            "localeCountry": "US"
                         }
                     ]
                 }


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/task/1211694500482776

## Description

Adds the vpnMenuItem feature on iOS targeting subscription-eligible users in the US and UK.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `privacyPro.features.vpnMenuItem` (disabled) targeting `GB` and `US` in `overrides/ios-override.json`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 835218b4415a236a47c140494a54b7437c9f7aa4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->