### PR TITLE
Setup RC for testing script with initialPing (H1)

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -3186,6 +3186,37 @@
                     }
                 }
             }
+        },
+        "webViewCompat": {
+            "state": "enabled",
+            "exceptions": [],
+            "settings": {
+                "jsInitialPingDelay": 0,
+                "initialPingDelay": 0
+            },
+            "features": {
+                "jsSendsInitialPing": {
+                    "state": "enabled"
+                },
+                "jsRepliesToNativeMessages": {
+                    "state": "disabled"
+                },
+                "replyToInitialPing": {
+                    "state": "disabled"
+                },
+                "useBlobDownloadsMessageListener": {
+                    "state": "disabled"
+                },
+                "sendMessageOnContexMenuOpened": {
+                    "state": "disabled"
+                },
+                "sendMessageOnPageStarted": {
+                    "state": "disabled"
+                },
+                "sendMessagesUsingReplyProxy": {
+                    "state": "disabled"
+                }
+            }
         }
     },
     "unprotectedTemporary": [],


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/72649045549333/task/1211759501637786?focus=true

## Description
RC setup to test script that uses initialPing with a dedicated message listener

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [x] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces `webViewCompat` in Android overrides to enable JS initial ping with zero delays while keeping other messaging subfeatures disabled.
> 
> - **Android overrides**:
>   - Add `webViewCompat` in `overrides/android-override.json`.
>     - Settings: `jsInitialPingDelay: 0`, `initialPingDelay: 0`.
>     - Features: enable `jsSendsInitialPing`; keep `jsRepliesToNativeMessages`, `replyToInitialPing`, `useBlobDownloadsMessageListener`, `sendMessageOnContexMenuOpened`, `sendMessageOnPageStarted`, `sendMessagesUsingReplyProxy` disabled.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4d69f8594528be02203004ecfca7f42740212a22. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->