### PR TITLE
Publish queue

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -13,7 +13,7 @@ jobs:
     publish:
         concurrency:
             group: build-and-publish
-            cancel-in-progress: true
+            cancel-in-progress: false # queue concurrent tasks only.
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@main


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1200890834746050/task/1212015886727139?focus=true

## Description

Cancel currently publishing jobs.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a concurrency group to the GitHub Actions build-and-publish workflow to queue runs instead of running them in parallel.
> 
> - **CI**:
>   - Update `/.github/workflows/build-and-publish.yml` to add `concurrency` with `group: build-and-publish` and `cancel-in-progress: false` to queue overlapping runs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit eb72e0fea0df9ff2219215a3e9539a4198040cd2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->