### PR TITLE
Update autoconsent to v14.47.0

### DIFF
--- a/features/autoconsent.json
+++ b/features/autoconsent.json
@@ -1819,7 +1819,7 @@
                 "body:not([id]) > div#onetrust-consent-sdk > div:nth-child(2)#onetrust-banner-sdk > div:not([id]) > div:nth-child(1):not([id]) > div:not([id]) > div:nth-child(2)#onetrust-button-group-parent > div#onetrust-button-group > button:nth-child(2)#onetrust-reject-all-handler",
                 "body#collection-59d726c7f6576e961db44d2c > div:not([id]) > section:not([id]) > div:nth-child(2):not([id]) > button:nth-child(2):not([id])",
                 "body > div#__next > div:nth-child(1):not([id]) > div:not([id]) > div:not([id]) > div:not([id])[data-testid=\"CookieBanner\"] > div:nth-child(3):not([id]) > button:nth-child(2):not([id])[data-testid=\"CookieBanner\\.DeclineButton\"]",
-                "body > main#app > div:nth-child(4):not([id]) > div:nth-child(2):not([id]) > button:nth-child(2):not([id])",
+                "body > main#app > div:nth-child(6):not([id]) > div:nth-child(2):not([id]) > div:nth-child(2):not([id]) > button:nth-child(2):not([id])",
                 "body:not([id]) > div#freeprivacypolicy-com---nb > div:not([id]) > div:nth-child(3):not([id]) > button:nth-child(2):not([id])",
                 "body > div#root > div:nth-child(4):not([id]) > div:not([id]) > div:not([id]) > div:nth-child(1):not([id]) > div:nth-child(3):not([id]) > button:nth-child(2):not([id])",
                 "body > div#cookie-consent > div:not([id]) > div:nth-child(3):not([id]) > div:not([id]) > div:nth-child(2):not([id]) > button:nth-child(2)#cookie-decline",
@@ -2377,7 +2377,7 @@
                 "body > div#cookiesjsr > div:not([id]) > div:not([id]) > div:nth-child(2):not([id]) > button:nth-child(2):not([id])",
                 "body > div:not([id]) > div:nth-child(3)#gdprCookie > div:nth-child(3):not([id]) > span:not([id]) > span:nth-child(2):not([id])",
                 "body > div#didomi-host > div:not([id]) > div#didomi-popup > div:nth-child(2):not([id]) > div:not([id])[data-testid=\"notice\"] > div:nth-child(2):not([id]) > div:nth-child(3)#buttons > button:nth-child(2)#didomi-notice-disagree-button",
-                "reddit-cookie-banner",
+                "body > div#root > div:nth-child(5):not([id]) > div:nth-child(2):not([id]) > button:nth-child(2):not([id])",
                 "body > div#c-pop > div:not([id]) > div:nth-child(2):not([id]) > button:nth-child(3)#ctl07_declinebtn",
                 "body > div#__next > div:nth-child(5):not([id]) > div:not([id]) > div:nth-child(3):not([id]) > button:nth-child(2):not([id])",
                 "body > div#__next > div:nth-child(5):not([id]) > div:not([id]) > div:nth-child(3):not([id]) > button:nth-child(1):not([id])",
@@ -3680,7 +3680,11 @@
                 "body > div:not([id]) > div:nth-child(2):not([id]) > div:nth-child(1):not([id]) > button:not([id])",
                 "body > div:not([id]) > div > div[data-cy=cookie-modal] > div:not([id]) > div:nth-child(2):not([id]) > div:nth-child(2):not([id]) > button:nth-child(2):not([id])",
                 "body > div:not([id]) > div:nth-child(4):not([id]) > div:nth-child(4):not([id]) > div:nth-child(2):not([id]) > button:nth-child(2):not([id])",
-                "body > div:not([id]) > div:nth-child(4):not([id]) > div:nth-child(4):not([id]) > div:nth-child(2):not([id]) > button:nth-child(3):not([id])"
+                "body > div:not([id]) > div:nth-child(4):not([id]) > div:nth-child(4):not([id]) > div:nth-child(2):not([id]) > button:nth-child(3):not([id])",
+                "body > div#__next > div#app-content-id > div:nth-child(1):not([id]) > div:nth-child(2):not([id]) > div:not([id]) > div:not([id]) > div:nth-child(2):not([id]) > button:nth-child(2):not([id])",
+                "body > div#__next > div:not([id]) > div:nth-child(4)#portal > div:not([id]) > div:not([id]) > aside:not([id]) > div:not([id]) > div:not([id]) > div:nth-child(2):not([id]) > button:nth-child(2):not([id])",
+                "#data-protection-consent-dialog rpl-modal-card > button.button-primary",
+                "#data-protection-consent-dialog rpl-modal-card > button.button-secondary"
             ],
             "r": [
                 [
@@ -16893,6 +16897,40 @@
                 ],
                 [
                     1,
+                    "auto_AU_rewardflightfinder.com_bgu",
+                    0,
+                    "^https?://(www\\.)?rewardflightfinder\\.com/",
+                    10,
+                    [],
+                    [
+                        {
+                            "e": 1599
+                        }
+                    ],
+                    [
+                        {
+                            "v": 1599
+                        }
+                    ],
+                    [
+                        {
+                            "wait": 500
+                        },
+                        {
+                            "c": 1599
+                        }
+                    ],
+                    [
+                        {
+                            "timeout": 1000,
+                            "check": "none",
+                            "wv": 1599
+                        }
+                    ],
+                    {}
+                ],
+                [
+                    1,
                     "auto_AU_rki.de_tp5",
                     0,
                     "^https?://(www\\.)?rki\\.de/",
@@ -18167,6 +18205,40 @@
                             "timeout": 1000,
                             "check": "none",
                             "wv": 1180
+                        }
+                    ],
+                    {}
+                ],
+                [
+                    1,
+                    "auto_AU_uniquephotiquebychristygraham.zenfoliosite.com_eh6",
+                    0,
+                    "^https?://(www\\.)?uniquephotiquebychristygraham\\.zenfoliosite\\.com/",
+                    10,
+                    [],
+                    [
+                        {
+                            "e": 2903
+                        }
+                    ],
+                    [
+                        {
+                            "v": 2903
+                        }
+                    ],
+                    [
+                        {
+                            "wait": 500
+                        },
+                        {
+                            "c": 2903
+                        }
+                    ],
+                    [
+                        {
+                            "timeout": 1000,
+                            "check": "none",
+                            "wv": 2903
                         }
                     ],
                     {}
@@ -53016,6 +53088,40 @@
                 ],
                 [
                     1,
+                    "auto_FR_scaleway.com_z7w",
+                    0,
+                    "^https?://(www\\.)?scaleway\\.com/",
+                    10,
+                    [],
+                    [
+                        {
+                            "e": 2904
+                        }
+                    ],
+                    [
+                        {
+                            "v": 2904
+                        }
+                    ],
+                    [
+                        {
+                            "wait": 500
+                        },
+                        {
+                            "c": 2904
+                        }
+                    ],
+                    [
+                        {
+                            "timeout": 1000,
+                            "check": "none",
+                            "wv": 2904
+                        }
+                    ],
+                    {}
+                ],
+                [
+                    1,
                     "auto_FR_sengager.fr_iu4",
                     0,
                     "^https?://(www\\.)?sengager\\.fr/",
@@ -87682,20 +87788,17 @@
                     ],
                     [
                         {
-                            "e": 1599
+                            "e": 2905
                         }
                     ],
                     [
                         {
-                            "v": 1599
+                            "v": 2905
                         }
                     ],
                     [
                         {
-                            "waitForThenClick": [
-                                "reddit-cookie-banner",
-                                "#reject-nonessential-cookies-button > button"
-                            ]
+                            "c": 2906
                         }
                     ],
                     [
@@ -88741,7 +88844,7 @@
                 ],
                 "specificRuleRange": [
                     183,
-                    2561
+                    2564
                 ],
                 "genericStringEnd": 702,
                 "frameStringEnd": 741


### PR DESCRIPTION
Asana Task/Github Issue: https://app.asana.com/1/137249556945/project/1201844467387842/task/1212702146976995

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates the autoconsent ruleset to v14.47.0 with new site support and selector fixes.
> 
> - Adds site-specific rules for `rewardflightfinder.com`, `uniquephotiquebychristygraham.zenfoliosite.com`, and `scaleway.com` (with associated `e/v/c/wv` actions and waits)
> - Tweaks/extends reject selectors (including Next.js paths and `#data-protection-consent-dialog` buttons); replaces a `reddit-cookie-banner` selector with an explicit button path
> - Updates `reddit.com` handling (new rule/action IDs; switches to a `c: 2906` click action)
> - Adjusts an app selector path under `main#app` and increments `specificRuleRange` to include new rules
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8e97eed331f0acf982057d25b06f08d4f1f01494. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->