### PR TITLE
Revert enabling AI Chat Page Context on Windows.

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -1517,18 +1517,6 @@
                     },
                     {
                         "condition": {
-                            "preview": true
-                        },
-                        "patchSettings": [
-                            {
-                                "op": "replace",
-                                "path": "/additionalCheck",
-                                "value": "enabled"
-                            }
-                        ]
-                    },
-                    {
-                        "condition": {
                             "domain": "reddit.com"
                         },
                         "patchSettings": [


### PR DESCRIPTION
https://app.asana.com/1/137249556945/project/1206780406371845/task/1211764205519395?focus=true

## Description
Revert enabling AI Chat Page Context on Windows.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Reverts AI Chat Page Context on Windows to internal-only and removes the preview-based conditional enabling, with other settings unchanged.
> 
> - **Windows overrides**:
>   - **`features.aiChat.features.pageContext`**:
>     - Change `state` to `internal` (was `preview`).
>     - Remove `minSupportedVersion`.
>   - **`features.pageContext.settings.conditionalChanges`**:
>     - Remove `preview`-based patch that enabled `additionalCheck`.
>     - Retain `internal` condition enabling `additionalCheck` and the Reddit-specific exclude selector.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 426e23fa457149464bdc76ec2b5f532fca2df1e8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->