### PR TITLE
SBT - remove blank space and mitigate CPM banner

### DIFF
--- a/features/autoconsent.json
+++ b/features/autoconsent.json
@@ -682,6 +682,10 @@
         {
             "domain": "epoznan.pl",
             "reason": "https://github.com/duckduckgo/privacy-configuration/pull/3968"
+        },
+        {
+            "domain": "quizlet.com",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/pull/4010"
         }
     ],
     "settings": {

--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -3081,6 +3081,29 @@
                 ]
             },
             {
+                "domain": "quizlet.com",
+                "rules": [
+                    {
+                        "selector": "#targetDiv-setpage_billboard",
+                        "type": "modify-style",
+                        "values": [
+                            {
+                                "property": "height",
+                                "value": "0px"
+                            },
+                            {
+                                "property": "min-height",
+                                "value": "0px"
+                            }
+                        ]
+                    },
+                    {
+                        "selector": ".SetPageTerms-embeddedDesktopAdWrapper",
+                        "type": "hide-empty"
+                    }
+                ]
+            },
+            {
                 "domain": "quora.com",
                 "rules": [
                     {


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1206670747178362/task/1211780052586963?focus=true

## Description

### Site breakage mitigation process:
#### Brief explanation
- Reported URL: quizlet.com
- Problems experienced: top banner blank space and cookie banner would remain open reaching the last stage
- Platforms affected:
  - [ x] iOS
  - [ x] Android
  - [ x] Windows
  - [ x] MacOS
  - [ x] Extensions
- Tracker(s) being unblocked: NA
- Feature being disabled/modified: element hiding and cpm
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds Quizlet element-hiding rules to remove top banner space and hides embedded ad wrapper; adds Quizlet to autoconsent exceptions.
> 
> - **Element Hiding**:
>   - `quizlet.com`:
>     - Modify `#targetDiv-setpage_billboard` style to `height: 0px` and `min-height: 0px`.
>     - Hide-empty `.SetPageTerms-embeddedDesktopAdWrapper`.
> - **Autoconsent**:
>   - Add exception for `quizlet.com`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b84d2838acacdd934f6de862a5765bbe5003f0fa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->