### PR TITLE
Add AppTP package names to VPN exclusions

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -2071,7 +2071,7 @@
                     },
                     {
                         "packageName": "com.samsung.android.oneconnect"
-                    } 
+                    }
                 ]
             },
             "minSupportedVersion": 51670000


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1200746877073315/task/1211542145487231?focus=true

## Description
Adding the VPN-incompatible exclusions from AppTP to the VPN list as well.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds five Android package names to the Network Protection VPN auto-exclusion list.
> 
> - **Android – Network Protection (VPN)**:
>   - Add apps to `features.networkProtection.settings.autoExcludeApps` in `overrides/android-override.json`:
>     - `com.TWCableTV`, `com.amazon.storm.lightning.client.aosp`, `com.infrasoft.uboi`, `com.cbq.CBMobile`, `com.samsung.android.oneconnect`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0363b1c09711d502018445c5ff8cbbedbd6dc577. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->