### PR TITLE
Add webNotifications feature for macOS

### DIFF
--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -696,8 +696,7 @@
                             }
                         ]
                     }
-                ],
-                "conditionalChanges": []
+                ]
             }
         },
         "autoconsent": {


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/72649045549333/task/1212732938251869?focus=true

## Description
<!-- 
  Please delete either or both process sections below.
-->

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables native web notifications on macOS and removes legacy experiment gating.
> 
> - Adds `webNotifications` to `webCompat` settings with `state: "enabled"` and `nativeEnabled: true`
> - Introduces `webNotifications` under `macOSBrowserConfig` with `state: "internal"`
> - Removes `webNotificationsFixExperiment` and its `conditionalChanges` in `webCompat`, simplifying rollout logic
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit df73a02f34cd7a22f5dc9c6b1768bb1b0832b31b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->