### PR TITLE
Enable showHideAiGeneratedImages for aiChat

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -163,6 +163,9 @@
                     "state": "enabled",
                     "description": "Toggle Choice Screen during onboarding",
                     "minSupportedVersion": "7.197.0"
+                },
+                "showHideAiGeneratedImages": {
+                    "state": "enabled"
                 }
             },
             "settings": {

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -265,6 +265,9 @@
                 },
                 "standaloneMigration": {
                     "state": "disabled"
+                },
+                "showHideAiGeneratedImages": {
+                    "state": "enabled"
                 }
             },
             "settings": {


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/1204006570077678/task/1212075266782985?focus=true

## Description
Enable `showHideAiGeneratedImages` feature flag for both macOS and iOS

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [x] iOS
  - [ ] Android
  - [ ] Windows
  - [x] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enable the `showHideAiGeneratedImages` feature flag for AI Chat on iOS and macOS.
> 
> - **AI Chat**:
>   - **iOS**: Add `showHideAiGeneratedImages` feature flag (enabled) in `overrides/ios-override.json` under `features.aiChat.features`.
>   - **macOS**: Add `showHideAiGeneratedImages` feature flag (enabled) in `overrides/macos-override.json` under `features.aiChat.features`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9cb4ebf6a418957339bef49de6514e484a40f10c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->