### PR TITLE
Re-enable freemium PIR on Windows

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -181,7 +181,7 @@
                     "state": "disabled"
                 },
                 "freemium": {
-                    "state": "disabled",
+                    "state": "enabled",
                     "minSupportedVersion": "0.133.4",
                     "targets": [
                         {


### PR DESCRIPTION
**Asana Task/Github Issue:**

## Description
Re-enabling freemium PIR on Windows

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables `features.dbp.features.freemium` in `overrides/windows-override.json` (US target, minSupportedVersion 0.133.4).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d590ffc12919070ff3d16eddb850b7a4752ff09b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->