### PR TITLE
Add initial Request Blocklist feature configuration

### DIFF
--- a/features/request-blocklist.json
+++ b/features/request-blocklist.json
@@ -1,0 +1,37 @@
+{
+    "_meta": {
+        "description": "Request blocking rules necessary to fix website breakage. Note: Tracker request blocking is handled elsewhere.",
+        "sampleExcludeRecords": {
+            "domain": "example.com",
+            "reason": "site breakage"
+        }
+    },
+    "state": "disabled",
+    "settings": {
+        "blockedRequests": {
+            "privacy-test-pages.site": {
+                "rules": [
+                    {
+                        "rule": "privacy-test-pages.site/privacy-protections/request-blocklist/*?block=true",
+                        "domains": [
+                            "privacy-test-pages.site"
+                        ],
+                        "reason": "Testing rule for the privacy test page, see https://privacy-test-pages.site/privacy-protections/request-blocklist/"
+                    }
+                ]
+            },
+            "third-party.site": {
+                "rules": [
+                    {
+                        "rule": "third-party.site/privacy-protections/request-blocklist/*?block=true",
+                        "domains": [
+                            "privacy-test-pages.site"
+                        ],
+                        "reason": "Testing rule for the privacy test page, see https://privacy-test-pages.site/privacy-protections/request-blocklist/"
+                    }
+                ]
+            }
+        }
+    },
+    "exceptions": []
+}

--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -9,6 +9,17 @@
     "state": "enabled",
     "settings": {
         "allowlistedTrackers": {
+            "third-party.site": {
+                "rules": [
+                    {
+                        "rule": "allowlisted.third-party.site",
+                        "domains": [
+                            "privacy-test-pages.site"
+                        ],
+                        "reason": "Testing rule for the privacy test pages"
+                    }
+                ]
+            },
             "2mdn.net": {
                 "rules": [
                     {

--- a/overrides/extension-override.json
+++ b/overrides/extension-override.json
@@ -208,6 +208,9 @@
                     ]
                 }
             }
+        },
+        "requestBlocklist": {
+            "state": "enabled"
         }
     },
     "unprotectedTemporary": [

--- a/schema/config.ts
+++ b/schema/config.ts
@@ -22,6 +22,7 @@ import { BurnFeature } from './features/burn';
 import { Taskbar } from './features/taskbar';
 import { AppHealth } from './features/appHealth';
 import { ElementHidingFeature } from './features/element-hiding';
+import { RequestBlocklistFeature } from './features/request-blocklist';
 
 export { WebCompatSettings } from './features/webcompat';
 export { DuckPlayerSettings } from './features/duckplayer';
@@ -68,6 +69,7 @@ export type ConfigV5<VersionType> = {
         windowsWebviewFailures_DDGWV?: WindowsWebViewFailures<VersionType>;
         customUserAgent?: CustomUserAgentFeature<VersionType>;
         elementHiding?: ElementHidingFeature<VersionType>;
+        requestBlocklist?: RequestBlocklistFeature<VersionType>;
     };
     unprotectedTemporary: SiteException[];
 };

--- a/schema/features/request-blocklist.ts
+++ b/schema/features/request-blocklist.ts
@@ -1,0 +1,17 @@
+import { Feature } from '../feature';
+
+type RuleType = {
+    rule: string;
+    domains: string[];
+    reason: string[] | string;
+};
+
+type SettingsType = {
+    blockedRequests: {
+        [domain: string]: {
+            rules: RuleType[];
+        };
+    };
+};
+
+export type RequestBlocklistFeature<VersionType> = Feature<SettingsType, VersionType>;


### PR DESCRIPTION
Add an initial configuration for the new Request Blocklist feature. Include a
couple of testing rules, for the privacy test page[1]. Also include a
corresponding Tracker Allowlist rule for the test page as well.

The feature is only implemented for the extension so far, so let's enable it
there but leave it disabled for other platforms.

1 - https://privacy-test-pages.site/privacy-protections/request-blocklist/

### Feature change process:

- [x] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [x] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [x] This feature was covered by a tech design.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a new Request Blocklist feature with initial test rules, updates schema, enables it for the extension, and adds a matching tracker allowlist entry for test pages.
> 
> - **Request Blocklist feature**:
>   - Add `features/request-blocklist.json` (state: `disabled`) with initial testing rules for `privacy-test-pages.site` and `third-party.site`.
>   - Enable feature for the extension via `overrides/extension-override.json` (`features.requestBlocklist.state: enabled`).
>   - Define schema: add `schema/features/request-blocklist.ts` and wire into `schema/config.ts` (`RequestBlocklistFeature` import and optional `features.requestBlocklist`).
> - **Tracker Allowlist**:
>   - Add allowlist entry for `third-party.site` scoped to `privacy-test-pages.site` in `features/tracker-allowlist.json`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 44192cf17b38e697e847144e0f3bb286aef27a54. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->