### PR TITLE
Allowlist ad_status.js on youtube on Apple platforms to prevent surrogate issue

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -1738,6 +1738,15 @@
                                 ]
                             },
                             {
+                                "rule": "static.doubleclick.net/instream/ad_status.js",
+                                "domains": [
+                                    "youtube.com"
+                                ],
+                                "reason": [
+                                    "https://github.com/duckduckgo/privacy-configuration/pull/4955"
+                                ]
+                            },
+                            {
                                 "rule": "www3.doubleclick.net",
                                 "domains": [
                                     "scrolller.com",

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -1609,6 +1609,15 @@
                                 ]
                             },
                             {
+                                "rule": "static.doubleclick.net/instream/ad_status.js",
+                                "domains": [
+                                    "youtube.com"
+                                ],
+                                "reason": [
+                                    "https://github.com/duckduckgo/privacy-configuration/pull/4955"
+                                ]
+                            },
+                            {
                                 "rule": "www3.doubleclick.net",
                                 "domains": [
                                     "scrolller.com",


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/246491496396031/task/1213921562188633?focus=true

## Description
Due to an issue with surrogates on Apple platforms, this request isn't properly redirected, which can cause streaming issues. Adding an allowlist entry for it for the time being; follow-up work will be done to fix the root surrogate issue on Apple platforms by replacing current implementation with webextension DNR redirects.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adjusts tracker allowlisting for `doubleclick.net` on Apple platforms, which can affect blocking behavior and privacy expectations. Scope is narrow (single script path on `youtube.com`), but misconfiguration could under-block or reintroduce tracking.
> 
> **Overview**
> Adds a new `trackerAllowlist` exception in both `overrides/ios-override.json` and `overrides/macos-override.json` to allow `static.doubleclick.net/instream/ad_status.js` when loaded on `youtube.com` (referencing PR `#4955`). This is intended as a temporary compatibility workaround for playback/streaming issues caused by surrogate handling on Apple platforms.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bbf9fc5b135d38aa8d922acbb44ef1b7b32e62d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->