### PR TITLE
Windows - Add an enabled feature flag for the unset-as-default pixel

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -3219,6 +3219,10 @@
         "combinedPermissionView": {
             "state": "internal",
             "exceptions": []
+        },
+        "unsetAsDefaultMonitor": {
+            "state": "enabled",
+            "exceptions": []
         }
     },
     "unprotectedTemporary": []


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1211150617965544/task/1211998245071877?focus=true

## Description
Add an enabled Windows-only feature flag, `unsetAsDefaultMonitor`, that can be used to disable the new unset_as_default pixel added by https://github.com/duckduckgo/windows-browser/pull/5871.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds enabled Windows feature flag `unsetAsDefaultMonitor` to control the unset-as-default pixel.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f3b977de2181edd2877b70c5c153960e7e4038af. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->