### PR TITLE
Test initialPing with 200ms delay

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -3331,7 +3331,7 @@
             "state": "enabled",
             "exceptions": [],
             "settings": {
-                "jsInitialPingDelay": 0,
+                "jsInitialPingDelay": 200,
                 "initialPingDelay": 0
             },
             "features": {


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1204920898013511/task/1211781649580237?focus=true

## Description
<!-- 
  Please delete either or both process sections below.
-->

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Sets `webViewCompat` `jsInitialPingDelay` to 200ms in `overrides/android-override.json`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b03be60574817620810600b62c6cd3c74ab9643a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->