### PR TITLE
Removing autotrader.com mitigation

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -1118,7 +1118,6 @@
                     {
                         "domain": [
                             "meet.google.com",
-                            "autotrader.com",
                             "canadiantire.ca"
                         ],
                         "patchSettings": [


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/task/1211609794191452?focus=true

## Description
### Site breakage mitigation process:
#### Brief explanation
- Reported URL: autotrader.com
- Problems experienced: Removing mitigation – underlying problem now fixed.
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [x] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked: N/A
- Feature being disabled/modified: N/A
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes the `autotrader.com` entry from `webCompat` domains, no longer disabling `enumerateDevices` for that site on Windows.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e05a49dff085d7379f81f3caceef388bbff12f12. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->