### PR TITLE
iOS: Set Duck.ai Full Mode Enabled, Min. Version 7.200. Also Disable Preview Setting

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -296,10 +296,6 @@
                     "state": "enabled",
                     "minSupportedVersion": "7.200.0"
                 },
-                "fullDuckAIModeExperimentalSetting": {
-                    "state": "enabled",
-                    "minSupportedVersion": "7.199.0"
-                },
                 "fadeOutOnToggle": {
                     "state": "internal",
                     "description": "Unify inputs for Duck.ai",


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1206488453854252/task/1211750191256510?focus=true

## Description
Set Duck.ai full mode enabled, min version 7.200. This means this will reach the public Jan 5, as 7.200 is not being publicly released due to holiday schedule.

Also removes the FF for an experimental setting, which we no longer want to display once we fully roll out.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables full Duck.ai mode for iOS and cleans up related flags.
> 
> - Set `aiChat.features.fullDuckAIMode` to `enabled` with `minSupportedVersion` `7.200.0` in `overrides/ios-override.json`
> - Remove `fullDuckAIModeExperimentalSetting` under `aiChat.features`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0b1097b330aadd570e4f1a0ebd693497e45968a6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->