### PR TITLE
Update autoconsent to v14.40.0

### DIFF
--- a/features/autoconsent.json
+++ b/features/autoconsent.json
@@ -3319,7 +3319,7 @@
                 "body > div:not([id]) > div:not([id]) > div:nth-child(3):not([id]) > button:nth-child(2)#decline-consent",
                 "body > div:not([id]) > div:nth-child(1):not([id]) > div:nth-child(2):not([id]) > div:nth-child(3):not([id]) > button:not([id])",
                 "body > div#root > div:not([id]) > div:nth-child(4):not([id]) > div:not([id]) > div:not([id]) > div:nth-child(2):not([id]) > div:nth-child(1):not([id]) > button:nth-child(2):not([id])",
-                "body > div#___gatsby > div:nth-child(1)#gatsby-focus-wrapper > div:nth-child(3):not([id]) > div:not([id]) > div:not([id]) > div:nth-child(2):not([id]) > button:nth-child(2):not([id])",
+                "body > div#___gatsby > div:nth-child(1)#gatsby-focus-wrapper > div:nth-child(3):not([id]) > div:not([id]) > div:nth-child(2):not([id]) > div:nth-child(1):not([id]) > button:not([id])",
                 "body > div#app > div:nth-child(7):not([id])[data-testid=\"cookieBanner\"] > div:not([id]) > div:nth-child(3):not([id]) > div:nth-child(3):not([id]) > button:nth-child(2):not([id])[data-testid=\"onlyNecessaryCookies\"]",
                 "body > div:not([id]) > aside:not([id]) > div:not([id]) > div:nth-child(3):not([id]) > div:nth-child(2):not([id]) > button:not([id])",
                 "body > section#cookieControl > a:nth-child(5):not([id])",
@@ -3620,7 +3620,8 @@
                 "body > div:not([id]) > div:nth-child(2)#\\30 b94133b-8573-43fe-8d37-771c47a4d616 > div:nth-child(2):not([id]) > button:nth-child(2):not([id])",
                 "button#decline-button",
                 "body > div#located-in-eu-ca-quebec > section:nth-child(2):not([id]) > div:nth-child(2):not([id]) > div:nth-child(2):not([id]) > button:nth-child(1)#gdpr-dismiss",
-                ".cookie-banner-wrapper .cookie-banner"
+                ".cookie-banner-wrapper .cookie-banner",
+                "body > div#__next > div:nth-child(4):not([id]) > div:nth-child(2)#\\:rh\\: > div:not([id]) > div:not([id]) > div:not([id]) > div:not([id]) > div:nth-child(2):not([id]) > div:nth-child(2):not([id]) > div:nth-child(2):not([id]) > button:not([id])[data-testid=\"modalRejectButton\"]"
             ],
             "r": [
                 [
@@ -17489,6 +17490,40 @@
                             "timeout": 1000,
                             "check": "none",
                             "wv": 2613
+                        }
+                    ],
+                    {}
+                ],
+                [
+                    1,
+                    "auto_AU_theperfectmatch-lufthansagroup.com_6kv_+2",
+                    0,
+                    "^https?://(www\\.)?theperfectmatch-lufthansagroup\\.com/|^https?://(www\\.)?globus\\.de/|^https?://(www\\.)?produkte\\.globus\\.de/",
+                    10,
+                    [],
+                    [
+                        {
+                            "e": 1831
+                        }
+                    ],
+                    [
+                        {
+                            "v": 1831
+                        }
+                    ],
+                    [
+                        {
+                            "wait": 500
+                        },
+                        {
+                            "c": 1831
+                        }
+                    ],
+                    [
+                        {
+                            "timeout": 1000,
+                            "check": "none",
+                            "wv": 1831
                         }
                     ],
                     {}
@@ -36392,40 +36427,6 @@
                 ],
                 [
                     1,
-                    "auto_DE_globus.de_b52_+1",
-                    0,
-                    "^https?://(www\\.)?globus\\.de/|^https?://(www\\.)?produkte\\.globus\\.de/",
-                    10,
-                    [],
-                    [
-                        {
-                            "e": 1831
-                        }
-                    ],
-                    [
-                        {
-                            "v": 1831
-                        }
-                    ],
-                    [
-                        {
-                            "wait": 500
-                        },
-                        {
-                            "c": 1831
-                        }
-                    ],
-                    [
-                        {
-                            "timeout": 1000,
-                            "check": "none",
-                            "wv": 1831
-                        }
-                    ],
-                    {}
-                ],
-                [
-                    1,
                     "auto_DE_go-e.com_ukq",
                     0,
                     "^https?://(www\\.)?go-e\\.com/",
@@ -48898,6 +48899,40 @@
                             "timeout": 1000,
                             "check": "none",
                             "wv": 2689
+                        }
+                    ],
+                    {}
+                ],
+                [
+                    1,
+                    "auto_FR_hyperice.com_sld",
+                    0,
+                    "^https?://(www\\.)?hyperice\\.com/",
+                    10,
+                    [],
+                    [
+                        {
+                            "e": 2891
+                        }
+                    ],
+                    [
+                        {
+                            "v": 2891
+                        }
+                    ],
+                    [
+                        {
+                            "wait": 500
+                        },
+                        {
+                            "c": 2891
+                        }
+                    ],
+                    [
+                        {
+                            "timeout": 1000,
+                            "check": "none",
+                            "wv": 2891
                         }
                     ],
                     {}
@@ -88381,7 +88416,7 @@
                 ],
                 "specificRuleRange": [
                     183,
-                    2554
+                    2555
                 ],
                 "genericStringEnd": 700,
                 "frameStringEnd": 739


### PR DESCRIPTION
Asana Task/Github Issue: https://app.asana.com/1/137249556945/project/1201844467387842/task/1212300073262278

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates autoconsent rules by adding Lufthansa/Globus and Hyperice entries, removing the old Globus rule, and refining reject-button selectors.
> 
> - **Autoconsent rules**:
>   - **New sites**:
>     - Add `auto_AU_theperfectmatch-lufthansagroup.com_6kv_+2` with pattern `theperfectmatch-lufthansagroup.com|globus.de|produkte.globus.de`.
>     - Add `auto_FR_hyperice.com_sld` for `hyperice.com`.
>   - **Removed**: `auto_DE_globus.de_b52_+1`.
>   - **Selector updates**:
>     - Replace Gatsby path selector under `body > div#___gatsby ...`.
>     - Add Next.js selector with `data-testid="modalRejectButton"`.
>   - **Metadata**: increment `specificRuleRange` end from `2554` to `2555`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c5a5e99a7484c3e3cc61a605443fdad1f0d72a3e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->