### PR TITLE
Add makerworld cpm exception

### DIFF
--- a/features/autoconsent.json
+++ b/features/autoconsent.json
@@ -742,6 +742,10 @@
         {
             "domain": "ala.org",
             "reason": "https://github.com/duckduckgo/privacy-configuration/pull/4232"
+        },
+        {
+            "domain": "makerworld.com",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/pull/4280"
         }
     ],
     "settings": {


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1206670747178362/task/1212537553290468?focus=true

### Site breakage mitigation process:
#### Brief explanation
- Reported URL: makerworld.com
- Problems experienced: CPM freezes secondary pop-up
- Platforms affected:
  - [x] All
- Feature being disabled/modified: autoconsent

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Mitigates site breakage by expanding autoconsent exceptions.
> 
> - Adds `makerworld.com` to `features/autoconsent.json` domain exceptions (with reference link) to disable autoconsent and avoid CPM pop-up freeze
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cf9b442a261805df1656acc28124c8cb7c85ab06. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->