### PR TITLE
Hide empty spaces on 01net.com

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -4434,6 +4434,19 @@
                         "type": "hide-empty"
                     }
                 ]
+            },
+            {
+                "domain": "01net.com",
+                "rules": [
+                    {
+                        "type": "hide-empty",
+                        "selector": ".od-wrapper"
+                    },
+                    {
+                        "type": "hide-empty",
+                        "selector": "div[data-openweb-ad]"
+                    }
+                ]
             }
         ]
     }


### PR DESCRIPTION
There are some empty spaces left on 01net.com left over (I assume) from tracker
blocking. Let's collapse those now to improve the UX.

**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1206670747178362/task/1212154652791977?focus=true

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds element-hiding rules for `01net.com` to hide empty `.od-wrapper` and `div[data-openweb-ad]` containers.
> 
> - **Element Hiding Configuration (`features/element-hiding.json`)**:
>   - **Domain `01net.com`**:
>     - Add `hide-empty` for `.od-wrapper`.
>     - Add `hide-empty` for `div[data-openweb-ad]`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5f4bfe95f2218253150b690323fd110acd6330a9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->