### PR TITLE
Privacy config changes for notificationPromptExperiment, disable flag

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -3219,11 +3219,11 @@
             }
         },
         "notificationPromptExperiment": {
-            "state": "enabled",
+            "state": "disabled",
             "exceptions": [],
             "features": {
                 "notificationPromptExperimentOct25": {
-                    "state": "enabled",
+                    "state": "disabled",
                     "minSupportedVersion": 52550000,
                     "rollout": {
                         "steps": [
@@ -3244,16 +3244,16 @@
                     "cohorts": [
                         {
                             "name": "control",
-                            "weight": 1
+                            "weight": 0
                         },
                         {
                             "name": "experimentalNoNotificationPrompt",
-                            "weight": 1
+                            "weight": 0
                         }
                     ]
                 },
                 "waitForLocalPrivacyConfig": {
-                    "state": "enabled",
+                    "state": "disabled",
                     "minSupportedVersion": 52550000
                 }
             }


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/72649045549333/task/1211980422368525?focus=true

## Description
<!-- 
  Please delete either or both process sections below.
-->
Disabled notificationPromptExperiment.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [x] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Disables Android `notificationPromptExperiment` and related feature flags/cohorts in `overrides/android-override.json`.
> 
> - **Android privacy config** (`overrides/android-override.json`):
>   - `notificationPromptExperiment`:
>     - `state`: enabled → disabled
>     - `features.notificationPromptExperimentOct25.state`: enabled → disabled
>     - `features.notificationPromptExperimentOct25.cohorts`: set `control` and `experimentalNoNotificationPrompt` `weight` to `0`
>     - `features.waitForLocalPrivacyConfig.state`: enabled → disabled
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d223ccaa933a89590c735e9242e51d706a866a18. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->