### PR TITLE
Test multiple complex scripts with messaging

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -3409,37 +3409,38 @@
             }
         },
         "webViewCompat": {
-            "state": "disabled",
+            "state": "enabled",
             "exceptions": [],
             "settings": {
                 "jsInitialPingDelay": 0,
                 "initialPingDelay": 0,
-                "numberOfScriptsToInject": 1
+                "numberOfScriptsToInject": 10
             },
+            "minSupportedVersion": 52580000,
             "features": {
                 "jsSendsInitialPing": {
-                    "state": "disabled"
+                    "state": "enabled"
                 },
                 "jsRepliesToNativeMessages": {
-                    "state": "disabled"
+                    "state": "enabled"
                 },
                 "replyToInitialPing": {
-                    "state": "disabled"
+                    "state": "enabled"
                 },
                 "useBlobDownloadsMessageListener": {
-                    "state": "disabled"
+                    "state": "enabled"
                 },
                 "sendMessageOnContexMenuOpened": {
-                    "state": "disabled"
+                    "state": "enabled"
                 },
                 "sendMessageOnPageStarted": {
                     "state": "disabled"
                 },
                 "sendMessagesUsingReplyProxy": {
-                    "state": "disabled"
+                    "state": "enabled"
                 },
                 "useComplexScript": {
-                    "state": "disabled"
+                    "state": "enabled"
                 },
                 "useLargeScript": {
                     "state": "disabled"


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1211991524308488/task/1211963296480302?focus=true

## Description
Stress test single message listener approach

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [x] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables `webViewCompat` on Android with multiple messaging features, sets `minSupportedVersion` to 52580000, and raises `numberOfScriptsToInject` to 10.
> 
> - **Android config (`overrides/android-override.json`)**:
>   - **`webViewCompat`**:
>     - State: `enabled` (was `disabled`)
>     - Settings: `numberOfScriptsToInject` → `10` (from `1`); `jsInitialPingDelay` and `initialPingDelay` unchanged; add `minSupportedVersion: 52580000`.
>     - Features enabled: `jsSendsInitialPing`, `jsRepliesToNativeMessages`, `replyToInitialPing`, `useBlobDownloadsMessageListener`, `sendMessageOnContexMenuOpened`, `sendMessagesUsingReplyProxy`, `useComplexScript`.
>     - Features unchanged/disabled: `sendMessageOnPageStarted` (disabled), `useLargeScript` (disabled).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 27918f927fde1f6034c942d2011a3dff94d3c349. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->