### PR TITLE
Enable URL predictor on 5.259.1+ (Android)

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -1236,7 +1236,8 @@
                     "state": "enabled"
                 },
                 "useUrlPredictor": {
-                    "state": "disabled"
+                    "state": "enabled",
+                    "minSupportedVersion": 52591000
                 },
                 "collectFullWebViewVersion": {
                     "state": "enabled"


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1200204095367872/task/1212382742998811?focus=true

## Description
Enables `useUrlPredictor` on 5.259.1+

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [x] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables `androidBrowserConfig.features.useUrlPredictor` on Android with `minSupportedVersion` 52591000.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 814e018f48772c9aa58f9d201f9dc612bf9a3b40. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->