### PR TITLE
Update autoconsent to v14.43.0

### DIFF
--- a/features/autoconsent.json
+++ b/features/autoconsent.json
@@ -3647,7 +3647,8 @@
                 "#globalCookieBanner .js-customizeGlobalCookies",
                 "#cookieBanner button.cbSecondaryCTA",
                 ".cookie-banner-wrapper button.btn-secondary-lg",
-                "RBXcb"
+                "RBXcb",
+                "body > div:not([id]) > div:nth-child(2):not([id]) > div:nth-child(2):not([id]) > div:nth-child(2):not([id]) > div:not([id]) > button:not([id])"
             ],
             "r": [
                 [
@@ -21054,6 +21055,40 @@
                             "timeout": 1000,
                             "check": "none",
                             "wv": 1323
+                        }
+                    ],
+                    {}
+                ],
+                [
+                    1,
+                    "auto_CA_ticketsource.com_kiv",
+                    0,
+                    "^https?://(www\\.)?ticketsource\\.com/",
+                    10,
+                    [],
+                    [
+                        {
+                            "e": 2898
+                        }
+                    ],
+                    [
+                        {
+                            "v": 2898
+                        }
+                    ],
+                    [
+                        {
+                            "wait": 500
+                        },
+                        {
+                            "c": 2898
+                        }
+                    ],
+                    [
+                        {
+                            "timeout": 1000,
+                            "check": "none",
+                            "wv": 2898
                         }
                     ],
                     {}
@@ -88538,7 +88573,7 @@
                 ],
                 "specificRuleRange": [
                     183,
-                    2556
+                    2557
                 ],
                 "genericStringEnd": 702,
                 "frameStringEnd": 741


### PR DESCRIPTION
Asana Task/Github Issue: https://app.asana.com/1/137249556945/project/1201844467387842/task/1212352003296515

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds an autoconsent rule for ticketsource.com and extends cookie banner dismissal selectors; updates internal rule counts.
> 
> - **Autoconsent rules (`features/autoconsent.json`)**:
>   - **New site rule**: `auto_CA_ticketsource.com_kiv` for `^https?://(www\.)?ticketsource\.com/` with event `2898`, wait `500ms`, and checks configured.
>   - **Selectors**: Add new dismissal selector `body > div:not([id]) > div:nth-child(2):not([id]) > div:nth-child(2):not([id]) > div:nth-child(2):not([id]) > div:not([id]) > button:not([id])` (and fix trailing comma).
>   - **Metadata**: Increment `specificRuleRange` end from `2556` to `2557`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9c34222427e15c6366bde089b7581750e5155088. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->