### PR TITLE
Revert "Re-enable initialPing with dedicated listener (#4171)"

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -3428,7 +3428,7 @@
             }
         },
         "webViewCompat": {
-            "state": "enabled",
+            "state": "disabled",
             "exceptions": [],
             "settings": {
                 "jsInitialPingDelay": 0,
@@ -3438,7 +3438,7 @@
             "minSupportedVersion": 52580000,
             "features": {
                 "jsSendsInitialPing": {
-                    "state": "enabled"
+                    "state": "disabled"
                 },
                 "jsRepliesToNativeMessages": {
                     "state": "disabled"


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/task/1212243705106356?focus=true

## Description
Disable WebViewCompat changes 

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [x] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Disables Android `webViewCompat` and its `jsSendsInitialPing` feature in `overrides/android-override.json`.
> 
> - **Android overrides** (`overrides/android-override.json`):
>   - **WebViewCompat**:
>     - `state`: `enabled` → `disabled`
>     - `features.jsSendsInitialPing.state`: `enabled` → `disabled`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c1e726aea484707421b8d9c4d9be543add5e5f48. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->