### PR TITLE
Set onboardingSearchExperience to internal

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -160,7 +160,7 @@
                     "state": "disabled"
                 },
                 "onboardingSearchExperience": {
-                    "state": "disabled",
+                    "state": "internal",
                     "description": "Toggle Choice Screen during onboarding",
                     "minSupportedVersion": "7.197.0"
                 },


### PR DESCRIPTION
**Asana Task/Github Issue:**

## Description
See https://app.asana.com/1/137249556945/project/1211654189969294/task/1212237432932966?focus=true.
Sets `onboardingSearchExperience` to internal

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [x] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Marks `aiChat` onboarding choice screen (`onboardingSearchExperience`) as internal in iOS overrides.
> 
> - **iOS overrides** (`overrides/ios-override.json`):
>   - **`aiChat`**:
>     - Set `features.onboardingSearchExperience.state` from `enabled` to `internal`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 60f201817d95d891fea41c03cbd7983d6e7e8aa6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->