### PR TITLE
Fix missing article comments on nationalpost.com

### DIFF
--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -1201,7 +1201,8 @@
                             "wutv29.com",
                             "wvah.com",
                             "wwmt.com",
-                            "youmath.it"
+                            "youmath.it",
+                            "nationalpost.com"
                         ],
                         "reason": [
                             "ah.nl - 'Bonus offer' elements do not render and are not clickable.",
@@ -1221,13 +1222,9 @@
                             "https://github.com/duckduckgo/privacy-configuration/pull/2869",
                             "https://github.com/duckduckgo/privacy-configuration/pull/2888",
                             "krcrtv.com - https://github.com/duckduckgo/privacy-configuration/pull/3489",
-                            "webmd.com - https://github.com/duckduckgo/privacy-configuration/pull/3737"
+                            "webmd.com - https://github.com/duckduckgo/privacy-configuration/pull/3737",
+                            "nationalpost.com - https://github.com/duckduckgo/privacy-configuration/pull/3969"
                         ]
-                    },
-                    {
-                        "rule": "securepubads.g.doubleclick.net/pagead/managed/js/gpt/.*/pubads_impl.js",
-                        "domains": ["stuff.co.nz"],
-                        "reason": ["stuff.co.nz - https://github.com/duckduckgo/privacy-configuration/issues/1740"]
                     },
                     {
                         "rule": "securepubads.g.doubleclick.net/gpt/pubads_impl_",
@@ -1270,7 +1267,9 @@
                             "triblive.com",
                             "kutv.com",
                             "lowes.com",
-                            "wunderground.com"
+                            "wunderground.com",
+                            "stuff.co.nz",
+                            "nationalpost.com"
                         ],
                         "reason": [
                             "applesfera.com - https://github.com/duckduckgo/privacy-configuration/issues/1723",
@@ -1278,7 +1277,9 @@
                             "triblive.com - https://github.com/duckduckgo/privacy-configuration/issues/1730",
                             "kutv.com - https://github.com/duckduckgo/privacy-configuration/pull/2806",
                             "lowes.com - https://github.com/duckduckgo/privacy-configuration/pull/2833",
-                            "wunderground.com - https://github.com/duckduckgo/privacy-configuration/pull/2885"
+                            "wunderground.com - https://github.com/duckduckgo/privacy-configuration/pull/2885",
+                            "stuff.co.nz - https://github.com/duckduckgo/privacy-configuration/issues/1740",
+                            "nationalpost.com - https://github.com/duckduckgo/privacy-configuration/pull/3969"
                         ]
                     },
                     {


### PR DESCRIPTION
Some users complained that the article comments on nationalpost.com were
missing. Looking into it, that seemed to be due to a couple of
blocked/redirected requests. Let's allow those requests for now so the comments
show up again.

While we're at it, let's fix a Tracker Allowlisting rule for a similar request
that incorrectly uses the .* wildcard syntax. So far, wildcards are not
supported here.

**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1206670747178362/task/1211713968603682?focus=true


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds nationalpost.com to DoubleClick GPT allowlist to restore article comments and replaces an invalid wildcard rule by moving stuff.co.nz to the correct rule.
> 
> - **Tracker allowlist (`features/tracker-allowlist.json`)**:
>   - Add `nationalpost.com` to DoubleClick GPT allowlist rules:
>     - `securepubads.g.doubleclick.net/tag/js/gpt.js`
>     - `securepubads.g.doubleclick.net/pagead/managed/js/gpt`
>     - Add corresponding reason entries.
>   - Clean up rules:
>     - Remove unsupported wildcard rule `securepubads.g.doubleclick.net/pagead/managed/js/gpt/.*/pubads_impl.js` (previously for `stuff.co.nz`).
>     - Move `stuff.co.nz` under `securepubads.g.doubleclick.net/pagead/managed/js/gpt` with matching reason.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c44459e38180660e2d1cdf159cd67da869bc32cc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->