### PR TITLE
Add macOS and iOS subfeature fro Black Friday promotion

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -1440,7 +1440,10 @@
                         {
                             "localeCountry": "US"
                         }
-                    ]
+                    ],
+                    "settings": {
+                        "discountPercent": "40"
+                    }
                 },
                 "vpnMenuItem": {
                     "state": "enabled",

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -1618,7 +1618,10 @@
                         {
                             "localeCountry": "US"
                         }
-                    ]
+                    ],
+                    "settings": {
+                        "discountPercent": "40"
+                    }
                 }
             }
         },


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/1210594645229050/task/1211612114679665?focus=true

## Description
This PR adds Black Friday-specific subscription subfeature for macOS and iOS.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `privacyPro.blackFridayCampaign` (disabled) with US targeting and 40% discount to iOS and macOS overrides.
> 
> - **Subscriptions/PrivacyPro**:
>   - iOS (`overrides/ios-override.json`): add `privacyPro.features.blackFridayCampaign` (state: `disabled`, `targets`: US, `settings.discountPercent`: `"40"`).
>   - macOS (`overrides/macos-override.json`): add `privacyPro.features.blackFridayCampaign` (state: `disabled`, `targets`: US, `settings.discountPercent`: `"40"`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f7dbbb1137f8781db5ec91b44f52992fe6bb307d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->