### PR TITLE
Disable CPM on veneziataxi.it

### DIFF
--- a/features/autoconsent.json
+++ b/features/autoconsent.json
@@ -802,6 +802,10 @@
         {
             "domain": "rutjespaardenboxen.nl",
             "reason": "https://github.com/duckduckgo/privacy-configuration/pull/4827"
+        },
+        {
+            "domain": "veneziataxi.it",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/pull/4932"
         }
     ],
     "settings": {


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/1206670747178362/task/1214017590315699?focus=true

## Description
### Site breakage mitigation process:
#### Brief explanation
- Reported URL: https://veneziataxi.it/en/
- Problems experienced: Dark overlay on the page caused by automatic cookie popup handling.
- Platforms affected:
  - [x] iOS
  - [x] Android
  - [x] Windows
  - [x] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked: N/A
- Feature being disabled/modified: CPM (Cookie Popup Management)
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk data-only change that extends the autoconsent exception list to mitigate site breakage; no logic changes beyond config update.
> 
> **Overview**
> Disables Cookie Popup Management for `veneziataxi.it` by adding it to the `features/autoconsent.json` exception list (with PR reference) to prevent the dark overlay issue during automatic consent handling.
> 
> Also normalizes the JSON file ending by ensuring it has a trailing newline.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 30b4b260cfe666175c6c6b87e6b00391bf4e00f9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->