### PR TITLE
Reverting overlay hiding on facebook.com

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -1632,10 +1632,6 @@
                     {
                         "selector": ".xnw9j1v:has(div > a[href='https://www.facebook.com/help/597429858389632/'])",
                         "type": "hide"
-                    },
-                    {
-                        "selector": ".x1n2onr6.x1vjfegm",
-                        "type": "hide"
                     }
                 ]
             },


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/1200277586140538/task/1212484837348031?focus=true

## Description
### Site breakage mitigation process:
#### Brief explanation
- Reported URL: https://www.facebook.com
- Problems experienced: Element hiding in #4259 and #4260 caused problems with scrolling and dynamically-loading elements, so reverting to the overlay as the least-worst while we look for a better solution.
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [x] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked: N/A
- Feature being disabled/modified: N/A
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes one element-hiding rule for facebook.com.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1a9c507b7dfe70a51f18c33aae622e23a501f986. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->