### PR TITLE
Disable Cookie Prompt Management (CPM) for ciwf.nl

### DIFF
--- a/features/autoconsent.json
+++ b/features/autoconsent.json
@@ -710,6 +710,10 @@
         {
             "domain": "mypremiercreditcard.com",
             "reason": "https://github.com/duckduckgo/privacy-configuration/pull/4122"
+        },
+        {
+            "domain": "ciwf.nl",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/pull/4133"
         }
     ],
     "settings": {


### PR DESCRIPTION
Users are unable to scroll down on this page[1], which seems to be somehow
related to CPM. Let's disable CPM for the website for now, while we work on a
fix.

1. https://www.ciwf.nl/nieuws/10-fascinerende-feiten-over-de-kip/

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Disable Cookie Prompt Management for ciwf.nl by adding a site exception in `features/autoconsent.json`.
> 
> - **Privacy Configuration**:
>   - **Autoconsent**: Add site exception in `features/autoconsent.json` to disable Cookie Prompt Management for `ciwf.nl`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 04bafd34e5309c9d5ef39abacbe9b0408e2cdd43. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->