### PR TITLE
Windows: Add feature flag for seamless sync account switching

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -878,6 +878,9 @@
                 },
                 "syncIdentities": {
                     "state": "internal"
+                },
+                "seamlessAccountSwitching": {
+                    "state": "internal"
                 }
             }
         },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/task/1211792158307690?focus=true

## Description
Adds the sub-feature flag `sync/seamlessAccountSwitching` currently for internal users only, which enables switching sync accounts when the user attempts to connect two devices which are already logged in to two different sync accounts.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add internal `sync/seamlessAccountSwitching` feature flag to `overrides/windows-override.json`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 34e8871f60ef2a5fbfcb211c1b90e4012fbb5180. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->