### PR TITLE
Expand exception for shop.app domain to mitigate multiple Shopify sites

### DIFF
--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -4067,9 +4067,9 @@
                     {
                         "rule": "shop.app",
                         "domains": [
-                            "laurageller.com"
+                            "<all>"
                         ],
-                        "reason": "https://github.com/duckduckgo/privacy-configuration/pull/4070"
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/pull/4264"
                     }
                 ]
             },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1206670747178362/task/1212423719134581?focus=true

### Site breakage mitigation process:
#### Brief explanation
- Reported URL: bertello.com (standard shopify storefront, so others very likely affected)
- Problems experienced: tracking QR code can't generate
- Platforms affected:
  - [x] All
- Tracker(s) being unblocked: `shop.app`

-Note: We will circle back and narrow this down once we adjust the blocklist to be more conservative.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Expands `shop.app` allowlist from a single domain to all domains and updates the reference link.
> 
> - **Tracker allowlist config**:
>   - `features/tracker-allowlist.json`
>     - `shop.app` rules: expand `"shop.app"` allowlist domains from `"laurageller.com"` to `"<all>"`.
>     - Update `reason` link to `https://github.com/duckduckgo/privacy-configuration/pull/4264`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f796648835a7b33c379280590ca246d80efe0cc9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->