### PR TITLE
Disable 'includeIframes' setting to windows override

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -1507,6 +1507,7 @@
             "exceptions": [],
             "settings": {
                 "additionalCheck": "disabled",
+                "includeIframes": "disabled",
                 "maxContentLength": 9500,
                 "excludeSelectors": [
                     ".ad",


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1201048563534612/task/1211798508441306?focus=true

## Description

Disable iframes due to issue with autofill.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Disables page-context iframe inclusion by adding `"includeIframes": "disabled"` to the Windows override config.
> 
> - **Config (Windows)**:
>   - **Page Context**: Add `"includeIframes": "disabled"` in `overrides/windows-override.json` under `features.pageContext.settings` to prevent iframe content inclusion.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fd09ffb61a39dcf201fb39f92592a8200e40c56a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->