### PR TITLE
Disable Cookie Prompt Management (CPM) for lucrin.com.au

### DIFF
--- a/features/autoconsent.json
+++ b/features/autoconsent.json
@@ -714,6 +714,10 @@
         {
             "domain": "ciwf.nl",
             "reason": "https://github.com/duckduckgo/privacy-configuration/pull/4133"
+        },
+        {
+            "domain": "lucrin.com.au",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/pull/4178"
         }
     ],
     "settings": {


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/1206670747178362/task/1212256585771248?focus=true

## Description
### Site breakage mitigation process:
#### Brief explanation
- Reported URL: https://www.lucrin.com.au/
- Problems experienced: Dark overlay caused by cookie popup management.
- Platforms affected:
  - [x] iOS
  - [x] Android
  - [x] Windows
  - [x] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked: N/A
- Feature being disabled/modified: Cookie popup management (CPM)
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `lucrin.com.au` to `features/autoconsent.json` exceptions to disable Cookie Prompt Management.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 49a218119af75300aac1c9bdd8ad08d4810d21d6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->