### PR TITLE
enable aiChat > viewAllFromRecentChats and aiChat > menuInApplicationMenu for the next release

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -1326,10 +1326,12 @@
                     "state": "internal"
                 },
                 "viewAllFromRecentChats": {
-                    "state": "internal"
+                    "state": "enabled",
+                    "minSupportedVersion": "0.154.0"
                 },
                 "menuInApplicationMenu": {
-                    "state": "internal"
+                    "state": "enabled",
+                    "minSupportedVersion": "0.154.0"
                 }
             },
             "minSupportedVersion": "0.100.0",


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1210407179200832/task/1213820975883476?focus=true

## Description
enable aiChat > viewAllFromRecentChats and aiChat > menuInApplicationMenu for the next release

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Enables previously-internal `aiChat` UI entry points for Windows, which could expose unready UX paths to users on the next release. Risk is limited to configuration/flag rollout but impacts user-visible behavior gated by `minSupportedVersion`.
> 
> **Overview**
> Enables **two Windows `aiChat` feature flags**—`viewAllFromRecentChats` and `menuInApplicationMenu`—by switching them from `internal` to `enabled` and gating rollout with `minSupportedVersion: 0.154.0`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7d2fcc051481782c3ae63a118966e154899959b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->