### PR TITLE
Fix rule precedence logic violations in tracker-allowlist-json

### DIFF
--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -402,18 +402,22 @@
                         ]
                     },
                     {
+                        "rule": "o.alicdn.com/frontend-lib/common-lib/jquery.min.js",
+                        "domains": [
+                            "chat.qwen.ai",
+                            "aliexpress.us"
+                        ],
+                        "reason": [
+                            "chat.qwen.ai - https://github.com/duckduckgo/privacy-configuration/pull/3243",
+                            "aliexpress.us - https://github.com/duckduckgo/privacy-configuration/issues/460"
+                        ]
+                    },
+                    {
                         "rule": "alicdn.com",
                         "domains": [
                             "aliexpress.us"
                         ],
-                        "reason": "aliexpress.us - https://github.com/duckduckgo/privacy-configuration/issues/460"
-                    },
-                    {
-                        "rule": "o.alicdn.com/frontend-lib/common-lib/jquery.min.js",
-                        "domains": [
-                            "chat.qwen.ai"
-                        ],
-                        "reason": "https://github.com/duckduckgo/privacy-configuration/pull/3243"
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/issues/460"
                     }
                 ]
             },
@@ -1256,7 +1260,7 @@
                             "wunderground.com"
                         ],
                         "reason": [
-                            "history.com, 10play.com.au - https://github.com/duckduckgo/privacy-configuration/issues/1185",
+                            "history.com, 10play.com.au -https://github.com/duckduckgo/privacy-configuration/issues/1185",
                             "rocketnews24.com - https://github.com/duckduckgo/privacy-configuration/issues/846",
                             "wunderground.com - https://github.com/duckduckgo/privacy-configuration/pull/3096"
                         ]
@@ -1289,17 +1293,6 @@
                         ]
                     },
                     {
-                        "rule": "doubleclick.net",
-                        "domains": [
-                            "rocketnews24.com",
-                            "wunderground.com"
-                        ],
-                        "reason": [
-                            "rocketnews24.com - https://github.com/duckduckgo/privacy-configuration/issues/846",
-                            "wunderground.com - https://github.com/duckduckgo/privacy-configuration/pull/3096"
-                        ]
-                    },
-                    {
                         "rule": "securepubads.g.doubleclick.net/gampad/ads",
                         "domains": [
                             "ah.nl",
@@ -1326,44 +1319,58 @@
                             "rocketnews24.com",
                             "crunchyroll.com",
                             "pch.com",
-                            "iheart.com"
+                            "iheart.com",
+                            "wunderground.com"
                         ],
                         "reason": [
                             "https://github.com/duckduckgo/privacy-configuration/issues/1185",
                             "rocketnews24.com - https://github.com/duckduckgo/privacy-configuration/issues/846",
                             "crunchyroll.com - https://github.com/duckduckgo/privacy-configuration/issues/1140",
                             "pch.com - https://github.com/duckduckgo/privacy-configuration/pull/2793",
-                            "iheart.com - https://github.com/duckduckgo/privacy-configuration/pull/3040"
+                            "iheart.com - https://github.com/duckduckgo/privacy-configuration/pull/3040",
+                            "wunderground.com - https://github.com/duckduckgo/privacy-configuration/pull/3096"
                         ]
                     },
                     {
                         "rule": "pubads.g.doubleclick.net/ondemand/hls/content",
                         "domains": [
                             "cc.com",
-                            "paramountplus.com"
+                            "paramountplus.com",
+                            "rocketnews24.com",
+                            "wunderground.com"
                         ],
                         "reason": [
                             "cc.com - https://github.com/duckduckgo/privacy-configuration/pull/3508",
-                            "paramount - https://github.com/duckduckgo/privacy-configuration/pull/3534"
+                            "paramount - https://github.com/duckduckgo/privacy-configuration/pull/3534",
+                            "rocketnews24.com - https://github.com/duckduckgo/privacy-configuration/issues/846",
+                            "wunderground.com - https://github.com/duckduckgo/privacy-configuration/pull/3096"
                         ]
                     },
                     {
                         "rule": "pubads.g.doubleclick.net/ssai/event/",
                         "domains": [
                             "cbssports.com",
-                            "rocketnews24.com"
+                            "rocketnews24.com",
+                            "wunderground.com"
                         ],
                         "reason": [
                             "cbssports.com - Live videos do not load or render.",
-                            "rocketnews24.com - https://github.com/duckduckgo/privacy-configuration/issues/846"
+                            "rocketnews24.com - https://github.com/duckduckgo/privacy-configuration/issues/846",
+                            "wunderground.com - https://github.com/duckduckgo/privacy-configuration/pull/3096"
                         ]
                     },
                     {
                         "rule": "pubads.g.doubleclick.net/ssai/pods/",
                         "domains": [
-                            "foxweather.com"
+                            "foxweather.com",
+                            "rocketnews24.com",
+                            "wunderground.com"
                         ],
-                        "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1541"
+                        "reason": [
+                            "foxweather.com - https://github.com/duckduckgo/privacy-configuration/issues/1541",
+                            "rocketnews24.com - https://github.com/duckduckgo/privacy-configuration/issues/846",
+                            "wunderground.com - https://github.com/duckduckgo/privacy-configuration/pull/3096"
+                        ]
                     },
                     {
                         "rule": "securepubads.g.doubleclick.net/tag/js/gpt.js",
@@ -1581,7 +1588,9 @@
                     {
                         "rule": "securepubads.g.doubleclick.net/pagead/ima_ppub_config",
                         "domains": [
-                            "sbs.com.au"
+                            "sbs.com.au",
+                            "rocketnews24.com",
+                            "wunderground.com"
                         ],
                         "reason": [
                             "sbs.com.au - https://github.com/duckduckgo/privacy-configuration/pull/2436"
@@ -1598,7 +1607,8 @@
                             "wunderground.com",
                             "stuff.co.nz",
                             "nationalpost.com",
-                            "modernhoney.com"
+                            "modernhoney.com",
+                            "rocketnews24.com"
                         ],
                         "reason": [
                             "applesfera.com - https://github.com/duckduckgo/privacy-configuration/issues/1723",
@@ -1609,15 +1619,33 @@
                             "wunderground.com - https://github.com/duckduckgo/privacy-configuration/pull/2885",
                             "stuff.co.nz - https://github.com/duckduckgo/privacy-configuration/issues/1740",
                             "nationalpost.com - https://github.com/duckduckgo/privacy-configuration/pull/3969",
-                            "modernhoney.com - https://github.com/duckduckgo/privacy-configuration/pull/4111"
+                            "modernhoney.com - https://github.com/duckduckgo/privacy-configuration/pull/4111",
+                            "rocketnews24.com - https://github.com/duckduckgo/privacy-configuration/issues/846"
                         ]
                     },
                     {
                         "rule": "googleads.g.doubleclick.net/ads/preferences/naioptout",
                         "domains": [
-                            "zojirushi.com"
+                            "zojirushi.com",
+                            "rocketnews24.com",
+                            "wunderground.com"
                         ],
-                        "reason": "https://github.com/duckduckgo/privacy-configuration/issues/2021"
+                        "reason": [
+                            "zojirushi.com - https://github.com/duckduckgo/privacy-configuration/issues/2021",
+                            "rocketnews24.com - https://github.com/duckduckgo/privacy-configuration/issues/846",
+                            "wunderground.com - https://github.com/duckduckgo/privacy-configuration/pull/3096"
+                        ]
+                    },
+                    {
+                        "rule": "doubleclick.net",
+                        "domains": [
+                            "rocketnews24.com",
+                            "wunderground.com"
+                        ],
+                        "reason": [
+                            "rocketnews24.com - https://github.com/duckduckgo/privacy-configuration/issues/846",
+                            "wunderground.com - https://github.com/duckduckgo/privacy-configuration/pull/3096"
+                        ]
                     }
                 ]
             },
@@ -1754,7 +1782,7 @@
             "exoclick.com": {
                 "rules": [
                     {
-                        "rule": "ads.exoclick.com/ads.js",
+                        "rule": "exoclick.com/ads.js",
                         "domains": [
                             "myreadingmanga.info"
                         ],
@@ -2508,18 +2536,22 @@
                         ]
                     },
                     {
+                        "rule": "api.grow.me",
+                        "domains": [
+                            "foodfornet.com",
+                            "grilledcheesesocial.com"
+                        ],
+                        "reason": [
+                            "foodfornet.com - https://github.com/duckduckgo/privacy-configuration/issues/2065",
+                            "grilledcheesesocial.com - https://github.com/duckduckgo/privacy-configuration/issues/2107"
+                        ]
+                    },
+                    {
                         "rule": "grow.me",
                         "domains": [
                             "grilledcheesesocial.com"
                         ],
                         "reason": "grilledcheesesocial.com - https://github.com/duckduckgo/privacy-configuration/issues/2107"
-                    },
-                    {
-                        "rule": "api.grow.me",
-                        "domains": [
-                            "foodfornet.com"
-                        ],
-                        "reason": "foodfornet.com - https://github.com/duckduckgo/privacy-configuration/issues/2065"
                     }
                 ]
             },
@@ -2773,18 +2805,22 @@
             "kampyle.com": {
                 "rules": [
                     {
+                        "rule": "nebula-cdn.kampyle.com/wu/392339/onsite/embed.js",
+                        "domains": [
+                            "lowes.com",
+                            "basspro.com"
+                        ],
+                        "reason": [
+                            "lowes.com - https://github.com/duckduckgo/privacy-configuration/issues/1453",
+                            "basspro.com - https://github.com/duckduckgo/privacy-configuration/issues/783"
+                        ]
+                    },
+                    {
                         "rule": "kampyle.com",
                         "domains": [
                             "basspro.com"
                         ],
                         "reason": "https://github.com/duckduckgo/privacy-configuration/issues/783"
-                    },
-                    {
-                        "rule": "nebula-cdn.kampyle.com/wu/392339/onsite/embed.js",
-                        "domains": [
-                            "lowes.com"
-                        ],
-                        "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1453"
                     }
                 ]
             },
@@ -2899,21 +2935,23 @@
                         "reason": "https://github.com/duckduckgo/privacy-configuration/issues/457"
                     },
                     {
+                        "rule": "oc.listrakbi.com/subscribestatus",
+                        "domains": [
+                            "ninjakitchen.com",
+                            "fsastore.com"
+                        ],
+                        "reason": [
+                            "ninjakitchen.com - https://github.com/duckduckgo/privacy-configuration/pull/3728",
+                            "fsastore.com - https://github.com/duckduckgo/privacy-configuration/issues/2114"
+                        ]
+                    },
+                    {
                         "rule": "listrakbi.com",
                         "domains": [
                             "fsastore.com"
                         ],
                         "reason": [
                             "fsastore.com - https://github.com/duckduckgo/privacy-configuration/issues/2114"
-                        ]
-                    },
-                    {
-                        "rule": "oc.listrakbi.com/subscribestatus",
-                        "domains": [
-                            "ninjakitchen.com"
-                        ],
-                        "reason": [
-                            "ninjakitchen.com - https://github.com/duckduckgo/privacy-configuration/pull/3728"
                         ]
                     }
                 ]
@@ -3086,6 +3124,7 @@
             },
             "monetate.net": {
                 "rules": [
+                    
                     {
                         "rule": "monetate.net/img",
                         "domains": [
@@ -3105,7 +3144,7 @@
                         "reason": [
                             "qvc.com - https://github.com/duckduckgo/privacy-configuration/issues/2109"
                         ]
-                    }
+                    }                    
                 ]
             },
             "mrf.io": {
@@ -3234,23 +3273,46 @@
                     {
                         "rule": "bankofamerica.tt.omtrdc.net/m2/bankofamerica/mbox/json",
                         "domains": [
-                            "bankofamerica.com"
+                            "bankofamerica.com",
+                            "pizzahut.com"
                         ],
-                        "reason": "https://github.com/duckduckgo/privacy-configuration/issues/798"
+                        "reason": [
+                            "bankofamerica.com - https://github.com/duckduckgo/privacy-configuration/issues/798",
+                            "pizzahut.com - https://github.com/duckduckgo/privacy-configuration/issues/805"
+                        ]
                     },
                     {
                         "rule": "cigna.sc.omtrdc.net/public/digital-experience/js/common.js",
                         "domains": [
-                            "cigna.com"
+                            "cigna.com",
+                            "pizzahut.com"
                         ],
-                        "reason": "https://github.com/duckduckgo/privacy-configuration/issues/820"
+                        "reason": [
+                            "cigna.com - https://github.com/duckduckgo/privacy-configuration/issues/820",
+                            "pizzahut.com - https://github.com/duckduckgo/privacy-configuration/issues/805"
+                        ]
                     },
                     {
                         "rule": "altriagroupinc.tt.omtrdc.net/rest/v1/delivery",
                         "domains": [
-                            "marlboro.com"
+                            "marlboro.com",
+                            "pizzahut.com"
                         ],
-                        "reason": "https://github.com/duckduckgo/privacy-configuration/issues/2057"
+                        "reason": [
+                            "marlboro.com - https://github.com/duckduckgo/privacy-configuration/issues/2057",
+                            "pizzahut.com - https://github.com/duckduckgo/privacy-configuration/issues/805"
+                        ]
+                    },
+                    {
+                        "rule": "whirlpool.tt.omtrdc.net/rest/v1/delivery",
+                        "domains": [
+                            "kitchenaid.com",
+                            "pizzahut.com"
+                        ],
+                        "reason": [
+                            "kitchenaid.com - https://github.com/duckduckgo/privacy-configuration/issues/2070",
+                            "pizzahut.com - https://github.com/duckduckgo/privacy-configuration/issues/805"
+                        ]
                     },
                     {
                         "rule": "omtrdc.net",
@@ -3258,13 +3320,6 @@
                             "pizzahut.com"
                         ],
                         "reason": "https://github.com/duckduckgo/privacy-configuration/issues/805"
-                    },
-                    {
-                        "rule": "whirlpool.tt.omtrdc.net/rest/v1/delivery",
-                        "domains": [
-                            "kitchenaid.com"
-                        ],
-                        "reason": "https://github.com/duckduckgo/privacy-configuration/issues/2070"
                     }
                 ]
             },
@@ -3377,23 +3432,31 @@
                     {
                         "rule": "cdn.optimizely.com/js/24096340716.js",
                         "domains": [
-                            "hgtv.com"
+                            "hgtv.com",
+                            "rushordertees.com"
                         ],
-                        "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1904"
+                        "reason": [
+                            "hgtv.com - https://github.com/duckduckgo/privacy-configuration/issues/1904",
+                            "rushordertees.com -https://github.com/duckduckgo/privacy-configuration/pull/2701"
+                        ]
                     },
                     {
                         "rule": "cdn.optimizely.com/js/271989291.js",
                         "domains": [
-                            "my.zipcar.com"
+                            "my.zipcar.com",
+                            "rushordertees.com"
                         ],
-                        "reason": "https://github.com/duckduckgo/privacy-configuration/issues/916"
+                        "reason": [
+                            "my.zipcar.com - https://github.com/duckduckgo/privacy-configuration/issues/916",
+                            "rushordertees.com - https://github.com/duckduckgo/privacy-configuration/pull/2701"
+                        ]
                     },
                     {
-                        "rule": "cdn.optimizely.com/js/28562140225.js",
+                        "rule": "cdn.optimizely.com",
                         "domains": [
-                            "shipsticks.com"
+                            "rushordertees.com"
                         ],
-                        "reason": "https://github.com/duckduckgo/privacy-configuration/pull/4152"
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2701"
                     }
                 ]
             },
@@ -3987,7 +4050,7 @@
                         "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1107"
                     },
                     {
-                        "rule": "shop.app",
+                        "rule": "server.shop.app",
                         "domains": [
                             "laurageller.com"
                         ],
@@ -4271,14 +4334,14 @@
             "tiqcdn.com": {
                 "rules": [
                     {
-                        "rule": "tags.tiqcdn.com/utag/.*/utag.js",
+                        "rule": "tags.tiqcdn.com/utag/.*/utag..*.js",
                         "domains": [
                             "<all>"
                         ],
                         "reason": "https://github.com/duckduckgo/privacy-configuration/issues/379"
                     },
                     {
-                        "rule": "tags.tiqcdn.com/utag/.*/utag..*.js",
+                        "rule": "tags.tiqcdn.com/utag/.*/utag.js",
                         "domains": [
                             "<all>"
                         ],


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1201534009035032/task/1212306499351463?focus=true

## Description

### Site breakage mitigation process:
#### Brief explanation
- Reported URL: multiple
- Problems experienced: batch fix of the json file
- Platforms affected:
  - [x ] iOS
  - [ x] Android
  - [x ] Windows
  - [ x] MacOS
  - [x ] Extensions
- Tracker(s) being unblocked: NA
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Reorders and refines allowlist rules to fix precedence, adds domain coverage, and updates reasons across multiple trackers.
> 
> - **Rule precedence/specification fixes**
>   - Swap/adjust rules and specificity for `alicdn.com`, `cloudflare.com` (`fingerprintjs2` vs `challenges`), `kampyle.com`, `klarnaservices.com`, `listrakbi.com`, `monetate.net`, `omtrdc.net`, and `tiqcdn.com` (regex/order tweaks).
> - **Expanded domain coverage (notable additions)**
>   - `doubleclick.net` and `*.g.doubleclick.net`: add `rocketnews24.com`, `wunderground.com`, `sbs.com.au`, and others across HLS/DASH/SSAI/GPT/pixel/NAI opt-out endpoints; update reasons.
>   - `optimizely.com`: add `rushordertees.com` and a general `cdn.optimizely.com` rule; update reasons.
>   - `grow.me`: add `grilledcheesesocial.com` to `main.js` and `api.grow.me`.
>   - `omtrdc.net`: add `pizzahut.com` across multiple endpoints and `kitchenaid.com` via `whirlpool.tt.omtrdc.net`.
>   - `tiqcdn.com`: include `bankofamerica.com` in `utag/cbsi/` rule.
> - **Rule generalization/host changes**
>   - `exoclick.com`: generalize rule from `ads.exoclick.com/ads.js` to `exoclick.com/ads.js`.
>   - `shop.app`: switch site-specific rule from `shop.app` to `server.shop.app`.
> - **Removals/cleanups**
>   - Remove generic `ezodn.com` allowlist entry; keep targeted `cmp`/`go` rules.
>   - Convert several single-string reasons to arrays and normalize reason texts/links.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 615f65d986e4be45369c57c5a1f16a98ab0ec69c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->