### PR TITLE
Add Cursor Cloud specific instructions to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,3 +25,13 @@ See `README.md` for full documentation including:
 - Feature implementer guides
 - Schema writing guides
 - Incremental rollout implementation
+
+## Cursor Cloud specific instructions
+
+- **Node.js version**: This project requires Node.js 20 (see `.nvmrc`). The update script handles `nvm use` automatically.
+- **Package manager**: npm (lockfile: `package-lock.json`). Run `npm install` to install dependencies.
+- **No services to start**: This is a build-tool repo, not a web application. There is no dev server or background service.
+- **Build**: `npm run build` generates platform config files into `generated/`. Requires internet access (fetches TDS from `staticcdn.duckduckgo.com`).
+- **Full test suite**: `npm test` runs build + unit tests (mocha) + lint (eslint + prettier) + TypeScript type-checking (`tsc`). See `package.json` scripts for individual commands.
+- **Lint auto-fix**: `npm run lint-fix` to auto-fix ESLint and Prettier issues.
+- **Schema validation**: TypeScript types in `schema/` are used to generate JSON schemas validated with `ajv`. Run `npm run tsc` to type-check.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Adds a `## Cursor Cloud specific instructions` section to `AGENTS.md` with development environment guidance for future cloud agents.

### Changes
- Documents Node.js 20 requirement (`.nvmrc`)
- Documents npm as the package manager
- Notes this is a build-tool repo with no dev server
- Documents build, test, lint, and schema validation commands

### Environment Verification

All checks pass with Node.js 20:

- `npm run build` — generates 14 platform config files across v3/v4/v5
- `npm run unit-tests` — 581 mocha tests passing
- `npm run lint` — ESLint + Prettier clean
- `npm run tsc` — TypeScript type-checking clean
- `npm test` — full suite (build + tests + lint + tsc) passes

Full test output:
[full_test_output.log](https://cursor.com/agents/bc-bf3a1a6f-a60f-49f5-9540-5f5c02ab4bb6/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ffull_test_output.log)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bf3a1a6f-a60f-49f5-9540-5f5c02ab4bb6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bf3a1a6f-a60f-49f5-9540-5f5c02ab4bb6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

