### PR TITLE
Enable Input Screen onboarding (Android)

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -1232,6 +1232,9 @@
         "androidBrowserConfig": {
             "state": "enabled",
             "features": {
+                "showInputScreenOnboarding": {
+                    "state": "enabled"
+                },
                 "useUrlPredictor": {
                     "state": "disabled"
                 },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1200204095367872/task/1212382580241537?focus=true

## Description
Enables `showInputScreenOnboarding`

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [x] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enable `showInputScreenOnboarding` feature in `androidBrowserConfig` for Android.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 617df66487c7d854b5fccb58c2fc65e6d6a34885. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->