### PR TITLE
SBT allow menu to open by adding cpm exception on android

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -488,6 +488,10 @@
                 {
                     "domain": "ashleyfurniture.com",
                     "reason": "https://github.com/duckduckgo/privacy-configuration/pull/3908"
+                },
+                {
+                    "domain": "tractorhouse.com",
+                    "reason": "https://github.com/duckduckgo/privacy-configuration/pull/4057"
                 }
             ],
             "features": {


### PR DESCRIPTION
**Asana Task/Github Issue:**  https://app.asana.com/1/137249556945/project/1206670747178362/task/1211895113641087?focus=true

## Description

### Site breakage mitigation process:
#### Brief explanation
- Reported URL: https://www.tractorhouse.com/listing/for-sale/228143045/oliver-super-55-less-than-40-hp-tractors
- Problems experienced: Menu would not open on android only
- Platforms affected:
  - [ ] iOS
  - [x ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked: NA
- Feature being disabled/modified: autoconsent
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add an autoconsent exception for `tractorhouse.com` in `overrides/android-override.json`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e7ba91190ff223797b4dd0761dd315099cbae538. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->