### PR TITLE
Disable webViewCompat

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -3428,38 +3428,38 @@
             }
         },
         "webViewCompat": {
-            "state": "enabled",
+            "state": "disabled",
             "exceptions": [],
             "settings": {
                 "jsInitialPingDelay": 0,
                 "initialPingDelay": 0,
-                "numberOfScriptsToInject": 20
+                "numberOfScriptsToInject": 1
             },
             "minSupportedVersion": 52580000,
             "features": {
                 "jsSendsInitialPing": {
-                    "state": "enabled"
+                    "state": "disabled"
                 },
                 "jsRepliesToNativeMessages": {
-                    "state": "enabled"
+                    "state": "disabled"
                 },
                 "replyToInitialPing": {
-                    "state": "enabled"
+                    "state": "disabled"
                 },
                 "useBlobDownloadsMessageListener": {
-                    "state": "enabled"
+                    "state": "disabled"
                 },
                 "sendMessageOnContexMenuOpened": {
-                    "state": "enabled"
+                    "state": "disabled"
                 },
                 "sendMessageOnPageStarted": {
                     "state": "disabled"
                 },
                 "sendMessagesUsingReplyProxy": {
-                    "state": "enabled"
+                    "state": "disabled"
                 },
                 "useComplexScript": {
-                    "state": "enabled"
+                    "state": "disabled"
                 },
                 "useLargeScript": {
                     "state": "disabled"


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/task/1212242065468755?focus=true

## Description
Disable webViewCompat

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [x] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Disables Android `webViewCompat`, turns off its subfeatures, and reduces `numberOfScriptsToInject` from 20 to 1.
> 
> - **Android Overrides**:
>   - **`features/webViewCompat`**:
>     - Set `state` to `disabled`.
>     - Settings: reduce `numberOfScriptsToInject` from `20` to `1` (keep `jsInitialPingDelay` and `initialPingDelay` at `0`).
>     - Features: disable `jsSendsInitialPing`, `jsRepliesToNativeMessages`, `replyToInitialPing`, `useBlobDownloadsMessageListener`, `sendMessageOnContexMenuOpened`, `sendMessagesUsingReplyProxy`, `useComplexScript` (others remain `disabled`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3348188b20ac16fc5e483afc65c88d81180e97f8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->