### PR TITLE
Downgrade AI recent chats on Windows to internal

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -1313,14 +1313,13 @@
                     "minSupportedVersion": "0.152.0"
                 },
                 "suggestions": {
-                    "state": "enabled"
+                    "state": "internal"
                 },
                 "suggestionsDeletion": {
                     "state": "disabled"
                 },
                 "ntpRecentChats": {
-                    "state": "enabled",
-                    "minSupportedVersion": "0.153.0"
+                    "state": "internal"
                 },
                 "imageGeneration": {
                     "state": "internal"


### PR DESCRIPTION
https://app.asana.com/1/137249556945/project/1204912272578138/task/1213993355760941?focus=true

Downgrade AI recent chats on Windows to internal

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change that reduces feature exposure on Windows by gating `aiChat` subfeatures behind `internal` flags.
> 
> **Overview**
> Downgrades Windows feature flags under `aiChat` by switching `suggestions` and `ntpRecentChats` from `enabled` to `internal` in `overrides/windows-override.json`, removing the Windows minimum-version rollout for recent chats.
> 
> This limits those AI chat surfaces to internal builds/users on Windows without changing application code.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 88b4f9001b875294237bb107c25aef9e4915aa1d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->