### PR TITLE
[macOS] Add tab suspension subfeature with settings

### DIFF
--- a/features/tab-suspension.json
+++ b/features/tab-suspension.json
@@ -5,11 +5,13 @@
     "state": "disabled",
     "features": {
         "memoryPressureTrigger": {
-            "state": "disabled"
+            "state": "disabled",
+            "settings": {
+                "tabInactivityPeriod": 600
+            }
         }
     },
     "settings": {
-        "memoryPressureTriggerTabInactivityPeriod": 600,
         "inputFieldFocusDetection": {
             "state": "disabled"
         }

--- a/features/tab-suspension.json
+++ b/features/tab-suspension.json
@@ -3,6 +3,11 @@
         "description": "Browser tab suspension for inactive tabs"
     },
     "state": "disabled",
+    "features": {
+        "isMemoryPressureTriggerEnabled": {
+            "state": "disabled"
+        }
+    },
     "settings": {
         "inputFieldFocusDetection": {
             "state": "disabled"

--- a/features/tab-suspension.json
+++ b/features/tab-suspension.json
@@ -5,10 +5,7 @@
     "state": "disabled",
     "features": {
         "memoryPressureTrigger": {
-            "state": "disabled",
-            "settings": {
-                "tabInactivityPeriod": 600
-            }
+            "state": "disabled"
         }
     },
     "settings": {

--- a/features/tab-suspension.json
+++ b/features/tab-suspension.json
@@ -4,7 +4,7 @@
     },
     "state": "disabled",
     "features": {
-        "isMemoryPressureTriggerEnabled": {
+        "memoryPressureTrigger": {
             "state": "disabled"
         }
     },

--- a/features/tab-suspension.json
+++ b/features/tab-suspension.json
@@ -9,6 +9,7 @@
         }
     },
     "settings": {
+        "memoryPressureTriggerTabInactivityPeriod": 600,
         "inputFieldFocusDetection": {
             "state": "disabled"
         }

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -2094,7 +2094,10 @@
             "state": "internal",
             "features": {
                 "memoryPressureTrigger": {
-                    "state": "internal"
+                    "state": "internal",
+                    "settings": {
+                        "tabInactivityPeriod": 600
+                    }
                 }
             },
             "settings": {

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -2092,6 +2092,11 @@
         },
         "tabSuspension": {
             "state": "internal",
+            "features": {
+                "isMemoryPressureTriggerEnabled": {
+                    "state": "internal"
+                }
+            },
             "settings": {
                 "inputFieldFocusDetection": {
                     "state": "enabled"

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -2093,7 +2093,7 @@
         "tabSuspension": {
             "state": "internal",
             "features": {
-                "isMemoryPressureTriggerEnabled": {
+                "memoryPressureTrigger": {
                     "state": "internal"
                 }
             },

--- a/schema/features/tab-suspension.ts
+++ b/schema/features/tab-suspension.ts
@@ -1,6 +1,7 @@
 import { Feature, FeatureState, SubFeature } from '../feature';
 
 type SettingsType = {
+    memoryPressureTriggerTabInactivityPeriod?: number;
     inputFieldFocusDetection?: {
         state: FeatureState;
     };

--- a/schema/features/tab-suspension.ts
+++ b/schema/features/tab-suspension.ts
@@ -1,4 +1,4 @@
-import { Feature, FeatureState } from '../feature';
+import { Feature, FeatureState, SubFeature } from '../feature';
 
 type SettingsType = {
     inputFieldFocusDetection?: {
@@ -6,4 +6,12 @@ type SettingsType = {
     };
 };
 
-export type TabSuspension<VersionType> = Feature<SettingsType, VersionType>;
+type SubFeatures<VersionType> = {
+    isMemoryPressureTriggerEnabled?: SubFeature<VersionType>;
+};
+
+export type TabSuspension<VersionType> = Feature<
+    SettingsType,
+    VersionType,
+    SubFeatures<VersionType> & Record<string, SubFeature<VersionType>>
+>;

--- a/schema/features/tab-suspension.ts
+++ b/schema/features/tab-suspension.ts
@@ -1,14 +1,18 @@
 import { Feature, FeatureState, SubFeature } from '../feature';
 
 type SettingsType = {
-    memoryPressureTriggerTabInactivityPeriod?: number;
     inputFieldFocusDetection?: {
         state: FeatureState;
     };
 };
 
 type SubFeatures<VersionType> = {
-    memoryPressureTrigger?: SubFeature<VersionType>;
+    memoryPressureTrigger?: SubFeature<
+        VersionType,
+        {
+            tabInactivityPeriod?: number;
+        }
+    >;
 };
 
 export type TabSuspension<VersionType> = Feature<

--- a/schema/features/tab-suspension.ts
+++ b/schema/features/tab-suspension.ts
@@ -8,7 +8,7 @@ type SettingsType = {
 };
 
 type SubFeatures<VersionType> = {
-    isMemoryPressureTriggerEnabled?: SubFeature<VersionType>;
+    memoryPressureTrigger?: SubFeature<VersionType>;
 };
 
 export type TabSuspension<VersionType> = Feature<


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/72649045549333/task/1213980149227712?focus=true

## Description
This change defines a subfeature that would be used for rolling out tab suspension, together with a configurable inactivity interval setting.

### Feature change process:

- [x] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [x] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [x] This feature was covered by a tech design.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config/schema update that adds a new `tabSuspension` subfeature and settings; main risk is schema/validator incompatibility if clients assume no subfeatures under `tabSuspension`.
> 
> **Overview**
> Adds a `memoryPressureTrigger` subfeature under `tabSuspension`, including support for a `tabInactivityPeriod` setting in the TypeScript schema.
> 
> Updates default `features/tab-suspension.json` to include the new subfeature (disabled by default) and enables it as *internal* in the macOS override with `tabInactivityPeriod: 600`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d2d2ee08794ebbb4877d63d67cbc43674105841b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->