### PR TITLE
Disable webViewCompat testing

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -3383,7 +3383,7 @@
             }
         },
         "webViewCompat": {
-            "state": "enabled",
+            "state": "disabled",
             "exceptions": [],
             "settings": {
                 "jsInitialPingDelay": 0,
@@ -3391,25 +3391,25 @@
             },
             "features": {
                 "jsSendsInitialPing": {
-                    "state": "enabled"
+                    "state": "disabled"
                 },
                 "jsRepliesToNativeMessages": {
-                    "state": "enabled"
+                    "state": "disabled"
                 },
                 "replyToInitialPing": {
-                    "state": "enabled"
+                    "state": "disabled"
                 },
                 "useBlobDownloadsMessageListener": {
-                    "state": "enabled"
+                    "state": "disabled"
                 },
                 "sendMessageOnContexMenuOpened": {
-                    "state": "enabled"
+                    "state": "disabled"
                 },
                 "sendMessageOnPageStarted": {
                     "state": "disabled"
                 },
                 "sendMessagesUsingReplyProxy": {
-                    "state": "enabled"
+                    "state": "disabled"
                 }
             }
         }


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1211991524308488/task/1211978539187493?focus=true

## Description
Disable flags for WebVewCompat testing

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [x] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Disables `webViewCompat` and all its subfeatures in `overrides/android-override.json`.
> 
> - **Android config (`overrides/android-override.json`)**:
>   - **Disable `webViewCompat`**:
>     - Set `state` to `disabled`.
>     - Disable subfeatures: `jsSendsInitialPing`, `jsRepliesToNativeMessages`, `replyToInitialPing`, `useBlobDownloadsMessageListener`, `sendMessageOnContexMenuOpened`, `sendMessagesUsingReplyProxy` (and keep `sendMessageOnPageStarted` disabled).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1cb59e16bb96aa90a679c25177be57f962ca2ccd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->