### PR TITLE
Enable webviewCompat test with initialPing

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -3328,7 +3328,7 @@
             }
         },
         "webViewCompat": {
-            "state": "disabled",
+            "state": "enabled",
             "exceptions": [],
             "settings": {
                 "jsInitialPingDelay": 0,
@@ -3336,7 +3336,7 @@
             },
             "features": {
                 "jsSendsInitialPing": {
-                    "state": "disabled"
+                    "state": "enabled"
                 },
                 "jsRepliesToNativeMessages": {
                     "state": "disabled"


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/72649045549333/task/1211759501637786?focus=true

## Description
<!-- 
  Please delete either or both process sections below.
-->

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enable `webViewCompat` and its `jsSendsInitialPing` feature in `overrides/android-override.json`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1e75639c288f7ec116ba15226acafb59125c96d3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->