### PR TITLE
Enable webViewCompat with complex script and full communication capabilities

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -3401,32 +3401,40 @@
             }
         },
         "webViewCompat": {
-            "state": "disabled",
+            "state": "enabled",
             "exceptions": [],
             "settings": {
                 "jsInitialPingDelay": 0,
-                "initialPingDelay": 0
+                "initialPingDelay": 0,
+                "numberOfScriptsToInject": 1
             },
+            "minSupportedVersion": 52580000,
             "features": {
                 "jsSendsInitialPing": {
-                    "state": "disabled"
+                    "state": "enabled"
                 },
                 "jsRepliesToNativeMessages": {
-                    "state": "disabled"
+                    "state": "enabled"
                 },
                 "replyToInitialPing": {
-                    "state": "disabled"
+                    "state": "enabled"
                 },
                 "useBlobDownloadsMessageListener": {
-                    "state": "disabled"
+                    "state": "enabled"
                 },
                 "sendMessageOnContexMenuOpened": {
-                    "state": "disabled"
+                    "state": "enabled"
                 },
                 "sendMessageOnPageStarted": {
                     "state": "disabled"
                 },
                 "sendMessagesUsingReplyProxy": {
+                    "state": "enabled"
+                },
+                "useComplexScript": {
+                    "state": "enabled"
+                },
+                "useLargeScript": {
                     "state": "disabled"
                 }
             }


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1211991524308488/task/1211977634333915?focus=true

## Description
Enable webViewCompat with complex script and full communication capabilities

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [x] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables `webViewCompat` on Android with min version gating, adds script injection setting, and turns on full JS-native messaging and complex script features.
> 
> - **Android config (`overrides/android-override.json`)**:
>   - **`webViewCompat`**:
>     - State: `enabled` (was `disabled`); `minSupportedVersion`: `52580000`.
>     - Settings: add `numberOfScriptsToInject: 1`; keep `jsInitialPingDelay`/`initialPingDelay` at `0`.
>     - Features enabled: `jsSendsInitialPing`, `jsRepliesToNativeMessages`, `replyToInitialPing`, `useBlobDownloadsMessageListener`, `sendMessageOnContexMenuOpened`, `sendMessagesUsingReplyProxy`, `useComplexScript`.
>     - Features unchanged: `sendMessageOnPageStarted: disabled`, `useLargeScript: disabled`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bf406ffa7ffb234ca47f41e24ae85e0a99b07085. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->