### PR TITLE
Disable autoconsent on elektramat.nl

### DIFF
--- a/features/autoconsent.json
+++ b/features/autoconsent.json
@@ -686,6 +686,10 @@
         {
             "domain": "quizlet.com",
             "reason": "https://github.com/duckduckgo/privacy-configuration/pull/4010"
+        },
+        {
+            "domain": "elektramat.nl",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/pull/4013"
         }
     ],
     "settings": {


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1206670747178362/task/1211749706545172?focus=true

## Description
Opting out of the cookie popup here via the cookiebot API leaves a grey overlay on the page.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Disables autoconsent on `elektramat.nl` by adding it to the exceptions list in `features/autoconsent.json`.
> 
> - **Autoconsent**:
>   - Add `elektramat.nl` to `exceptions` in `features/autoconsent.json` (reason: `https://github.com/duckduckgo/privacy-configuration/pull/4013`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ce0a251f4d003de852d43417dfd1a6992be4633c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->