### PR TITLE
Add VYOM app to AppTP disable list

### DIFF
--- a/features/app-tracker-protection.json
+++ b/features/app-tracker-protection.json
@@ -720,7 +720,7 @@
                 },
                 {
                     "packageName": "com.infrasoft.uboi",
-                    "reason": "Users report app issues with AppTP enabled"
+                    "reason": "App doesn't run over any VPN connection"
                 }
             ],
             "unhideSystemApps": [


### PR DESCRIPTION
**Asana Task/Github Issue:**  https://app.asana.com/1/137249556945/project/1200746877073315/task/1211542145487231?focus=true

## Description
VYOM Indian banking app won't launch while connection is over VPN. Disabling AppTP for the app unblocks usage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add `com.infrasoft.uboi` (VYOM banking app) to AppTP `unprotectedApps` due to incompatibility with VPN connections.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f282ee056627a3c3dc2c9cebf8a4bb8cc03bd325. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->