### PR TITLE
[Autofill import] Remove manage-button-click step

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -35802,16 +35802,6 @@
                                                             "selector": "div[data-configure-step=\"1\"] button"
                                                         }
                                                     ]
-                                                },
-                                                {
-                                                    "id": "manage-button-click",
-                                                    "actionType": "click",
-                                                    "elements": [
-                                                        {
-                                                            "type": "element",
-                                                            "selector": "a[href=\"manage\"]"
-                                                        }
-                                                    ]
                                                 }
                                             ]
                                         }


### PR DESCRIPTION
**Asana Task/Github Issue:**

## Description
https://github.com/duckduckgo/content-scope-scripts/pull/2026/files removes the need of having this step, as we straight away navigate to manage page in the code.

PS: Merging this config early has no public impact, as the feature is not yet out!

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes the redundant `manage-button-click` action from `overrides/android-override.json` in the autofill import flow.
> 
> - **Android override config**
>   - Remove `manage-button-click` action step from `overrides/android-override.json` within the autofill import flow, leaving `create-export-button-click` as the preceding action.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d6d92470fbc8a26097ea55810bf7b9113ade9567. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->