### PR TITLE
SBT load homedepot-ca by unblocking a tracker

### DIFF
--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -1716,6 +1716,17 @@
                     }
                 ]
             },
+            "evgnet.com": {
+                "rules": [
+                    {
+                        "rule": "cdn.evgnet.com/beacon/homedepotofcainc/engage/scripts/evergage.min.js",
+                        "domains": [
+                            "homedepot.ca"
+                        ],
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/pull/4058"
+                    }
+                ]
+            },
             "exoclick.com": {
                 "rules": [
                     {


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1206670747178362/task/1211907384203482?focus=true

## Description

### Site breakage mitigation process:
#### Brief explanation
- Reported URL: https://www.homedepot.ca/en/home.html
- Problems experienced: site does not load
- Platforms affected:
  - [x ] iOS
  - [x ] Android
  - [ x] Windows
  - [x ] MacOS
  - [x ] Extensions
- Tracker(s) being unblocked: cdn.evgnet.com/beacon/homedepotofcainc/engage/scripts/evergage.min.js
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Allowlists `evgnet.com` Evergage script for `homedepot.ca` in `features/tracker-allowlist.json` to address site loading breakage.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 155b76707cadc2a526fbc9fa22165a2c79fef6f2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->