### PR TITLE
Exception to display nutrition calculator on chipotle.com

### DIFF
--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -621,6 +621,17 @@
                     }
                 ]
             },
+            "azurefd.net": {
+                "rules": [
+                    {
+                        "rule": "orderwebstrg-prd-cdn-h3apayd2cuehgffe.a03.azurefd.net",
+                        "domains": [
+                            "chipotle.com"
+                        ],
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/pull/4244"
+                    }
+                ]
+            },
             "bc0a.com": {
                 "rules": [
                     {


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/1200277586140538/task/1212347585564086?focus=true

## Description
### Site breakage mitigation process:
#### Brief explanation
- Reported URL: https://www.chipotle.com/nutrition-calculator
- Problems experienced: The nutrition calculator content is not displayed on some platforms.
- Platforms affected:
  - [ ] iOS
  - [x] Android
  - [x] Windows
  - [ ] MacOS
  - [x] Extensions
- Tracker(s) being unblocked: azurefd.net
- Feature being disabled/modified: N/A
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds an allowlist entry for `azurefd.net` (specific CDN host) on `chipotle.com` to mitigate site breakage.
> 
> - **Tracker allowlist**:
>   - Add `azurefd.net` rule `orderwebstrg-prd-cdn-h3apayd2cuehgffe.a03.azurefd.net` for `chipotle.com` in `features/tracker-allowlist.json` (reason references PR 4244).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 67b1638604e9d58c61005fdafa9778824a524746. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->