### PR TITLE
Enables web telemetry on macOS

### DIFF
--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -558,6 +558,9 @@
                 }
             }
         },
+        "webTelemetry": {
+            "state": "enabled"
+        },
         "newTabContinueSetUp": {
             "state": "enabled",
             "settings": {

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -559,7 +559,8 @@
             }
         },
         "webTelemetry": {
-            "state": "enabled"
+            "state": "enabled",
+            "exceptions": []
         },
         "newTabContinueSetUp": {
             "state": "enabled",

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -174,6 +174,14 @@
                 }
             }
         },
+        "webTelemetry": {
+            "state": "enabled",
+            "exceptions": [],
+            "settings": {
+                "videoPlayback": "enabled",
+                "urlChanged": "enabled"
+            }
+        },
         "networkProtection": {
             "state": "enabled",
             "features": {
@@ -557,10 +565,6 @@
                     "state": "disabled"
                 }
             }
-        },
-        "webTelemetry": {
-            "state": "enabled",
-            "exceptions": []
         },
         "newTabContinueSetUp": {
             "state": "enabled",


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/1211150618152277/task/1206366936874174?focus=true

## Description
This PR enables Web Telemtry on macOS

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [x] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Enables a telemetry feature flag on macOS, which can change what browsing-related events are collected and sent. Main risk is unintended data collection/volume changes or behavioral differences if clients interpret the new `webTelemetry` settings differently.
> 
> **Overview**
> Enables **Web Telemetry** for macOS via `overrides/macos-override.json` by adding a new `webTelemetry` feature block.
> 
> The override turns the feature `enabled` with no exceptions and explicitly enables telemetry for `videoPlayback` and `urlChanged` events.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d49133dd901a4a96b25b8034fdfd7657a4ef3c60. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->