### PR TITLE
Deny notification permission requests (fixes overlay on facebook.com)

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -45,16 +45,29 @@
                         "getterValue": {
                             "type": "undefined"
                         }
-                    },
-                    "Notification.permission": {
-                        "type": "descriptor",
-                        "getterValue": {
-                            "type": "string",
-                            "value": "denied"
-                        }
                     }
                 },
                 "conditionalChanges": [
+                    {
+                        "condition": [
+                            {
+                                "domain": "facebook.com"
+                            }
+                        ],
+                        "patchSettings": [
+                            {
+                                "op": "add",
+                                "path": "/apiChanges/Notification.permission",
+                                "value": {
+                                    "type": "descriptor",
+                                    "getterValue": {
+                                        "type": "string",
+                                        "value": "denied"
+                                    }
+                                }
+                            }
+                        ]
+                    },
                     {
                         "condition": [
                             {


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/1206670747178362/task/1212484837348031?focus=true

## Description
### Site breakage mitigation process:
#### Brief explanation
- Reported URL: https://www.facebook.com
- Problems experienced: Blank overlay covering the site due to push notification issue.
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [x] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked: N/A
- Feature being disabled/modified: `Notification.permission`
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> On Windows, add a conditional override so `Notification.permission` returns "denied" on `facebook.com`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4e3f1c55df73ff5499a7f305cae64808354e515d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->