### PR TITLE
[android] disable AndroidBrowserConfig#reportWebViewCapabilities

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -1382,7 +1382,7 @@
                     ]
                 },
                 "reportWebViewCapabilities": {
-                    "state": "enabled",
+                    "state": "disabled",
                     "minSupportedVersion": 52560000,
                     "rollout": {
                         "steps": [


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/task/1211934720240671?focus=true

## Description
<!-- 
  Please delete either or both process sections below.
-->

Disables `AndroidBrowserConfig#reportWebViewCapabilities`

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Sets `androidBrowserConfig.features.reportWebViewCapabilities.state` to `disabled` in `overrides/android-override.json`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fa0db2067d52cb272d3ecf423cc51f65dbedee44. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->