### PR TITLE
iOS: Full Duck.ai Mode - Enable feature internal, Enable user setting external, min version 7.199

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -291,6 +291,14 @@
                 },
                 "showHideAiGeneratedImages": {
                     "state": "enabled"
+                },
+                "fullDuckAIMode": {
+                    "state": "internal",
+                    "minSupportedVersion": "7.199.0"
+                },
+                "fullDuckAIModeExperimentalSetting": {
+                    "state": "enabled",
+                    "minSupportedVersion": "7.199.0"
                 }
             },
             "settings": {


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/task/1212325432674521

## Description
1. Enable full duck.ai mode for internal users, starting v7.199
2. Enable experimental setting for silent external release, starting v7.199

### Feature change process:
- [x] I have tested this change locally in all supported browsers.

### Site breakage mitigation process:
#### Brief explanation
- Platforms affected:
  - [x] iOS
- Feature being disabled/modified

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `aiChat` flags for Full Duck.ai mode (internal) and its experimental user setting, both gated at iOS app version 7.199.0.
> 
> - **iOS config (AI Chat)**
>   - Update `overrides/ios-override.json`:
>     - Add `features.aiChat.features.fullDuckAIMode` set to `internal` with `minSupportedVersion` `7.199.0`.
>     - Add `features.aiChat.features.fullDuckAIModeExperimentalSetting` set to `enabled` with `minSupportedVersion` `7.199.0`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1bd8fe565125c1919faa50fcd44b1fc94d081537. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->