### PR TITLE
Disable CPM on rubgyrama.fr (Pay or OK)

### DIFF
--- a/features/autoconsent.json
+++ b/features/autoconsent.json
@@ -706,6 +706,10 @@
         {
             "domain": "brocardi.it",
             "reason": "https://github.com/duckduckgo/privacy-configuration/pull/4088"
+        },
+        {
+            "domain": "rugbyrama.fr",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/pull/4101"
         }
     ],
     "settings": {


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1206670747178362/task/1211988649876337?focus=true

## Description
rubgyrama.fr has a pay or ok wall. The current didomi rule was clicking the subscribe button, sending users directly to the subscription page. Let's disable CPM here so users can decide if they'd prefer to accept cookies.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `rugbyrama.fr` to autoconsent exceptions to disable CMP handling.
> 
> - **Autoconsent**:
>   - **Site exception**: Add `rugbyrama.fr` to `features/autoconsent.json` with reason link to PR 4101, disabling CMP handling for that domain.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6ee34d55e60bf12f9a0fc6b2ec99ce5e0bd78eb9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->