### PR TITLE
Enable ntpChatTools for macOS 1.186.0+

### DIFF
--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -364,6 +364,10 @@
                 "omnibarTools": {
                     "state": "enabled",
                     "minSupportedVersion": "1.182.0"
+                },
+                "ntpChatTools": {
+                    "state": "enabled",
+                    "minSupportedVersion": "1.186.0"
                 }
             },
             "settings": {


### PR DESCRIPTION
**Asana Task/Github Issue:**

## Description

Enable `ntpChatTools` sub-feature under `aiChat` for macOS with `minSupportedVersion` 1.186.0.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk configuration-only change that gates an existing `aiChat` sub-feature by minimum macOS app version.
> 
> **Overview**
> Enables the `aiChat` sub-feature `ntpChatTools` in `overrides/macos-override.json`, gated behind `minSupportedVersion` `1.186.0` for macOS builds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 534241ed0ee1c574c12c2ba5af9169b7a92b70f5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->