### PR TITLE
Android: Roll-out the split omnibar to 5%

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -1415,6 +1415,16 @@
                             }
                         ]
                     }
+                },
+                "splitOmnibar": {
+                    "state": "enabled",
+                    "rollout": {
+                        "steps": [
+                            {
+                                "percent": 5
+                            }
+                        ]
+                    }
                 }
             }
         },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/task/1211854617128266?focus=true

## Description

Roll-out the split omnibar feature on Android to 5% of users.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [x] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables the `splitOmnibar` feature on Android with a 5% rollout.
> 
> - **Android config**:
>   - Add `splitOmnibar` feature in `overrides/android-override.json` under `features.androidBrowserConfig` and enable with a 5% rollout.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 461a9761367d65b71288f08418e271842437ae0c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->