### PR TITLE
Enables Autoplay Policy for Internal

### DIFF
--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -2151,6 +2151,18 @@
                 },
                 "semaphoreAlwaysVisible": {
                     "state": "internal"
+                },
+                "autoplayPolicy": {
+                    "state": "internal",
+                    "settings": {
+                        "domainsAllowList": [
+                            "youtube.com",
+                            "netflix.com",
+                            "hulu.com",
+                            "vimeo.com",
+                            "primevideo.com"
+                        ]
+                    }
                 }
             }
         },

--- a/schema/features/macos-browser-config.ts
+++ b/schema/features/macos-browser-config.ts
@@ -9,6 +9,12 @@ type SubFeatures<VersionType> = {
             domains: string[];
         }
     >;
+    autoplayPolicy?: SubFeature<
+        VersionType,
+        {
+            domainsAllowList: string[];
+        }
+    >;
 };
 
 export type MacOSBrowserConfig<VersionType> = Feature<


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/72649045549333/task/1213886802186284?focus=true

## Description
This PR enables the `autoplayPolicy` for **internal**.
Plus we're adding 5x domains to the `allowList`, which will have `Video Autoplay Enabled` by default

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new *internal-only* `macOSBrowserConfig.autoplayPolicy` configuration plus schema typing, with no changes to runtime code paths beyond consuming this config.
> 
> **Overview**
> Enables a new *internal* `macOSBrowserConfig.autoplayPolicy` subfeature in `macos-override.json`, including a `domainsAllowList` that defaults video autoplay to enabled for `youtube.com`, `netflix.com`, `hulu.com`, `vimeo.com`, and `primevideo.com`.
> 
> Updates the macOS browser config schema (`schema/features/macos-browser-config.ts`) to validate/typed-support the new `autoplayPolicy` subfeature and its `domainsAllowList` setting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 667c57018c958cc45e900deea7188d1f72dfadcd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->