### PR TITLE
Hide overlay on facebook.com

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -1632,6 +1632,14 @@
                     {
                         "selector": ".xnw9j1v:has(div > a[href='https://www.facebook.com/help/597429858389632/'])",
                         "type": "hide"
+                    },
+                    {
+                        "selector": ".x1ey2m1c.xtijo5x.x1o0tod.xixxii4.x13vifvy.x1h0vfkc",
+                        "type": "hide-empty"
+                    },
+                    {
+                        "selector": ".x1uvtmcs.x4k7w5x.x1h91t0o.x1beo9mf.xaigb6o.x12ejxvf.x3igimt.xarpa2k.xedcshv.x1lytzrv.x1t2pt76.x7ja8zs.x1n2onr6.x1qrby5j.x1jfb8zj",
+                        "type": "hide"
                     }
                 ]
             },


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/1200277586140538/task/1212484837348031?focus=true

## Description
### Site breakage mitigation process:
#### Brief explanation
- Reported URL: https://www.facebook.com
- Problems experienced: Overlay covering the page.
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [x] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked: N/A
- Feature being disabled/modified: N/A
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add two element-hiding rules on facebook.com to hide/clean up overlay containers.
> 
> - **Domains**:
>   - **`facebook.com`**:
>     - Add `hide-empty` rule for selector `.x1ey2m1c.xtijo5x.x1o0tod.xixxii4.x13vifvy.x1h0vfkc`.
>     - Add `hide` rule for selector `.x1uvtmcs.x4k7w5x.x1h91t0o.x1beo9mf.xaigb6o.x12ejxvf.x3igimt.xarpa2k.xedcshv.x1lytzrv.x1t2pt76.x7ja8zs.x1n2onr6.x1qrby5j.x1jfb8zj`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b1b8eeb1f6bc83f102990677444be93fcc3d1650. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->