### PR TITLE
SBT: add element-hiding rule for huffingtonpost.fr

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -2145,6 +2145,15 @@
                 ]
             },
             {
+                "domain": "huffingtonpost.fr",
+                "rules": [
+                    {
+                        "selector": ".ads-inreadArticle",
+                        "type": "hide-empty"
+                    }
+                ]
+            },
+            {
                 "domain": "huffpost.com",
                 "rules": [
                     {


### PR DESCRIPTION
**Asana Task/Github Issue:**: https://app.asana.com/1/137249556945/project/1200277586140538/task/1211780369724603?focus=true

### Site breakage mitigation process:
#### Brief explanation
- Reported URL: https://www.huffingtonpost.fr/international/video/le-mega-ouragan-melissa-frappe-la-jamaique-de-premieres-images-de-degats-impressionnantes_256521.html
- Problems experienced: Blank space
- Platforms affected:
  - [x ] iOS
  - [ x] Android
  - [x ] Windows
  - [x ] MacOS
  - [x ] Extensions
- Tracker(s) being unblocked: NA
- Feature being disabled/modified: element-Hiding
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a domain-specific rule to hide empty `.ads-inreadArticle` containers on `huffingtonpost.fr`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dca919ea7bafbff8b98b961f1f383d5a086441a8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->