### PR TITLE
Update autoconsent to v14.45.0

### DIFF
--- a/features/autoconsent.json
+++ b/features/autoconsent.json
@@ -3658,7 +3658,9 @@
                 "RBXcb",
                 "body > div:not([id]) > div:nth-child(2):not([id]) > div:nth-child(2):not([id]) > div:nth-child(2):not([id]) > div:not([id]) > button:not([id])",
                 "body > div:not([id]) > div:nth-child(2):not([id]) > div:nth-child(1):not([id]) > button:not([id])",
-                "body > div:not([id]) > div > div[data-cy=cookie-modal] > div:not([id]) > div:nth-child(2):not([id]) > div:nth-child(2):not([id]) > button:nth-child(2):not([id])"
+                "body > div:not([id]) > div > div[data-cy=cookie-modal] > div:not([id]) > div:nth-child(2):not([id]) > div:nth-child(2):not([id]) > button:nth-child(2):not([id])",
+                "body > div:not([id]) > div:nth-child(4):not([id]) > div:nth-child(4):not([id]) > div:nth-child(2):not([id]) > button:nth-child(2):not([id])",
+                "body > div:not([id]) > div:nth-child(4):not([id]) > div:nth-child(4):not([id]) > div:nth-child(2):not([id]) > button:nth-child(3):not([id])"
             ],
             "r": [
                 [
@@ -11855,6 +11857,40 @@
                 ],
                 [
                     1,
+                    "auto_AU_acetool.com_n0w_+1",
+                    0,
+                    "^https?://(www\\.)?acetool\\.com/|^https?://(www\\.)?unclewiener\\.com/",
+                    10,
+                    [],
+                    [
+                        {
+                            "e": 1299
+                        }
+                    ],
+                    [
+                        {
+                            "v": 1299
+                        }
+                    ],
+                    [
+                        {
+                            "wait": 500
+                        },
+                        {
+                            "c": 1299
+                        }
+                    ],
+                    [
+                        {
+                            "timeout": 1000,
+                            "check": "none",
+                            "wv": 1299
+                        }
+                    ],
+                    {}
+                ],
+                [
+                    1,
                     "auto_AU_adultwork.com_942",
                     0,
                     "^https?://(www\\.)?adultwork\\.com/",
@@ -17075,6 +17111,74 @@
                 ],
                 [
                     1,
+                    "auto_AU_spark.worldstrides.com_7j4",
+                    0,
+                    "^https?://(www\\.)?spark\\.worldstrides\\.com/",
+                    10,
+                    [],
+                    [
+                        {
+                            "e": 2901
+                        }
+                    ],
+                    [
+                        {
+                            "v": 2901
+                        }
+                    ],
+                    [
+                        {
+                            "wait": 500
+                        },
+                        {
+                            "c": 2901
+                        }
+                    ],
+                    [
+                        {
+                            "timeout": 1000,
+                            "check": "none",
+                            "wv": 2901
+                        }
+                    ],
+                    {}
+                ],
+                [
+                    1,
+                    "auto_AU_spark.worldstrides.com_qbl",
+                    0,
+                    "^https?://(www\\.)?spark\\.worldstrides\\.com/",
+                    10,
+                    [],
+                    [
+                        {
+                            "e": 2902
+                        }
+                    ],
+                    [
+                        {
+                            "v": 2902
+                        }
+                    ],
+                    [
+                        {
+                            "wait": 500
+                        },
+                        {
+                            "c": 2902
+                        }
+                    ],
+                    [
+                        {
+                            "timeout": 1000,
+                            "check": "none",
+                            "wv": 2902
+                        }
+                    ],
+                    {}
+                ],
+                [
+                    1,
                     "auto_AU_sqlservercentral.com_bmw",
                     0,
                     "^https?://(www\\.)?sqlservercentral\\.com/",
@@ -21371,40 +21475,6 @@
                             "timeout": 1000,
                             "check": "none",
                             "wv": 1325
-                        }
-                    ],
-                    {}
-                ],
-                [
-                    1,
-                    "auto_CA_unclewiener.com_c12",
-                    0,
-                    "^https?://(www\\.)?unclewiener\\.com/",
-                    10,
-                    [],
-                    [
-                        {
-                            "e": 1299
-                        }
-                    ],
-                    [
-                        {
-                            "v": 1299
-                        }
-                    ],
-                    [
-                        {
-                            "wait": 500
-                        },
-                        {
-                            "c": 1299
-                        }
-                    ],
-                    [
-                        {
-                            "timeout": 1000,
-                            "check": "none",
-                            "wv": 1299
                         }
                     ],
                     {}
@@ -88651,7 +88721,7 @@
                 ],
                 "specificRuleRange": [
                     183,
-                    2559
+                    2561
                 ],
                 "genericStringEnd": 702,
                 "frameStringEnd": 741


### PR DESCRIPTION
Asana Task/Github Issue: https://app.asana.com/1/137249556945/project/1201844467387842/task/1212497058434327

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates autoconsent data and selectors.
> 
> - Adds new site rules: `acetool.com` (also matching `unclewiener.com`) and two for `spark.worldstrides.com`
> - Removes `auto_CA_unclewiener.com_c12` rule
> - Extends cookie modal selectors with two additional button paths
> - Updates `specificRuleRange` end from `2559` to `2561` in `features/autoconsent.json`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ffc2058bb9d8a5bf429fb17e8f93c5ba5f7669f3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->