### PR TITLE
Add popup blocking configuration for macOS

### DIFF
--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -1816,6 +1816,13 @@
                     }
                 ]
             }
+        },
+        "popupBlocking": {
+            "state": "internal",
+            "exceptions": [],
+            "settings": {
+                "userInitiatedPopupThreshold": 6.0
+            }
         }
     },
     "unprotectedTemporary": []


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1199230911884351/task/1211371141963410?focus=true
Tech Design URL: https://app.asana.com/1/137249556945/project/481882893211075/task/1211803987794914?focus=true

- Add popup-blocking.json feature file with base configuration
- Add macOS override with enabled popup blocking subfeatures:
  - extendedUserInitiatedPopupTimeout
  - suppressEmptyPopUpsOnApproval
  - allowPopupsForCurrentPage
  - popupPermissionButtonPersistence
- Configure userInitiatedPopupThreshold to 6.0 seconds
- Add allowListDomains for common social media and content sites

**Asana Task/Github Issue:**

## Description
<!-- 
  Please delete either or both process sections below.
-->

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add macOS popup blocking override with a 6.0s user-initiated popup threshold.
> 
> - **macOS overrides (`overrides/macos-override.json`)**:
>   - **Popup blocking**: add `features.popupBlocking` (state: `internal`) with `settings.userInitiatedPopupThreshold` set to `6.0` seconds and no exceptions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1d10ef078f4bfa6425c3195f13bd6c59406457ca. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->