### PR TITLE
Re-enable Sourcepoint, disable trustarc on mac

### DIFF
--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -577,7 +577,8 @@
                     "healthline-media",
                     "cookie-notice",
                     "notice-cookie",
-                    "Sourcepoint-frame"
+                    "TrustArc-top",
+                    "TrustArc-frame"
                 ],
                 "filterlistExceptions": [],
                 "compactRuleList": {


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/task/1211834508118316?focus=true

## Description
<!-- 
  Please delete either or both process sections below.
-->

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates macOS overrides to disable TrustArc (top/frame) while re-enabling Sourcepoint by removing its frame from disabled CMPs.
> 
> - **macOS overrides (`overrides/macos-override.json`)**
>   - **CMP settings**:
>     - Remove `Sourcepoint-frame` from `settings.disabledCMPs` (re-enables Sourcepoint).
>     - Add `TrustArc-top` and `TrustArc-frame` to `settings.disabledCMPs` (disables TrustArc).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c58794cb7b056c0b104d80411572270f75c5a314. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->