### PR TITLE
Hide adblock wall on la7.it

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -2447,6 +2447,15 @@
                 ]
             },
             {
+                "domain": "la7.it",
+                "rules": [
+                    {
+                        "selector": "#site-message-overlay",
+                        "type": "hide"
+                    }
+                ]
+            },
+            {
                 "domain": "leboncoin.fr",
                 "rules": [
                     {


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/1206670747178362/task/1212486511148250?focus=true

## Description
### Site breakage mitigation process:
#### Brief explanation
- Reported URL: https://www.la7.it
- Problems experienced: Adblock wall.
- Platforms affected:
  - [x] iOS
  - [x] Android
  - [x] Windows
  - [x] MacOS
  - [x] Extensions
- Tracker(s) being unblocked: N/A
- Feature being disabled/modified: N/A
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add domain-specific rule to hide `#site-message-overlay` on `la7.it`.
> 
> - **Element hiding config**:
>   - Add domain `la7.it` with a hide rule for `#site-message-overlay` to remove the adblock wall.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8e1fe3c96327cbc0c97fe2ff6b250d862d9d3533. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->