### PR TITLE
add web detection owners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -20,6 +20,8 @@ features/click-to-load.json @daxtheduck @duckduckgo/config-aor @kzar @ladamski @
 features/click-to-play.json @daxtheduck @duckduckgo/config-aor @kzar @ladamski @duckduckgo/breakage-aor @duckduckgo/breakage @duckduckgo/content-scope-scripts-owners
 features/tracker-allowlist.json @daxtheduck @duckduckgo/config-aor @duckduckgo/breakage-aor @duckduckgo/breakage @duckduckgo/content-scope-scripts-owners
 features/incontext-signup.json @daxtheduck @duckduckgo/config-aor @alistairjcbrown @duckduckgo/breakage-aor @duckduckgo/breakage @duckduckgo/content-scope-scripts-owners
+features/web-detection.json @daxtheduck @duckduckgo/config-aor @jdorweiler @GuiltyDolphin @duckduckgo/breakage-aor @duckduckgo/breakage @duckduckgo/content-scope-scripts-owners
+features/web-interference-detection.json @daxtheduck @duckduckgo/config-aor @jdorweiler @GuiltyDolphin @duckduckgo/breakage-aor @duckduckgo/breakage @duckduckgo/content-scope-scripts-owners
 
 # Platform owners
 overrides/browsers/ @daxtheduck @duckduckgo/config-aor @duckduckgo/extension-owners @duckduckgo/breakage-aor @duckduckgo/breakage @duckduckgo/content-scope-scripts-owners

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -19,7 +19,7 @@ features/element-hiding.json @daxtheduck @duckduckgo/config-aor @jonathanKingsto
 features/click-to-load.json @daxtheduck @duckduckgo/config-aor @kzar @ladamski @duckduckgo/breakage-aor @duckduckgo/breakage @duckduckgo/content-scope-scripts-owners
 features/click-to-play.json @daxtheduck @duckduckgo/config-aor @kzar @ladamski @duckduckgo/breakage-aor @duckduckgo/breakage @duckduckgo/content-scope-scripts-owners
 features/tracker-allowlist.json @daxtheduck @duckduckgo/config-aor @duckduckgo/breakage-aor @duckduckgo/breakage @duckduckgo/content-scope-scripts-owners
-features/incontext-signup.json @daxtheduck @duckduckgo/config-aor @alistairjcbrown @duckduckgo/breakage-aor @duckduckgo/breakage @duckduckgo/content-scope-scripts-owners
+features/incontext-signup.json @daxtheduck @duckduckgo/config-aor @duckduckgo/breakage-aor @duckduckgo/breakage @duckduckgo/content-scope-scripts-owners
 features/web-detection.json @daxtheduck @duckduckgo/config-aor @jdorweiler @GuiltyDolphin @duckduckgo/breakage-aor @duckduckgo/breakage @duckduckgo/content-scope-scripts-owners
 features/web-interference-detection.json @daxtheduck @duckduckgo/config-aor @jdorweiler @GuiltyDolphin @duckduckgo/breakage-aor @duckduckgo/breakage @duckduckgo/content-scope-scripts-owners
 


### PR DESCRIPTION
**Asana Task/Github Issue:**

## Description
<!-- 
  Please delete either or both process sections below.
-->
add owners for web interference

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CODEOWNERS-only changes affect review routing, not runtime privacy config or product behavior.
> 
> **Overview**
> Updates **CODEOWNERS** so web-detection features have explicit reviewers and **incontext-signup** ownership is adjusted.
> 
> Adds dedicated owner lines for **`features/web-detection.json`** and **`features/web-interference-detection.json`**, assigning **@jdorweiler** and **@GuiltyDolphin** alongside the usual config/breakage/CSS owner groups. Removes **@alistairjcbrown** from the **`features/incontext-signup.json`** entry (that feature still uses the standard owner set).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e032f40c326761c732a136f420fec218725a4a94. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->