### PR TITLE
Add duckAiNativeStorage setting to messageBridge (Android)

### DIFF
--- a/features/message-bridge.json
+++ b/features/message-bridge.json
@@ -7,6 +7,7 @@
         "aiChat": "disabled",
         "subscriptions": "disabled",
         "serpSettings": "disabled",
+        "duckAiNativeStorage": "enabled",
         "domains": []
     }
 }

--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -2057,6 +2057,7 @@
                 "aiChat": "disabled",
                 "subscriptions": "disabled",
                 "serpSettings": "disabled",
+                "duckAiNativeStorage": "enabled",
                 "domains": [
                     {
                         "domain": [

--- a/schema/features/message-bridge.ts
+++ b/schema/features/message-bridge.ts
@@ -5,6 +5,7 @@ export type MessageBridgeSettings = CSSInjectFeatureSettings<{
     subscriptions?: FeatureState;
     subscriptionPages?: FeatureState;
     serpSettings?: FeatureState;
+    duckAiNativeStorage?: FeatureState;
 }>;
 
 export type MessageBridgeFeature<VersionType> = Feature<MessageBridgeSettings, VersionType>;


### PR DESCRIPTION
## Summary
- Adds `duckAiNativeStorage: enabled` to the `messageBridge` feature settings in the Android override

## Test plan
- [ ] Check the preview config comment for the Android config URL once CI builds
- [ ] Verify `duckAiNativeStorage` appears as `enabled` in the generated Android config

🤖 Generated with [Claude Code](https://claude.com/claude-code)