### PR TITLE
Android: Remove SERP easter egg logo feature toggle

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -3411,28 +3411,7 @@
         "serpEasterEggLogos": {
             "state": "enabled",
             "exceptions": [],
-            "features": {
-                "feature": {
-                    "state": "enabled",
-                    "minSupportedVersion": 52470000,
-                    "rollout": {
-                        "steps": [
-                            {
-                                "percent": 5
-                            },
-                            {
-                                "percent": 20
-                            },
-                            {
-                                "percent": 50
-                            },
-                            {
-                                "percent": 100
-                            }
-                        ]
-                    }
-                }
-            }
+            "features": {}
         },
         "onboardingDesignExperiment": {
             "state": "disabled",


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/10125252356626/task/1212374007733022?focus=true

## Description
<!-- 
  Please delete either or both process sections below.
-->

Remove the SERP Easter Egg Logo feature toggle as the toggle has been removed from the Android codebase and the feature permanently enabled.

Leaving the global serpEasterEggLogos toggle as I intend to do future work on this.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes the per-rollout sub-feature for SERP easter egg logos while keeping the global toggle enabled.
> 
> - In `overrides/android-override.json`, replaced `serpEasterEggLogos.features` (previously contained an enabled feature with version and rollout steps) with an empty object.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9d2785eec7bdc7b73493385a5543c88d721258fc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->