### PR TITLE
Disable pinnedTabsViewRewrite on macOS

### DIFF
--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -1727,8 +1727,7 @@
                     "state": "enabled"
                 },
                 "pinnedTabsViewRewrite": {
-                    "state": "enabled",
-                    "minSupportedVersion": "1.166.0"
+                    "state": "disabled"
                 }
             }
         },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1201899738287924/task/1211966386032840?focus=true

## Description
This change updates pinnedTabsViewRewrite flag to only become enabled in the next release.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [x] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `features.macOSBrowserConfig.features.pinnedTabsViewRewrite` set to `disabled` in `overrides/macos-override.json`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dee16d2a3321ee8c67ebec5c3c3a3ff5ca35e716. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->