### PR TITLE
Windows browser: Enabled service_worker watchdog service on Preview

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -2763,6 +2763,9 @@
                             }
                         ]
                     }
+                },
+                "serviceWorkerWatchdog": {
+                    "state": "preview"
                 }
             },
             "exceptions": []


### PR DESCRIPTION
**Asana Task/Github Issue:** 

https://app.asana.com/1/137249556945/project/1207414201589134/task/1211898170055682?focus=true

## Description

- Enabled service_worker watchdog service on Preview, to validate this reduced page load hangs.
- This feature monitors service_worker hangs, and kicks them into action after 2 seconds if hang is detected.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [x] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables the `serviceWorkerWatchdog` feature in `overrides/windows-override.json` under `features.webview` with state `preview`.
> 
> - **Windows config (`overrides/windows-override.json`)**:
>   - **Webview features**:
>     - Add `serviceWorkerWatchdog` with state `preview`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 55a779da53a0782fba787ab6fd588fbd9a812e7b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->