### PR TITLE
Bumps webNotificationsFixExperiment to 50%

### DIFF
--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -239,6 +239,9 @@
                     "rollout": {
                         "steps": [
                             {
+                                "percent": 10
+                            },
+                            {
                                 "percent": 50
                             }
                         ]


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/task/1212458320749306

## Description

Bumps webNotificationsFixExperiment to 50%

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Increase `webNotificationsFixExperiment` rollout from 10% to 50% in `overrides/macos-override.json`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8279a70d55825aece0c3adc7633550279c7fe65a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->