### PR TITLE
Hide blank spaces on birminghammail.co.uk

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -904,6 +904,25 @@
                 ]
             },
             {
+                "domain": "birminghammail.co.uk",
+                "rules": [
+                    {
+                        "selector": "[data-tmdatatrack='non-content-unit']",
+                        "type": "hide"
+                    },
+                    {
+                        "selector": ".iSMTT.sticky ~ header",
+                        "type": "modify-style",
+                        "values": [
+                            {
+                                "property": "top",
+                                "value": "0"
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
                 "domain": "bizjournals.com",
                 "rules": [
                     {


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/1206670747178362/task/1212259561342059?focus=true

## Description
### Site breakage mitigation process:
#### Brief explanation
- Reported URL: https://www.birminghammail.co.uk/news/midlands-news/shark-suit-spectator-sits-calmly-32986345
- Problems experienced: Multiple blank spaces on the page, caused by trackers being blocked.
- Platforms affected:
  - [x] iOS
  - [x] Android
  - [x] Windows
  - [x] MacOS
  - [x] Extensions
- Tracker(s) being unblocked: N/A
- Feature being disabled/modified: N/A
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds element-hiding and header style adjustment rules for `birminghammail.co.uk` to remove blank spaces.
> 
> - **Element Hiding config (`features/element-hiding.json`)**:
>   - **`birminghammail.co.uk`**:
>     - Hide `"[data-tmdatatrack='non-content-unit']"`.
>     - Modify header offset when preceded by `.iSMTT.sticky` sibling (`top: 0`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b530c1a151b7fcd2e814beaefdb0cbc380c3dcf0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->