### PR TITLE
Updated hiding overlay on facebook.com

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -1634,11 +1634,7 @@
                         "type": "hide"
                     },
                     {
-                        "selector": ".x1ey2m1c.xtijo5x.x1o0tod.xixxii4.x13vifvy.x1h0vfkc",
-                        "type": "hide-empty"
-                    },
-                    {
-                        "selector": ".x1uvtmcs.x4k7w5x.x1h91t0o.x1beo9mf.xaigb6o.x12ejxvf.x3igimt.xarpa2k.xedcshv.x1lytzrv.x1t2pt76.x7ja8zs.x1n2onr6.x1qrby5j.x1jfb8zj",
+                        "selector": ".x1n2onr6.x1vjfegm",
                         "type": "hide"
                     }
                 ]


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/1200277586140538/task/1212484837348031?focus=true

## Description
### Site breakage mitigation process:
#### Brief explanation
- Reported URL: https://www.facebook.com
- Problems experienced: Overlay covering the page. Previously hidden in #4259 but that affected scrolling. Moving the element hiding further up the DOM tree seems to be better.
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [x] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked: N/A
- Feature being disabled/modified: N/A
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces two Facebook selectors with a single `.x1n2onr6.x1vjfegm` hide rule, retaining the existing help-link overlay hide.
> 
> - **Domains**:
>   - **`facebook.com`**:
>     - Replace two previous selectors (one `hide-empty`, one `hide`) with a single `hide` selector: `.x1n2onr6.x1vjfegm`.
>     - Retains rule hiding `.xnw9j1v:has(div > a[href='https://www.facebook.com/help/597429858389632/'])`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 56ecccc747ea777645be8fa0d2c79d5a09a6b5d8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->