### PR TITLE
Enable TDS experiment at 25%

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -193,19 +193,19 @@
             "state": "enabled",
             "exceptions": [],
             "features": {
-                "tdsNextExperiment003": {
-                    "state": "disabled",
+                "tdsNextExperiment004": {
+                    "state": "enabled",
                     "minSupportedVersion": 52361000,
                     "rollout": {
                         "steps": [
                             {
-                                "percent": 100
+                                "percent": 25
                             }
                         ]
                     },
                     "settings": {
-                        "controlUrl": "v5/experiments/202508v2-android-tds-control.json",
-                        "treatmentUrl": "v5/experiments/202508v2-android-tds-treatment.json"
+                        "controlUrl": "v5/experiments/202511v1-android-tds-control.json",
+                        "treatmentUrl": "v5/experiments/202511v1-android-tds-treatment.json"
                     },
                     "cohorts": [
                         {

--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -315,18 +315,18 @@
             "state": "enabled",
             "exceptions": [],
             "features": {
-                "tdsNextExperiment003": {
-                    "state": "disabled",
+                "tdsNextExperiment004": {
+                    "state": "enabled",
                     "rollout": {
                         "steps": [
                             {
-                                "percent": 100
+                                "percent": 25
                             }
                         ]
                     },
                     "settings": {
-                        "controlUrl": "v5/experiments/202508v2-ios-tds-control.json",
-                        "treatmentUrl": "v5/experiments/202508v2-ios-tds-treatment.json"
+                        "controlUrl": "v5/experiments/202511v1-ios-tds-control.json",
+                        "treatmentUrl": "v5/experiments/202511v1-ios-tds-treatment.json"
                     },
                     "cohorts": [
                         {

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -350,18 +350,18 @@
                 }
             ],
             "features": {
-                "tdsNextExperiment003": {
-                    "state": "disabled",
+                "tdsNextExperiment004": {
+                    "state": "enabled",
                     "rollout": {
                         "steps": [
                             {
-                                "percent": 100
+                                "percent": 25
                             }
                         ]
                     },
                     "settings": {
-                        "controlUrl": "v6/experiments/202508v2-macos-tds-control.json",
-                        "treatmentUrl": "v6/experiments/202508v2-macos-tds-treatment.json"
+                        "controlUrl": "v6/experiments/202511v1-macos-tds-control.json",
+                        "treatmentUrl": "v6/experiments/202511v1-macos-tds-treatment.json"
                     },
                     "cohorts": [
                         {


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1200342317600122/task/1211820948344386?focus=true

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables `tdsNextExperiment004` at 25% rollout across Android, iOS, and macOS and updates control/treatment URLs to the 202511v1 variants.
> 
> - **Content Blocking / TDS Experiment**:
>   - **Android (`overrides/android-override.json`)**:
>     - Replace `tdsNextExperiment003` with `tdsNextExperiment004`; state `enabled`, rollout `25%`.
>     - Update URLs: `controlUrl` → `v5/experiments/202511v1-android-tds-control.json`, `treatmentUrl` → `v5/experiments/202511v1-android-tds-treatment.json`.
>   - **iOS (`overrides/ios-override.json`)**:
>     - Replace `tdsNextExperiment003` with `tdsNextExperiment004`; state `enabled`, rollout `25%`.
>     - Update URLs: `controlUrl` → `v5/experiments/202511v1-ios-tds-control.json`, `treatmentUrl` → `v5/experiments/202511v1-ios-tds-treatment.json`.
>   - **macOS (`overrides/macos-override.json`)**:
>     - Replace `tdsNextExperiment003` with `tdsNextExperiment004`; state `enabled`, rollout `25%`.
>     - Update URLs: `controlUrl` → `v6/experiments/202511v1-macos-tds-control.json`, `treatmentUrl` → `v6/experiments/202511v1-macos-tds-treatment.json`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 41eb56db02bee299fcca5d3c1bd20e78ece78a0f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->