### PR TITLE
Disable CPM on mypremiercreditcard.com

### DIFF
--- a/features/autoconsent.json
+++ b/features/autoconsent.json
@@ -706,6 +706,10 @@
         {
             "domain": "rugbyrama.fr",
             "reason": "https://github.com/duckduckgo/privacy-configuration/pull/4101"
+        },
+        {
+            "domain": "mypremiercreditcard.com",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/pull/4122"
         }
     ],
     "settings": {


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1206670747178362/task/1212011456533034?focus=true

## Description
On https://connect.mypremiercreditcard.com/auth/login, when the user rejects consent, the consent status is cleared and the site reloaded. With CPM enabled, this leads to an infinite reload loop.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Disable autoconsent for `mypremiercreditcard.com` by adding a domain exception.
> 
> - **Autoconsent config** (`features/autoconsent.json`):
>   - Add domain exception for `mypremiercreditcard.com` with reference to PR `#4122` to disable autoconsent behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ff6cda6d05da00f5a146ff9e8fb8ab3bcf47ac79. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->