### PR TITLE
SBT remove blank space - update element-hiding rule on wiwo-de

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -3878,6 +3878,10 @@
                 "rules": [
                     {
                         "type": "disable-default"
+                    },
+                    {
+                        "selector": ".top-ad-container",
+                        "type": "hide-empty"
                     }
                 ]
             },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1200277586140538/task/1211926424296229?focus=true

## Description

### Site breakage mitigation process:
#### Brief explanation
- Reported URL: wiwo.de
- Problems experienced: blank space 
- Platforms affected:
  - [ x] iOS
  - [x ] Android
  - [ x] Windows
  - [ x] MacOS
  - [ x] Extensions
- Tracker(s) being unblocked: NA
- Feature being disabled/modified: element-hiding
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a wiwo.de domain override to hide empty `.top-ad-container` elements to remove blank space.
> 
> - **Element Hiding rules**
>   - **`wiwo.de`**:
>     - Add `hide-empty` for `.top-ad-container` alongside `disable-default` to remove empty ad slot spacing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 756237087f7e8d362e3d42ff5401d78f3f4e20b5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->