### PR TITLE
Enable WebViewCompat test with initialPing and blob downloads listener

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -3345,7 +3345,7 @@
             }
         },
         "webViewCompat": {
-            "state": "disabled",
+            "state": "enabled",
             "exceptions": [],
             "settings": {
                 "jsInitialPingDelay": 0,
@@ -3353,7 +3353,7 @@
             },
             "features": {
                 "jsSendsInitialPing": {
-                    "state": "disabled"
+                    "state": "enabled"
                 },
                 "jsRepliesToNativeMessages": {
                     "state": "disabled"
@@ -3362,7 +3362,7 @@
                     "state": "disabled"
                 },
                 "useBlobDownloadsMessageListener": {
-                    "state": "disabled"
+                    "state": "enabled"
                 },
                 "sendMessageOnContexMenuOpened": {
                     "state": "disabled"


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/72649045549333/task/1211755269770785?focus=true

## Description
Enable WebViewCompat test with initialPing and blob downloads listener

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [x] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables `webViewCompat` on Android and turns on initial JS ping and blob download message listener.
> 
> - **Android config (`overrides/android-override.json`)**:
>   - **`webViewCompat`**: set `state` to `enabled`.
>     - Enable `features`.`jsSendsInitialPing`.
>     - Enable `features`.`useBlobDownloadsMessageListener`.
>     - Keep other sub-features unchanged; `settings` delays remain `0`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 71323546876362fe6221b9cbb480b5a8e4d07bc8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->