### PR TITLE
Set fadeOutOnToggle to enabled

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -301,9 +301,9 @@
                     "minSupportedVersion": "7.199.0"
                 },
                 "fadeOutOnToggle": {
-                    "state": "internal",
+                    "state": "enabled",
                     "description": "Unify inputs for Duck.ai",
-                    "minSupportedVersion": "7.199.0"
+                    "minSupportedVersion": "7.201.0"
                 }
             },
             "settings": {


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1210947754188321/task/1212545829363462

## Description
This PR sets `fadeOutOnToggle` to `enabled` with defined minimum version

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [x] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables the `aiChat` feature flag for `fadeOutOnToggle` and updates its minimum supported version.
> 
> - In `overrides/ios-override.json`, set `aiChat.features.fadeOutOnToggle.state` to `enabled`
> - Bump `aiChat.features.fadeOutOnToggle.minSupportedVersion` from `7.199.0` to `7.201.0`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a87f612a2af25c8899dc56dbaa89612948796501. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->