### PR TITLE
Add macOS subfeature and settings for inactive user prompts

### DIFF
--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -436,7 +436,9 @@
             "settings": {
                 "firstPopoverDelayDays": 14,
                 "bannerAfterPopoverDelayDays": 14,
-                "bannerRepeatIntervalDays": 14
+                "bannerRepeatIntervalDays": 14,
+                "inactiveModalNumberOfDaysSinceInstall": 28,
+                "inactiveModalNumberOfInactiveDays": 7
             },
             "features": {
                 "popoverVsBannerExperiment": {
@@ -459,6 +461,9 @@
                 "scheduledDefaultBrowserAndDockPrompts": {
                     "state": "enabled",
                     "minSupportedVersion": "1.143.0"
+                },
+                "scheduledDefaultBrowserAndDockPromptsInactiveUser": {
+                    "state": "enabled"
                 }
             }
         },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/492600419927320/task/1210864108628364?focus=true

## Description

Adds a macOS subfeature and settings to enable/disable default browser prompt for inactive users.

This can be tested in the macOS client with the steps in https://github.com/duckduckgo/apple-browsers/pull/2364.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [x] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a new macOS subfeature and settings to schedule default browser/dock prompts for inactive users.
> 
> - **macOS overrides (`overrides/macos-override.json`)**:
>   - **`setAsDefaultAndAddToDock`**:
>     - Settings: add `inactiveModalNumberOfDaysSinceInstall: 28` and `inactiveModalNumberOfInactiveDays: 7`.
>     - Features: add `scheduledDefaultBrowserAndDockPromptsInactiveUser` (enabled).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ff4a88e96b35ca679c2f3be47c078109a52a19e7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->