### PR TITLE
SBT add cpm exception to ala-org

### DIFF
--- a/features/autoconsent.json
+++ b/features/autoconsent.json
@@ -738,6 +738,10 @@
         {
             "domain": "err.ch",
             "reason": "https://github.com/duckduckgo/privacy-configuration/pull/4203"
+        },
+        {
+            "domain": "ala.org",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/pull/4232"
         }
     ],
     "settings": {


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1206670747178362/task/1212348173293130?focus=true

## Description

### Site breakage mitigation process:
#### Brief explanation
- Reported URL: ala.org
- Problems experienced: users need to accept cookies to browse the site
- Platforms affected:
  - [x] iOS
  - [ ] Android
  - [x] Windows
  - [x] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked: NA
- Feature being disabled/modified: CPM
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `ala.org` to the autoconsent exceptions list.
> 
> - **Autoconsent config**:
>   - Add `ala.org` to the `exceptions` in `features/autoconsent.json` with reference to PR `#4232`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 36d2e550058b32fc7071055f1d435a0f512096d7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->