### PR TITLE
SBT - blind mitigate bankofamerica-com

### DIFF
--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -974,6 +974,11 @@
                         "rule": "sbs.demdex.net",
                         "domains": ["sbs.com.au"],
                         "reason": ["sbs.com.au - https://github.com/duckduckgo/privacy-configuration/pull/2436"]
+                    },
+                    {
+                        "rule": "adobedc.demdex.net",
+                        "domains": ["bankofamerica.com"],
+                        "reason": ["bankofamerica.com - https://github.com/duckduckgo/privacy-configuration/pull/4034"]
                     }
                 ]
             },
@@ -3542,6 +3547,13 @@
                             "cbs.com"
                         ],
                         "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2435"
+                    },
+                    {
+                        "rule": "tags.tiqcdn.com",
+                        "domains": [
+                            "bankofamerica.com"
+                        ],
+                        "reason": "bankofamerica.com - https://github.com/duckduckgo/privacy-configuration/pull/4034"
                     }
                 ]
             },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1200277586140538/task/1211418168036793?focus=true

## Description

### Site breakage mitigation process: 
#### Brief explanation
- Reported URL: bankofamerica.com
- Problems experienced: users struggle to log into their account. mitigation is for all platforms.
- Platforms affected:
  - [ x] iOS
  - [x ] Android
  - [ ] Windows
  - [x ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked: adobedc.demdex.net, tags.tiqcdn.com
- Feature being disabled/modified: NA
- [ x] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Allowlists `adobedc.demdex.net` and `tags.tiqcdn.com` for `bankofamerica.com` in `features/tracker-allowlist.json` to mitigate login issues.
> 
> - **Privacy config** (`features/tracker-allowlist.json`):
>   - **Allowlisted trackers for `bankofamerica.com`**:
>     - `demdex.net`: add rule for `adobedc.demdex.net`.
>     - `tiqcdn.com`: add rule for `tags.tiqcdn.com`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 26063f699e43fad358dc45e126e6d4d6dd2f2c40. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->