### PR TITLE
Roll out AppTP A/A experiment

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -46,9 +46,9 @@
         "appTrackerProtection": {
             "state": "enabled",
             "features": {
-                "atpTdsExperiment001": {
-                    "state": "disabled",
-                    "minSupportedVersion": 52361000,
+                "atpTdsExperiment002": {
+                    "state": "enabled",
+                    "minSupportedVersion": 52550000,
                     "rollout": {
                         "steps": [
                             {
@@ -57,8 +57,8 @@
                         ]
                     },
                     "settings": {
-                        "controlUrl": "experiment/tds-202510AA-control-android.json",
-                        "treatmentUrl": "experiment/tds-202510AA-treatment-android.json"
+                        "controlUrl": "experiment/tds-202511AA-control-android.json",
+                        "treatmentUrl": "experiment/tds-202511AA-treatment-android.json"
                     },
                     "cohorts": [
                         {


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1200811069326255/task/1209826460205284?focus=true

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches App Tracker Protection TDS experiment to `atpTdsExperiment002`, enabling it at 100% with updated control/treatment URLs and a higher min supported version.
> 
> - **Android overrides**
>   - **App Tracker Protection (`features.appTrackerProtection`)**:
>     - Replace `atpTdsExperiment001` with `atpTdsExperiment002` (enabled, 100% rollout).
>     - Update `minSupportedVersion` to `52550000`.
>     - Update URLs: `controlUrl` -> `experiment/tds-202511AA-control-android.json`, `treatmentUrl` -> `experiment/tds-202511AA-treatment-android.json`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 57f85a58077e20645efc51527ad9077a2ec23706. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->