### PR TITLE
Enable vpnMenuItem for iOS

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -1414,7 +1414,7 @@
                     "state": "disabled"
                 },
                 "vpnMenuItem": {
-                    "state": "disabled",
+                    "state": "enabled",
                     "targets": [
                         {
                             "localeCountry": "GB"


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/task/1211717393835210?focus=true

## Description

This enables the `vpnMenuItem` feature flag for iOS. This is available in debug/alpha builds on a real device in the US/UK:

1. Go to Settings > All debug options > Configuration URLs > Privacy Config and enter the iOS config URL from this PR.
2. On the new tab page, open the overflow menu.
3. Confirm a “VPN” menu item appears.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [x] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables the `vpnMenuItem` feature flag for iOS users in the US and GB.
> 
> - **iOS Privacy Config**:
>   - Enable `privacyPro.features.vpnMenuItem` in `overrides/ios-override.json`.
>   - Targets: `US`, `GB`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7edf58567e927efa162b8346d956befbe0e9ff3e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->