### PR TITLE
Single tab burn: Disable the feature

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -1617,8 +1617,8 @@
                     }
                 },
                 "singleTabFireDialog": {
-                    "state": "enabled",
-                    "minSupportedVersion": 52742000,
+                    "state": "disabled",
+                    "minSupportedVersion": 52760000,
                     "rollout": {
                         "steps": [
                             {

--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -1618,7 +1618,7 @@
                 },
                 "singleTabFireDialog": {
                     "state": "disabled",
-                    "minSupportedVersion": 52760000,
+                    "minSupportedVersion": 52742000,
                     "rollout": {
                         "steps": [
                             {


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1207418217763355/task/1214044754400239?focus=true

## Description

Disables the single tab burn feature.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [x] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change that disables a single Android feature flag; no code paths or data/security logic are modified.
> 
> **Overview**
> Disables the Android `singleTabFireDialog` feature flag by switching its override `state` from **enabled** to **disabled** in `overrides/android-override.json`, effectively stopping its rollout for supported versions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1eb392fd160c2f19861a54bfcb1a19d18da43085. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->