### PR TITLE
Trigger the workflow to create the Asana task for feature flag cleanup only after the PR is merged

### DIFF
--- a/.github/workflows/feature-flag-cleanup-tracker.yml
+++ b/.github/workflows/feature-flag-cleanup-tracker.yml
@@ -2,19 +2,14 @@ name: Feature Flag Cleanup Tracker (Android)
 
 on:
     pull_request:
-        types: [opened, synchronize]
+        types: [closed]
         paths:
             - 'overrides/android-override.json'
-    workflow_dispatch:
-        inputs:
-            pr_number:
-                description: 'PR number to check for feature flags'
-                required: true
-                type: number
 
 jobs:
     create-cleanup-task:
         runs-on: ubuntu-latest
+        if: github.event.pull_request.merged == true
 
         steps:
             - name: Checkout code
@@ -22,36 +17,13 @@ jobs:
               with:
                   fetch-depth: 0
 
-            - name: Get PR details (for workflow_dispatch)
-              if: github.event_name == 'workflow_dispatch'
-              id: pr_details
-              env:
-                  GH_TOKEN: ${{ github.token }}
-              run: |
-                  PR_NUMBER=${{ inputs.pr_number }}
-
-                  # Fetch PR details using gh CLI
-                  PR_DATA=$(gh pr view $PR_NUMBER --json number,headRefOid,baseRefOid,url,author)
-
-                  echo "base_sha=$(echo "$PR_DATA" | jq -r '.baseRefOid')" >> $GITHUB_OUTPUT
-                  echo "head_sha=$(echo "$PR_DATA" | jq -r '.headRefOid')" >> $GITHUB_OUTPUT
-                  echo "pr_number=$PR_NUMBER" >> $GITHUB_OUTPUT
-                  echo "pr_url=$(echo "$PR_DATA" | jq -r '.url')" >> $GITHUB_OUTPUT
-
             - name: Set PR context variables
               id: pr_context
               run: |
-                  if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
-                    echo "base_sha=${{ steps.pr_details.outputs.base_sha }}" >> $GITHUB_OUTPUT
-                    echo "head_sha=${{ steps.pr_details.outputs.head_sha }}" >> $GITHUB_OUTPUT
-                    echo "pr_number=${{ steps.pr_details.outputs.pr_number }}" >> $GITHUB_OUTPUT
-                    echo "pr_url=${{ steps.pr_details.outputs.pr_url }}" >> $GITHUB_OUTPUT
-                  else
-                    echo "base_sha=${{ github.event.pull_request.base.sha }}" >> $GITHUB_OUTPUT
-                    echo "head_sha=${{ github.event.pull_request.head.sha }}" >> $GITHUB_OUTPUT
-                    echo "pr_number=${{ github.event.pull_request.number }}" >> $GITHUB_OUTPUT
-                    echo "pr_url=${{ github.event.pull_request.html_url }}" >> $GITHUB_OUTPUT
-                  fi
+                  echo "base_sha=${{ github.event.pull_request.base.sha }}" >> $GITHUB_OUTPUT
+                  echo "head_sha=${{ github.event.pull_request.head.sha }}" >> $GITHUB_OUTPUT
+                  echo "pr_number=${{ github.event.pull_request.number }}" >> $GITHUB_OUTPUT
+                  echo "pr_url=${{ github.event.pull_request.html_url }}" >> $GITHUB_OUTPUT
 
             - name: Install jq
               run: sudo apt-get update && sudo apt-get install -y jq


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1211724162604201/task/1212427451803374?focus=true

## Description
Trigger the workflow to create the Asana task for feature flag cleanup only after the PR is merged.
Also remove the workflow dispatch from the yaml file.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [x] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Update the Android feature-flag cleanup workflow to trigger only on merged PRs, remove manual workflow_dispatch, and simplify PR context retrieval.
> 
> - **CI/Workflows**:
>   - Trigger `Feature Flag Cleanup Tracker (Android)` only on `pull_request` `closed` events for `overrides/android-override.json`, gated by `merged == true`.
>   - Remove `workflow_dispatch` entry and associated `gh`/`jq` PR detail fetching logic.
>   - Simplify PR context setup to use `github.event.pull_request` fields directly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bced7f9b45ad70c01caa00e1cb0b84e2181ed068. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->