### PR TITLE
Test full JS<>Kt communication

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -3381,22 +3381,22 @@
                     "state": "enabled"
                 },
                 "jsRepliesToNativeMessages": {
-                    "state": "disabled"
+                    "state": "enabled"
                 },
                 "replyToInitialPing": {
-                    "state": "disabled"
+                    "state": "enabled"
                 },
                 "useBlobDownloadsMessageListener": {
                     "state": "enabled"
                 },
                 "sendMessageOnContexMenuOpened": {
-                    "state": "disabled"
+                    "state": "enabled"
                 },
                 "sendMessageOnPageStarted": {
                     "state": "disabled"
                 },
                 "sendMessagesUsingReplyProxy": {
-                    "state": "disabled"
+                    "state": "enabled"
                 }
             }
         }


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/task/1211963296480296

## Description
Test full JS<>Kt communication
* JS replies to native messages
* Kt replies to initialPing
* Kt sends messages (not replies) to Kt using replyProxy

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [x] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables JS↔native messaging in `overrides/android-override.json` by turning on `jsRepliesToNativeMessages`, `replyToInitialPing`, `sendMessageOnContexMenuOpened`, and `sendMessagesUsingReplyProxy`.
> 
> - **Android WebView compatibility** (`overrides/android-override.json`):
>   - Enable JS-native messaging features:
>     - `webViewCompat.features.jsRepliesToNativeMessages`
>     - `webViewCompat.features.replyToInitialPing`
>     - `webViewCompat.features.sendMessageOnContexMenuOpened`
>     - `webViewCompat.features.sendMessagesUsingReplyProxy`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4b6df21a14ed3d42f1188bd694703649cbda0541. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->