### PR TITLE
Revert "Re-enable adsjs with no messaging"

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -1244,12 +1244,6 @@
                             "isPrivacyProEligible": true
                         }
                     ]
-                },
-                "updateScriptOnProtectionsChanged": {
-                    "state": "enabled"
-                },
-                "stopLoadingBeforeUpdatingScript": {
-                    "state": "disabled"
                 }
             }
         },
@@ -1269,19 +1263,6 @@
                                 "op": "add",
                                 "path": "/additionalCheck",
                                 "value": "disabled"
-                            }
-                        ]
-                    },
-                    {
-                        "condition": {
-                            "injectName": "android",
-                            "minSupportedVersion": 52530000
-                        },
-                        "patchSettings": [
-                            {
-                                "op": "add",
-                                "path": "/additionalCheck",
-                                "value": "enabled"
                             }
                         ]
                     }
@@ -2125,17 +2106,6 @@
             "state": "enabled",
             "features": {
                 "useNewWebCompatApis": {
-                    "state": "enabled",
-                    "minSupportedVersion": 52530000,
-                    "rollout": {
-                        "steps": [
-                            {
-                                "percent": 50
-                            }
-                        ]
-                    }
-                },
-                "useWebMessageListener": {
                     "state": "disabled"
                 }
             },


### PR DESCRIPTION
This reverts commit 957e2c7c8495b0609a07b386194c38e311832c52.

**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/task/1211767917352308?focus=true

## Description
Revert config changes to stop using new WebView APIs

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [x] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Reverts prior adsjs-related changes by removing the Android conditional, disabling `useNewWebCompatApis`, and dropping script-update flags in `androidBrowserConfig`.
> 
> - **Android config (`overrides/android-override.json`)**:
>   - **Client content features**:
>     - `useNewWebCompatApis`: set to `disabled` (removes min version and rollout).
>     - Removes `useWebMessageListener` feature.
>   - **Breakage reporting**:
>     - Removes conditional change for `injectName` `android` (minSupportedVersion `52530000`).
>   - **Browser config**:
>     - Removes `updateScriptOnProtectionsChanged` and `stopLoadingBeforeUpdatingScript` feature flags under `androidBrowserConfig.features`.
>   - Keeps adsjs-specific conditional checks as `disabled` in affected features (no new adsjs enablement).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8ab6f35f521c357b59e1e0995571740843e88bb7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->