### PR TITLE
Add FF for showing autoconsent stats on the NTP, disabled by default 

### DIFF
--- a/features/html-new-tab-page.json
+++ b/features/html-new-tab-page.json
@@ -20,9 +20,6 @@
         },
         "newTabPageTabIDs": {
             "state": "disabled"
-        },
-        "autoconsentStats": {
-            "state": "disabled"
         }
     }
 }

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -962,9 +962,6 @@
                 },
                 "newTabPageTabIDs": {
                     "state": "enabled"
-                },                
-                "autoconsentStats": {
-                    "state": "disabled"
                 }
             }
         },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/task/1212256610164916?focus=true

## Description
Add a FF for showing autoconsent stats on the NTP. This should be disabled for now while it's being worked on and rolled out. 

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [x] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds an `autoconsentStats` feature flag to Windows `htmlNewTabPage`, defaulting to disabled.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5a73f934c2b841db9c2d1c0873fdb1b1f9134cb6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->