### PR TITLE
Disable Cookie Prompt Management (CPM) for epoznan.pl

### DIFF
--- a/features/autoconsent.json
+++ b/features/autoconsent.json
@@ -678,6 +678,10 @@
         {
             "domain": "gegen-hartz.de",
             "reason": "https://github.com/duckduckgo/privacy-configuration/pull/3959"
+        },
+        {
+            "domain": "epoznan.pl",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/pull/3968"
         }
     ],
     "settings": {


### PR DESCRIPTION
After the cookie prompt is automatically managed, the user sometimes can't
scroll down for some seconds until the prompt is re-shown and closed
manually. Let's disable CPM for now, while we look into it what's happening.

**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1206670747178362/task/1211713782511944?focus=true

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Disable Cookie Prompt Management for `epoznan.pl` by adding it to the `exceptions` in `features/autoconsent.json`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f4220fac69c291a4a91dfb04dc285d20b800ebf8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->