### PR TITLE
Mitigate sciensus.com blank page, re-order omtrdc rule

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -2121,17 +2121,6 @@
                             }
                         ]
                     },
-                    "omtrdc.net": {
-                        "rules": [
-                            {
-                                "rule": "tracfonewireless.tt.omtrdc.net",
-                                "domains": [
-                                    "tracfone.com"
-                                ],
-                                "reason": "tracfone.com - https://github.com/duckduckgo/privacy-configuration/pull/4032"
-                            }
-                        ]
-                    },
                     "doubleclick.net": {
                         "rules": [
                             {
@@ -2147,6 +2136,28 @@
                                     "tractorhouse.com"
                                 ],
                                 "reason": "tractorhouse.com - https://github.com/duckduckgo/privacy-configuration/pull/4065"
+                            }
+                        ]
+                    },
+                    "omtrdc.net": {
+                        "rules": [
+                            {
+                                "rule": "tracfonewireless.tt.omtrdc.net",
+                                "domains": [
+                                    "tracfone.com"
+                                ],
+                                "reason": "tracfone.com - https://github.com/duckduckgo/privacy-configuration/pull/4032"
+                            }
+                        ]
+                    },
+                    "posthog.com": {
+                        "rules": [
+                            {
+                                "rule": "eu.i.posthog.com",
+                                "domains": [
+                                    "sciensus.com"
+                                ],
+                                "reason": "sciensus.com - https://github.com/duckduckgo/privacy-configuration/pull/4210"
                             }
                         ]
                     },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1206670747178362/task/1212276669711460?focus=true

## Description

### Site breakage mitigation process:
#### Brief explanation
- Reported URL: intouch.sciensus.com
- Problems experienced: login page for app sends to blank browser page
- Platforms affected: (only Android, logging into app)
  - [ ] iOS
  - [x] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked: `eu.i.posthog.com`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Allowlists `eu.i.posthog.com` for `sciensus.com` on Android and reorders the `omtrdc.net` rule.
> 
> - **Android privacy config (`overrides/android-override.json`)**:
>   - **Tracker allowlist**:
>     - Add `posthog.com` rule for `eu.i.posthog.com` scoped to `sciensus.com`.
>     - Reorder `omtrdc.net` rule for `tracfonewireless.tt.omtrdc.net` (scoped to `tracfone.com`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ec5390cb5e177cd4e9597019212ed97481d07b5e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->