### PR TITLE
Add disabled feature flag for addressBarTrackerAnimation

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -2842,7 +2842,8 @@
             "minSupportedVersion": "0.100.0"
         },
         "addressBarTrackerAnimation": {
-            "state": "disabled"
+            "state": "disabled",
+            "exceptions": []
         },
         "fullScreenMode": {
             "state": "enabled",


### PR DESCRIPTION
**Asana Task/Github Issue:** [Create and integrate feature flag](https://app.asana.com/1/137249556945/project/1209292120581622/task/1212008709808457?focus=true)

## Description
Added a new feature flag `addressBarTrackerAnimation` to control whether the current or a new tracker blocking animation is shown in the address bar.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a new disabled feature flag `addressBarTrackerAnimation` in `overrides/windows-override.json`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f619a47d50fbc422ff4b89885a76c30033ed8a59. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->