### PR TITLE
Enable omnibar toggle for internal users

### DIFF
--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -402,6 +402,10 @@
                     "state": "enabled",
                     "minSupportedVersion": "1.161.0"
                 },
+                "omnibarToggle": {
+                    "state": "internal",
+                    "minSupportedVersion": "1.170.0"
+                },
                 "keepSession": {
                     "state": "enabled",
                     "minSupportedVersion": "1.161.0",


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/1204167627774280/task/1212325763449474?focus=true

## Description
Enable macOS omnibar AI Chat toggle for internal users

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [x] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [x] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `aiChat` `omnibarToggle` (state: `internal`, minSupportedVersion: `1.170.0`) to `overrides/macos-override.json`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 69245476d1bd2e2dcb790640a098b7ba1ae28d66. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->