### PR TITLE
Enabled attributed metrics to internal builds

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -73,6 +73,122 @@
                 }
             }
         },
+        "attributedMetrics": {
+            "state": "internal",
+            "exceptions": [],
+            "features": {
+                "emitAllMetrics": {
+                    "state": "internal"
+                },
+                "retention": {
+                    "state": "internal"
+                },
+                "canEmitRetention": {
+                    "state": "internal"
+                },
+                "searchDaysAvg": {
+                    "state": "internal"
+                },
+                "canEmitSearchDaysAvg": {
+                    "state": "internal"
+                },
+                "searchCountAvg": {
+                    "state": "internal"
+                },
+                "canEmitSearchCountAvg": {
+                    "state": "internal"
+                },
+                "adClickCountAvg": {
+                    "state": "internal"
+                },
+                "canEmitAdClickCountAvg": {
+                    "state": "internal"
+                },
+                "aiUsageAvg": {
+                    "state": "internal"
+                },
+                "canEmitAIUsageAvg": {
+                    "state": "internal"
+                },
+                "subscriptionRetention": {
+                    "state": "internal"
+                },
+                "canEmitSubscriptionRetention": {
+                    "state": "internal"
+                },
+                "syncDevices": {
+                    "state": "internal"
+                },
+                "canEmitSyncDevices": {
+                    "state": "internal"
+                }
+            },
+            "settings": {
+                "attributed_metric_retention_week": {
+                    "buckets": [
+                        1,
+                        2,
+                        3
+                    ],
+                    "version": 1
+                },
+                "attributed_metric_retention_month": {
+                    "buckets": [
+                        2,
+                        3,
+                        4,
+                        5
+                    ],
+                    "version": 1
+                },
+                "attributed_metric_active_past_week": {
+                    "buckets": [
+                        2,
+                        4
+                    ],
+                    "version": 1
+                },
+                "attributed_metric_average_searches_past_week_first_month": {
+                    "buckets": [
+                        5,
+                        9
+                    ],
+                    "version": 1
+                },
+                "attributed_metric_average_searches_past_week": {
+                    "buckets": [
+                        5,
+                        9
+                    ],
+                    "version": 1
+                },
+                "attributed_metric_average_ad_clicks_past_week": {
+                    "buckets": [
+                        2,
+                        5
+                    ],
+                    "version": 1
+                },
+                "attributed_metric_average_duck_ai_usage_past_week": {
+                    "buckets": [
+                        5,
+                        9
+                    ],
+                    "version": 1
+                },
+                "attributed_metric_subscribed": {
+                    "buckets": [
+                        0,
+                        1
+                    ],
+                    "version": 1
+                },
+                "attributed_metric_synced_device": {
+                    "buckets": [1],
+                    "version": 1
+                }
+            }
+        },
         "blockList": {
             "state": "enabled",
             "exceptions": [],


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/488551667048375/task/1211904469055921?focus=true

## Description
Enables Attributed metrics to internal builds

### Feature change process:

- [x] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [x] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [x] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [x] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables internal-only `attributedMetrics` on Android with metric flags and bucketed settings for retention, activity, searches, ad clicks, AI usage, subscription, and device sync.
> 
> - **Android Config**:
>   - **`features/attributedMetrics`**: Added with `state: internal`.
>     - Metric flags: `emitAllMetrics`, `retention`/`canEmitRetention`, `searchDaysAvg`/`canEmitSearchDaysAvg`, `searchCountAvg`/`canEmitSearchCountAvg`, `adClickCountAvg`/`canEmitAdClickCountAvg`, `aiUsageAvg`/`canEmitAIUsageAvg`, `subscriptionRetention`/`canEmitSubscriptionRetention`, `syncDevices`/`canEmitSyncDevices`.
>     - Settings: bucketed configs for `attributed_metric_retention_week`, `attributed_metric_retention_month`, `attributed_metric_active_past_week`, `attributed_metric_average_searches_past_week_first_month`, `attributed_metric_average_searches_past_week`, `attributed_metric_average_ad_clicks_past_week`, `attributed_metric_average_duck_ai_usage_past_week`, `attributed_metric_subscribed`, `attributed_metric_synced_device`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d1ae60fab6896c22436bd0bebd982817a59a4a45. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->