### PR TITLE
[iOS][Modal Prompt Coordination] Define cooldown interval value in json config

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -1581,6 +1581,9 @@
         },
         "iOSBrowserConfig": {
             "state": "enabled",
+            "settings": {
+                "promptCooldownInterval": 24
+            },
             "features": {
                 "widgetReporting": {
                     "state": "disabled"


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/72649045549333/task/1211817439010293

## Description

Adds a remote settings to define the cooldown interval between prompts in iOS.

Screenshot with test value:

<img width="2559" height="1359" alt="Screenshot 2025-11-04 at 5 17 57 pm" src="https://github.com/user-attachments/assets/22e47aa1-5f0d-4a30-8925-f575419943d2" />

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [x] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.
