### PR TITLE
Disable Mac hang reporting

### DIFF
--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -1913,8 +1913,7 @@
                     "state": "enabled"
                 },
                 "hangReporting": {
-                    "state": "enabled",
-                    "minSupportedVersion": "1.166.0"
+                    "state": "disabled"
                 },
                 "unifiedURLPredictor": {
                     "state": "enabled",


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1211264967278501/task/1212360881699392?focus=true

## Description

We’re still seeing over-reporting of hang pixels on Mac, so I’m disabling the feature flag again.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Disables `macOSBrowserConfig.features.hangReporting` in `overrides/macos-override.json`, removing its prior minSupportedVersion.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4383203cc301c687b7aa1e10c5d053597df52761. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->