### PR TITLE
Broaden pub.network exception for pc-builds.com

### DIFF
--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -3721,7 +3721,7 @@
                         "reason": "https://github.com/duckduckgo/privacy-configuration/pull/3501"
                     },
                     {
-                        "rule": "a.pub.network/pc-builds-com/pubfig.min.js",
+                        "rule": "pub.network/",
                         "domains": [
                             "pc-builds.com"
                         ],


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1206670747178362/task/1211961644821369?focus=true

## Description
#4092 Wasn't sufficient to disable the adblock wall, it looks like we need a broader exception for pub.network.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Expands the `pub.network` allowlist for `pc-builds.com` from a specific script (`a.pub.network/pc-builds-com/pubfig.min.js`) to all paths (`pub.network/`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 829929a147826b317d1511a44cac4f862342b095. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->