### PR TITLE
Hide blank space on backpacker.com

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -846,6 +846,15 @@
                 ]
             },
             {
+                "domain": "backpacker.com",
+                "rules": [
+                    {
+                        "selector": ".prestitial-ad",
+                        "type": "hide-empty"
+                    }
+                ]
+            },
+            {
                 "domain": "bbc.com",
                 "rules": [
                     {


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/1206670747178362/task/1212525924667436?focus=true

## Description
### Site breakage mitigation process:
#### Brief explanation
- Reported URL: https://www.backpacker.com/gear-reviews/the-4-best-satellite-communicators-for-backpackers/
- Problems experienced: Blank space below top nav bar, caused by tracker blocking.
- Platforms affected:
  - [x] iOS
  - [x] Android
  - [x] Windows
  - [x] MacOS
  - [x] Extensions
- Tracker(s) being unblocked: N/A
- Feature being disabled/modified: Element hiding
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Mitigates visible blank space on backpacker.com caused by blocked ad slots.
> 
> - Adds `backpacker.com` domain rule in `features/element-hiding.json` to `hide-empty` for `.prestitial-ad`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d36e2a7f8a9be99c2f96bbe0b92063ad1e021f71. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->