### PR TITLE
Remove id-onfido-com duplicate

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -2767,10 +2767,6 @@
                     "reason": "experimental mitigation for unreproduced issue as description corresponds to similar breakage"
                 },
                 {
-                    "domain": "id.onfido.com",
-                    "reason": "Camera capture doesn't work for id verification"
-                },
-                {
                     "domain": "thrifty.com",
                     "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2527"
                 },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1206670747178362/task/1211995050031191?focus=true

## Description
<!-- 
  Please delete either or both process sections below.
-->

### Site breakage mitigation process:
#### Brief explanation
- Reported URL: id.onfido.com
- Problems experienced: None, saw a duplicate, removing it
- Platforms affected:
  - [ ] iOS
  - [ x] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked: NA
- Feature being disabled/modified: 
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes a duplicate `id.onfido.com` entry from `overrides/android-override.json` media playback exceptions, retaining the remaining entry.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 593b24442fdf12605ce50e188d16754444e1493a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->