### PR TITLE
Re-enable initialPing with dedicated listener

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -3428,7 +3428,7 @@
             }
         },
         "webViewCompat": {
-            "state": "disabled",
+            "state": "enabled",
             "exceptions": [],
             "settings": {
                 "jsInitialPingDelay": 0,
@@ -3438,7 +3438,7 @@
             "minSupportedVersion": 52580000,
             "features": {
                 "jsSendsInitialPing": {
-                    "state": "disabled"
+                    "state": "enabled"
                 },
                 "jsRepliesToNativeMessages": {
                     "state": "disabled"


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1211991524308488/task/1212243705106356?focus=true

## Description
Re-enable initialPing with dedicated listener for extra validation 

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [\x] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables `features.webViewCompat` and its `jsSendsInitialPing` in `overrides/android-override.json`.
> 
> - **Android overrides** (`overrides/android-override.json`):
>   - **WebView compatibility**:
>     - Enable `features.webViewCompat` (`state: enabled`).
>     - Enable `features.webViewCompat.features.jsSendsInitialPing` (`state: enabled`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5e6e39b6e10cce690013e175dd0347eb1996d8ec. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->