### PR TITLE
Revert complex script test

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -3409,38 +3409,37 @@
             }
         },
         "webViewCompat": {
-            "state": "enabled",
+            "state": "disabled",
             "exceptions": [],
             "settings": {
                 "jsInitialPingDelay": 0,
                 "initialPingDelay": 0,
                 "numberOfScriptsToInject": 1
             },
-            "minSupportedVersion": 52580000,
             "features": {
                 "jsSendsInitialPing": {
-                    "state": "enabled"
+                    "state": "disabled"
                 },
                 "jsRepliesToNativeMessages": {
-                    "state": "enabled"
+                    "state": "disabled"
                 },
                 "replyToInitialPing": {
-                    "state": "enabled"
+                    "state": "disabled"
                 },
                 "useBlobDownloadsMessageListener": {
-                    "state": "enabled"
+                    "state": "disabled"
                 },
                 "sendMessageOnContexMenuOpened": {
-                    "state": "enabled"
+                    "state": "disabled"
                 },
                 "sendMessageOnPageStarted": {
                     "state": "disabled"
                 },
                 "sendMessagesUsingReplyProxy": {
-                    "state": "enabled"
+                    "state": "disabled"
                 },
                 "useComplexScript": {
-                    "state": "enabled"
+                    "state": "disabled"
                 },
                 "useLargeScript": {
                     "state": "disabled"


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/task/1212218460154885?focus=true

## Description
Revert complex script test

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Disables `webViewCompat` and turns off its subfeatures, removing its `minSupportedVersion` in `overrides/android-override.json`.
> 
> - **Android overrides (`overrides/android-override.json`)**:
>   - **`webViewCompat`**:
>     - Set `state` to `disabled`.
>     - Disabled feature flags: `jsSendsInitialPing`, `jsRepliesToNativeMessages`, `replyToInitialPing`, `useBlobDownloadsMessageListener`, `sendMessageOnContexMenuOpened`, `sendMessagesUsingReplyProxy`, `useComplexScript`.
>     - Removed `minSupportedVersion`.
>     - `sendMessageOnPageStarted` and `useLargeScript` remain `disabled`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c5a5e4df9dc7de61893d6f7848fd6de80d318055. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->