### PR TITLE
Remove 'chrome' from allowed scheme list for Windows browser

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -3219,7 +3219,6 @@
                     "https",
                     "file",
                     "mailto",
-                    "chrome",
                     "duck"
                 ]
             }


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/72649045549333/task/1212351124377050?focus=true

## Description
This was an oversight previously and we've never meant to support `chrome://` scheme urls.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes 'chrome' from `urlPredictor.settings.allowedSchemes` in `overrides/windows-override.json`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 425ef2ebf9678c96b67ae2b0a3fbd5b0eb326c75. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->