### PR TITLE
Windows: Enable seamless sync account switching for external users

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -887,7 +887,7 @@
                     "state": "internal"
                 },
                 "seamlessAccountSwitching": {
-                    "state": "internal"
+                    "state": "enabled"
                 }
             }
         },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/task/1211792158307690?focus=true

## Description
Changes the sub-feature flag `sync/seamlessAccountSwitching` from `internal` to `enabled`. The flag enables switching sync accounts when the user attempts to connect two devices which are already logged in to two different sync accounts.

There is no `minSupportedVersion`, because the flag is enabled with the first release that has the feature.
