### PR TITLE
Correct name of customization feature in config for iOS

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -1829,7 +1829,14 @@
                 "customization": {
                     "state": "enabled",
                     "minSupportedVersion": "7.198.0",
-                    "description": "Allow users to customize button on toolbar and addressbar"
+                    "description": "Allow users to customize button on toolbar and addressbar",
+                    "rollout": {
+                        "steps": [
+                            {
+                                "percent": 25
+                            }
+                        ]
+                    }
                 },
                 "productTelemetrySurfaceUsage": {
                     "state": "enabled",


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/72649045549333/task/1211670987582450?focus=true

## Description
Fix the name the name for the feature.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Renames the iOS browser config feature key from `mobileCustomization` to `customization`.
> 
> - **iOS config (`overrides/ios-override.json`)**:
>   - Rename feature key in `features.iOSBrowserConfig.features` from `mobileCustomization` to `customization` (retains existing settings and rollout).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d7d8d9693b9c2e41ad5388b4181dd2c8f95d5167. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->