### PR TITLE
Add luna.amazon.com to message listeners hack

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -1407,17 +1407,11 @@
                 },
                 "domains": [
                     {
-                        "domain": "www.cbsnews.com",
-                        "patchSettings": [
-                            {
-                                "op": "replace",
-                                "path": "/messageHandlers/state",
-                                "value": "enabled"
-                            }
-                        ]
-                    },
-                    {
-                        "domain": "myhome.experian.co.uk",
+                        "domain": [
+                            "www.cbsnews.com",
+                            "myhome.experian.co.uk",
+                            "luna.amazon.com"
+                        ],
                         "patchSettings": [
                             {
                                 "op": "replace",

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -703,17 +703,11 @@
                         ]
                     },
                     {
-                        "domain": "www.cbsnews.com",
-                        "patchSettings": [
-                            {
-                                "op": "replace",
-                                "path": "/messageHandlers/state",
-                                "value": "enabled"
-                            }
-                        ]
-                    },
-                    {
-                        "domain": "myhome.experian.co.uk",
+                        "domain": [
+                            "www.cbsnews.com",
+                            "myhome.experian.co.uk",
+                            "luna.amazon.com"
+                        ],
                         "patchSettings": [
                             {
                                 "op": "replace",


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1207686573307971/task/1212259562546282

## Description

Broken page deemed to be caused by our listeners.

<img width="3024" height="1884" alt="image" src="https://github.com/user-attachments/assets/683d86e9-508e-4467-9c83-edde06120bc0" />


### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `luna.amazon.com` to the WebCompat message handler allowlist (grouped with `www.cbsnews.com` and `myhome.experian.co.uk`) for both iOS and macOS.
> 
> - **WebCompat**:
>   - **iOS (`overrides/ios-override.json`)**:
>     - Group `domains` into an array and add `luna.amazon.com`; keep `www.cbsnews.com` and `myhome.experian.co.uk`.
>     - Ensure `/messageHandlers/state` is set to `enabled` via `patchSettings`.
>   - **macOS (`overrides/macos-override.json`)**:
>     - Group `domains` into an array and add `luna.amazon.com`; keep `www.cbsnews.com` and `myhome.experian.co.uk`.
>     - Ensure `/messageHandlers/state` is set to `enabled` via `patchSettings`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5f1b93e48c3a7b52242154aca3875a67d479d297. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->