### PR TITLE
Enable burn.fireproofSettingsVisibility for 0.142 and later on Windows

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -2881,7 +2881,8 @@
                     "state": "enabled"
                 },
                 "fireproofSettingsVisibility": {
-                    "state": "disabled"
+                    "state": "enabled",
+                    "minSupportedVersion": "0.142.0"
                 }
             }
         },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1211150617965544/task/1211983018110289?focus=true

## Description
This change enables the `burn.fireproofSettingsVisibility` feature flag for 0.142 and later in order to have the Fireproof Sites section  shown in settings for the Windows browser.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enable `burn.fireproofSettingsVisibility` on Windows with `minSupportedVersion` set to `0.142.0`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8fd35d54025ff95eb855d58e7619762c7eb910c8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->