### PR TITLE
Hide blank space on moviewalker.jp

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -2622,6 +2622,19 @@
                 ]
             },
             {
+                "domain": "moviewalker.jp",
+                "rules": [
+                    {
+                        "selector": "#mw_all_bb_gam",
+                        "type": "closest-empty"
+                    },
+                    {
+                        "selector": "#mw_all_1r_gam",
+                        "type": "closest-empty"
+                    }
+                ]
+            },
+            {
                 "domain": "n1info.si",
                 "rules": [
                     {


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/1200277586140538/task/1212223325430667?focus=true

## Description
### Site breakage mitigation process:
#### Brief explanation
- Reported URL: https://press.moviewalker.jp/list/
- Problems experienced: Big blank space above the fold.
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [x] Windows
  - [x] MacOS
  - [x] Extensions
- Tracker(s) being unblocked: N/A
- Feature being disabled/modified: N/A
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add element-hiding rules on moviewalker.jp to collapse `#mw_all_bb_gam` and `#mw_all_1r_gam` empty ad containers.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 19ab18926668547ec5de35afa2bf4513b643b86f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->