### PR TITLE
[Autofill] exception for checkout.pci.shopifyinc.com on windows

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -1324,6 +1324,12 @@
         },
         "autofill": {
             "state": "enabled",
+            "exceptions": [
+                {
+                    "domain": "checkout.pci.shopifyinc.com",
+                    "reason": "Some shopify cc inputs cause jumpy scroll behavior. See https://app.asana.com/1/137249556945/project/1201048563534612/task/1211981991454055?focus=true"
+                }
+            ],
             "features": {
                 "autofillPopupReuse": {
                     "state": "enabled",

--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -1326,7 +1326,7 @@
             "state": "enabled",
             "exceptions": [
                 {
-                    "domain": "checkout.pci.shopifyinc.com",
+                    "domain": "https://bakedjustsweet.com/checkout/*",
                     "reason": "Some shopify cc inputs cause jumpy scroll behavior. See https://app.asana.com/1/137249556945/project/1201048563534612/task/1211981991454055?focus=true"
                 }
             ],


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1201048563534612/task/1211981991454055?focus=true

## Description
Jumpy scrolling issue on Shopify check out page - probably best to disable autofill on this specific shopify domain for now, while we look for a real fix.

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [x] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds an autofill exception on Windows for `https://bakedjustsweet.com/checkout/*` (Shopify) to mitigate jumpy scrolling on credit card inputs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d0c8cd15f513715456c12714905163b3044ff9e2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->