### PR TITLE
Re-enable webviewcompat test

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -3312,6 +3312,37 @@
                     }
                 }
             }
+        },
+        "webViewCompat": {
+            "state": "enabled",
+            "exceptions": [],
+            "settings": {
+                "jsInitialPingDelay": 0,
+                "initialPingDelay": 0
+            },
+            "features": {
+                "jsSendsInitialPing": {
+                    "state": "enabled"
+                },
+                "jsRepliesToNativeMessages": {
+                    "state": "disabled"
+                },
+                "replyToInitialPing": {
+                    "state": "disabled"
+                },
+                "useBlobDownloadsMessageListener": {
+                    "state": "disabled"
+                },
+                "sendMessageOnContexMenuOpened": {
+                    "state": "disabled"
+                },
+                "sendMessageOnPageStarted": {
+                    "state": "disabled"
+                },
+                "sendMessagesUsingReplyProxy": {
+                    "state": "disabled"
+                }
+            }
         }
     },
     "unprotectedTemporary": [],


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/72649045549333/task/1211759501637786?focus=true

## Description
<!-- 
  Please delete either or both process sections below.
-->

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [x] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables Android `webViewCompat` with zero initial ping delays, turning on `jsSendsInitialPing` while keeping other subfeatures disabled.
> 
> - **Android overrides**:
>   - **`features/webViewCompat`** in `overrides/android-override.json` set to `enabled`.
>     - Settings: `jsInitialPingDelay: 0`, `initialPingDelay: 0`.
>     - Subfeatures: `jsSendsInitialPing` enabled; `jsRepliesToNativeMessages`, `replyToInitialPing`, `useBlobDownloadsMessageListener`, `sendMessageOnContexMenuOpened`, `sendMessageOnPageStarted`, `sendMessagesUsingReplyProxy` disabled.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8922f0e3b481a49798fd9df784fca9713db9b675. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->