### PR TITLE
Revert "Temporarily disable ketch and twitter CPM rules"

### DIFF
--- a/features/autoconsent.json
+++ b/features/autoconsent.json
@@ -696,9 +696,7 @@
         "disabledCMPs": [
             "healthline-media",
             "cookie-notice",
-            "notice-cookie",
-            "ketch",
-            "twitter"
+            "notice-cookie"
         ],
         "filterlistExceptions": [],
         "compactRuleList": {


### PR DESCRIPTION
Reverts duckduckgo/privacy-configuration#4026

We didn't see any change in error rates from this change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes `ketch` and `twitter` from `settings.disabledCMPs` in `features/autoconsent.json` (keeping `notice-cookie`).
> 
> - **Config (`features/autoconsent.json`)**:
>   - Updates `settings.disabledCMPs`: removes `ketch` and `twitter`; retains `notice-cookie`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0cf37f3b55260a49c658b4ff4624d70348af8fc3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->