### PR TITLE
Avoid triggering anti-bot wall on flyfrontier.com

### DIFF
--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -1856,7 +1856,8 @@
                             "vizio.com",
                             "wps.com",
                             "comparethemarket.com",
-                            "birminghamairport.co.uk"
+                            "birminghamairport.co.uk",
+                            "flyfrontier.com"
                         ],
                         "reason": [
                             "https://github.com/duckduckgo/privacy-configuration/issues/929",
@@ -1873,7 +1874,8 @@
                             "newsweek.com - https://github.com/duckduckgo/privacy-configuration/pull/2697",
                             "vizio.com - https://github.com/duckduckgo/privacy-configuration/pull/2761",
                             "wps.com - https://github.com/duckduckgo/privacy-configuration/pull/2826",
-                            "birminghamairport.co.uk - https://github.com/duckduckgo/privacy-configuration/pull/3558"
+                            "birminghamairport.co.uk - https://github.com/duckduckgo/privacy-configuration/pull/3558",
+                            "flyfrontier.com - https://github.com/duckduckgo/privacy-configuration/pull/3982"
                         ]
                     }
                 ]


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1206670747178362/task/1211738452417691?focus=true

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `flyfrontier.com` to the allowlist for `googletagmanager.com/gtag/js`, with corresponding reason entry.
> 
> - **Privacy configuration**:
>   - **Tracker allowlist**: Update `features/tracker-allowlist.json`
>     - Add `flyfrontier.com` to `googletagmanager.com` rule `gtag/js` domains.
>     - Add matching reason entry and tidy trailing comma after `birminghamairport.co.uk`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 41af589db41142d1d073b832f595c8ec5b73a2bd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->