### PR TITLE
Disabling original HW Acceleration experiment

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -1544,10 +1544,10 @@
             }
         },
         "hwAccelerationExperiment": {
-            "state": "enabled",
+            "state": "disabled",
             "features": {
                 "disableHwAccelerationOnRenderCrash": {
-                    "state": "enabled",
+                    "state": "disabled",
                     "rollout": {
                         "steps": [
                             {


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/72649045549333/task/1211662951584963?focus=true

## Description

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Disable Windows `hwAccelerationExperiment` and `disableHwAccelerationOnRenderCrash` feature in overrides.
> 
> - **Windows config (`overrides/windows-override.json`)**:
>   - Disable `features.hwAccelerationExperiment` and its subfeature `disableHwAccelerationOnRenderCrash` (was enabled).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8f6099730515893cc322451ab826fa6cfb7f3f5d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->