### PR TITLE
Release autoconsent stats in 1.169.0

### DIFF
--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -1131,7 +1131,8 @@
                     "state": "enabled"
                 },
                 "autoconsentStats": {
-                    "state": "internal"
+                    "state": "enabled",
+                    "minSupportedVersion": "1.169.0"
                 }
             }
         },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1163321984198618/task/1203578778040829?focus=true

## Description
Release autoconsent stats in 1.169.0

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables `htmlNewTabPage` feature `autoconsentStats` on macOS with minSupportedVersion 1.169.0.
> 
> - **macOS override config**:
>   - `features.htmlNewTabPage.features.autoconsentStats`: set to `enabled` and add `minSupportedVersion` `1.169.0`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 66afc434cec0e508dff50b31c5c0184ecbae445f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->