### PR TITLE
[android] roll out AndroidBrowserConfig#reportWebViewCapabilities to 10%

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -1260,6 +1260,17 @@
                             "isPrivacyProEligible": true
                         }
                     ]
+                },
+                "reportWebViewCapabilities": {
+                    "state": "enabled",
+                    "minSupportedVersion": 52560000,
+                    "rollout": {
+                        "steps": [
+                            {
+                                "percent": 10
+                            }
+                        ]
+                    }
                 }
             }
         },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1208671518894266/task/1211861349209828?focus=true

## Description
<!-- 
  Please delete either or both process sections below.
-->
Rolls out the `AndroidBrowserConfig#reportWebViewCapabilities` to 10% as soon as v5.256.0 is released.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables `androidBrowserConfig` feature `reportWebViewCapabilities` with `minSupportedVersion` 52560000 and rolls it out to 10%.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 45b7725ef38553619d8ea7acffbb49c2c4b25247. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->