### PR TITLE
Crank up webViewProviderPreviewOptIn to 5% in Preview

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -1216,10 +1216,15 @@
             "state": "enabled",
             "features": {
                 "webViewProviderPreviewOptIn": {
-                    "state": "disabled"
-                },
-                "webViewProviderPreviewOptInFallbackToDefault": {
-                    "state": "disabled"
+                    "state": "preview",
+                    "minSupportedVersion": "0.136.2",
+                    "rollout": {
+                        "steps": [
+                            {
+                                "percent": 5.0
+                            }
+                        ]
+                    }
                 },
                 "certificateTransparency": {
                     "state": "enabled"


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/1142021229838617/task/1211732461430909

## Description

Crank up webViewProviderPreviewOptIn to 5% in Preview

cc: @q71114 @BalintFarkas 

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [x] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [x] This feature was covered by a tech design.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Set `webViewProviderPreviewOptIn` to preview with `minSupportedVersion` 0.136.2 and a 5% rollout in `overrides/windows-override.json`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ebef4bd8f0fbc86d0a8d0adfd4c6689c5b951d34. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->