### PR TITLE
SBT - revert initial mitigation and add tracker exceptions

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -488,10 +488,6 @@
                 {
                     "domain": "ashleyfurniture.com",
                     "reason": "https://github.com/duckduckgo/privacy-configuration/pull/3908"
-                },
-                {
-                    "domain": "tractorhouse.com",
-                    "reason": "https://github.com/duckduckgo/privacy-configuration/pull/4057"
                 }
             ],
             "features": {
@@ -2049,6 +2045,24 @@
                                     "tracfone.com"
                                 ],
                                 "reason": "tracfone.com - https://github.com/duckduckgo/privacy-configuration/pull/4032"
+                            }
+                        ]
+                    },
+                    "doubleclick.net": {
+                        "rules": [
+                            {
+                                "rule": "securepubads.g.doubleclick.net/tag/js/gpt.js",
+                                "domains": [
+                                    "tractorhouse.com"
+                                ],
+                                "reason": "tractorhouse.com - https://github.com/duckduckgo/privacy-configuration/pull/4063"
+                            },
+                            {
+                                "rule": "securepubads.g.doubleclick.net/pagead/managed/js/gpt",
+                                "domains": [
+                                    "tractorhouse.com"
+                                ],
+                                "reason": "tractorhouse.com - https://github.com/duckduckgo/privacy-configuration/pull/4063"
                             }
                         ]
                     },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1206670747178362/task/1211895113641087?focus=true

## Description

### Site breakage mitigation process:
#### Brief explanation
- Reported URL: https://www.tractorhouse.com/listing/for-sale/228143045/oliver-super-55-less-than-40-hp-tractors
- Problems experienced: Menu is unresponsive
- Platforms affected:
  - [ ] iOS
  - [ x] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked: securepubads.g.doubleclick.net/tag/js/gpt.js, securepubads.g.doubleclick.net/pagead/managed/js/gpt
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Allowlists DoubleClick GPT scripts for tractorhouse.com and removes its autoconsent exception in Android overrides.
> 
> - **Android overrides (`overrides/android-override.json`)**:
>   - **Tracker allowlist**: Add `doubleclick.net` rules to allow `securepubads.g.doubleclick.net/tag/js/gpt.js` and `securepubads.g.doubleclick.net/pagead/managed/js/gpt` on `tractorhouse.com`.
>   - **Autoconsent**: Remove exception for `tractorhouse.com`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2a689adeabba5a43d1889d661f06329966cb82d3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->