### PR TITLE
Workaround redirect-loop issue on cnbc.com

### DIFF
--- a/features/cookie.json
+++ b/features/cookie.json
@@ -66,6 +66,10 @@
         {
             "domain": "duckduckgo.com",
             "reason": "Prevent expiry of SERP settings"
+        },
+        {
+            "domain": "cnbc.com",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/pull/4151"
         }
     ]
 }


### PR DESCRIPTION
There is an issue today on cnbc.com which causes the page to reload after the
"Reject All" button is clicked in the cookie prompt. When combined with Cookie
Prompt Management (CPM) that automatically clicks that button, users were seeing
the page reload over and over again. Let's work around the issue for now.

**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1206670747178362/task/1212198592317702?focus=true

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add `cnbc.com` to cookie exceptions in `features/cookie.json`.
> 
> - **Cookies**:
>   - Add `cnbc.com` to `features/cookie.json` `exceptions` to bypass cookie restrictions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 80fbeab98dbb0f4d212e31fbd8b02a6d8804c67b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->