### PR TITLE
Allow ServiceWorker.Unregister in serviceWorkerWatchdog 

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -2791,6 +2791,9 @@
                 },
                 "serviceWorkerWatchdog": {
                     "state": "enabled"
+                },
+                "serviceWorkerWatchdogUnregister": {
+                    "state": "preview"
                 }
             },
             "exceptions": []


### PR DESCRIPTION
**Asana Task/Github Issue:**

- Asana: https://app.asana.com/1/137249556945/project/1207414201589134/task/1211898170055682
- Related Windows browser change: https://github.com/duckduckgo/windows-browser/pull/5893

## Description

-  Allow serviceWorkerWatchdog service to attempt to Unregister stuck service_workers through CDP on Windows Preview channel


### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [x] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `features.webview.serviceWorkerWatchdogUnregister` with state `preview` in `overrides/windows-override.json`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1c368a10b7c6d94359d91f7683aea26580a77ae4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->