### PR TITLE
Enable contextualFireButton sub-feature under aiChat for Android

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -437,6 +437,10 @@
                 "supportsMultipleContexts": {
                     "state": "enabled",
                     "minSupportedVersion": 52720000
+                },
+                "contextualFireButton": {
+                    "state": "enabled",
+                    "minSupportedVersion": 52760000
                 }
             }
         },


### PR DESCRIPTION
**Asana Task/Github Issue:**https://app.asana.com/1/137249556945/project/1211654189969294/task/1214047448169811?focus=true

## Description
Enable the FF for [Android: Add Fire Button to half sheet](https://app.asana.com/1/137249556945/project/1211654189969294/task/1213651404656705?focus=true) project. 
The code is complete in Android 5.276.0

### Feature change process:

- [X] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [x] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
NA

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change that gates a UI sub-feature behind `minSupportedVersion` for Android, with no code or data-handling logic changes.
> 
> **Overview**
> Enables the `aiChat` sub-feature `contextualFireButton` in `overrides/android-override.json`, gated to Android builds with `minSupportedVersion` `52760000`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 783298b28b3eb698405051a1608a224fad312855. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->