### PR TITLE
Disable hwAccelerationExperiment

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -3101,7 +3101,7 @@
             }
         },
         "hwAccelerationExperiment": {
-            "state": "enabled",
+            "state": "disabled",
             "features": {
                 "disableHwAccelerationOnRenderCrash": {
                     "state": "disabled",
@@ -3117,7 +3117,7 @@
                     }
                 },
                 "disableHwAccelerationExperimentGroup": {
-                    "state": "enabled",
+                    "state": "disabled",
                     "cohorts": [
                         {
                             "name": "groupCom",
@@ -3130,7 +3130,7 @@
                     ]
                 },
                 "disableHwAccelerationOnRenderCrashCom": {
-                    "state": "enabled",
+                    "state": "disabled",
                     "cohorts": [
                         {
                             "name": "controlCom",
@@ -3143,7 +3143,7 @@
                     ]
                 },
                 "disableHwAccelerationOnRenderCrashOom": {
-                    "state": "enabled",
+                    "state": "disabled",
                     "cohorts": [
                         {
                             "name": "controlOom",


### PR DESCRIPTION
**Asana Task/Github Issue:** [Turn off Separate HW Acceleration Experiment (both groups)](https://app.asana.com/1/137249556945/task/1212067994337742)

## Description
Turning off the HW Acceleration Experiment.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [x] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [x] This feature was covered by a tech design.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Disables the Windows HW Acceleration experiment and all related subfeatures/cohorts in `overrides/windows-override.json`.
> 
> - **Config (Windows overrides)**
>   - Disable `features.hwAccelerationExperiment.state`.
>   - Turn off subfeatures in `hwAccelerationExperiment.features`:
>     - `disableHwAccelerationOnRenderCrash`
>     - `disableHwAccelerationExperimentGroup`
>     - `disableHwAccelerationOnRenderCrashCom`
>     - `disableHwAccelerationOnRenderCrashOom`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 58d34650411ab5f1c096a187b6d6c54e21528d87. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->