### PR TITLE
More adwalls

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -3455,7 +3455,8 @@
                     }
                 ]
             },
-            "domain": "statesman.com",
+            {
+                "domain": "statesman.com",
                 "rules": [
                     {
                         "type": "disable-default"


### PR DESCRIPTION
**Asana Task/Github Issue:**

- https://app.asana.com/1/137249556945/project/1206670747178362/task/1211838098434837?focus=true
- https://app.asana.com/1/137249556945/project/1206670747178362/task/1211838157433366


### Site breakage mitigation process:
#### Brief explanation
- Reported URL: statesman.com & kleinezeitung.at
- Problems experienced: adwalls
- Platforms affected:
  - [x] All
- Feature being disabled/modified: element hiding

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Disables default element-hiding rules for statesman.com (new entry) and kleinezeitung.at (updated), retaining site-specific selectors.
> 
> - **Element Hiding configuration**:
>   - **Domains**:
>     - `statesman.com`: add `disable-default` rule.
>     - `kleinezeitung.at`: add `disable-default` rule alongside existing `[class*='adblocker-intercept']` hide rule.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d13e1c8f216e8623b866e5fba43f636df75f6669. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->