### PR TITLE
Enable macOS hang reporting feature flag for >= 1.166.0

### DIFF
--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -1913,7 +1913,8 @@
                     "state": "enabled"
                 },
                 "hangReporting": {
-                    "state": "disabled"
+                    "state": "enabled",
+                    "minSupportedVersion": "1.166.0"
                 },
                 "unifiedURLPredictor": {
                     "state": "enabled",


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1211264967278501/task/1212358376130718?focus=true

## Description

This PR simply re-enables the macOS hang reporting feature flag for versions 1.166.0 of the Mac browser and above.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables `macOSBrowserConfig.features.hangReporting` with `minSupportedVersion` 1.166.0 in `overrides/macos-override.json`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5a758bd0e102b0ba13adc7c73e6449ea3cbe430c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->