### PR TITLE
Disable WebViewCompat test

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -3334,15 +3334,15 @@
             }
         },
         "webViewCompat": {
-            "state": "enabled",
+            "state": "disabled",
             "exceptions": [],
             "settings": {
-                "jsInitialPingDelay": 200,
+                "jsInitialPingDelay": 0,
                 "initialPingDelay": 0
             },
             "features": {
                 "jsSendsInitialPing": {
-                    "state": "enabled"
+                    "state": "disabled"
                 },
                 "jsRepliesToNativeMessages": {
                     "state": "disabled"


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1204920898013511/task/1211861342360907?focus=true

## Description
Disable WebViewCompat test

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [x] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Disables `webViewCompat` on Android and sets `jsInitialPingDelay` to 0, also disabling JS initial ping behavior.
> 
> - **Android overrides (`overrides/android-override.json`)**:
>   - **`webViewCompat`**:
>     - Set `state` to `disabled`.
>     - Settings: `jsInitialPingDelay` changed from `200` to `0`.
>     - Features: `jsSendsInitialPing` set to `disabled`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4d997019c19e606c5385f8b83724ec97ba873bdb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->