### PR TITLE
Enabling V135 decryption for Edge

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -1795,7 +1795,7 @@
                     "settings": {
                         "chrome": "enabled",
                         "brave": "enabled",
-                        "edge": "disabled",
+                        "edge": "enabled",
                         "vivaldi": "disabled"
                     }
                 },
@@ -1804,7 +1804,7 @@
                     "settings": {
                         "chrome": "enabled",
                         "brave": "enabled",
-                        "edge": "disabled",
+                        "edge": "enabled",
                         "vivaldi": "disabled",
                         "chromium": "enabled"
                     }


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/inbox/1210407179200807/item/1212343543749193/story/1212343605021321?focus=true

## Description
Enabling V135 decryption for Edge. Their latest 143 release seems to have begun requiring it.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables Edge support for multi-step import and app-bound decryption in Windows overrides.
> 
> - **Config (Windows)**:
>   - `import.features.browserMultiStepImport.settings.edge`: set to `enabled`.
>   - `import.features.appBoundDecryption.settings.edge`: set to `enabled`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4006f7bcff3cc2f19eeafa77d6aac8ce5f4ab98c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->