### PR TITLE
Hide empty space on msn.com

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -4447,6 +4447,15 @@
                         "selector": "div[data-openweb-ad]"
                     }
                 ]
+            },
+            {
+                "domain": "msn.com",
+                "rules": [
+                    {
+                        "type": "hide-empty",
+                        "selector": ".consumption-page-banner-ad"
+                    }
+                ]
             }
         ]
     }


### PR DESCRIPTION
When viewing articles, if the top banner advert doesn't load it leaves a large
empty space. That seems to be giving the impression to users that the page
hasn't finished loading, causing them to refresh repeatedly trying to load the
article. Let's collapse the element in question when it's empty.

**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1200277586140538/task/1212216051654334?focus=true

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a domain rule for `msn.com` to hide empty `.consumption-page-banner-ad` elements, collapsing empty banner space.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3a979d911d66f83f0d849fe222d7df512e367111. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->