### PR TITLE
Avoid triggering ad blocker wall on tvtropes.org

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -3728,15 +3728,6 @@
                 ]
             },
             {
-                "domain": "tvtropes.org",
-                "rules": [
-                    {
-                        "selector": "[class*='-fad-unit']",
-                        "type": "hide-empty"
-                    }
-                ]
-            },
-            {
                 "domain": "uol.com.br",
                 "rules": [
                     {


### PR DESCRIPTION
Better to leave the empty space where the adverts would have been, than to
trigger the ad blocker wall.

**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1206670747178362/task/1211738459173064?focus=true

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a site-specific rule for `tvtropes.org` to hide empty ad containers matching `[class*='-fad-unit']`.
> 
> - **Element hiding config**:
>   - `tvtropes.org`: Add rule `"[class*='-fad-unit']"` with `hide-empty`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3292a71af92b7a06e92484965cadbfe5f089a11f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->