### PR TITLE
[Autofill] bet365.com login form boundary

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -737,6 +737,19 @@
                                 ]
                             },
                             {
+                                "domain": [
+                                    "bet365.bet.br",
+                                    "bet365.com"
+                                ],
+                                "patchSettings": [
+                                    {
+                                        "path": "/formBoundarySelector",
+                                        "op": "replace",
+                                        "value": "div[style*=transform] > div"
+                                    }
+                                ]
+                            },
+                            {
                                 "domain": ["order.yodobashi.com"],
                                 "patchSettings": [
                                     {

--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -746,6 +746,19 @@
                                 ]
                             },
                             {
+                                "domain": [
+                                    "bet365.bet.br",
+                                    "bet365.com"
+                                ],
+                                "patchSettings": [
+                                    {
+                                        "path": "/formBoundarySelector",
+                                        "op": "replace",
+                                        "value": "div[style*=transform] > div"
+                                    }
+                                ]
+                            },
+                            {
                                 "domain": ["order.yodobashi.com"],
                                 "patchSettings": [
                                     {

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -823,6 +823,19 @@
                                 ]
                             },
                             {
+                                "domain": [
+                                    "bet365.bet.br",
+                                    "bet365.com"
+                                ],
+                                "patchSettings": [
+                                    {
+                                        "path": "/formBoundarySelector",
+                                        "op": "replace",
+                                        "value": "div[style*=transform] > div"
+                                    }
+                                ]
+                            },
+                            {
                                 "domain": ["order.yodobashi.com"],
                                 "patchSettings": [
                                     {

--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -485,6 +485,19 @@
                                 ]
                             },
                             {
+                                "domain": [
+                                    "bet365.bet.br",
+                                    "bet365.com"
+                                ],
+                                "patchSettings": [
+                                    {
+                                        "path": "/formBoundarySelector",
+                                        "op": "replace",
+                                        "value": "div[style*=transform] > div"
+                                    }
+                                ]
+                            },
+                            {
                                 "domain": ["order.yodobashi.com"],
                                 "patchSettings": [
                                     {


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1200930669568058/task/1211716411030109?focus=true

## Description
<!-- 
  Please delete either or both process sections below.
-->

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [x] iOS
  - [x] Android
  - [x] Windows
  - [x] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a site-specific autofill form boundary for bet365 domains across Android, iOS, macOS, and Windows.
> 
> - **Autofill — site-specific fix**:
>   - For `bet365.bet.br` and `bet365.com`, set `formBoundarySelector` to `"div[style*=transform] > div"` in `overrides/android-override.json`, `overrides/ios-override.json`, `overrides/macos-override.json`, and `overrides/windows-override.json`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c3db83fb934be29ae43260c3dc70f59be901cae1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->