### PR TITLE
Enable fadeOutOnToggle feature flag for internal users

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -299,6 +299,11 @@
                 "fullDuckAIModeExperimentalSetting": {
                     "state": "enabled",
                     "minSupportedVersion": "7.199.0"
+                },
+                "fadeOutOnToggle": {
+                    "state": "internal",
+                    "description": "Unify inputs for Duck.ai",
+                    "minSupportedVersion": "7.199.0"
                 }
             },
             "settings": {


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1210947754188321/task/1212381268571774?focus=true

## Description
<!-- 
  Please delete either or both process sections below.
-->

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [x] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `aiChat.features.fadeOutOnToggle` as an internal feature flag for iOS (min version 7.199.0) with a brief description.
> 
> - **iOS Config (`overrides/ios-override.json`)**:
>   - **AI Chat**:
>     - Add `features.fadeOutOnToggle` with `state: internal`, `minSupportedVersion: 7.199.0`, and description "Unify inputs for Duck.ai".
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f1280a6bab3e79e0094412d99185cb59d0b24d42. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->