### PR TITLE
disable CPM (only) on amazon.com on macos

### DIFF
--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -577,11 +577,7 @@
                     "healthline-media",
                     "cookie-notice",
                     "notice-cookie",
-                    "amazon.com",
-                    "abconcerts.be",
-                    "amex",
-                    "aquasana.com",
-                    "automattic-cmp-optout"
+                    "amazon.com"
                 ],
                 "filterlistExceptions": [],
                 "compactRuleList": {


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/30173902528854/task/1211834508118316?focus=true

## Description
<!-- 
  Please delete either or both process sections below.
-->

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> MacOS override now disables CMP only for amazon.com, removing other entries from settings.disabledCMPs.
> 
> - **MacOS privacy config**:
>   - Update `overrides/macos-override.json`: `settings.disabledCMPs` now only includes `amazon.com` (removed `abconcerts.be`, `amex`, `aquasana.com`, `automattic-cmp-optout`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 87a7b4be27d948b7d357962b2f9d1e135707b99e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->