### PR TITLE
Update macOS override to enable additional check

### DIFF
--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -286,7 +286,22 @@
                 "chatImagesIndexDbNameObjectStoreNamePairs": [[
                         "savedAIChatData",
                         "chat-images"
-                    ]]
+                    ]],
+                "additionalCheck": "disabled",
+                "conditionalChanges": [
+                    {
+                        "condition": {
+                            "domain": ["duck.ai", "duckduckgo.com"]
+                        },
+                        "patchSettings": [
+                            {
+                                "op": "replace",
+                                "path": "/additionalCheck",
+                                "value": "enabled"
+                            }
+                        ]
+                    }
+                ]
             }
         },
         "autocompleteTabs": {


### PR DESCRIPTION
Enable additional check for specific domains in macOS override settings.

**Asana Task/Github Issue:**

## Description
<!-- 
  Please delete either or both process sections below.
-->

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.
