### PR TITLE
Update content-blocker scriptlets to 2026.3.30

### DIFF
--- a/features/ad-blocking-extension.json
+++ b/features/ad-blocking-extension.json
@@ -4,24 +4,24 @@
     },
     "exceptions": [],
     "settings": {
-        "version": "2026.3.24",
+        "version": "2026.3.30",
         "enabledByDefault": false,
         "scriptlets": {
             "scriptlets/isolated/ublock-filters.js": {
                 "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/982bf709ce6dccf19fe0e273faac43271dcdae440b73461dad3cb56cca9ac4a1.js",
-                "signature": "MEUCIBleAbOazQlaJtCwfyvuo1XM3CQW1NFxo5FdmCgsPqdvAiEA4ZAKMEApCwU2R0iPJ1qJZCr9nXF/AoaA0CV8Az7mods="
+                "signature": "MEYCIQDKOPEDn6zvjQRZvVecl9/uhLUqIS8RILohL3t6DEaJRgIhAOOBBLQ4BcEn0EvYRQ8YD/vQ0fISOHZrpxiy7G+0ms4Z"
             },
             "scriptlets/main/ublock-filters.js": {
                 "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/fbc57b6303c9be1d728aeae4f3817e8946cf598cdab23322eb5ca2dec8a76507.js",
-                "signature": "MEUCIAogsPOudJ09fZDtiexYp11shHSlbDZeUsJwNCrtl3b8AiEA0qFbneuZ7NZsKqBrVmimFboiXklvA8Sh0seA9VACM3w="
+                "signature": "MEUCIDhz5NHbuBlaLxjlyoooTxvxIgzzMCgiVnBPGWS6ytwOAiEAm7G/mjcRYc540qnm/QuS9oCjHQzdazSZqvDdlioKDPE="
             },
             "scriptlets/main/ublock-experimental.js": {
                 "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855.js",
-                "signature": "MEUCIGXW1fuc8QECooM3fk74EEA3zjgNNaHlut7XIo7BXuJqAiEA7OhJKQS9fxD82JC2kPDUpuHDZCheqGobRhBNh7rr/c0="
+                "signature": "MEUCIF1kZZ69ocw+tahj7KIZ+wEwmBWBtXEme0FifxZh8HMlAiEA187alMokxyE9vNalsaDRs3boLqectXi0IsUtkqwJGG8="
             },
             "scriptlets/isolated/ublock-experimental.js": {
                 "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855.js",
-                "signature": "MEYCIQDpMg8qnYVPi1lo7554608a6k9ujR9gYsR5vhfy7vUGNwIhAIXxxIHBX2cKF5W40VqsaDIDNdlYnUj1D0diHx0JQnw5"
+                "signature": "MEQCIA4YUPGX9PK4EPMbmIiECaMr72aGWRhzPocVvsgDKHG9AiAsnmA64mv2QOFV5f1t3Px1KI8NMNtOBHnAuiK69ET5VA=="
             }
         }
     }


### PR DESCRIPTION
Update content-blocker scriptlets to 2026.3.30

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config update that only bumps the scriptlet bundle version and updates the expected signatures for downloaded scriptlets. Main risk is mismatched signatures/URLs causing scriptlet fetch/validation failures.
> 
> **Overview**
> Updates `features/ad-blocking-extension.json` to **version `2026.3.30`** and refreshes the cryptographic `signature` values for the referenced uBlock scriptlet bundles (main and isolated, filters and experimental).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d0dab4c692330726989f9ddf6f78276144046ea7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->