### PR TITLE
enable product surface telemetry for ios

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -1833,7 +1833,7 @@
                         ]
                     }
                 },
-                "productTelemeterySurfaceUsage": {
+                "productTelemetrySurfaceUsage": {
                     "state": "enabled",
                     "minSupportedVersion": "7.199.0",
                     "description": "Temporarily gather telemetry around product surfaces being used."


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/414235014887631/task/1212057154681076?focus=true

## Description
Enables product telemetry for surface usage.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables `productTelemetrySurfaceUsage` in iOS config with minSupportedVersion `7.199.0`.
> 
> - **iOS config (`overrides/ios-override.json`)**:
>   - **`iOSBrowserConfig.features`**:
>     - Add `productTelemetrySurfaceUsage` (state: `enabled`, `minSupportedVersion`: `7.199.0`) to collect surface usage telemetry.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 815f2309679d0c47e8e4757ea65f26617d50d7e4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->