### PR TITLE
Hide empty spaces on manchestereveningnews.co.uk

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -2542,6 +2542,25 @@
                 ]
             },
             {
+                "domain": "manchestereveningnews.co.uk",
+                "rules": [
+                    {
+                        "selector": "[data-tmdatatrack='non-content-unit']",
+                        "type": "hide"
+                    },
+                    {
+                        "selector": ".qQnbZ.sticky ~ header",
+                        "type": "modify-style",
+                        "values": [
+                            {
+                                "property": "top",
+                                "value": "0"
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
                 "domain": "mantan-web.jp",
                 "rules": [
                     {


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/1200277586140538/task/1212259719627227?focus=true

## Description
### Site breakage mitigation process:
#### Brief explanation
- Reported URL: https://www.manchestereveningnews.co.uk/news/greater-manchester-news/thieves-steal-running-clubs-sweet-21286141
- Problems experienced: Big blank spaces and header not at the top of the page. Similar issue to #4179 
- Platforms affected:
  - [x] iOS
  - [x] Android
  - [x] Windows
  - [x] MacOS
  - [x] Extensions
- Tracker(s) being unblocked: N/A
- Feature being disabled/modified: N/A
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds element-hiding and header style adjustments for manchestereveningnews.co.uk to remove blank spaces and keep the header at the top.
> 
> - **Config updates (`features/element-hiding.json`)**:
>   - **Domain: `manchestereveningnews.co.uk`**
>     - Hide non-content units: `[data-tmdatatrack='non-content-unit']` (`hide`).
>     - Ensure header stays at top when sticky element present: `.qQnbZ.sticky ~ header` (`modify-style: top: 0`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 49e48c808d30b7c1fdcbcf4f09806976f4c071d9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->