### PR TITLE
Android: Set min sdk level for subscription allowPurchase

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -3279,7 +3279,12 @@
                     "minSupportedVersion": 52220000
                 },
                 "allowPurchase": {
-                    "state": "enabled"
+                    "state": "enabled",
+                    "targets": [
+                        {
+                            "minSdkVersion": 28
+                        }
+                    ]
                 },
                 "useUnifiedFeedback": {
                     "state": "enabled",

--- a/schema/feature.ts
+++ b/schema/feature.ts
@@ -34,7 +34,7 @@ export type SubFeature<VersionType, SettingsType = Record<string, string>> = {
         isReturningUser?: boolean;
         isPrivacyProEligible?: boolean;
         entitlement?: string;
-        minSdkVersion?: number,
+        minSdkVersion?: number;
     }[];
     cohorts?: Cohort[];
     minSupportedVersion?: VersionType;

--- a/schema/feature.ts
+++ b/schema/feature.ts
@@ -34,6 +34,7 @@ export type SubFeature<VersionType, SettingsType = Record<string, string>> = {
         isReturningUser?: boolean;
         isPrivacyProEligible?: boolean;
         entitlement?: string;
+        minSdkVersion?: number,
     }[];
     cohorts?: Cohort[];
     minSupportedVersion?: VersionType;


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/task/1213419489119413?focus=true

## Description
Since we are soon deprecating Android 8 (26) and 8.1 (27), we want to only allow purchase from android 9 and up.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the eligibility rules for in-app subscription purchasing on Android, which can directly affect conversion/revenue and requires client-side support for the new targeting field.
> 
> **Overview**
> Updates the Android override config so `privacyPro.allowPurchase` is only targeted to devices running **Android 9+** by adding a `targets` rule with `minSdkVersion: 28`.
> 
> Extends the TypeScript schema (`schema/feature.ts`) to allow `minSdkVersion` within `targets`, so this new gating can be validated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e66d631b7b48a994efc72cee2b50287d2f67fcfa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->