### PR TITLE
Add StartupBoost's `startInForeground`

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -1323,7 +1323,7 @@
             "exceptions": [],
             "state": "enabled",
             "features": {
-                "startupBoostStartInForeground": {
+                "startInForeground": {
                     "state": "internal"
                 }
             }


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/task/1211941333629267

## Description

Enable internally for now.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [x] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `features.startInForeground` (state: `internal`) and initializes `exceptions: []` under `windowsStartupBoost` in `overrides/windows-override.json`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 220e9c71235b2b6c5a663bf6b4a6ad933d8b9a62. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->