### PR TITLE
Disable notification shim again on chewy.com & realtor.com for users on older app versions

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -1998,6 +1998,30 @@
                                 }
                             }
                         ]
+                    },
+                    {
+                        "condition": {
+                            "domain": "realtor.com"
+                        },
+                        "patchSettings": [
+                            {
+                                "op": "replace",
+                                "path": "/notification/state",
+                                "value": "disabled"
+                            }
+                        ]
+                    },
+                    {
+                        "condition": {
+                            "domain": "chewy.com"
+                        },
+                        "patchSettings": [
+                            {
+                                "op": "replace",
+                                "path": "/notification/state",
+                                "value": "disabled"
+                            }
+                        ]
                     }
                 ],
                 "cleanIframeValue": {


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/task/1211264455407109

### Site breakage mitigation process:
#### Brief explanation
- Reported URL: chewy.com | realtor.com
- Problems experienced: 429 errors after bot failure
- Platforms affected:
  - [ ] iOS
  - [x] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Feature being disabled/modified: webcompat notification shim

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Disables the webCompat notification shim for `chewy.com` and `realtor.com` in Android overrides.
> 
> - **Android config (`overrides/android-override.json`)**:
>   - **WebCompat settings**:
>     - Add domain-specific overrides to set `notification/state` to `disabled` for:
>       - `realtor.com`
>       - `chewy.com`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c51521aa27f783114adb9afdbc02a1e0d4dbbccc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->