### PR TITLE
Enable product reviews on robertwelch.com

### DIFF
--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -1944,6 +1944,17 @@
                     }
                 ]
             },
+            "feefo.com": {
+                "rules": [
+                    {
+                        "rule": "register.feefo.com/feefo-widgets-app/feefo_widgets_loader.js",
+                        "domains": [
+                            "robertwelch.com"
+                        ],
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/pull/4249"
+                    }
+                ]
+            },
             "flodesk.com": {
                 "rules": [
                     {


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/1200277586140538/task/1212431056202349?focus=true

## Description
### Site breakage mitigation process:
#### Brief explanation
- Reported URL: https://www.robertwelch.com/products/limbrey-salt-pepper-mill-set-bright
- Problems experienced: Review section is not displaying due to feefo.com being blocked.
- Platforms affected:
  - [x] iOS
  - [x] Android
  - [x] Windows
  - [x] MacOS
  - [x] Extensions
- Tracker(s) being unblocked: Feefo
- Feature being disabled/modified: N/A
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Allowlists the Feefo widget script to enable product reviews on robertwelch.com.
> 
> - **Config**
>   - Update `features/tracker-allowlist.json`:
>     - Add `feefo.com` allowlist rule for `register.feefo.com/feefo-widgets-app/feefo_widgets_loader.js` scoped to `robertwelch.com`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1c0832416b69d702c8243cfed957095b08e142d3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->