### PR TITLE
SBT - remove athena-io ios ua blind mitigation

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -957,10 +957,6 @@
                     {
                         "domain": "arcteryx.com",
                         "reason": "https://github.com/duckduckgo/privacy-configuration/pull/3701"
-                    },
-                    {
-                        "domain": "messaginganalytics.athena.io",
-                        "reason": "https://github.com/duckduckgo/privacy-configuration/pull/3900"
                     }
                 ],
                 "ddgDefaultSites": [
@@ -996,10 +992,6 @@
                     {
                         "domain": "arcteryx.com",
                         "reason": "https://github.com/duckduckgo/privacy-configuration/pull/3701"
-                    },
-                    {
-                        "domain": "messaginganalytics.athena.io",
-                        "reason": "https://github.com/duckduckgo/privacy-configuration/pull/3900"
                     }
                 ],
                 "omitVersionSites": []


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1200277586140538/task/1211573250320293?focus=true

## Description


### Site breakage mitigation process:
#### Brief explanation
- Reported URL: athena.io
- Problems experienced: messaging interface reported as not loading - this action removes the previous blind mitigation to monitor reports and consider next steps.
- Platforms affected:
  - [ x] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked: NA
- Feature being disabled/modified: iOS UA
- [ x] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes iOS customUserAgent blind mitigation for messaginganalytics.athena.io by deleting it from fixed and omit lists.
> 
> - **iOS configuration (`overrides/ios-override.json`)**:
>   - **customUserAgent**: removed `messaginganalytics.athena.io` from `ddgFixedSites` and `omitApplicationSites`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8691fb0e5c4e51aeee5069d8fd8cdf003954ec39. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->