### PR TITLE
Hide empty ad footer space on modernhoney.com

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -2597,6 +2597,10 @@
                     {
                         "selector": ".adthrive",
                         "type": "override"
+                    },
+                    {
+                        "selector": ".adthrive-footer",
+                        "type": "hide-empty"
                     }
                 ]
             },


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/1206670747178362/task/1211531480905366?focus=true

## Description
### Site breakage mitigation process:
#### Brief explanation
- Reported URL: https://www.modernhoney.com/the-best-chocolate-chip-cookies/
- Problems experienced: Empty white footer.
- Platforms affected:
  - [x] iOS
  - [x] Android
  - [x] Windows
  - [x] MacOS
  - [x] Extensions
- Tracker(s) being unblocked: N/A
- Feature being disabled/modified: N/A
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a domain rule to hide empty `.adthrive-footer` on `modernhoney.com`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cf8710b1616f40e6c9729983e578c85e9f2057cb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->