### PR TITLE
Update content-blocker extension to 2026.4.13

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -4544,7 +4544,7 @@
             "minSupportedVersion": "0.148.0",
             "exceptions": [],
             "settings": {
-                "extensionUrl": "https://staticcdn.duckduckgo.com/extensions/content-blocker/content-blocker-extension-2026.3.30.crx"
+                "extensionUrl": "https://staticcdn.duckduckgo.com/extensions/content-blocker/content-blocker-extension-2026.4.13.crx"
             },
             "features": {
                 "onboardingEnabled": {


### PR DESCRIPTION
Update content-blocker extension to 2026.4.13.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change that updates a CDN URL for the packaged content-blocker extension; primary risk is a bad/invalid artifact URL causing extension download/installation issues on Windows.
> 
> **Overview**
> Updates the Windows override config to point `adBlockV2Extension.settings.extensionUrl` at the `content-blocker-extension-2026.4.13.crx` artifact (from `2026.3.30`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6cd3a946f24fc4408aad71be3edffdb4fa32304e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->