### PR TITLE
Enable tabLabelTransition and faviconTransitions  in preview for Windows

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -4791,11 +4791,13 @@
             "exceptions": []
         },
         "tabLabelTransition": {
-            "state": "internal",
+            "minSupportedVersion": "0.155.0",
+            "state": "preview",
             "exceptions": []
         },
         "faviconTransitions": {
-            "state": "internal",
+            "minSupportedVersion": "0.155.0",
+            "state": "preview",
             "exceptions": []
         },
         "tabNavigationHistoryRestore": {


### PR DESCRIPTION
**Asana Task/Github Issue:**

## Description
<!-- 
  Please delete either or both process sections below.
-->

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk configuration-only change that broadens exposure of two Windows UI transition flags by moving them from `internal` to `preview` with a minimum supported version gate.
> 
> **Overview**
> Promotes the Windows feature flags `tabLabelTransition` and `faviconTransitions` from **internal** to **preview**, adding `minSupportedVersion: 0.155.0` for both in `windows-override.json`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 78338672722995a0eaec05f12aa63e97a9f2fd3f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->