### PR TITLE
Revert "Re-enable adsjs with updateScriptOnProtectionsChanged disabled (#3948)"

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -36099,12 +36099,6 @@
                             "isPrivacyProEligible": true
                         }
                     ]
-                },
-                "updateScriptOnProtectionsChanged": {
-                    "state": "disabled"
-                },
-                "stopLoadingBeforeUpdatingScript": {
-                    "state": "disabled"
                 }
             }
         },
@@ -36124,32 +36118,6 @@
                                 "op": "add",
                                 "path": "/additionalCheck",
                                 "value": "disabled"
-                            }
-                        ]
-                    },
-                    {
-                        "condition": {
-                            "injectName": "android",
-                            "minSupportedVersion": 52530000
-                        },
-                        "patchSettings": [
-                            {
-                                "op": "add",
-                                "path": "/additionalCheck",
-                                "value": "enabled"
-                            }
-                        ]
-                    },
-                    {
-                        "condition": {
-                            "injectName": "android-adsjs",
-                            "minSupportedVersion": 52530000
-                        },
-                        "patchSettings": [
-                            {
-                                "op": "add",
-                                "path": "/additionalCheck",
-                                "value": "enabled"
                             }
                         ]
                     }
@@ -36993,18 +36961,7 @@
             "state": "enabled",
             "features": {
                 "useNewWebCompatApis": {
-                    "state": "enabled",
-                    "minSupportedVersion": 52530000,
-                    "rollout": {
-                        "steps": [
-                            {
-                                "percent": 50
-                            }
-                        ]
-                    }
-                },
-                "useWebMessageListener": {
-                    "state": "enabled"
+                    "state": "disabled"
                 }
             },
             "exceptions": []


### PR DESCRIPTION


This reverts commit e5e6c7669fcaed0e97a6153a008203a3cd760f49.

**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/72649045549333/task/1211371112177598?focus=true

## Description
<!-- 
  Please delete either or both process sections below.
-->

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [x] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Reverts prior adsjs re-enable by removing related patches and disables new web compatibility APIs in Android overrides.
> 
> - **Android overrides (`overrides/android-override.json`)**:
>   - Remove `updateScriptOnProtectionsChanged` and `stopLoadingBeforeUpdatingScript` settings.
>   - **Breakage reporting**: drop conditional patches that added `additionalCheck: enabled` for `injectName: android` and `android-adsjs` with `minSupportedVersion`.
>   - **Client content features**: disable `useNewWebCompatApis`; remove its rollout/min version and the `useWebMessageListener` feature.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 84e7a446858f6b92c5b17cfa063f9af0467450f0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->