### PR TITLE
Add popup blocking configuration for macOS

### DIFF
--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -1823,6 +1823,7 @@
         },
         "popupBlocking": {
             "state": "enabled",
+            "minSupportedVersion": "1.168.0",
             "exceptions": [],
             "settings": {
                 "userInitiatedPopupThreshold": 6.0,


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1202406491309510/task/1212291177855697?focus=true
Tech Design URL: N/A
CC: @ayoy

### Description
- Enable popup blocking feature for macOS public users

### Testing Steps
1. Modify `macOS/scripts/update_embedded.sh` to use temporary config URL from PR: `CONFIG_URL="https://duckduckgo.github.io/privacy-configuration/pr-4187/v4/macos-config.json"`
2. Run `./macOS/scripts/update_embedded.sh` to update embedded config
3. Update `macOS/DuckDuckGo/Application/AppConfigurationURLProvider.swift` at line 31 to point to the same temporary URL so it doesn't replace from server: `public static let defaultPrivacyConfigurationURL = URL(string: "https://duckduckgo.github.io/privacy-configuration/pr-4187/v4/macos-config.json")!`
4. Build and run the macOS browser
5. Deactivate internal user from Debug menu (to test as public user)
6. Validate the updated popup features work (e.g., the extended wait timeout to 6 seconds)

### Impact and Risks
**Impact Level: Medium**

#### What could go wrong?
- Popup handling breakages

### Quality Considerations
- Configuration follows existing privacy-configuration patterns
- All 222 tests pass including schema validation
- Allowlist includes 21 domains with known popup requirements
- Feature state can be remotely controlled for quick rollback if needed


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables `popupBlocking` on macOS and gates it behind `minSupportedVersion` 1.168.0.
> 
> - **macOS privacy configuration**:
>   - **`features.popupBlocking`**: Set `state` to `enabled` and added `minSupportedVersion` `1.168.0`.
>   - Retains existing settings (e.g., `userInitiatedPopupThreshold: 6.0`, domain `allowlist`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 57b259256f078fdbbad7204ec969340d4047761b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->