### PR TITLE
SBT remove blank space by updating rule

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -2308,6 +2308,10 @@
                 "rules": [
                     {
                         "type": "disable-default"
+                    },
+                    {
+                        "selector": "ins.adsbygoogle",
+                        "type": "closest-empty"
                     }
                 ]
             },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1204912272578138/task/1211925335857433?focus=true

## Description


### Site breakage mitigation process: 
#### Brief explanation
- Reported URL: kamus.net
- Problems experienced:
- Platforms affected:
  - [x ] iOS
  - [x ] Android
  - [ x] Windows
  - [x ] MacOS
  - [x ] Extensions
- Tracker(s) being unblocked: NA
- Feature being disabled/modified: element-hiding
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a domain-specific rule for `kamus.net` to `closest-empty` on `ins.adsbygoogle`, collapsing leftover ad space.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a7f60d66a14c90c0ec0255fa08c7615d8c9739e0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->