### PR TITLE
Fix domain exception for sudouest.fr

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -512,7 +512,7 @@
                     "reason": "https://github.com/duckduckgo/privacy-configuration/issues/326"
                 },
                 {
-                    "domain": "https://www.sudouest.fr",
+                    "domain": "sudouest.fr",
                     "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2790"
                 },
                 {


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1206670747178362/task/1209521422716491?focus=true

## Description
Fixing my copy & paste fail 🤦‍♀️ 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes the `autoconsent` exceptions entry by changing `https://www.sudouest.fr` to `sudouest.fr` in `overrides/android-override.json`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bb44236658ca0fcc5490030d95a136a0829d4561. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->