### PR TITLE
Enable serviceWorkerWatchdog for non-preview users as well

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -2790,7 +2790,7 @@
                     }
                 },
                 "serviceWorkerWatchdog": {
-                    "state": "preview"
+                    "state": "enabled"
                 }
             },
             "exceptions": []


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1207414201589134/task/1211898170055682?focus=true

## Description

- Enabled the service_worker watchdog (feature to kick stuck service_workers into action) for non-Preview channel users as well

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [x] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables `serviceWorkerWatchdog` by changing its state from `preview` to `enabled` in `overrides/windows-override.json`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1a1615a3c53e2d439217d1fcc3f4a07867d5f557. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->