### PR TITLE
CPM: re-enable trustarc, disable rules for cookiealert and privacymanager

### DIFF
--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -577,8 +577,8 @@
                     "healthline-media",
                     "cookie-notice",
                     "notice-cookie",
-                    "TrustArc-top",
-                    "TrustArc-frame"
+                    "cookiealert",
+                    "privacymanager.io"
                 ],
                 "filterlistExceptions": [],
                 "compactRuleList": {


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/30173902528854/task/1211834508118316?focus=true

## Description
<!-- 
  Please delete either or both process sections below.
-->

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Re-enables TrustArc and disables `cookiealert` and `privacymanager.io` in the macOS overrides.
> 
> - **Config (macOS)**:
>   - Update `overrides/macos-override.json` → `settings.disabledCMPs`:
>     - Remove `TrustArc-top`, `TrustArc-frame`.
>     - Add `cookiealert`, `privacymanager.io`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 477fab69df399eefca5a39af199eb01abc70641e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->