### PR TITLE
Enable AI web search and image drag and drop on Windows (internal only)

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -1325,6 +1325,12 @@
                 "imageGeneration": {
                     "state": "internal"
                 },
+                "omnibarWebSearch": {
+                    "state": "internal"
+                },
+                "dragAndDropImages": {
+                    "state": "internal"
+                },
                 "viewAllFromRecentChats": {
                     "state": "enabled",
                     "minSupportedVersion": "0.154.0"


### PR DESCRIPTION
https://app.asana.com/1/137249556945/project/1209072953775241/task/1213491209452567

Enable AI web search and image drag and drop on Windows (internal only)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a configuration-only change that toggles two feature flags to `internal` for Windows without altering runtime code paths beyond gated feature availability.
> 
> **Overview**
> Enables two additional `aiChat` sub-features on Windows behind *internal-only* flags: `omnibarWebSearch` (AI web search from the omnibar) and `dragAndDropImages` (image drag-and-drop support).
> 
> No other feature states, rollouts, or version gates are changed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f7523ba3992dba44437b1f8dcdbe1f09f1eee20. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->