### PR TITLE
New Experiment for disabling HW Acceleration using cohorts

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -1563,7 +1563,7 @@
             }
         },
         "hwAccelerationExperiment": {
-            "state": "disabled",
+            "state": "enabled",
             "features": {
                 "disableHwAccelerationOnRenderCrash": {
                     "state": "disabled",
@@ -1577,6 +1577,45 @@
                             }
                         ]
                     }
+                },
+                "disableHwAccelerationExperimentGroup": {
+                    "state": "enabled",
+                    "cohorts": [
+                        {
+                            "name": "groupCom",
+                            "weight": 1
+                        },
+                        {
+                            "name": "groupOom",
+                            "weight": 1
+                        }
+                    ]
+                },
+                "disableHwAccelerationOnRenderCrashCom": {
+                    "state": "enabled",
+                    "cohorts": [
+                        {
+                            "name": "controlCom",
+                            "weight": 1
+                        },
+                        {
+                            "name": "treatmentCom",
+                            "weight": 1
+                        }
+                    ]
+                },
+                "disableHwAccelerationOnRenderCrashOom": {
+                    "state": "enabled",
+                    "cohorts": [
+                        {
+                            "name": "controlOom",
+                            "weight": 1
+                        },
+                        {
+                            "name": "treatmentOom",
+                            "weight": 1
+                        }
+                    ]
                 }
             },
             "exceptions": []


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1210132634900450/task/1211772569392719?focus=true

## Description
Experiment design: https://app.asana.com/1/137249556945/project/1201621853593513/task/1211774812264481?focus=true

In this new experiment, we'll effectively divide the users in 4 groups (see: [Comment by Maria on Experiment Design: Turning HW Acceleration off to prevent crashes in Windows Browser (Part 2)](https://app.asana.com/1/137249556945/project/1201621853593513/task/1211774812264481/comment/1211774331635938?focus=true))
Experiment A: 50% of users, for COM Exceptions, divided in two further groups: control and treatment for COM only
Experiment B: 50% of users, for OOM Exceptions, divided in two further  groups: control and treatment for OOM only

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [x] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [x] This feature was covered by a tech design.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables `hwAccelerationExperiment` and adds COM/OOM cohort groups with control/treatment splits for render-crash handling.
> 
> - **Windows config (`overrides/windows-override.json`)**
>   - Enable `hwAccelerationExperiment`.
>   - Add cohort grouping `disableHwAccelerationExperimentGroup` with `groupCom` and `groupOom`.
>   - Add COM cohorts `disableHwAccelerationOnRenderCrashCom` with `controlCom` and `treatmentCom`.
>   - Add OOM cohorts `disableHwAccelerationOnRenderCrashOom` with `controlOom` and `treatmentOom`.
>   - Keep `disableHwAccelerationOnRenderCrash` with rollout steps (still disabled).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 79411fab1f55f172e13da6b5b38b0ca45c6c9b14. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->