### PR TITLE
Single tab burning: Re-enable the feature flag

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -1617,7 +1617,7 @@
                     }
                 },
                 "singleTabFireDialog": {
-                    "state": "disabled",
+                    "state": "enabled",
                     "minSupportedVersion": 52742000,
                     "rollout": {
                         "steps": [


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1202552961248957/task/1214044754400239?focus=true

## Description

This PR re-enables the FF at 50% rollout.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [x] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Enables a previously disabled Android feature flag, which will change end-user behavior for a sizable rollout and could reintroduce prior UX or stability issues.
> 
> **Overview**
> Re-enables the Android `singleTabFireDialog` feature flag in `overrides/android-override.json`, allowing it to roll out again (up to the existing 50% step) for supported app versions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4eb8c1606b56fb12ae82571f0f6a8ccc875a1bd8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->