### PR TITLE
Update autoconsent to v14.70.0

### DIFF
--- a/features/autoconsent.json
+++ b/features/autoconsent.json
@@ -1519,6 +1519,10 @@
                 "#cookie-consent-banner #accept-button",
                 "#sp-cc-wrapper *,[data-action=sp-cc],span[data-action=\"sp-cc\"][data-sp-cc*=\"rejectAllAction\"]",
                 ".axeptio_mount .needsclick",
+                "[class*=\"gcb-modal-overlay\"]",
+                "[data-gcb-modal-show-prefs]",
+                "[data-gcb-modal-save]",
+                "gcbcl=a3|m3",
                 "body > div#root > div#ccpa-iframe-theme-provider[data-testid=\"ccpa-iframe-theme-provider\"] > div#ccpa-iframe[data-testid=\"ccpa-iframe\"] > div#ccpa_consent_banner[data-testid=\"ccpa_consent_banner\"] > div:not([id]) > div:nth-child(3):not([id]) > span:not([id]) > span:not([id]) > div:nth-child(2):not([id]) > span:nth-child(1):not([id]) > button#decline_cookies_button[data-testid=\"decline_cookies_button\"]",
                 "body > div#banner-0 > div:nth-child(1)#grouped-pageload-Banner > div:not([id]) > div:not([id]) > div:not([id]) > div:nth-child(3):not([id]) > button:nth-child(3):not([id])",
                 "body:not([id]) > div#banner-0 > div:nth-child(1)#grouped-pageload-Banner > div:not([id]) > div:not([id]) > div:not([id]) > div:nth-child(3):not([id]) > button:nth-child(2):not([id])",
@@ -1560,10 +1564,6 @@
                 "span[role=checkbox][aria-checked=true]",
                 "#save-all-pur",
                 "#reminder",
-                "#cookiesPortletDiv",
-                "#cookiesPortletDiv .cookie-buttons",
-                "#cookiesPortletDiv button[aria-label='Only Mandatory']",
-                "#tc-privacy-wrapper",
                 "[data-testid=\"consentManager\"]",
                 "[data-testid=\"privacyBanner-rejectAll\"]",
                 "#cookie-consent-banner button[aria-label=\"Reject non-essential cookies and continue.\"]",
@@ -3983,7 +3983,11 @@
                 "cookie_preferences=%7B%22allow%22%3A%5B%5D",
                 "#cookie-consent-banner .all4-cc-primary-button",
                 "#banner-cookie-setting-btn",
-                "#settings-only-required-btn"
+                "#settings-only-required-btn",
+                "#cookiesPortletDiv",
+                "#cookiesPortletDiv .cookie-buttons",
+                "#cookiesPortletDiv button[aria-label='Only Mandatory']",
+                "#tc-privacy-wrapper"
             ],
             "r": [
                 [
@@ -7095,6 +7099,43 @@
                         }
                     ],
                     [],
+                    {}
+                ],
+                [
+                    1,
+                    "gallup",
+                    2,
+                    "",
+                    22,
+                    [
+                        701
+                    ],
+                    [
+                        {
+                            "e": 702
+                        }
+                    ],
+                    [
+                        {
+                            "v": 702
+                        }
+                    ],
+                    [
+                        {
+                            "c": 702
+                        },
+                        {
+                            "wait": 500
+                        },
+                        {
+                            "c": 703
+                        }
+                    ],
+                    [
+                        {
+                            "cc": 704
+                        }
+                    ],
                     {}
                 ],
                 [
@@ -10932,133 +10973,6 @@
                     [],
                     [
                         {
-                            "e": 701
-                        }
-                    ],
-                    [
-                        {
-                            "v": 701
-                        }
-                    ],
-                    [
-                        {
-                            "wait": 500
-                        },
-                        {
-                            "c": 701
-                        }
-                    ],
-                    [
-                        {
-                            "timeout": 1000,
-                            "check": "none",
-                            "wv": 701
-                        }
-                    ],
-                    {}
-                ],
-                [
-                    1,
-                    "auto_AU_theoriginalshotels.com_ny2_+1",
-                    0,
-                    "^https?://(www\\.)?theoriginalshotels\\.com/|^https?://(www\\.)?village-hotels\\.co\\.uk/",
-                    1,
-                    [],
-                    [
-                        {
-                            "e": 702
-                        }
-                    ],
-                    [
-                        {
-                            "v": 702
-                        }
-                    ],
-                    [
-                        {
-                            "wait": 500
-                        },
-                        {
-                            "c": 702
-                        }
-                    ],
-                    [
-                        {
-                            "timeout": 1000,
-                            "check": "none",
-                            "wv": 702
-                        }
-                    ],
-                    {}
-                ],
-                [
-                    1,
-                    "auto_CA_coasthotels.com_f8m",
-                    0,
-                    "^https?://(www\\.)?coasthotels\\.com/",
-                    1,
-                    [],
-                    [
-                        {
-                            "e": 703
-                        }
-                    ],
-                    [
-                        {
-                            "v": 703
-                        }
-                    ],
-                    [
-                        {
-                            "c": 703
-                        }
-                    ],
-                    [],
-                    {}
-                ],
-                [
-                    1,
-                    "auto_CA_epihunter.eu_hd4",
-                    0,
-                    "^https?://(www\\.)?combell\\.com/",
-                    1,
-                    [],
-                    [
-                        {
-                            "e": 704
-                        }
-                    ],
-                    [
-                        {
-                            "v": 704
-                        }
-                    ],
-                    [
-                        {
-                            "wait": 500
-                        },
-                        {
-                            "c": 704
-                        }
-                    ],
-                    [
-                        {
-                            "timeout": 1000,
-                            "check": "none",
-                            "wv": 704
-                        }
-                    ],
-                    {}
-                ],
-                [
-                    1,
-                    "auto_CA_nationalarchives.gov.uk_rx0",
-                    0,
-                    "^https?://(www\\.)?webarchive\\.nationalarchives\\.gov\\.uk/",
-                    1,
-                    [],
-                    [
-                        {
                             "e": 705
                         }
                     ],
@@ -11086,9 +11000,9 @@
                 ],
                 [
                     1,
-                    "auto_CA_natureconservancy.ca_3pp",
+                    "auto_AU_theoriginalshotels.com_ny2_+1",
                     0,
-                    "^https?://(www\\.)?natureconservancy\\.ca/",
+                    "^https?://(www\\.)?theoriginalshotels\\.com/|^https?://(www\\.)?village-hotels\\.co\\.uk/",
                     1,
                     [],
                     [
@@ -11120,9 +11034,9 @@
                 ],
                 [
                     1,
-                    "auto_CA_ontariospca.ca_k32",
+                    "auto_CA_coasthotels.com_f8m",
                     0,
-                    "^https?://(www\\.)?widget-next\\.clym-sdk\\.net/",
+                    "^https?://(www\\.)?coasthotels\\.com/",
                     1,
                     [],
                     [
@@ -11137,26 +11051,17 @@
                     ],
                     [
                         {
-                            "wait": 500
-                        },
-                        {
                             "c": 707
                         }
                     ],
-                    [
-                        {
-                            "timeout": 1000,
-                            "check": "none",
-                            "wv": 707
-                        }
-                    ],
+                    [],
                     {}
                 ],
                 [
                     1,
-                    "auto_CA_phoenixnap.com_hrb",
+                    "auto_CA_epihunter.eu_hd4",
                     0,
-                    "^https?://(www\\.)?widget-next\\.clym-sdk\\.net/",
+                    "^https?://(www\\.)?combell\\.com/",
                     1,
                     [],
                     [
@@ -11188,9 +11093,9 @@
                 ],
                 [
                     1,
-                    "auto_CH_phoenixnap.com_lx5",
+                    "auto_CA_nationalarchives.gov.uk_rx0",
                     0,
-                    "^https?://(www\\.)?widget-next\\.clym-sdk\\.net/",
+                    "^https?://(www\\.)?webarchive\\.nationalarchives\\.gov\\.uk/",
                     1,
                     [],
                     [
@@ -11222,9 +11127,9 @@
                 ],
                 [
                     1,
-                    "auto_CH_swisscare.com_arx",
+                    "auto_CA_natureconservancy.ca_3pp",
                     0,
-                    "^https?://(www\\.)?swisscare\\.com/",
+                    "^https?://(www\\.)?natureconservancy\\.ca/",
                     1,
                     [],
                     [
@@ -11256,9 +11161,9 @@
                 ],
                 [
                     1,
-                    "auto_DE_alfaromeo.de_gvg_+2",
+                    "auto_CA_ontariospca.ca_k32",
                     0,
-                    "^https?://(www\\.)?cookielaw\\.emea\\.fcagroup\\.com/|^https?://(www\\.)?cookielaw\\.emea\\.fcagroup\\.com/|^https?://(www\\.)?cookielaw\\.emea\\.fcagroup\\.com/",
+                    "^https?://(www\\.)?widget-next\\.clym-sdk\\.net/",
                     1,
                     [],
                     [
@@ -11290,9 +11195,9 @@
                 ],
                 [
                     1,
-                    "auto_DE_huss-licht-ton.de_jj0",
+                    "auto_CA_phoenixnap.com_hrb",
                     0,
-                    "^https?://(www\\.)?huss-licht-ton\\.de/",
+                    "^https?://(www\\.)?widget-next\\.clym-sdk\\.net/",
                     1,
                     [],
                     [
@@ -11324,9 +11229,9 @@
                 ],
                 [
                     1,
-                    "auto_DE_modellbau-berlinski.de_8vm",
+                    "auto_CH_phoenixnap.com_lx5",
                     0,
-                    "^https?://(www\\.)?modellbau-berlinski\\.de/",
+                    "^https?://(www\\.)?widget-next\\.clym-sdk\\.net/",
                     1,
                     [],
                     [
@@ -11358,9 +11263,9 @@
                 ],
                 [
                     1,
-                    "auto_DE_phase-6.de_jkj",
+                    "auto_CH_swisscare.com_arx",
                     0,
-                    "^https?://(www\\.)?phase-6\\.de/",
+                    "^https?://(www\\.)?swisscare\\.com/",
                     1,
                     [],
                     [
@@ -11392,9 +11297,9 @@
                 ],
                 [
                     1,
-                    "auto_DE_phoenixnap.com_xq7",
+                    "auto_DE_alfaromeo.de_gvg_+2",
                     0,
-                    "^https?://(www\\.)?widget-next\\.clym-sdk\\.net/",
+                    "^https?://(www\\.)?cookielaw\\.emea\\.fcagroup\\.com/|^https?://(www\\.)?cookielaw\\.emea\\.fcagroup\\.com/|^https?://(www\\.)?cookielaw\\.emea\\.fcagroup\\.com/",
                     1,
                     [],
                     [
@@ -11426,9 +11331,9 @@
                 ],
                 [
                     1,
-                    "auto_FR_bnpparibasfortis.be_02b",
+                    "auto_DE_huss-licht-ton.de_jj0",
                     0,
-                    "^https?://(www\\.)?bnpparibasfortis\\.be/",
+                    "^https?://(www\\.)?huss-licht-ton\\.de/",
                     1,
                     [],
                     [
@@ -11460,9 +11365,9 @@
                 ],
                 [
                     1,
-                    "auto_FR_fiat.fr_3fh",
+                    "auto_DE_modellbau-berlinski.de_8vm",
                     0,
-                    "^https?://(www\\.)?cookielaw\\.emea\\.fcagroup\\.com/",
+                    "^https?://(www\\.)?modellbau-berlinski\\.de/",
                     1,
                     [],
                     [
@@ -11494,43 +11399,9 @@
                 ],
                 [
                     1,
-                    "auto_FR_stellantis.com_67q",
+                    "auto_DE_phase-6.de_jkj",
                     0,
-                    "^https?://(www\\.)?cookielaw\\.emea\\.fcagroup\\.com/",
-                    1,
-                    [],
-                    [
-                        {
-                            "e": 717
-                        }
-                    ],
-                    [
-                        {
-                            "v": 717
-                        }
-                    ],
-                    [
-                        {
-                            "wait": 500
-                        },
-                        {
-                            "c": 717
-                        }
-                    ],
-                    [
-                        {
-                            "timeout": 1000,
-                            "check": "none",
-                            "wv": 717
-                        }
-                    ],
-                    {}
-                ],
-                [
-                    1,
-                    "auto_GB_alfaromeo.co.uk_0_+1",
-                    0,
-                    "^https?://(www\\.)?cookielaw\\.emea\\.fcagroup\\.com/|^https?://(www\\.)?cookielaw\\.emea\\.fcagroup\\.com/",
+                    "^https?://(www\\.)?phase-6\\.de/",
                     1,
                     [],
                     [
@@ -11545,17 +11416,26 @@
                     ],
                     [
                         {
+                            "wait": 500
+                        },
+                        {
                             "c": 718
                         }
                     ],
-                    [],
+                    [
+                        {
+                            "timeout": 1000,
+                            "check": "none",
+                            "wv": 718
+                        }
+                    ],
                     {}
                 ],
                 [
                     1,
-                    "auto_GB_dropbox.com_0_+1",
+                    "auto_DE_phoenixnap.com_xq7",
                     0,
-                    "^https?://(www\\.)?dropbox\\.com/|^https?://(www\\.)?dropbox\\.com/",
+                    "^https?://(www\\.)?widget-next\\.clym-sdk\\.net/",
                     1,
                     [],
                     [
@@ -11570,51 +11450,26 @@
                     ],
                     [
                         {
-                            "c": 719
-                        }
-                    ],
-                    [],
-                    {}
-                ],
-                [
-                    1,
-                    "auto_GB_fiat.co.uk_cwa_+1",
-                    0,
-                    "^https?://(www\\.)?cookielaw\\.emea\\.fcagroup\\.com/|^https?://(www\\.)?cookielaw\\.emea\\.fcagroup\\.com/",
-                    1,
-                    [],
-                    [
-                        {
-                            "e": 711
-                        }
-                    ],
-                    [
-                        {
-                            "v": 711
-                        }
-                    ],
-                    [
-                        {
                             "wait": 500
                         },
                         {
-                            "c": 711
+                            "c": 719
                         }
                     ],
                     [
                         {
                             "timeout": 1000,
                             "check": "none",
-                            "wv": 711
+                            "wv": 719
                         }
                     ],
                     {}
                 ],
                 [
                     1,
-                    "auto_GB_investing.thisismoney.co.uk_0",
+                    "auto_FR_bnpparibasfortis.be_02b",
                     0,
-                    "^https?://(www\\.)?thisismoney\\.co\\.uk/",
+                    "^https?://(www\\.)?bnpparibasfortis\\.be/",
                     1,
                     [],
                     [
@@ -11629,17 +11484,26 @@
                     ],
                     [
                         {
+                            "wait": 500
+                        },
+                        {
                             "c": 720
                         }
                     ],
-                    [],
+                    [
+                        {
+                            "timeout": 1000,
+                            "check": "none",
+                            "wv": 720
+                        }
+                    ],
                     {}
                 ],
                 [
                     1,
-                    "auto_GB_lse.co.uk_0_+1",
+                    "auto_FR_fiat.fr_3fh",
                     0,
-                    "^https?://(www\\.)?lse\\.co\\.uk/|^https?://(www\\.)?nigella\\.com/",
+                    "^https?://(www\\.)?cookielaw\\.emea\\.fcagroup\\.com/",
                     1,
                     [],
                     [
@@ -11654,18 +11518,60 @@
                     ],
                     [
                         {
-                            "text": "Decline",
+                            "wait": 500
+                        },
+                        {
                             "c": 721
                         }
                     ],
-                    [],
+                    [
+                        {
+                            "timeout": 1000,
+                            "check": "none",
+                            "wv": 721
+                        }
+                    ],
                     {}
                 ],
                 [
                     1,
-                    "auto_GB_vintage-erotica-forum.com_0",
+                    "auto_FR_stellantis.com_67q",
                     0,
-                    "^https?://(www\\.)?best\\.aliexpress\\.com/",
+                    "^https?://(www\\.)?cookielaw\\.emea\\.fcagroup\\.com/",
+                    1,
+                    [],
+                    [
+                        {
+                            "e": 721
+                        }
+                    ],
+                    [
+                        {
+                            "v": 721
+                        }
+                    ],
+                    [
+                        {
+                            "wait": 500
+                        },
+                        {
+                            "c": 721
+                        }
+                    ],
+                    [
+                        {
+                            "timeout": 1000,
+                            "check": "none",
+                            "wv": 721
+                        }
+                    ],
+                    {}
+                ],
+                [
+                    1,
+                    "auto_GB_alfaromeo.co.uk_0_+1",
+                    0,
+                    "^https?://(www\\.)?cookielaw\\.emea\\.fcagroup\\.com/|^https?://(www\\.)?cookielaw\\.emea\\.fcagroup\\.com/",
                     1,
                     [],
                     [
@@ -11688,9 +11594,9 @@
                 ],
                 [
                     1,
-                    "auto_NL_analyticsvidhya.com_set",
+                    "auto_GB_dropbox.com_0_+1",
                     0,
-                    "^https?://(www\\.)?linkedin\\.com/",
+                    "^https?://(www\\.)?dropbox\\.com/|^https?://(www\\.)?dropbox\\.com/",
                     1,
                     [],
                     [
@@ -11705,36 +11611,27 @@
                     ],
                     [
                         {
-                            "wait": 500
-                        },
-                        {
                             "c": 723
                         }
                     ],
-                    [
-                        {
-                            "timeout": 1000,
-                            "check": "none",
-                            "wv": 723
-                        }
-                    ],
+                    [],
                     {}
                 ],
                 [
                     1,
-                    "auto_NL_fiat.nl_trv_+1",
+                    "auto_GB_fiat.co.uk_cwa_+1",
                     0,
                     "^https?://(www\\.)?cookielaw\\.emea\\.fcagroup\\.com/|^https?://(www\\.)?cookielaw\\.emea\\.fcagroup\\.com/",
                     1,
                     [],
                     [
                         {
-                            "e": 717
+                            "e": 715
                         }
                     ],
                     [
                         {
-                            "v": 717
+                            "v": 715
                         }
                     ],
                     [
@@ -11742,23 +11639,23 @@
                             "wait": 500
                         },
                         {
-                            "c": 717
+                            "c": 715
                         }
                     ],
                     [
                         {
                             "timeout": 1000,
                             "check": "none",
-                            "wv": 717
+                            "wv": 715
                         }
                     ],
                     {}
                 ],
                 [
                     1,
-                    "auto_NL_flitsmeister.nl_ws8",
+                    "auto_GB_investing.thisismoney.co.uk_0",
                     0,
-                    "^https?://(www\\.)?cookies\\.flitsmeister\\.com/",
+                    "^https?://(www\\.)?thisismoney\\.co\\.uk/",
                     1,
                     [],
                     [
@@ -11773,26 +11670,17 @@
                     ],
                     [
                         {
-                            "wait": 500
-                        },
-                        {
                             "c": 724
                         }
                     ],
-                    [
-                        {
-                            "timeout": 1000,
-                            "check": "none",
-                            "wv": 724
-                        }
-                    ],
+                    [],
                     {}
                 ],
                 [
                     1,
-                    "auto_NL_interpolis.nl_jk9",
+                    "auto_GB_lse.co.uk_0_+1",
                     0,
-                    "^https?://(www\\.)?interpolis\\.nl/",
+                    "^https?://(www\\.)?lse\\.co\\.uk/|^https?://(www\\.)?nigella\\.com/",
                     1,
                     [],
                     [
@@ -11807,26 +11695,18 @@
                     ],
                     [
                         {
-                            "wait": 500
-                        },
-                        {
+                            "text": "Decline",
                             "c": 725
                         }
                     ],
-                    [
-                        {
-                            "timeout": 1000,
-                            "check": "none",
-                            "wv": 725
-                        }
-                    ],
+                    [],
                     {}
                 ],
                 [
                     1,
-                    "auto_US_dropbox.com_0_+1",
+                    "auto_GB_vintage-erotica-forum.com_0",
                     0,
-                    "^https?://(www\\.)?dropbox\\.com/|^https?://(www\\.)?dropbox\\.com/",
+                    "^https?://(www\\.)?best\\.aliexpress\\.com/",
                     1,
                     [],
                     [
@@ -11841,8 +11721,169 @@
                     ],
                     [
                         {
-                            "text": "Decline",
                             "c": 726
+                        }
+                    ],
+                    [],
+                    {}
+                ],
+                [
+                    1,
+                    "auto_NL_analyticsvidhya.com_set",
+                    0,
+                    "^https?://(www\\.)?linkedin\\.com/",
+                    1,
+                    [],
+                    [
+                        {
+                            "e": 727
+                        }
+                    ],
+                    [
+                        {
+                            "v": 727
+                        }
+                    ],
+                    [
+                        {
+                            "wait": 500
+                        },
+                        {
+                            "c": 727
+                        }
+                    ],
+                    [
+                        {
+                            "timeout": 1000,
+                            "check": "none",
+                            "wv": 727
+                        }
+                    ],
+                    {}
+                ],
+                [
+                    1,
+                    "auto_NL_fiat.nl_trv_+1",
+                    0,
+                    "^https?://(www\\.)?cookielaw\\.emea\\.fcagroup\\.com/|^https?://(www\\.)?cookielaw\\.emea\\.fcagroup\\.com/",
+                    1,
+                    [],
+                    [
+                        {
+                            "e": 721
+                        }
+                    ],
+                    [
+                        {
+                            "v": 721
+                        }
+                    ],
+                    [
+                        {
+                            "wait": 500
+                        },
+                        {
+                            "c": 721
+                        }
+                    ],
+                    [
+                        {
+                            "timeout": 1000,
+                            "check": "none",
+                            "wv": 721
+                        }
+                    ],
+                    {}
+                ],
+                [
+                    1,
+                    "auto_NL_flitsmeister.nl_ws8",
+                    0,
+                    "^https?://(www\\.)?cookies\\.flitsmeister\\.com/",
+                    1,
+                    [],
+                    [
+                        {
+                            "e": 728
+                        }
+                    ],
+                    [
+                        {
+                            "v": 728
+                        }
+                    ],
+                    [
+                        {
+                            "wait": 500
+                        },
+                        {
+                            "c": 728
+                        }
+                    ],
+                    [
+                        {
+                            "timeout": 1000,
+                            "check": "none",
+                            "wv": 728
+                        }
+                    ],
+                    {}
+                ],
+                [
+                    1,
+                    "auto_NL_interpolis.nl_jk9",
+                    0,
+                    "^https?://(www\\.)?interpolis\\.nl/",
+                    1,
+                    [],
+                    [
+                        {
+                            "e": 729
+                        }
+                    ],
+                    [
+                        {
+                            "v": 729
+                        }
+                    ],
+                    [
+                        {
+                            "wait": 500
+                        },
+                        {
+                            "c": 729
+                        }
+                    ],
+                    [
+                        {
+                            "timeout": 1000,
+                            "check": "none",
+                            "wv": 729
+                        }
+                    ],
+                    {}
+                ],
+                [
+                    1,
+                    "auto_US_dropbox.com_0_+1",
+                    0,
+                    "^https?://(www\\.)?dropbox\\.com/|^https?://(www\\.)?dropbox\\.com/",
+                    1,
+                    [],
+                    [
+                        {
+                            "e": 730
+                        }
+                    ],
+                    [
+                        {
+                            "v": 730
+                        }
+                    ],
+                    [
+                        {
+                            "text": "Decline",
+                            "c": 730
                         }
                     ],
                     [],
@@ -11857,25 +11898,25 @@
                     [],
                     [
                         {
-                            "e": 727
+                            "e": 731
                         }
                     ],
                     [
                         {
-                            "v": 727
+                            "v": 731
                         }
                     ],
                     [
                         {
-                            "k": 728
+                            "k": 732
                         },
                         {
                             "all": true,
                             "optional": true,
-                            "k": 729
+                            "k": 733
                         },
                         {
-                            "k": 730
+                            "k": 734
                         }
                     ],
                     [
@@ -11894,49 +11935,49 @@
                     "^https://cmp-consent-tool\\.privacymanager\\.io/",
                     1,
                     [
-                        731,
-                        732
+                        735,
+                        736
                     ],
                     [
                         {
-                            "e": 733
+                            "e": 737
                         }
                     ],
                     [
                         {
-                            "v": 733
+                            "v": 737
                         }
                     ],
                     [
                         {
                             "if": {
-                                "e": 734
+                                "e": 738
                             },
                             "then": [
                                 {
-                                    "k": 734
+                                    "k": 738
                                 },
                                 {
-                                    "c": 735
+                                    "c": 739
                                 }
                             ],
                             "else": [
                                 {
-                                    "c": 736
+                                    "c": 740
                                 },
                                 {
-                                    "w": 737
+                                    "w": 741
                                 },
                                 {
-                                    "w": 738
+                                    "w": 742
                                 },
                                 {
                                     "all": true,
                                     "optional": true,
-                                    "k": 739
+                                    "k": 743
                                 },
                                 {
-                                    "k": 738
+                                    "k": 742
                                 }
                             ]
                         }
@@ -11953,20 +11994,20 @@
                     [],
                     [
                         {
-                            "e": 740
+                            "e": 744
                         },
                         {
-                            "e": 741
+                            "e": 745
                         }
                     ],
                     [
                         {
-                            "v": 741
+                            "v": 745
                         }
                     ],
                     [
                         {
-                            "c": 741
+                            "c": 745
                         }
                     ],
                     [],
@@ -14932,28 +14973,28 @@
                     "^https?://(www\\.)?flysaa\\.com/",
                     10,
                     [
-                        742
+                        3166
                     ],
                     [
                         {
-                            "e": 742
+                            "e": 3166
                         }
                     ],
                     [
                         {
-                            "v": 743
+                            "v": 3167
                         }
                     ],
                     [
                         {
-                            "c": 744
+                            "c": 3168
                         }
                     ],
                     [
                         {
                             "timeout": 1000,
                             "check": "none",
-                            "wv": 743
+                            "wv": 3167
                         }
                     ],
                     {}
@@ -43016,7 +43057,7 @@
                     "^https?://(www\\.)?immobilien\\.sparkasse\\.de/",
                     10,
                     [
-                        745
+                        3169
                     ],
                     [
                         {
@@ -93062,12 +93103,12 @@
                     [],
                     [
                         {
-                            "e": 704
+                            "e": 708
                         }
                     ],
                     [
                         {
-                            "v": 704
+                            "v": 708
                         }
                     ],
                     [
@@ -93075,14 +93116,14 @@
                             "wait": 500
                         },
                         {
-                            "c": 704
+                            "c": 708
                         }
                     ],
                     [
                         {
                             "timeout": 1000,
                             "check": "none",
-                            "wv": 704
+                            "wv": 708
                         }
                     ],
                     {}
@@ -99358,18 +99399,18 @@
             "index": {
                 "genericRuleRange": [
                     0,
-                    181
+                    182
                 ],
                 "frameRuleRange": [
-                    180,
-                    213
+                    181,
+                    214
                 ],
                 "specificRuleRange": [
-                    181,
-                    2859
+                    182,
+                    2860
                 ],
-                "genericStringEnd": 701,
-                "frameStringEnd": 742
+                "genericStringEnd": 705,
+                "frameStringEnd": 746
             }
         }
     }


### PR DESCRIPTION
Asana Task/Github Issue: https://app.asana.com/1/137249556945/project/1201844467387842/task/1214029524168415

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Data-only update to the `autoconsent` ruleset; risk is limited to potential site-specific false positives/negatives in consent popup handling.
> 
> **Overview**
> Updates `features/autoconsent.json` to the latest AutoConsent ruleset (v14.70.0).
> 
> Adds new generic selectors for a `gcb` consent modal, introduces a new site-specific rule for `gallup`, and reorders/migrates a few existing selectors (e.g., `#cookiesPortletDiv`, `#tc-privacy-wrapper`) with corresponding ID/index renumbering across the generated rules/index ranges.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eca4fa75a3fa3598afb3a35229c33c28b158ab2b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->