### PR TITLE
Disable CPM on brocardi.it

### DIFF
--- a/features/autoconsent.json
+++ b/features/autoconsent.json
@@ -702,6 +702,10 @@
         {
             "domain": "membersuite.com",
             "reason": "https://github.com/duckduckgo/privacy-configuration/pull/4074"
+        },
+        {
+            "domain": "brocardi.it",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/pull/4088"
         }
     ],
     "settings": {


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1206670747178362/task/1211976091883484?focus=true

## Description
On brocardi.it, the site does not handle rejected consent properly, therefore CPM leaves the site in a broken state.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `brocardi.it` to autoconsent domain exceptions to disable CMP handling on that site.
> 
> - **Config**:
>   - **Autoconsent**: Add domain exception for `brocardi.it` in `features/autoconsent.json` (with reference link).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 77e5ba309dcfd39fe5986b735573bef8eded23e9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->