### PR TITLE
Add new autoconsentStats feature flag

### DIFF
--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -962,6 +962,9 @@
                 },
                 "newTabPageTabIDs": {
                     "state": "enabled"
+                },
+                "autoconsentStats": {
+                    "state": "internal"
                 }
             }
         },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1163321984198618/task/1203578778040829?focus=true

## Description
Add new `autoconsentStats` feature flag under `htmlNewTabPage`.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `autoconsentStats` feature flag (state: `internal`) under `features.htmlNewTabPage` in `overrides/macos-override.json`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 70faef2bc73a0900898c6be9b8e1e05877e8c238. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->