### PR TITLE
Hiding blank spaces on coindesk.com

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -1166,6 +1166,10 @@
                     {
                         "selector": "[data-freestar-ad='true']",
                         "type": "closest-empty"
+                    },
+                    {
+                        "selector": "[class*='--ad-height']",
+                        "type": "hide"
                     }
                 ]
             },


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/1200277586140538/task/1212444786802582?focus=true

## Description
### Site breakage mitigation process:
#### Brief explanation
- Reported URL: https://www.coindesk.com/
- Problems experienced: Big blank spaces where tracker-blocking has blocked ads.
- Platforms affected:
  - [x] iOS
  - [x] Android
  - [x] Windows
  - [x] MacOS
  - [x] Extensions
- Tracker(s) being unblocked: N/A
- Feature being disabled/modified: N/A
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add a coindesk.com rule to hide elements matching `[class*='--ad-height']` to remove blank ad space.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1c4d8efc1f9d49b88f0bdfe5de2d08e7326772cc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->