### PR TITLE
disable progressbar upgrade until a new app release is done

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -4057,11 +4057,12 @@
             "minSupportedVersion": 52720000
         },
         "progressBarUpgrade": {
-            "state": "enabled",
+            "state": "disabled",
             "exceptions": [],
             "features": {
                 "behaviourUpdate": {
-                    "state": "enabled",
+                    "state": "disabled",
+                    "minSupportedVersion": 52760000,
                     "rollout": {
                         "steps": [
                             {


### PR DESCRIPTION
**Asana Task/Github Issue:**  https://app.asana.com/1/137249556945/project/1212608036467427/task/1213877617250611?focus=true

## Description
Disable until the change in https://github.com/duckduckgo/Android/pull/8253 is included in the app release.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change that disables a feature flag; main risk is unintentionally keeping the upgrade off longer than intended for eligible app versions.
> 
> **Overview**
> **Disables the `progressBarUpgrade` rollout on Android.** The override flips `progressBarUpgrade` and its `behaviourUpdate` subfeature from `enabled` to `disabled`, and adds a `minSupportedVersion` gate to `behaviourUpdate` (`52760000`) for when it is re-enabled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a929a81a5069fa9f3b14a7fecf8bf3b052b6e44a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->