### PR TITLE
Turn on Black Friday offer, Turn off win-back offer

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -1467,7 +1467,7 @@
                     "minSupportedVersion": "7.181.0"
                 },
                 "winBackOffer": {
-                    "state": "enabled",
+                    "state": "disabled",
                     "minSupportedVersion": "7.195.0",
                     "targets": [
                         {
@@ -1476,7 +1476,7 @@
                     ]
                 },
                 "blackFridayCampaign": {
-                    "state": "disabled",
+                    "state": "enabled",
                     "targets": [
                         {
                             "localeCountry": "US"

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -1634,7 +1634,7 @@
                     "minSupportedVersion": "1.153.0"
                 },
                 "winBackOffer": {
-                    "state": "enabled",
+                    "state": "disabled",
                     "minSupportedVersion": "1.165.0",
                     "targets": [
                         {
@@ -1643,7 +1643,7 @@
                     ]
                 },
                 "blackFridayCampaign": {
-                    "state": "disabled",
+                    "state": "enabled",
                     "targets": [
                         {
                             "localeCountry": "US"


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1202552961248957/task/1211580424218790

## Description
* As part of the Black Friday promotion, this will turn on the Black Friday campaign, and turn off the win-back offer.
* To be merged on Nov 28.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [x] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [x] iOS
  - [ ] Android
  - [ ] Windows
  - [x] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Turns on `blackFridayCampaign` and turns off `winBackOffer` (US target) in `overrides/ios-override.json` and `overrides/macos-override.json`.
> 
> - **Promotions (feature toggles)**:
>   - **iOS (`overrides/ios-override.json`)**:
>     - `privacyPro.features.winBackOffer.state`: `enabled` → `disabled` (min `7.195.0`, US)
>     - `privacyPro.features.blackFridayCampaign.state`: `disabled` → `enabled` (US, `discountPercent: "40"`)
>   - **macOS (`overrides/macos-override.json`)**:
>     - `privacyPro.features.winBackOffer.state`: `enabled` → `disabled` (min `1.165.0`, US)
>     - `privacyPro.features.blackFridayCampaign.state`: `disabled` → `enabled` (US, `discountPercent: "40"`)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 68ed4adb11d307f24c87f5dbed667557d9ff78ff. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->