### PR TITLE
[Apple] Turn off Black Friday campaign, enable win-back offer

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -1487,7 +1487,7 @@
                     "minSupportedVersion": "7.181.0"
                 },
                 "winBackOffer": {
-                    "state": "disabled",
+                    "state": "enabled",
                     "minSupportedVersion": "7.195.0",
                     "targets": [
                         {
@@ -1496,7 +1496,7 @@
                     ]
                 },
                 "blackFridayCampaign": {
-                    "state": "enabled",
+                    "state": "disabled",
                     "targets": [
                         {
                             "localeCountry": "US"

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -1637,7 +1637,7 @@
                     "minSupportedVersion": "1.153.0"
                 },
                 "winBackOffer": {
-                    "state": "disabled",
+                    "state": "enabled",
                     "minSupportedVersion": "1.165.0",
                     "targets": [
                         {
@@ -1646,7 +1646,7 @@
                     ]
                 },
                 "blackFridayCampaign": {
-                    "state": "enabled",
+                    "state": "disabled",
                     "targets": [
                         {
                             "localeCountry": "US"


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1210594645229050/task/1212047040557413

## Description
This PR turns off Black Friday campaign, and turns on the win-back offer for Apple platforms. Set to be merged on Dec 3, 2025, 9:00am CET

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [x] iOS
  - [ ] Android
  - [ ] Windows
  - [x] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Turns on the win-back offer and turns off the Black Friday campaign for US users on iOS and macOS.
> 
> - **Apple platform overrides**:
>   - **iOS (`overrides/ios-override.json`)**:
>     - `privacyPro.winBackOffer`: `enabled` (US target; `minSupportedVersion` unchanged).
>     - `privacyPro.blackFridayCampaign`: `disabled` (US target; `discountPercent` unchanged).
>   - **macOS (`overrides/macos-override.json`)**:
>     - `privacyPro.winBackOffer`: `enabled` (US target; `minSupportedVersion` unchanged).
>     - `privacyPro.blackFridayCampaign`: `disabled` (US target; `discountPercent` unchanged).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 68c815908635612ab0a878d2c6b564210d7b3a5d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->