### PR TITLE
Temporarily disable ketch and twitter CPM rules

### DIFF
--- a/features/autoconsent.json
+++ b/features/autoconsent.json
@@ -696,7 +696,9 @@
         "disabledCMPs": [
             "healthline-media",
             "cookie-notice",
-            "notice-cookie"
+            "notice-cookie",
+            "ketch",
+            "twitter"
         ],
         "filterlistExceptions": [],
         "compactRuleList": {


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/task/1211834508118316?focus=true

## Description
<!-- 
  Please delete either or both process sections below.
-->

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add `ketch` and `twitter` to the autoconsent `disabledCMPs` list.
> 
> - **Autoconsent config**:
>   - Add `ketch` and `twitter` to `settings.disabledCMPs` in `features/autoconsent.json`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c25b5b72b060a893e66c5957cf898ff58a202cc7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->