### PR TITLE
Disable hang reporting on macOS

### DIFF
--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -1680,8 +1680,7 @@
                     "state": "enabled"
                 },
                 "hangReporting": {
-                    "state": "enabled",
-                    "minSupportedVersion": "1.161.0"
+                    "state": "disabled"
                 },
                 "unifiedURLPredictor": {
                     "state": "enabled",


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1201037661562251/task/1211739361599212?focus=true

## Description
This change disables hang reporting on macOS due to overreporting.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [x] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [x] This feature was covered by a tech design.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Disables `hangReporting` under `features.macOSBrowserConfig` in `overrides/macos-override.json` (removes `minSupportedVersion`).
> 
> - **macOS config**:
>   - Disable `hangReporting` in `features.macOSBrowserConfig` within `overrides/macos-override.json`; remove `minSupportedVersion`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5944cdcbb44f3d71992520b4c1d9b06c98ff541f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->