### PR TITLE
keep re-enabling rules on macos (3)

### DIFF
--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -578,8 +578,6 @@
                     "cookie-notice",
                     "notice-cookie",
                     "amazon.com",
-                    "adopt",
-                    "anthropic",
                     "abconcerts.be",
                     "amex",
                     "aquasana.com",


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/30173902528854/task/1211834508118316?focus=true

## Description
<!-- 
  Please delete either or both process sections below.
-->

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adjusts the macOS `disabledCMPs` list by removing several entries and adding new ones (e.g., `amazon.com`, `abconcerts.be`, `amex`, `aquasana.com`, `automattic-cmp-optout`).
> 
> - **Config (macOS overrides)**:
>   - Update `settings.disabledCMPs` in `overrides/macos-override.json`:
>     - Add: `amazon.com`, `abconcerts.be`, `amex`, `aquasana.com`, `automattic-cmp-optout`.
>     - Remove multiple prior entries (e.g., `aws.amazon.com`, `axeptio`, `borlabs`, `bing.com`, etc.).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 86237582ba381587b7cf0bf5e01bacd0b74d74f3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->