### PR TITLE
Revert Enable crashAutoRecovery for DDG-WV

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -2783,8 +2783,8 @@
                     "state": "enabled"
                 },
                 "crashAutoRecovery": {
-                    "state": "enabled",
-                    "minSupportedVersion": "0.142.1",
+                    "state": "disabled",
+                    "minSupportedVersion": "0.125.0",
                     "settings": {
                         "autoRecoveryBrowserEngine": true,
                         "autoRecoveryTab": true,


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/72649045549333/task/1212529160807639?focus=true

## Description
We're seeing a huge spike in tab crashes on ddg-webview for 0.142.1 this config change is the only real big change, so revert for now.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Disables `features.windowsWebviewFailures.crashAutoRecovery` and lowers its `minSupportedVersion` to `0.125.0` in `overrides/windows-override.json`.
> 
> - **Windows configuration** (`overrides/windows-override.json`):
>   - **WebView failures**:
>     - Set `features.windowsWebviewFailures.crashAutoRecovery.state` to `disabled`.
>     - Adjust `features.windowsWebviewFailures.crashAutoRecovery.minSupportedVersion` from `0.142.1` to `0.125.0`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1e7031ae1ead03c086ea0955973ab01282e90d1c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->