### PR TITLE
[Apple] Disable showHideAIGeneratedImagesSection for macOS and iOS

### DIFF
--- a/features/show-hide-ai-generated-images-section.json
+++ b/features/show-hide-ai-generated-images-section.json
@@ -1,0 +1,8 @@
+{
+    "_meta": {
+        "description": "Controls the display of the Hide AI generated images section on native browsers settings.",
+        "sampleExcludeRecords": {}
+    },
+    "state": "disabled",
+    "exceptions": []
+}


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/1204006570077678/task/1211967140961135?focus=true

## Description
We merged all the code and set the feature flag to true, thinking we would get it done last week. Since we were unable to do it, I'm disabling the feature flags in the privacy config.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [x] iOS
  - [ ] Android
  - [ ] Windows
  - [x] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a new feature flag file to disable the "Hide AI generated images" settings section.
> 
> - **Config**:
>   - Add feature flag file `features/show-hide-ai-generated-images-section.json` with `state: "disabled"` to control display of the "Hide AI generated images" settings section.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8fb223678955ffe54e5c0a3d3d687887d1091c48. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->