### PR TITLE
Remove mitigations for improved notification shim on Android

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -2283,30 +2283,6 @@
                                 }
                             }
                         ]
-                    },
-                    {
-                        "condition": {
-                            "domain": "realtor.com"
-                        },
-                        "patchSettings": [
-                            {
-                                "op": "replace",
-                                "path": "/notification/state",
-                                "value": "disabled"
-                            }
-                        ]
-                    },
-                    {
-                        "condition": {
-                            "domain": "chewy.com"
-                        },
-                        "patchSettings": [
-                            {
-                                "op": "replace",
-                                "path": "/notification/state",
-                                "value": "disabled"
-                            }
-                        ]
                     }
                 ],
                 "cleanIframeValue": {


### PR DESCRIPTION
Removed conditions for realtor.com and chewy.com notifications.

**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1201870266890790/task/1211264455407109?focus=true

## Description
We still had 5%+ users on the older, still broken app version when I first tried to remove these, but it's been another month, so users should be mostly updated by now 🤞 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes `webCompat` conditional changes that disabled `notification` on `realtor.com` and `chewy.com` in `overrides/android-override.json`.
> 
> - **Android web compat config** (`overrides/android-override.json`):
>   - Remove domain-specific patches that set `notification/state` to `disabled` for `realtor.com` and `chewy.com`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d82e59e3bda2e0df68a880c73c5f389387a27b76. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->