### PR TITLE
Revert Setup RC for testing script with initialPing (H1)

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -3312,37 +3312,6 @@
                     }
                 }
             }
-        },
-        "webViewCompat": {
-            "state": "enabled",
-            "exceptions": [],
-            "settings": {
-                "jsInitialPingDelay": 20,
-                "initialPingDelay": 0
-            },
-            "features": {
-                "jsSendsInitialPing": {
-                    "state": "enabled"
-                },
-                "jsRepliesToNativeMessages": {
-                    "state": "disabled"
-                },
-                "replyToInitialPing": {
-                    "state": "disabled"
-                },
-                "useBlobDownloadsMessageListener": {
-                    "state": "disabled"
-                },
-                "sendMessageOnContexMenuOpened": {
-                    "state": "disabled"
-                },
-                "sendMessageOnPageStarted": {
-                    "state": "disabled"
-                },
-                "sendMessagesUsingReplyProxy": {
-                    "state": "disabled"
-                }
-            }
         }
     },
     "unprotectedTemporary": [],


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/72649045549333/task/1211876703229913
## Description
Revert #4040

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [x] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes the `webViewCompat` feature block (including its settings and flags) from `overrides/android-override.json`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d9d5566191e729c1d381d57639628988a27b2332. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->