### PR TITLE
Windows - Enable import.importShortcuts for browser version 0.135.0 and later

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -686,7 +686,8 @@
                     "state": "internal"
                 },
                 "importShortcuts": {
-                    "state": "disabled",
+                    "state": "enabled",
+                    "minSupportedVersion": "0.135.0",
                     "settings": {
                         "chrome": "enabled",
                         "brave": "enabled",


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1211150617965544/task/1211609111475941?focus=true

## Description
Enable the `import.importShortcuts` subfeature for 0.135.0 and later.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables `import.importShortcuts` on Windows with a minimum supported version of `0.135.0`.
> 
> - **Windows overrides (`overrides/windows-override.json`)**:
>   - **Import**:
>     - Enable `import.importShortcuts`.
>     - Add `minSupportedVersion` `0.135.0` (settings for `chrome`, `brave`, `edge`, `firefox` remain enabled).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 32f6cbeb40180bac06e1e6f37ff9c48afed3c137. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->