### PR TITLE
Kill service_worker watchdog to validate if its causing webview2 stability issues

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -2797,10 +2797,10 @@
                     }
                 },
                 "serviceWorkerWatchdog": {
-                    "state": "enabled"
+                    "state": "disabled"
                 },
                 "serviceWorkerWatchdogUnregister": {
-                    "state": "preview"
+                    "state": "disabled"
                 }
             },
             "exceptions": []


### PR DESCRIPTION
## Description

Kill service_worker watchdog to validate if its causing webview2 stability issues

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Disables `serviceWorkerWatchdog` and `serviceWorkerWatchdogUnregister` in `overrides/windows-override.json` under `features.webview`.
> 
> - **Windows config (`overrides/windows-override.json`)**:
>   - **Webview features**:
>     - Set `features.webview.serviceWorkerWatchdog` to `disabled` (was `enabled`).
>     - Set `features.webview.serviceWorkerWatchdogUnregister` to `disabled` (was `preview`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b8075bef16510bf19e8c121bd454722d35a9fb51. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->