### PR TITLE
Revert "Re-enable adsjs with stopLoadingBeforeUpdatingScript (#3946)"

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -36099,12 +36099,6 @@
                             "isPrivacyProEligible": true
                         }
                     ]
-                },
-                "updateScriptOnProtectionsChanged": {
-                    "state": "enabled"
-                },
-                "stopLoadingBeforeUpdatingScript": {
-                    "state": "enabled"
                 }
             }
         },
@@ -36124,32 +36118,6 @@
                                 "op": "add",
                                 "path": "/additionalCheck",
                                 "value": "disabled"
-                            }
-                        ]
-                    },
-                    {
-                        "condition": {
-                            "injectName": "android",
-                            "minSupportedVersion": 52530000
-                        },
-                        "patchSettings": [
-                            {
-                                "op": "add",
-                                "path": "/additionalCheck",
-                                "value": "enabled"
-                            }
-                        ]
-                    },
-                    {
-                        "condition": {
-                            "injectName": "android-adsjs",
-                            "minSupportedVersion": 52530000
-                        },
-                        "patchSettings": [
-                            {
-                                "op": "add",
-                                "path": "/additionalCheck",
-                                "value": "enabled"
                             }
                         ]
                     }
@@ -36993,18 +36961,7 @@
             "state": "enabled",
             "features": {
                 "useNewWebCompatApis": {
-                    "state": "enabled",
-                    "minSupportedVersion": 52530000,
-                    "rollout": {
-                        "steps": [
-                            {
-                                "percent": 50
-                            }
-                        ]
-                    }
-                },
-                "useWebMessageListener": {
-                    "state": "enabled"
+                    "state": "disabled"
                 }
             },
             "exceptions": []


### PR DESCRIPTION
This reverts commit d651900105368aa3e7b8c6c653448bff632262c0.

**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/72649045549333/task/1211371112177598?focus=true

## Description
<!-- 
  Please delete either or both process sections below.
-->

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Reverts the adsjs re-enable by removing script update flags, rolling back breakage-reporting conditions, and disabling new web compat APIs in Android overrides.
> 
> - **Android override config (`overrides/android-override.json`)**:
>   - **Ads/script injection**: remove `updateScriptOnProtectionsChanged` and `stopLoadingBeforeUpdatingScript` flags.
>   - **Breakage reporting**: remove `additionalCheck: enabled` conditions for `injectName: android` and `injectName: android-adsjs` (with `minSupportedVersion`), leaving `android-adsjs` with `additionalCheck: disabled`.
>   - **Client content features**: set `useNewWebCompatApis.state` to `disabled`; remove `minSupportedVersion`/`rollout` and the `useWebMessageListener` feature.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f616caefce16e0c9af176b5d6b006d171b474cf9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->