### PR TITLE
Android: Disable useUrlPredictor

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -1231,6 +1231,9 @@
         "androidBrowserConfig": {
             "state": "enabled",
             "features": {
+                "useUrlPredictor": {
+                    "state": "disabled"
+                },
                 "collectFullWebViewVersion": {
                     "state": "enabled"
                 },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1202552961248957/task/1212197001176944?focus=true

## Description

- Disables `useUrlPredictor`.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [x] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Disables `androidBrowserConfig.features.useUrlPredictor` on Android.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1beaa1f94df30879bd06fbbdb0b70ed4de74c9d9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->