### PR TITLE
Reverting speculative exception for paypal.com

### DIFF
--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -1157,13 +1157,9 @@
                     {
                         "rule": "datadoghq-browser-agent.com",
                         "domains": [
-                            "indeed.com",
-                            "paypal.com"
+                            "indeed.com"
                         ],
-                        "reason": [
-                            "indeed.com - https://github.com/duckduckgo/privacy-configuration/issues/2163",
-                            "paypal.com - https://github.com/duckduckgo/privacy-configuration/pull/4069"
-                        ]
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/issues/2163"
                     }
                 ]
             },


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/1200277586140538/task/1211919491192201?focus=true

## Description
### Site breakage mitigation process:
#### Brief explanation
- Reported URL: https://www.paypal.com
- Problems experienced: Tried to mitigate a suspected checkout issue but no effect, so reverting it. See https://github.com/duckduckgo/privacy-configuration/pull/4069
- Platforms affected:
  - [X] iOS
  - [X] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked: N/A
- Feature being disabled/modified: N/A
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes the `paypal.com` exception from `datadoghq-browser-agent.com` allowlist, keeping `indeed.com` and normalizing the reason format.
> 
> - **Tracker allowlist updates (`features/tracker-allowlist.json`)**:
>   - Remove `paypal.com` from `datadoghq-browser-agent.com` rule (retain `indeed.com`).
>   - Simplify `reason` from array to single URL (`issues/2163`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f16175cebebb010445221bc1bbbeebc2acfa617f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->