### PR TITLE
Generated config status UI

### DIFF
--- a/generated/gui/app.js
+++ b/generated/gui/app.js
@@ -1,0 +1,131 @@
+import { PLATFORMS, loadConfig, extractSubfeatures } from "./config-loader.js";
+import { renderRows } from "./table-renderer.js";
+
+const platformSelect = document.getElementById("platform-select");
+const searchInput = document.getElementById("search-input");
+const tableWrap = document.getElementById("table-wrap");
+const tbody = document.getElementById("results-body");
+const loadingEl = document.getElementById("loading");
+const emptyEl = document.getElementById("empty");
+const statsEl = document.getElementById("stats");
+const statsText = document.getElementById("stats-text");
+
+let allRows = [];
+let sortKey = "feature";
+let sortDir = "asc";
+
+function init() {
+  for (const p of PLATFORMS) {
+    const opt = document.createElement("option");
+    opt.value = p.id;
+    opt.textContent = p.label;
+    platformSelect.appendChild(opt);
+  }
+
+  platformSelect.addEventListener("change", onPlatformChange);
+  searchInput.addEventListener("input", onFilter);
+  document.querySelectorAll("th.sortable").forEach((th) => {
+    th.addEventListener("click", () => onSort(th.dataset.key));
+  });
+}
+
+async function onPlatformChange() {
+  const id = platformSelect.value;
+  if (!id) {
+    reset();
+    return;
+  }
+
+  loadingEl.hidden = false;
+  tableWrap.hidden = true;
+  emptyEl.hidden = true;
+  statsEl.hidden = true;
+  searchInput.value = "";
+  searchInput.disabled = true;
+
+  try {
+    const config = await loadConfig(id);
+    allRows = extractSubfeatures(config);
+    allRows.sort(comparator());
+    searchInput.disabled = false;
+    applyFilter();
+  } catch (err) {
+    loadingEl.hidden = true;
+    emptyEl.textContent = `Error loading config: ${err.message}`;
+    emptyEl.hidden = false;
+  }
+}
+
+function onFilter() {
+  applyFilter();
+}
+
+function applyFilter() {
+  loadingEl.hidden = true;
+
+  const query = searchInput.value.trim().toLowerCase();
+  const filtered = query
+    ? allRows.filter(
+        (r) =>
+          r.feature.toLowerCase().includes(query) ||
+          r.subfeature.toLowerCase().includes(query)
+      )
+    : allRows;
+
+  if (filtered.length === 0) {
+    tableWrap.hidden = true;
+    emptyEl.textContent = "No matching subfeatures found.";
+    emptyEl.hidden = false;
+    statsEl.hidden = true;
+    return;
+  }
+
+  emptyEl.hidden = true;
+  renderRows(tbody, filtered);
+  tableWrap.hidden = false;
+  statsText.textContent = `${filtered.length} subfeature${filtered.length === 1 ? "" : "s"}` +
+    (query ? ` matching "${searchInput.value.trim()}"` : "") +
+    ` · ${allRows.length} total`;
+  statsEl.hidden = false;
+}
+
+function onSort(key) {
+  if (sortKey === key) {
+    sortDir = sortDir === "asc" ? "desc" : "asc";
+  } else {
+    sortKey = key;
+    sortDir = "asc";
+  }
+
+  document.querySelectorAll("th.sortable").forEach((th) => {
+    th.classList.remove("sort-asc", "sort-desc");
+    if (th.dataset.key === sortKey) {
+      th.classList.add(sortDir === "asc" ? "sort-asc" : "sort-desc");
+    }
+  });
+
+  allRows.sort(comparator());
+  applyFilter();
+}
+
+function comparator() {
+  return (a, b) => {
+    const av = a[sortKey] ?? "";
+    const bv = b[sortKey] ?? "";
+    const cmp = String(av).localeCompare(String(bv));
+    return sortDir === "asc" ? cmp : -cmp;
+  };
+}
+
+function reset() {
+  allRows = [];
+  tbody.innerHTML = "";
+  tableWrap.hidden = true;
+  emptyEl.hidden = true;
+  loadingEl.hidden = true;
+  statsEl.hidden = true;
+  searchInput.value = "";
+  searchInput.disabled = true;
+}
+
+init();

--- a/generated/gui/app.js
+++ b/generated/gui/app.js
@@ -9,6 +9,24 @@ const loadingEl = document.getElementById("loading");
 const emptyEl = document.getElementById("empty");
 const statsEl = document.getElementById("stats");
 const statsText = document.getElementById("stats-text");
+const filtersFieldset = document.getElementById("filters");
+const filterRollout = document.getElementById("filter-rollout");
+const filterCohorts = document.getElementById("filter-cohorts");
+
+const ALL_STATES = ["enabled", "disabled", "internal"];
+const stateCheckboxes = filtersFieldset.querySelectorAll('input[type="checkbox"][value]');
+
+function getSelectedStates() {
+  return [...stateCheckboxes]
+    .filter((cb) => cb.checked)
+    .map((cb) => cb.value);
+}
+
+function setSelectedStates(states) {
+  for (const cb of stateCheckboxes) {
+    cb.checked = states.includes(cb.value);
+  }
+}
 
 let allRows = [];
 let sortKey = "feature";
@@ -16,9 +34,13 @@ let sortDir = "asc";
 
 function readHash() {
   const params = new URLSearchParams(location.hash.slice(1));
+  const statesRaw = params.get("states");
   return {
     platform: params.get("platform") ?? "",
     search: params.get("search") ?? "",
+    states: statesRaw ? statesRaw.split(",").filter((s) => ALL_STATES.includes(s)) : [...ALL_STATES],
+    rollout: params.get("rollout") === "1",
+    cohorts: params.get("cohorts") === "1",
   };
 }
 
@@ -26,6 +48,12 @@ function writeHash() {
   const params = new URLSearchParams();
   if (platformSelect.value) params.set("platform", platformSelect.value);
   if (searchInput.value.trim()) params.set("search", searchInput.value.trim());
+  const states = getSelectedStates();
+  if (states.length !== ALL_STATES.length || !ALL_STATES.every((s) => states.includes(s))) {
+    params.set("states", states.join(","));
+  }
+  if (filterRollout.checked) params.set("rollout", "1");
+  if (filterCohorts.checked) params.set("cohorts", "1");
   const fragment = params.toString();
   history.replaceState(null, "", fragment ? `#${fragment}` : location.pathname);
 }
@@ -40,11 +68,17 @@ async function init() {
 
   platformSelect.addEventListener("change", onPlatformChange);
   searchInput.addEventListener("input", onFilter);
+  for (const cb of stateCheckboxes) cb.addEventListener("change", onFilter);
+  filterRollout.addEventListener("change", onFilter);
+  filterCohorts.addEventListener("change", onFilter);
   document.querySelectorAll("th.sortable").forEach((th) => {
     th.addEventListener("click", () => onSort(th.dataset.key));
   });
 
   const initial = readHash();
+  setSelectedStates(initial.states);
+  filterRollout.checked = initial.rollout;
+  filterCohorts.checked = initial.cohorts;
   if (initial.platform && PLATFORMS.some((p) => p.id === initial.platform)) {
     platformSelect.value = initial.platform;
     await onPlatformChange(initial.search);
@@ -65,12 +99,14 @@ async function onPlatformChange(initialSearch) {
   statsEl.hidden = true;
   if (typeof initialSearch !== "string") searchInput.value = "";
   searchInput.disabled = true;
+  filtersFieldset.disabled = true;
 
   try {
     const config = await loadConfig(id);
     allRows = extractSubfeatures(config);
     allRows.sort(comparator());
     searchInput.disabled = false;
+    filtersFieldset.disabled = false;
     if (typeof initialSearch === "string") searchInput.value = initialSearch;
     writeHash();
     applyFilter();
@@ -90,13 +126,17 @@ function applyFilter() {
   loadingEl.hidden = true;
 
   const query = searchInput.value.trim().toLowerCase();
-  const filtered = query
-    ? allRows.filter(
-        (r) =>
-          r.feature.toLowerCase().includes(query) ||
-          r.subfeature.toLowerCase().includes(query)
-      )
-    : allRows;
+  const states = new Set(getSelectedStates());
+  const needRollout = filterRollout.checked;
+  const needCohorts = filterCohorts.checked;
+
+  const filtered = allRows.filter((r) => {
+    if (!states.has(r.state)) return false;
+    if (needRollout && !r.rollout) return false;
+    if (needCohorts && !r.cohorts) return false;
+    if (query && !r.feature.toLowerCase().includes(query) && !r.subfeature.toLowerCase().includes(query)) return false;
+    return true;
+  });
 
   if (filtered.length === 0) {
     tableWrap.hidden = true;
@@ -152,6 +192,7 @@ function reset() {
   statsEl.hidden = true;
   searchInput.value = "";
   searchInput.disabled = true;
+  filtersFieldset.disabled = true;
 }
 
 init();

--- a/generated/gui/app.js
+++ b/generated/gui/app.js
@@ -14,7 +14,23 @@ let allRows = [];
 let sortKey = "feature";
 let sortDir = "asc";
 
-function init() {
+function readHash() {
+  const params = new URLSearchParams(location.hash.slice(1));
+  return {
+    platform: params.get("platform") ?? "",
+    search: params.get("search") ?? "",
+  };
+}
+
+function writeHash() {
+  const params = new URLSearchParams();
+  if (platformSelect.value) params.set("platform", platformSelect.value);
+  if (searchInput.value.trim()) params.set("search", searchInput.value.trim());
+  const fragment = params.toString();
+  history.replaceState(null, "", fragment ? `#${fragment}` : location.pathname);
+}
+
+async function init() {
   for (const p of PLATFORMS) {
     const opt = document.createElement("option");
     opt.value = p.id;
@@ -27,12 +43,19 @@ function init() {
   document.querySelectorAll("th.sortable").forEach((th) => {
     th.addEventListener("click", () => onSort(th.dataset.key));
   });
+
+  const initial = readHash();
+  if (initial.platform && PLATFORMS.some((p) => p.id === initial.platform)) {
+    platformSelect.value = initial.platform;
+    await onPlatformChange(initial.search);
+  }
 }
 
-async function onPlatformChange() {
+async function onPlatformChange(initialSearch) {
   const id = platformSelect.value;
   if (!id) {
     reset();
+    writeHash();
     return;
   }
 
@@ -40,7 +63,7 @@ async function onPlatformChange() {
   tableWrap.hidden = true;
   emptyEl.hidden = true;
   statsEl.hidden = true;
-  searchInput.value = "";
+  if (typeof initialSearch !== "string") searchInput.value = "";
   searchInput.disabled = true;
 
   try {
@@ -48,6 +71,8 @@ async function onPlatformChange() {
     allRows = extractSubfeatures(config);
     allRows.sort(comparator());
     searchInput.disabled = false;
+    if (typeof initialSearch === "string") searchInput.value = initialSearch;
+    writeHash();
     applyFilter();
   } catch (err) {
     loadingEl.hidden = true;
@@ -57,6 +82,7 @@ async function onPlatformChange() {
 }
 
 function onFilter() {
+  writeHash();
   applyFilter();
 }
 

--- a/generated/gui/config-loader.js
+++ b/generated/gui/config-loader.js
@@ -1,0 +1,65 @@
+const PLATFORMS = [
+  { id: "android",               label: "Android",                    file: "android-config.json" },
+  { id: "ios",                   label: "iOS",                        file: "ios-config.json" },
+  { id: "macos",                 label: "macOS",                      file: "macos-config.json" },
+  { id: "windows",               label: "Windows",                    file: "windows-config.json" },
+  { id: "extension",             label: "Extension (base)",           file: "extension-config.json" },
+  { id: "extension-chrome",      label: "Extension — Chrome",         file: "extension-chrome-config.json" },
+  { id: "extension-firefox",     label: "Extension — Firefox",        file: "extension-firefox-config.json" },
+  { id: "extension-brave",       label: "Extension — Brave",          file: "extension-brave-config.json" },
+  { id: "extension-edge",        label: "Extension — Edge",           file: "extension-edge-config.json" },
+  { id: "extension-edg",         label: "Extension — Edge (legacy)",  file: "extension-edg-config.json" },
+  { id: "extension-chromemv3",   label: "Extension — Chrome MV3",     file: "extension-chromemv3-config.json" },
+  { id: "extension-bravemv3",    label: "Extension — Brave MV3",      file: "extension-bravemv3-config.json" },
+  { id: "extension-edgmv3",     label: "Extension — Edge MV3",       file: "extension-edgmv3-config.json" },
+  { id: "extension-safarimv3",   label: "Extension — Safari MV3",     file: "extension-safarimv3-config.json" },
+];
+
+const cache = new Map();
+
+/**
+ * Fetch and cache a platform config. Returns the parsed JSON.
+ * Configs are resolved relative to `../v5/` from this module's location.
+ */
+export async function loadConfig(platformId) {
+  if (cache.has(platformId)) return cache.get(platformId);
+
+  const platform = PLATFORMS.find((p) => p.id === platformId);
+  if (!platform) throw new Error(`Unknown platform: ${platformId}`);
+
+  const url = `../v5/${platform.file}`;
+  const res = await fetch(url);
+  if (!res.ok) throw new Error(`Failed to load ${url}: ${res.status}`);
+
+  const data = await res.json();
+  cache.set(platformId, data);
+  return data;
+}
+
+/**
+ * Extract a flat list of subfeature rows from a config object.
+ * Each row: { feature, subfeature, state, rollout, cohorts, minSupportedVersion }
+ */
+export function extractSubfeatures(config) {
+  const rows = [];
+
+  for (const [featureKey, feature] of Object.entries(config.features)) {
+    const subs = feature.features;
+    if (!subs) continue;
+
+    for (const [subKey, sub] of Object.entries(subs)) {
+      rows.push({
+        feature: featureKey,
+        subfeature: subKey,
+        state: sub.state ?? "unknown",
+        rollout: sub.rollout ?? null,
+        cohorts: sub.cohorts ?? null,
+        minSupportedVersion: sub.minSupportedVersion ?? null,
+      });
+    }
+  }
+
+  return rows;
+}
+
+export { PLATFORMS };

--- a/generated/gui/config-loader.js
+++ b/generated/gui/config-loader.js
@@ -15,25 +15,14 @@ const PLATFORMS = [
   { id: "extension-safarimv3",   label: "Extension — Safari MV3",     file: "extension-safarimv3-config.json" },
 ];
 
-const cache = new Map();
-
-/**
- * Fetch and cache a platform config. Returns the parsed JSON.
- * Configs are resolved relative to `../v5/` from this module's location.
- */
 export async function loadConfig(platformId) {
-  if (cache.has(platformId)) return cache.get(platformId);
-
   const platform = PLATFORMS.find((p) => p.id === platformId);
   if (!platform) throw new Error(`Unknown platform: ${platformId}`);
 
   const url = `../v5/${platform.file}`;
   const res = await fetch(url);
   if (!res.ok) throw new Error(`Failed to load ${url}: ${res.status}`);
-
-  const data = await res.json();
-  cache.set(platformId, data);
-  return data;
+  return res.json();
 }
 
 /**

--- a/generated/gui/index.html
+++ b/generated/gui/index.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Config Status — Sub-feature Inspector</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <header>
+    <h1>Sub-feature Status Inspector</h1>
+    <p class="subtitle">Privacy Remote Configuration — Generated v5 Configs</p>
+  </header>
+
+  <main>
+    <div class="controls">
+      <div class="control-group">
+        <label for="platform-select">Platform</label>
+        <select id="platform-select">
+          <option value="">— Select a platform —</option>
+        </select>
+      </div>
+      <div class="control-group">
+        <label for="search-input">Search</label>
+        <input type="text" id="search-input" placeholder="Filter by feature or subfeature name…" disabled>
+      </div>
+      <div class="control-group stats" id="stats" hidden>
+        <span id="stats-text"></span>
+      </div>
+    </div>
+
+    <div id="loading" class="message" hidden>Loading config…</div>
+    <div id="empty" class="message" hidden>No matching subfeatures found.</div>
+
+    <div class="table-wrap" id="table-wrap" hidden>
+      <table id="results-table">
+        <thead>
+          <tr>
+            <th class="sortable" data-key="feature">Feature</th>
+            <th class="sortable" data-key="subfeature">Subfeature</th>
+            <th class="sortable" data-key="state">State</th>
+            <th>Rollout</th>
+            <th>Cohorts</th>
+          </tr>
+        </thead>
+        <tbody id="results-body"></tbody>
+      </table>
+    </div>
+  </main>
+
+  <script type="module" src="app.js"></script>
+</body>
+</html>

--- a/generated/gui/index.html
+++ b/generated/gui/index.html
@@ -29,6 +29,32 @@
       </div>
     </div>
 
+    <fieldset class="filters" id="filters" disabled>
+      <legend>Filters</legend>
+      <div class="filter-row">
+        <div class="filter-group">
+          <span class="filter-label">State</span>
+          <label class="chip-toggle">
+            <input type="checkbox" value="enabled" checked> <span class="chip chip-enabled">enabled</span>
+          </label>
+          <label class="chip-toggle">
+            <input type="checkbox" value="disabled" checked> <span class="chip chip-disabled">disabled</span>
+          </label>
+          <label class="chip-toggle">
+            <input type="checkbox" value="internal" checked> <span class="chip chip-internal">internal</span>
+          </label>
+        </div>
+        <div class="filter-group">
+          <label class="chip-toggle">
+            <input type="checkbox" id="filter-rollout"> <span class="chip">Has rollout</span>
+          </label>
+          <label class="chip-toggle">
+            <input type="checkbox" id="filter-cohorts"> <span class="chip">Has cohorts</span>
+          </label>
+        </div>
+      </div>
+    </fieldset>
+
     <div id="loading" class="message" hidden>Loading config…</div>
     <div id="empty" class="message" hidden>No matching subfeatures found.</div>
 

--- a/generated/gui/styles.css
+++ b/generated/gui/styles.css
@@ -114,6 +114,100 @@ input[type="text"]:disabled {
   padding-bottom: 8px;
 }
 
+/* Filters fieldset */
+.filters {
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 12px 16px;
+  margin: 0 0 20px;
+  background: var(--surface);
+}
+
+.filters[disabled] {
+  opacity: .45;
+  pointer-events: none;
+}
+
+.filters legend {
+  font-size: 12px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: .04em;
+  color: var(--text-muted);
+  padding: 0 6px;
+}
+
+.filter-row {
+  display: flex;
+  gap: 24px;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.filter-group {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+.filter-label {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text);
+  margin-right: 2px;
+}
+
+.chip-toggle {
+  cursor: pointer;
+  user-select: none;
+}
+
+.chip-toggle input {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.chip {
+  display: inline-block;
+  padding: 3px 10px;
+  border-radius: 12px;
+  font-size: 12px;
+  font-weight: 600;
+  border: 1.5px solid var(--border);
+  background: var(--surface);
+  color: var(--text-muted);
+  transition: all .15s;
+}
+
+.chip-toggle input:checked + .chip {
+  border-color: var(--text);
+  color: var(--text);
+  background: var(--bg);
+}
+
+.chip-toggle input:checked + .chip-enabled {
+  border-color: var(--enabled);
+  color: var(--enabled);
+  background: #d1e7dd;
+}
+
+.chip-toggle input:checked + .chip-disabled {
+  border-color: var(--disabled);
+  color: var(--disabled);
+  background: #f8d7da;
+}
+
+.chip-toggle input:checked + .chip-internal {
+  border-color: var(--internal);
+  color: var(--internal);
+  background: #e2d9f3;
+}
+
+.chip-toggle input:focus-visible + .chip {
+  box-shadow: 0 0 0 3px var(--accent-light);
+}
+
 /* Messages */
 .message {
   text-align: center;
@@ -308,5 +402,10 @@ td.subfeature-name {
 
   .stats {
     margin-left: 0;
+  }
+
+  .filter-row {
+    flex-direction: column;
+    align-items: flex-start;
   }
 }

--- a/generated/gui/styles.css
+++ b/generated/gui/styles.css
@@ -1,0 +1,312 @@
+:root {
+  --bg: #f8f9fa;
+  --surface: #ffffff;
+  --border: #dee2e6;
+  --text: #212529;
+  --text-muted: #6c757d;
+  --accent: #de5833;
+  --accent-light: #fef0ec;
+  --enabled: #198754;
+  --disabled: #dc3545;
+  --internal: #6f42c1;
+  --preview: #0d6efd;
+  --radius: 6px;
+  --shadow: 0 1px 3px rgba(0,0,0,.08);
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+  font-size: 14px;
+  line-height: 1.5;
+  color: var(--text);
+  background: var(--bg);
+}
+
+header {
+  padding: 24px 32px 16px;
+  background: var(--surface);
+  border-bottom: 1px solid var(--border);
+}
+
+header h1 {
+  margin: 0 0 4px;
+  font-size: 22px;
+  font-weight: 700;
+}
+
+.subtitle {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 13px;
+}
+
+main {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 24px 32px 48px;
+}
+
+/* Controls */
+.controls {
+  display: flex;
+  gap: 16px;
+  align-items: flex-end;
+  flex-wrap: wrap;
+  margin-bottom: 20px;
+}
+
+.control-group {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.control-group label {
+  font-size: 12px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: .04em;
+  color: var(--text-muted);
+}
+
+select,
+input[type="text"] {
+  font-size: 14px;
+  padding: 8px 12px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--surface);
+  color: var(--text);
+  outline: none;
+  transition: border-color .15s;
+}
+
+select:focus,
+input[type="text"]:focus {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px var(--accent-light);
+}
+
+select {
+  min-width: 240px;
+}
+
+input[type="text"] {
+  min-width: 300px;
+}
+
+input[type="text"]:disabled {
+  opacity: .5;
+  cursor: not-allowed;
+}
+
+.stats {
+  margin-left: auto;
+  font-size: 13px;
+  color: var(--text-muted);
+  padding-bottom: 8px;
+}
+
+/* Messages */
+.message {
+  text-align: center;
+  padding: 48px 16px;
+  color: var(--text-muted);
+  font-size: 15px;
+}
+
+/* Table */
+.table-wrap {
+  overflow-x: auto;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--surface);
+  box-shadow: var(--shadow);
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  background: var(--bg);
+  text-align: left;
+  padding: 10px 14px;
+  font-size: 12px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: .04em;
+  color: var(--text-muted);
+  border-bottom: 2px solid var(--border);
+  white-space: nowrap;
+  user-select: none;
+}
+
+th.sortable {
+  cursor: pointer;
+}
+
+th.sortable:hover {
+  color: var(--accent);
+}
+
+th.sortable::after {
+  content: " ↕";
+  font-size: 10px;
+  opacity: .4;
+}
+
+th.sort-asc::after {
+  content: " ↑";
+  opacity: 1;
+  color: var(--accent);
+}
+
+th.sort-desc::after {
+  content: " ↓";
+  opacity: 1;
+  color: var(--accent);
+}
+
+tbody tr {
+  border-bottom: 1px solid var(--border);
+}
+
+tbody tr:last-child {
+  border-bottom: none;
+}
+
+tbody tr:hover {
+  background: #f1f3f5;
+}
+
+td {
+  padding: 8px 14px;
+  vertical-align: top;
+}
+
+td.feature-name {
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+td.subfeature-name {
+  white-space: nowrap;
+}
+
+/* State badges */
+.badge {
+  display: inline-block;
+  padding: 2px 8px;
+  border-radius: 10px;
+  font-size: 12px;
+  font-weight: 600;
+  line-height: 1.4;
+}
+
+.badge-enabled {
+  background: #d1e7dd;
+  color: var(--enabled);
+}
+
+.badge-disabled {
+  background: #f8d7da;
+  color: var(--disabled);
+}
+
+.badge-internal {
+  background: #e2d9f3;
+  color: var(--internal);
+}
+
+.badge-preview {
+  background: #cfe2ff;
+  color: var(--preview);
+}
+
+/* Rollout */
+.rollout-bar-wrap {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 140px;
+}
+
+.rollout-bar {
+  flex: 1;
+  height: 6px;
+  background: var(--border);
+  border-radius: 3px;
+  overflow: hidden;
+}
+
+.rollout-bar-fill {
+  height: 100%;
+  background: var(--accent);
+  border-radius: 3px;
+  transition: width .3s;
+}
+
+.rollout-steps {
+  font-size: 11px;
+  color: var(--text-muted);
+  white-space: nowrap;
+}
+
+/* Cohorts */
+.cohort-list {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+.cohort-tag {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 8px;
+  border-radius: 10px;
+  font-size: 12px;
+  background: #e9ecef;
+  color: var(--text);
+}
+
+.cohort-weight {
+  font-weight: 700;
+  color: var(--text-muted);
+  font-size: 11px;
+}
+
+/* Responsive */
+@media (max-width: 768px) {
+  header,
+  main {
+    padding-left: 16px;
+    padding-right: 16px;
+  }
+
+  .controls {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  select,
+  input[type="text"] {
+    min-width: 0;
+    width: 100%;
+  }
+
+  .stats {
+    margin-left: 0;
+  }
+}

--- a/generated/gui/table-renderer.js
+++ b/generated/gui/table-renderer.js
@@ -1,0 +1,66 @@
+/**
+ * Render subfeature rows into the given <tbody> element.
+ */
+export function renderRows(tbody, rows) {
+  tbody.innerHTML = "";
+  const fragment = document.createDocumentFragment();
+
+  for (const row of rows) {
+    const tr = document.createElement("tr");
+    tr.innerHTML =
+      `<td class="feature-name">${esc(row.feature)}</td>` +
+      `<td class="subfeature-name">${esc(row.subfeature)}</td>` +
+      `<td>${stateBadge(row.state)}</td>` +
+      `<td>${rolloutCell(row.rollout)}</td>` +
+      `<td>${cohortsCell(row.cohorts)}</td>`;
+    fragment.appendChild(tr);
+  }
+
+  tbody.appendChild(fragment);
+}
+
+function esc(s) {
+  const el = document.createElement("span");
+  el.textContent = s;
+  return el.innerHTML;
+}
+
+function stateBadge(state) {
+  const cls = {
+    enabled: "badge-enabled",
+    disabled: "badge-disabled",
+    internal: "badge-internal",
+    preview: "badge-preview",
+  }[state] ?? "badge-disabled";
+
+  return `<span class="badge ${cls}">${esc(state)}</span>`;
+}
+
+function rolloutCell(rollout) {
+  if (!rollout?.steps?.length) return '<span class="text-muted">—</span>';
+
+  const maxPercent = rollout.steps[rollout.steps.length - 1].percent;
+  const stepsLabel = rollout.steps.map((s) => `${s.percent}%`).join(" → ");
+
+  return (
+    `<div class="rollout-bar-wrap">` +
+      `<div class="rollout-bar"><div class="rollout-bar-fill" style="width:${maxPercent}%"></div></div>` +
+      `<span class="rollout-steps">${esc(stepsLabel)}</span>` +
+    `</div>`
+  );
+}
+
+function cohortsCell(cohorts) {
+  if (!cohorts?.length) return '<span class="text-muted">—</span>';
+
+  return (
+    `<div class="cohort-list">` +
+    cohorts
+      .map(
+        (c) =>
+          `<span class="cohort-tag">${esc(c.name)} <span class="cohort-weight">w:${c.weight}</span></span>`
+      )
+      .join("") +
+    `</div>`
+  );
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**Asana Task/Github Issue:** N/A

## Description
This PR introduces a new, self-contained web application at `generated/gui/` to visualize sub-feature statuses from the latest v5 generated config files. The tool provides a user interface with a platform selector, search filter, and a table displaying sub-feature names, enabled states, and detailed rollout/experiment cohort information. This simplifies the inspection and understanding of feature configurations across different platforms.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [x] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

<div><a href="https://cursor.com/agents/bc-d3a78f54-79a1-4f9b-ae57-30443db6676e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d3a78f54-79a1-4f9b-ae57-30443db6676e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- CURSOR_AGENT_PR_BODY_END -->