### PR TITLE
Enable useSingleWebViewEnvironment from v0.155.0

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -4349,7 +4349,8 @@
                     }
                 },
                 "useSingleWebViewEnvironment": {
-                    "state": "internal"
+                    "state": "enabled",
+                    "minSupportedVersion": "0.155.0"
                 }
             },
             "exceptions": []


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1210594645311934/task/1214004511825292?focus=true

## Description
`webview.useSingleWebViewEnvironment` will be enabled from v0.155.0

### Feature change process:

- [x] This code for the config change is ready to merge.

- Platforms affected:
  - [x] Windows


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Enables a Windows `webview` feature flag that can change WebView environment behavior at runtime; risk is limited to clients on/after `0.155.0` but could affect rendering/session behavior if issues arise.
> 
> **Overview**
> **Windows feature configuration update:** flips `webview.useSingleWebViewEnvironment` from `internal` to **enabled** and gates it behind `minSupportedVersion: 0.155.0` in `overrides/windows-override.json`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c28f83f7b5bcc22fd071269ad5e1ad6f20390059. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->