### PR TITLE
Revert "Test multiple complex scripts with messaging (#4159)"

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -3409,38 +3409,37 @@
             }
         },
         "webViewCompat": {
-            "state": "enabled",
+            "state": "disabled",
             "exceptions": [],
             "settings": {
                 "jsInitialPingDelay": 0,
                 "initialPingDelay": 0,
-                "numberOfScriptsToInject": 10
+                "numberOfScriptsToInject": 1
             },
-            "minSupportedVersion": 52580000,
             "features": {
                 "jsSendsInitialPing": {
-                    "state": "enabled"
+                    "state": "disabled"
                 },
                 "jsRepliesToNativeMessages": {
-                    "state": "enabled"
+                    "state": "disabled"
                 },
                 "replyToInitialPing": {
-                    "state": "enabled"
+                    "state": "disabled"
                 },
                 "useBlobDownloadsMessageListener": {
-                    "state": "enabled"
+                    "state": "disabled"
                 },
                 "sendMessageOnContexMenuOpened": {
-                    "state": "enabled"
+                    "state": "disabled"
                 },
                 "sendMessageOnPageStarted": {
                     "state": "disabled"
                 },
                 "sendMessagesUsingReplyProxy": {
-                    "state": "enabled"
+                    "state": "disabled"
                 },
                 "useComplexScript": {
-                    "state": "enabled"
+                    "state": "disabled"
                 },
                 "useLargeScript": {
                     "state": "disabled"


### PR DESCRIPTION
This reverts commit 4ae34ab1c980e1d96ddd19939b38f83314863682.

**Asana Task/Github Issue:**

## Description
Revert "Test multiple complex scripts with messaging (#4159)"

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [x] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Disables `webViewCompat` on Android, turns off all related messaging/script features, and reduces injected scripts to 1.
> 
> - **Android overrides (`overrides/android-override.json`)**:
>   - **`webViewCompat`**
>     - `state`: `enabled` -> `disabled`
>     - `settings.numberOfScriptsToInject`: `10` -> `1`
>     - `features`
>       - `jsSendsInitialPing`: `enabled` -> `disabled`
>       - `jsRepliesToNativeMessages`: `enabled` -> `disabled`
>       - `replyToInitialPing`: `enabled` -> `disabled`
>       - `useBlobDownloadsMessageListener`: `enabled` -> `disabled`
>       - `sendMessageOnContexMenuOpened`: `enabled` -> `disabled`
>       - `sendMessagesUsingReplyProxy`: `enabled` -> `disabled`
>       - `useComplexScript`: `enabled` -> `disabled`
>       - `sendMessageOnPageStarted`: remains `disabled`
>       - `useLargeScript`: remains `disabled`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 895630358faa39daf0d89106dae49649a585955f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->