### PR TITLE
Element hiding: Generalize "switch to Chrome" pop up handling for several domains

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -1919,11 +1919,34 @@
             },
             {
                 "domain": [
-                    "google.com",
                     "google.ca",
                     "google.de",
-                    "google.dk",
                     "google.es",
+                    "google.co.uk"
+                ],
+                "rules": [
+                    {
+                        "selector": "div:has(> iframe[src*='prid=190'])",
+                        "type": "hide"
+                    },
+                    {
+                        "selector": "[aria-labelledby='promo-header']",
+                        "type": "hide"
+                    },
+                    {
+                        "selector": "div:has(> [aria-labelledby='promo_label_id'])",
+                        "type": "hide"
+                    },
+                    {
+                        "selector": "div[role='banner']:has(div > a[href='https://support.google.com/a/answer/33864'])",
+                        "type": "hide"
+                    }
+                ]
+            },
+            {
+                "domain": [
+                    "google.com",
+                    "google.dk",
                     "google.fr",
                     "google.ie",
                     "google.it",
@@ -1935,8 +1958,7 @@
                     "google.com.mx",
                     "google.co.in",
                     "google.co.jp",
-                    "google.co.nz",
-                    "google.co.uk"
+                    "google.co.nz"
                 ],
                 "rules": [
                     {


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/246491496396031/task/1212346837083574?focus=true

## Description
<!-- 
  Please delete either or both process sections below.
-->
This PR generalizes the approach we take to hiding the annoying "Switch to Chrome" pop-ups that are shown on several Google properties. We are going to begin trying this on several less popular TLDs, then if all goes well we will expand to the full set.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Reorganizes Google domain groups and adds generic hide rules to more TLDs to suppress "Switch to Chrome" promos/banners.
> 
> - **Element Hiding (features/element-hiding.json)**:
>   - **Google domains**:
>     - Split/reorganized TLD groups; moved `google.co.uk` into a generic group; removed `google.com`/`google.dk` from it and added them to the broader group.
>     - Added generic hide rules: `div:has(> iframe[src*='prid=190'])`, `[aria-labelledby='promo-header']`, `div:has(> [aria-labelledby='promo_label_id'])`, and `div[role='banner']:has(div > a[href='https://support.google.com/a/answer/33864'])`.
>     - Retained and expanded specific `prid=` iframe selectors for many TLDs (e.g., `google.com`, `google.dk`, EU/JP/IN/AU/BR/MX/NZ).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9f8e72112d5ce2246e49bf8710debccadd73b7a4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->