### PR TITLE
Remove old flags in privacy config: postCtaExperienceExperimentJun25 and onboardingHomeScreenWidgetExperimentJun25

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -37759,29 +37759,6 @@
             "features": {
                 "simpleSearchWidgetPrompt": {
                     "state": "enabled"
-                },
-                "postCtaExperienceExperimentJun25": {
-                    "state": "enabled",
-                    "minSupportedVersion": 52400000,
-                    "rollout": {
-                        "steps": [
-                            {
-                                "percent": 5
-                            },
-                            {
-                                "percent": 50
-                            },
-                            {
-                                "percent": 100
-                            }
-                        ]
-                    },
-                    "cohorts": [
-                        {
-                            "name": "simpleSearchWidgetPrompt",
-                            "weight": 1
-                        }
-                    ]
                 }
             }
         },
@@ -37791,26 +37768,6 @@
             "features": {
                 "onboardingHomeScreenWidgetPrompt": {
                     "state": "enabled"
-                },
-                "onboardingHomeScreenWidgetExperimentJun25": {
-                    "state": "enabled",
-                    "minSupportedVersion": 52400000,
-                    "rollout": {
-                        "steps": [
-                            {
-                                "percent": 5
-                            },
-                            {
-                                "percent": 100
-                            }
-                        ]
-                    },
-                    "cohorts": [
-                        {
-                            "name": "experimentalOnboardingHomeScreenWidgetPrompt",
-                            "weight": 1
-                        }
-                    ]
                 }
             }
         },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1200581511062568/task/1211313356974622?focus=true

## Description
<!-- 
  Please delete either or both process sections below.
-->

Removed old flags in privacy config: `postCtaExperienceExperimentJun25` and `onboardingHomeScreenWidgetExperimentJun25`.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes obsolete Android privacy config experiments `postCtaExperienceExperimentJun25` and `onboardingHomeScreenWidgetExperimentJun25` from `overrides/android-override.json`.
> 
> - **Android privacy config (`overrides/android-override.json`)**:
>   - Remove `postCtaExperienceExperimentJun25` feature (including rollout steps and cohorts) under `postCtaExperience`.
>   - Remove `onboardingHomeScreenWidgetExperimentJun25` feature (including rollout steps and cohorts) under `onboardingHomeScreenWidget`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ff67181ceea17fdd5d4fa1f4b509ff77d7cc1c27. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->