### PR TITLE
Updates pinnedTabsViewRewrite minSupportedVersion to 1.166.0

### DIFF
--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -1757,7 +1757,8 @@
                     "state": "enabled"
                 },
                 "pinnedTabsViewRewrite": {
-                    "state": "enabled"
+                    "state": "enabled",
+                    "minSupportedVersion": "1.166.0"
                 }
             }
         },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1201048563534612/task/1212071886074882?focus=true

## Description
This PR updates the pinnedTabsViewRewrite minimum supported version to 1.166.0

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [x] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Sets `minSupportedVersion` to `1.166.0` for `macOSBrowserConfig` → `pinnedTabsViewRewrite` in `overrides/macos-override.json`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit af304950c30696f992fddea3c591bf6177aa25ca. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->