### PR TITLE
Privacy config changes for notificationPromptExperiment, rollout 5%

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -2978,6 +2978,7 @@
         },
         "notificationPromptExperiment": {
             "state": "enabled",
+            "exceptions": [],
             "features": {
                 "notificationPromptExperimentOct25": {
                     "state": "enabled",


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1200581511062568/task/1211534289863810?focus=true

## Description
<!-- 
  Please delete either or both process sections below.
-->
Added notificationPromptExperiment and rolled out to 5%.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [x] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds Android `notificationPromptExperiment` feature (min v52550000) with 5% rollout, control vs experimentalNoNotificationPrompt cohorts, plus `waitForLocalPrivacyConfig`.
> 
> - **Android privacy config**:
>   - **`notificationPromptExperiment`**: `enabled`.
>     - `notificationPromptExperimentOct25`: `enabled`, `minSupportedVersion` 52550000, rollout 5%, cohorts `control` and `experimentalNoNotificationPrompt` (equal weight).
>     - `waitForLocalPrivacyConfig`: `enabled`, `minSupportedVersion` 52550000.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bed7fe4050c9be2cadbdae026c02db57cbde91b6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->