### PR TITLE
Update autoconsent to v14.71.0

### DIFF
--- a/features/autoconsent.json
+++ b/features/autoconsent.json
@@ -1527,6 +1527,14 @@
                 "[data-gcb-modal-show-prefs]",
                 "[data-gcb-modal-save]",
                 "gcbcl=a3|m3",
+                "csm-cookie-consent",
+                "#didomi-popup,.didomi-popup-container,.didomi-popup-notice,.didomi-consent-popup-preferences,#didomi-notice,.didomi-popup-backdrop,.didomi-screen-medium",
+                "#didomi-host",
+                "#didomi-popup, #didomi-notice, .didomi-popup-notice, .didomi-notice-banner",
+                "#didomi-notice-disagree-button,.didomi-continue-without-agreeing",
+                ".cookie-banner-mount-point",
+                ".cookie-banner-mount-point section[aria-label='Cookie banner']",
+                ".cookie-banner-mount-point button.decline",
                 "body > div#root > div#ccpa-iframe-theme-provider[data-testid=\"ccpa-iframe-theme-provider\"] > div#ccpa-iframe[data-testid=\"ccpa-iframe\"] > div#ccpa_consent_banner[data-testid=\"ccpa_consent_banner\"] > div:not([id]) > div:nth-child(3):not([id]) > span:not([id]) > span:not([id]) > div:nth-child(2):not([id]) > span:nth-child(1):not([id]) > button#decline_cookies_button[data-testid=\"decline_cookies_button\"]",
                 "body > div#banner-0 > div:nth-child(1)#grouped-pageload-Banner > div:not([id]) > div:not([id]) > div:not([id]) > div:nth-child(3):not([id]) > button:nth-child(3):not([id])",
                 "body:not([id]) > div#banner-0 > div:nth-child(1)#grouped-pageload-Banner > div:not([id]) > div:not([id]) > div:not([id]) > div:nth-child(3):not([id]) > button:nth-child(2):not([id])",
@@ -1568,14 +1576,6 @@
                 "span[role=checkbox][aria-checked=true]",
                 "#save-all-pur",
                 "#reminder",
-                "[data-testid=\"consentManager\"]",
-                "[data-testid=\"privacyBanner-rejectAll\"]",
-                "#cookie-consent-banner button[aria-label=\"Reject non-essential cookies and continue.\"]",
-                "#cookie-popup-with-overlay [data-ref='cookie.no-thanks']",
-                "RY_COOKIE_CONSENT",
-                "div.cookie-bar",
-                "[data-component=CookieBanner]",
-                "[data-component=CookieBanner] [data-component=CookieBanner_AcceptAll]",
                 "[data-component=CookieBanner] [data-component=CookieBanner_AcceptABCRequired]",
                 "trackingconsent",
                 "aside#cookies,.overlay-cookies",
@@ -1861,7 +1861,7 @@
                 "body:not([id]) > div:not([id]) > div:not([id]) > div:not([id]) > div:nth-child(2):not([id]) > div:nth-child(2):not([id]) > button:nth-child(2):not([id])",
                 "body > div#__next > div:nth-child(3):not([id]) > div:nth-child(2):not([id]) > div:nth-child(2):not([id]) > button:not([id]) > span:not([id])",
                 "body:not([id]) > div#onetrust-consent-sdk > div:nth-child(2)#onetrust-banner-sdk > div:not([id]) > div:nth-child(1):not([id]) > div:not([id]) > div:nth-child(2)#onetrust-button-group-parent > div#onetrust-button-group > button:nth-child(2)#onetrust-reject-all-handler",
-                "body#collection-59d726c7f6576e961db44d2c > div:not([id]) > section:not([id]) > div:nth-child(2):not([id]) > button:nth-child(2):not([id])",
+                "[data-component=CookieBanner]",
                 "body > div#__next > div:nth-child(1):not([id]) > div:not([id]) > div:not([id]) > div:not([id])[data-testid=\"CookieBanner\"] > div:nth-child(3):not([id]) > button:nth-child(2):not([id])[data-testid=\"CookieBanner\\.DeclineButton\"]",
                 "body > footer:not([id]) > div:nth-child(3)#cookie_consent_banner_main_app > div:not([id]) > div#controlled_banner-cookie_consent-consent_banner > div:nth-child(1):not([id]) > div:not([id]) > div:not([id]) > div:not([id]) > div:nth-child(3):not([id]) > div:nth-child(2):not([id]) > div:nth-child(2):not([id]) > button:not([id])",
                 "body:not([id]) > div#freeprivacypolicy-com---nb > div:not([id]) > div:nth-child(3):not([id]) > button:nth-child(2):not([id])",
@@ -2124,7 +2124,7 @@
                 "body > div#shopify-section-popups > div:nth-child(1):not([id]) > modal-box#modal-popups-0 > div:nth-child(1):not([id]) > div:nth-child(3):not([id]) > button:nth-child(2):not([id])",
                 "body#outerContainer > div#didomi-host > div:not([id]) > div#didomi-popup > div:nth-child(2):not([id]) > div:not([id]) > div:nth-child(2):not([id]) > div:nth-child(2)#buttons > button:nth-child(2)#didomi-notice-disagree-button",
                 "body > main#main > div:nth-child(6):not([id]) > div:not([id]) > div:not([id]) > div:nth-child(3):not([id]) > div:nth-child(1):not([id]) > a:not([id])",
-                "body:not([id]) > div#cookie-consent > div:nth-child(3):not([id]) > button:nth-child(1)#reject-cookies",
+                "[data-component=CookieBanner] [data-component=CookieBanner_AcceptAll]",
                 "body > div > div:nth-child(1) > div:nth-child(1) > div:nth-child(2) > button:nth-child(3)",
                 "body > aou-root:not([id]) > solidify-cookie-consent-banner-container:nth-child(3):not([id]) > div:nth-child(2):not([id]) > button:nth-child(2):not([id]) > span:nth-child(2):not([id])",
                 "body > div#privacy_modal > div:nth-child(2)#privacy__modal__only > div:not([id]) > div:nth-child(3):not([id]) > button:nth-child(1)#privacy__modal__close",
@@ -2242,7 +2242,7 @@
                 "body > div#app > div:not([id]) > div:nth-child(4):not([id]) > div:nth-child(1):not([id]) > div:nth-child(4):not([id]) > button:nth-child(2):not([id])",
                 "body > div:not([id]) > div#truendo_container > div:nth-child(2):not([id]) > div:not([id]) > div:nth-child(4):not([id]) > div:not([id]) > button:nth-child(2)#tru_deselect_btn",
                 "body:not([id]) > div#cookies-modal > div:nth-child(2)#consent-modal > div:not([id]) > div:nth-child(3):not([id]) > button:nth-child(1):not([id]) > span#consent-modal-refuse",
-                "body > div#a52a380d7-7829-4b5e-8585-b929383da38e > dialog:not([id]) > div:not([id]) > div:not([id]) > div:nth-child(3):not([id]) > div:nth-child(1):not([id]) > div:nth-child(2):not([id]) > a:nth-child(2):not([id])",
+                ".MuiStack-root:has(a[href='/privacy']):has(button)",
                 "body:not([id]) > div:not([id]) > form:nth-child(3):not([id]) > div:nth-child(2):not([id]) > button:nth-child(2):not([id])",
                 "body > div:not([id]) > div:not([id]) > p:nth-child(5):not([id]) > button:nth-child(1):not([id])",
                 "body > app-root:not([id]) > app-wrapper:nth-child(2):not([id]) > div:nth-child(2):not([id]) > div:nth-child(2):not([id]) > app-cookie-hint:nth-child(3):not([id]) > div#cookie-hint > div:nth-child(2):not([id]) > button:nth-child(2)#cookie-hint-btn-decline",
@@ -2340,7 +2340,7 @@
                 "body > footer:not([id]) > div:nth-child(4)#cookiePopup > div:not([id]) > div:not([id]) > div:nth-child(2):not([id]) > div:not([id]) > button:nth-child(1):not([id])",
                 "body > div[id] > dialog:nth-child(2) > div:nth-child(2) > div:nth-child(2) > div:nth-child(2) > button:nth-child(2)",
                 "body > div#blocCookies > button:nth-child(3):not([id])",
-                "body > div[id][class] > div:nth-child(3) > button:nth-child(1)",
+                "[data-testid=\"consentManager\"]",
                 "body > div#cookie-notice > ul:nth-child(2):not([id]) > li:nth-child(1):not([id]) > button#accept-min-cookie-notice",
                 "body > div:not([id]) > div:not([id]) > a:nth-child(5):not([id])",
                 "body > div:not([id]) > main:nth-child(2):not([id]) > div:nth-child(2):not([id]) > div:nth-child(2)#analytics-consent-div > div:not([id]) > div:not([id]) > div:nth-child(2):not([id]) > button:nth-child(1)#reject",
@@ -3446,7 +3446,7 @@
                 "body > div#cookieConsentModal > div:not([id]) > div:not([id]) > div:not([id]) > div:nth-child(3):not([id]) > div:not([id]) > button:nth-child(2):not([id])",
                 "body > aside#cookie-banner > div:not([id]) > button:nth-child(2):not([id])",
                 "body > div#cookie-policy > div:not([id]) > div:nth-child(2):not([id]) > button:nth-child(2):not([id])",
-                "body > div#__next > div:nth-child(7):not([id]) > div:nth-child(1):not([id]) > div:nth-child(2):not([id]) > button:nth-child(1):not([id])",
+                "[data-testid=\"privacyBanner-rejectAll\"]",
                 "body > div#cookie-bar > p:nth-child(2):not([id]) > button:nth-child(1)#reject-all",
                 "body > div#page > div:nth-child(11)#pum-128427 > div#popmake-128427 > div:nth-child(1):not([id]) > form:nth-child(1):not([id]) > div:nth-child(11):not([id]) > button:nth-child(1)#btn-reject-all",
                 "body > div#messages > div:nth-child(1)#shopify-section-cookie-banner > section#shopify-section-cookie-banner > div:nth-child(1):not([id]) > button:nth-child(2):not([id])",
@@ -3837,7 +3837,7 @@
                 "body > div:not([id]) > div:nth-child(2):not([id]) > div:nth-child(3)#cookie-notice > div:not([id]) > div:not([id]) > div:not([id]) > div:nth-child(2):not([id]) > div:nth-child(3):not([id]) > div:nth-child(2):not([id]) > div:not([id]) > div:nth-child(4):not([id]) > button:nth-child(3):not([id])",
                 "body > div#__next > div:nth-child(7):not([id]) > div:nth-child(2):not([id]) > div:not([id]) > div:not([id]) > div:not([id]) > div:nth-child(2):not([id]) > button:nth-child(3):not([id])",
                 "body > div#cookie-consent-banner > div:not([id]) > div:nth-child(2):not([id]) > button:nth-child(2):not([id])",
-                "body > header#header > div:nth-child(1):not([id]) > div:nth-child(2):not([id]) > button:nth-child(2)#reject-button[data-testid=\"reject-button\"]",
+                "[data-testid='reject-button']",
                 "body > main:not([id]) > div:nth-child(1):not([id]) > div:not([id]) > div:nth-child(2):not([id]) > button:nth-child(1):not([id])",
                 "body > aside:not([id]) > div:nth-child(1):not([id]) > div:not([id]) > div:nth-child(2):not([id]) > button:nth-child(3):not([id])",
                 "body > div#cookiebar > div:not([id]) > div:nth-child(3):not([id]) > button:nth-child(2)#cookie-decline",
@@ -3991,7 +3991,11 @@
                 "#cookiesPortletDiv",
                 "#cookiesPortletDiv .cookie-buttons",
                 "#cookiesPortletDiv button[aria-label='Only Mandatory']",
-                "#tc-privacy-wrapper"
+                "#tc-privacy-wrapper",
+                "#cookie-consent-banner button[aria-label=\"Reject non-essential cookies and continue.\"]",
+                "#cookie-popup-with-overlay [data-ref='cookie.no-thanks']",
+                "RY_COOKIE_CONSENT",
+                "div.cookie-bar"
             ],
             "r": [
                 [
@@ -5611,6 +5615,75 @@
                 ],
                 [
                     1,
+                    "consentmo",
+                    2,
+                    "",
+                    22,
+                    [
+                        705
+                    ],
+                    [
+                        {
+                            "exists": [
+                                "csm-cookie-consent",
+                                ".csm-wrapper"
+                            ]
+                        }
+                    ],
+                    [
+                        {
+                            "visible": [
+                                "csm-cookie-consent",
+                                ".csm-wrapper button"
+                            ]
+                        }
+                    ],
+                    [
+                        {
+                            "if": {
+                                "exists": [
+                                    "csm-cookie-consent",
+                                    ".csm-wrapper .cc-deny"
+                                ]
+                            },
+                            "then": [
+                                {
+                                    "waitForThenClick": [
+                                        "csm-cookie-consent",
+                                        ".csm-wrapper .cc-deny"
+                                    ]
+                                }
+                            ],
+                            "else": [
+                                {
+                                    "waitForThenClick": [
+                                        "csm-cookie-consent",
+                                        ".csm-wrapper .cc-settings"
+                                    ]
+                                },
+                                {
+                                    "waitForThenClick": [
+                                        "csm-cookie-consent",
+                                        ".csm-wrapper .cc-deny"
+                                    ]
+                                }
+                            ]
+                        }
+                    ],
+                    [
+                        {
+                            "waitForVisible": [
+                                "csm-cookie-consent",
+                                ".csm-wrapper button"
+                            ],
+                            "timeout": 1000,
+                            "check": "none"
+                        }
+                    ],
+                    {}
+                ],
+                [
+                    1,
                     "Cookie Information Banner",
                     2,
                     "",
@@ -6415,6 +6488,50 @@
                         }
                     ],
                     [],
+                    {}
+                ],
+                [
+                    1,
+                    "didomi",
+                    2,
+                    "",
+                    22,
+                    [
+                        706
+                    ],
+                    [
+                        {
+                            "v": 707
+                        }
+                    ],
+                    [
+                        {
+                            "check": "any",
+                            "v": 708
+                        }
+                    ],
+                    [
+                        {
+                            "if": {
+                                "e": 709
+                            },
+                            "then": [
+                                {
+                                    "c": 709
+                                }
+                            ],
+                            "else": [
+                                {
+                                    "eval": "EVAL_DIDOMI_OPT_OUT"
+                                }
+                            ]
+                        }
+                    ],
+                    [
+                        {
+                            "eval": "EVAL_DIDOMI_TEST"
+                        }
+                    ],
                     {}
                 ],
                 [
@@ -8992,7 +9109,7 @@
                         {
                             "waitForThenClick": [
                                 "div[consent-skip-blocker=\"1\"][id][data-bg] > dialog > div > div > div > div > div > a[role=button]:not([id])",
-                                "xpath///span[contains(., ' ohne ') or contains(., 'without')]"
+                                "xpath///span[contains(., ' ohne ') or contains(., 'without') or contains(., 'Ablehnen')]"
                             ]
                         }
                     ],
@@ -9254,6 +9371,39 @@
                     [
                         {
                             "cc": 136
+                        }
+                    ],
+                    {}
+                ],
+                [
+                    1,
+                    "squarespace-cookie-banner",
+                    2,
+                    "",
+                    22,
+                    [
+                        710
+                    ],
+                    [
+                        {
+                            "e": 711
+                        }
+                    ],
+                    [
+                        {
+                            "v": 711
+                        }
+                    ],
+                    [
+                        {
+                            "c": 712
+                        }
+                    ],
+                    [
+                        {
+                            "timeout": 1000,
+                            "check": "none",
+                            "wv": 711
                         }
                     ],
                     {}
@@ -10977,269 +11127,6 @@
                     [],
                     [
                         {
-                            "e": 705
-                        }
-                    ],
-                    [
-                        {
-                            "v": 705
-                        }
-                    ],
-                    [
-                        {
-                            "wait": 500
-                        },
-                        {
-                            "c": 705
-                        }
-                    ],
-                    [
-                        {
-                            "timeout": 1000,
-                            "check": "none",
-                            "wv": 705
-                        }
-                    ],
-                    {}
-                ],
-                [
-                    1,
-                    "auto_AU_theoriginalshotels.com_ny2_+1",
-                    0,
-                    "^https?://(www\\.)?theoriginalshotels\\.com/|^https?://(www\\.)?village-hotels\\.co\\.uk/",
-                    1,
-                    [],
-                    [
-                        {
-                            "e": 706
-                        }
-                    ],
-                    [
-                        {
-                            "v": 706
-                        }
-                    ],
-                    [
-                        {
-                            "wait": 500
-                        },
-                        {
-                            "c": 706
-                        }
-                    ],
-                    [
-                        {
-                            "timeout": 1000,
-                            "check": "none",
-                            "wv": 706
-                        }
-                    ],
-                    {}
-                ],
-                [
-                    1,
-                    "auto_CA_coasthotels.com_f8m",
-                    0,
-                    "^https?://(www\\.)?coasthotels\\.com/",
-                    1,
-                    [],
-                    [
-                        {
-                            "e": 707
-                        }
-                    ],
-                    [
-                        {
-                            "v": 707
-                        }
-                    ],
-                    [
-                        {
-                            "c": 707
-                        }
-                    ],
-                    [],
-                    {}
-                ],
-                [
-                    1,
-                    "auto_CA_epihunter.eu_hd4",
-                    0,
-                    "^https?://(www\\.)?combell\\.com/",
-                    1,
-                    [],
-                    [
-                        {
-                            "e": 708
-                        }
-                    ],
-                    [
-                        {
-                            "v": 708
-                        }
-                    ],
-                    [
-                        {
-                            "wait": 500
-                        },
-                        {
-                            "c": 708
-                        }
-                    ],
-                    [
-                        {
-                            "timeout": 1000,
-                            "check": "none",
-                            "wv": 708
-                        }
-                    ],
-                    {}
-                ],
-                [
-                    1,
-                    "auto_CA_nationalarchives.gov.uk_rx0",
-                    0,
-                    "^https?://(www\\.)?webarchive\\.nationalarchives\\.gov\\.uk/",
-                    1,
-                    [],
-                    [
-                        {
-                            "e": 709
-                        }
-                    ],
-                    [
-                        {
-                            "v": 709
-                        }
-                    ],
-                    [
-                        {
-                            "wait": 500
-                        },
-                        {
-                            "c": 709
-                        }
-                    ],
-                    [
-                        {
-                            "timeout": 1000,
-                            "check": "none",
-                            "wv": 709
-                        }
-                    ],
-                    {}
-                ],
-                [
-                    1,
-                    "auto_CA_natureconservancy.ca_3pp",
-                    0,
-                    "^https?://(www\\.)?natureconservancy\\.ca/",
-                    1,
-                    [],
-                    [
-                        {
-                            "e": 710
-                        }
-                    ],
-                    [
-                        {
-                            "v": 710
-                        }
-                    ],
-                    [
-                        {
-                            "wait": 500
-                        },
-                        {
-                            "c": 710
-                        }
-                    ],
-                    [
-                        {
-                            "timeout": 1000,
-                            "check": "none",
-                            "wv": 710
-                        }
-                    ],
-                    {}
-                ],
-                [
-                    1,
-                    "auto_CA_ontariospca.ca_k32",
-                    0,
-                    "^https?://(www\\.)?widget-next\\.clym-sdk\\.net/",
-                    1,
-                    [],
-                    [
-                        {
-                            "e": 711
-                        }
-                    ],
-                    [
-                        {
-                            "v": 711
-                        }
-                    ],
-                    [
-                        {
-                            "wait": 500
-                        },
-                        {
-                            "c": 711
-                        }
-                    ],
-                    [
-                        {
-                            "timeout": 1000,
-                            "check": "none",
-                            "wv": 711
-                        }
-                    ],
-                    {}
-                ],
-                [
-                    1,
-                    "auto_CA_phoenixnap.com_hrb",
-                    0,
-                    "^https?://(www\\.)?widget-next\\.clym-sdk\\.net/",
-                    1,
-                    [],
-                    [
-                        {
-                            "e": 712
-                        }
-                    ],
-                    [
-                        {
-                            "v": 712
-                        }
-                    ],
-                    [
-                        {
-                            "wait": 500
-                        },
-                        {
-                            "c": 712
-                        }
-                    ],
-                    [
-                        {
-                            "timeout": 1000,
-                            "check": "none",
-                            "wv": 712
-                        }
-                    ],
-                    {}
-                ],
-                [
-                    1,
-                    "auto_CH_phoenixnap.com_lx5",
-                    0,
-                    "^https?://(www\\.)?widget-next\\.clym-sdk\\.net/",
-                    1,
-                    [],
-                    [
-                        {
                             "e": 713
                         }
                     ],
@@ -11267,9 +11154,9 @@
                 ],
                 [
                     1,
-                    "auto_CH_swisscare.com_arx",
+                    "auto_AU_theoriginalshotels.com_ny2_+1",
                     0,
-                    "^https?://(www\\.)?swisscare\\.com/",
+                    "^https?://(www\\.)?theoriginalshotels\\.com/|^https?://(www\\.)?village-hotels\\.co\\.uk/",
                     1,
                     [],
                     [
@@ -11301,9 +11188,9 @@
                 ],
                 [
                     1,
-                    "auto_DE_alfaromeo.de_gvg_+2",
+                    "auto_CA_coasthotels.com_f8m",
                     0,
-                    "^https?://(www\\.)?cookielaw\\.emea\\.fcagroup\\.com/|^https?://(www\\.)?cookielaw\\.emea\\.fcagroup\\.com/|^https?://(www\\.)?cookielaw\\.emea\\.fcagroup\\.com/",
+                    "^https?://(www\\.)?coasthotels\\.com/",
                     1,
                     [],
                     [
@@ -11318,26 +11205,17 @@
                     ],
                     [
                         {
-                            "wait": 500
-                        },
-                        {
                             "c": 715
                         }
                     ],
-                    [
-                        {
-                            "timeout": 1000,
-                            "check": "none",
-                            "wv": 715
-                        }
-                    ],
+                    [],
                     {}
                 ],
                 [
                     1,
-                    "auto_DE_huss-licht-ton.de_jj0",
+                    "auto_CA_epihunter.eu_hd4",
                     0,
-                    "^https?://(www\\.)?huss-licht-ton\\.de/",
+                    "^https?://(www\\.)?combell\\.com/",
                     1,
                     [],
                     [
@@ -11369,9 +11247,9 @@
                 ],
                 [
                     1,
-                    "auto_DE_modellbau-berlinski.de_8vm",
+                    "auto_CA_nationalarchives.gov.uk_rx0",
                     0,
-                    "^https?://(www\\.)?modellbau-berlinski\\.de/",
+                    "^https?://(www\\.)?webarchive\\.nationalarchives\\.gov\\.uk/",
                     1,
                     [],
                     [
@@ -11403,9 +11281,9 @@
                 ],
                 [
                     1,
-                    "auto_DE_phase-6.de_jkj",
+                    "auto_CA_natureconservancy.ca_3pp",
                     0,
-                    "^https?://(www\\.)?phase-6\\.de/",
+                    "^https?://(www\\.)?natureconservancy\\.ca/",
                     1,
                     [],
                     [
@@ -11437,7 +11315,7 @@
                 ],
                 [
                     1,
-                    "auto_DE_phoenixnap.com_xq7",
+                    "auto_CA_ontariospca.ca_k32",
                     0,
                     "^https?://(www\\.)?widget-next\\.clym-sdk\\.net/",
                     1,
@@ -11471,9 +11349,9 @@
                 ],
                 [
                     1,
-                    "auto_FR_bnpparibasfortis.be_02b",
+                    "auto_CA_phoenixnap.com_hrb",
                     0,
-                    "^https?://(www\\.)?bnpparibasfortis\\.be/",
+                    "^https?://(www\\.)?widget-next\\.clym-sdk\\.net/",
                     1,
                     [],
                     [
@@ -11505,9 +11383,9 @@
                 ],
                 [
                     1,
-                    "auto_FR_fiat.fr_3fh",
+                    "auto_CH_phoenixnap.com_lx5",
                     0,
-                    "^https?://(www\\.)?cookielaw\\.emea\\.fcagroup\\.com/",
+                    "^https?://(www\\.)?widget-next\\.clym-sdk\\.net/",
                     1,
                     [],
                     [
@@ -11539,43 +11417,9 @@
                 ],
                 [
                     1,
-                    "auto_FR_stellantis.com_67q",
+                    "auto_CH_swisscare.com_arx",
                     0,
-                    "^https?://(www\\.)?cookielaw\\.emea\\.fcagroup\\.com/",
-                    1,
-                    [],
-                    [
-                        {
-                            "e": 721
-                        }
-                    ],
-                    [
-                        {
-                            "v": 721
-                        }
-                    ],
-                    [
-                        {
-                            "wait": 500
-                        },
-                        {
-                            "c": 721
-                        }
-                    ],
-                    [
-                        {
-                            "timeout": 1000,
-                            "check": "none",
-                            "wv": 721
-                        }
-                    ],
-                    {}
-                ],
-                [
-                    1,
-                    "auto_GB_alfaromeo.co.uk_0_+1",
-                    0,
-                    "^https?://(www\\.)?cookielaw\\.emea\\.fcagroup\\.com/|^https?://(www\\.)?cookielaw\\.emea\\.fcagroup\\.com/",
+                    "^https?://(www\\.)?swisscare\\.com/",
                     1,
                     [],
                     [
@@ -11590,17 +11434,26 @@
                     ],
                     [
                         {
+                            "wait": 500
+                        },
+                        {
                             "c": 722
                         }
                     ],
-                    [],
+                    [
+                        {
+                            "timeout": 1000,
+                            "check": "none",
+                            "wv": 722
+                        }
+                    ],
                     {}
                 ],
                 [
                     1,
-                    "auto_GB_dropbox.com_0_+1",
+                    "auto_DE_alfaromeo.de_gvg_+2",
                     0,
-                    "^https?://(www\\.)?dropbox\\.com/|^https?://(www\\.)?dropbox\\.com/",
+                    "^https?://(www\\.)?cookielaw\\.emea\\.fcagroup\\.com/|^https?://(www\\.)?cookielaw\\.emea\\.fcagroup\\.com/|^https?://(www\\.)?cookielaw\\.emea\\.fcagroup\\.com/",
                     1,
                     [],
                     [
@@ -11615,51 +11468,26 @@
                     ],
                     [
                         {
-                            "c": 723
-                        }
-                    ],
-                    [],
-                    {}
-                ],
-                [
-                    1,
-                    "auto_GB_fiat.co.uk_cwa_+1",
-                    0,
-                    "^https?://(www\\.)?cookielaw\\.emea\\.fcagroup\\.com/|^https?://(www\\.)?cookielaw\\.emea\\.fcagroup\\.com/",
-                    1,
-                    [],
-                    [
-                        {
-                            "e": 715
-                        }
-                    ],
-                    [
-                        {
-                            "v": 715
-                        }
-                    ],
-                    [
-                        {
                             "wait": 500
                         },
                         {
-                            "c": 715
+                            "c": 723
                         }
                     ],
                     [
                         {
                             "timeout": 1000,
                             "check": "none",
-                            "wv": 715
+                            "wv": 723
                         }
                     ],
                     {}
                 ],
                 [
                     1,
-                    "auto_GB_investing.thisismoney.co.uk_0",
+                    "auto_DE_huss-licht-ton.de_jj0",
                     0,
-                    "^https?://(www\\.)?thisismoney\\.co\\.uk/",
+                    "^https?://(www\\.)?huss-licht-ton\\.de/",
                     1,
                     [],
                     [
@@ -11674,17 +11502,26 @@
                     ],
                     [
                         {
+                            "wait": 500
+                        },
+                        {
                             "c": 724
                         }
                     ],
-                    [],
+                    [
+                        {
+                            "timeout": 1000,
+                            "check": "none",
+                            "wv": 724
+                        }
+                    ],
                     {}
                 ],
                 [
                     1,
-                    "auto_GB_lse.co.uk_0_+1",
+                    "auto_DE_modellbau-berlinski.de_8vm",
                     0,
-                    "^https?://(www\\.)?lse\\.co\\.uk/|^https?://(www\\.)?nigella\\.com/",
+                    "^https?://(www\\.)?modellbau-berlinski\\.de/",
                     1,
                     [],
                     [
@@ -11699,18 +11536,26 @@
                     ],
                     [
                         {
-                            "text": "Decline",
+                            "wait": 500
+                        },
+                        {
                             "c": 725
                         }
                     ],
-                    [],
+                    [
+                        {
+                            "timeout": 1000,
+                            "check": "none",
+                            "wv": 725
+                        }
+                    ],
                     {}
                 ],
                 [
                     1,
-                    "auto_GB_vintage-erotica-forum.com_0",
+                    "auto_DE_phase-6.de_jkj",
                     0,
-                    "^https?://(www\\.)?best\\.aliexpress\\.com/",
+                    "^https?://(www\\.)?phase-6\\.de/",
                     1,
                     [],
                     [
@@ -11725,17 +11570,26 @@
                     ],
                     [
                         {
+                            "wait": 500
+                        },
+                        {
                             "c": 726
                         }
                     ],
-                    [],
+                    [
+                        {
+                            "timeout": 1000,
+                            "check": "none",
+                            "wv": 726
+                        }
+                    ],
                     {}
                 ],
                 [
                     1,
-                    "auto_NL_analyticsvidhya.com_set",
+                    "auto_DE_phoenixnap.com_xq7",
                     0,
-                    "^https?://(www\\.)?linkedin\\.com/",
+                    "^https?://(www\\.)?widget-next\\.clym-sdk\\.net/",
                     1,
                     [],
                     [
@@ -11767,43 +11621,9 @@
                 ],
                 [
                     1,
-                    "auto_NL_fiat.nl_trv_+1",
+                    "auto_FR_bnpparibasfortis.be_02b",
                     0,
-                    "^https?://(www\\.)?cookielaw\\.emea\\.fcagroup\\.com/|^https?://(www\\.)?cookielaw\\.emea\\.fcagroup\\.com/",
-                    1,
-                    [],
-                    [
-                        {
-                            "e": 721
-                        }
-                    ],
-                    [
-                        {
-                            "v": 721
-                        }
-                    ],
-                    [
-                        {
-                            "wait": 500
-                        },
-                        {
-                            "c": 721
-                        }
-                    ],
-                    [
-                        {
-                            "timeout": 1000,
-                            "check": "none",
-                            "wv": 721
-                        }
-                    ],
-                    {}
-                ],
-                [
-                    1,
-                    "auto_NL_flitsmeister.nl_ws8",
-                    0,
-                    "^https?://(www\\.)?cookies\\.flitsmeister\\.com/",
+                    "^https?://(www\\.)?bnpparibasfortis\\.be/",
                     1,
                     [],
                     [
@@ -11835,9 +11655,9 @@
                 ],
                 [
                     1,
-                    "auto_NL_interpolis.nl_jk9",
+                    "auto_FR_fiat.fr_3fh",
                     0,
-                    "^https?://(www\\.)?interpolis\\.nl/",
+                    "^https?://(www\\.)?cookielaw\\.emea\\.fcagroup\\.com/",
                     1,
                     [],
                     [
@@ -11869,9 +11689,43 @@
                 ],
                 [
                     1,
-                    "auto_US_dropbox.com_0_+1",
+                    "auto_FR_stellantis.com_67q",
                     0,
-                    "^https?://(www\\.)?dropbox\\.com/|^https?://(www\\.)?dropbox\\.com/",
+                    "^https?://(www\\.)?cookielaw\\.emea\\.fcagroup\\.com/",
+                    1,
+                    [],
+                    [
+                        {
+                            "e": 729
+                        }
+                    ],
+                    [
+                        {
+                            "v": 729
+                        }
+                    ],
+                    [
+                        {
+                            "wait": 500
+                        },
+                        {
+                            "c": 729
+                        }
+                    ],
+                    [
+                        {
+                            "timeout": 1000,
+                            "check": "none",
+                            "wv": 729
+                        }
+                    ],
+                    {}
+                ],
+                [
+                    1,
+                    "auto_GB_alfaromeo.co.uk_0_+1",
+                    0,
+                    "^https?://(www\\.)?cookielaw\\.emea\\.fcagroup\\.com/|^https?://(www\\.)?cookielaw\\.emea\\.fcagroup\\.com/",
                     1,
                     [],
                     [
@@ -11886,8 +11740,304 @@
                     ],
                     [
                         {
-                            "text": "Decline",
                             "c": 730
+                        }
+                    ],
+                    [],
+                    {}
+                ],
+                [
+                    1,
+                    "auto_GB_dropbox.com_0_+1",
+                    0,
+                    "^https?://(www\\.)?dropbox\\.com/|^https?://(www\\.)?dropbox\\.com/",
+                    1,
+                    [],
+                    [
+                        {
+                            "e": 731
+                        }
+                    ],
+                    [
+                        {
+                            "v": 731
+                        }
+                    ],
+                    [
+                        {
+                            "c": 731
+                        }
+                    ],
+                    [],
+                    {}
+                ],
+                [
+                    1,
+                    "auto_GB_fiat.co.uk_cwa_+1",
+                    0,
+                    "^https?://(www\\.)?cookielaw\\.emea\\.fcagroup\\.com/|^https?://(www\\.)?cookielaw\\.emea\\.fcagroup\\.com/",
+                    1,
+                    [],
+                    [
+                        {
+                            "e": 723
+                        }
+                    ],
+                    [
+                        {
+                            "v": 723
+                        }
+                    ],
+                    [
+                        {
+                            "wait": 500
+                        },
+                        {
+                            "c": 723
+                        }
+                    ],
+                    [
+                        {
+                            "timeout": 1000,
+                            "check": "none",
+                            "wv": 723
+                        }
+                    ],
+                    {}
+                ],
+                [
+                    1,
+                    "auto_GB_investing.thisismoney.co.uk_0",
+                    0,
+                    "^https?://(www\\.)?thisismoney\\.co\\.uk/",
+                    1,
+                    [],
+                    [
+                        {
+                            "e": 732
+                        }
+                    ],
+                    [
+                        {
+                            "v": 732
+                        }
+                    ],
+                    [
+                        {
+                            "c": 732
+                        }
+                    ],
+                    [],
+                    {}
+                ],
+                [
+                    1,
+                    "auto_GB_lse.co.uk_0_+1",
+                    0,
+                    "^https?://(www\\.)?lse\\.co\\.uk/|^https?://(www\\.)?nigella\\.com/",
+                    1,
+                    [],
+                    [
+                        {
+                            "e": 733
+                        }
+                    ],
+                    [
+                        {
+                            "v": 733
+                        }
+                    ],
+                    [
+                        {
+                            "text": "Decline",
+                            "c": 733
+                        }
+                    ],
+                    [],
+                    {}
+                ],
+                [
+                    1,
+                    "auto_GB_vintage-erotica-forum.com_0",
+                    0,
+                    "^https?://(www\\.)?best\\.aliexpress\\.com/",
+                    1,
+                    [],
+                    [
+                        {
+                            "e": 734
+                        }
+                    ],
+                    [
+                        {
+                            "v": 734
+                        }
+                    ],
+                    [
+                        {
+                            "c": 734
+                        }
+                    ],
+                    [],
+                    {}
+                ],
+                [
+                    1,
+                    "auto_NL_analyticsvidhya.com_set",
+                    0,
+                    "^https?://(www\\.)?linkedin\\.com/",
+                    1,
+                    [],
+                    [
+                        {
+                            "e": 735
+                        }
+                    ],
+                    [
+                        {
+                            "v": 735
+                        }
+                    ],
+                    [
+                        {
+                            "wait": 500
+                        },
+                        {
+                            "c": 735
+                        }
+                    ],
+                    [
+                        {
+                            "timeout": 1000,
+                            "check": "none",
+                            "wv": 735
+                        }
+                    ],
+                    {}
+                ],
+                [
+                    1,
+                    "auto_NL_fiat.nl_trv_+1",
+                    0,
+                    "^https?://(www\\.)?cookielaw\\.emea\\.fcagroup\\.com/|^https?://(www\\.)?cookielaw\\.emea\\.fcagroup\\.com/",
+                    1,
+                    [],
+                    [
+                        {
+                            "e": 729
+                        }
+                    ],
+                    [
+                        {
+                            "v": 729
+                        }
+                    ],
+                    [
+                        {
+                            "wait": 500
+                        },
+                        {
+                            "c": 729
+                        }
+                    ],
+                    [
+                        {
+                            "timeout": 1000,
+                            "check": "none",
+                            "wv": 729
+                        }
+                    ],
+                    {}
+                ],
+                [
+                    1,
+                    "auto_NL_flitsmeister.nl_ws8",
+                    0,
+                    "^https?://(www\\.)?cookies\\.flitsmeister\\.com/",
+                    1,
+                    [],
+                    [
+                        {
+                            "e": 736
+                        }
+                    ],
+                    [
+                        {
+                            "v": 736
+                        }
+                    ],
+                    [
+                        {
+                            "wait": 500
+                        },
+                        {
+                            "c": 736
+                        }
+                    ],
+                    [
+                        {
+                            "timeout": 1000,
+                            "check": "none",
+                            "wv": 736
+                        }
+                    ],
+                    {}
+                ],
+                [
+                    1,
+                    "auto_NL_interpolis.nl_jk9",
+                    0,
+                    "^https?://(www\\.)?interpolis\\.nl/",
+                    1,
+                    [],
+                    [
+                        {
+                            "e": 737
+                        }
+                    ],
+                    [
+                        {
+                            "v": 737
+                        }
+                    ],
+                    [
+                        {
+                            "wait": 500
+                        },
+                        {
+                            "c": 737
+                        }
+                    ],
+                    [
+                        {
+                            "timeout": 1000,
+                            "check": "none",
+                            "wv": 737
+                        }
+                    ],
+                    {}
+                ],
+                [
+                    1,
+                    "auto_US_dropbox.com_0_+1",
+                    0,
+                    "^https?://(www\\.)?dropbox\\.com/|^https?://(www\\.)?dropbox\\.com/",
+                    1,
+                    [],
+                    [
+                        {
+                            "e": 738
+                        }
+                    ],
+                    [
+                        {
+                            "v": 738
+                        }
+                    ],
+                    [
+                        {
+                            "text": "Decline",
+                            "c": 738
                         }
                     ],
                     [],
@@ -11902,25 +12052,25 @@
                     [],
                     [
                         {
-                            "e": 731
+                            "e": 739
                         }
                     ],
                     [
                         {
-                            "v": 731
+                            "v": 739
                         }
                     ],
                     [
                         {
-                            "k": 732
+                            "k": 740
                         },
                         {
                             "all": true,
                             "optional": true,
-                            "k": 733
+                            "k": 741
                         },
                         {
-                            "k": 734
+                            "k": 742
                         }
                     ],
                     [
@@ -11939,49 +12089,49 @@
                     "^https://cmp-consent-tool\\.privacymanager\\.io/",
                     1,
                     [
-                        735,
-                        736
+                        743,
+                        744
                     ],
                     [
                         {
-                            "e": 737
+                            "e": 745
                         }
                     ],
                     [
                         {
-                            "v": 737
+                            "v": 745
                         }
                     ],
                     [
                         {
                             "if": {
-                                "e": 738
+                                "e": 746
                             },
                             "then": [
                                 {
-                                    "k": 738
+                                    "k": 746
                                 },
                                 {
-                                    "c": 739
+                                    "c": 747
                                 }
                             ],
                             "else": [
                                 {
-                                    "c": 740
+                                    "c": 748
                                 },
                                 {
-                                    "w": 741
+                                    "w": 749
                                 },
                                 {
-                                    "w": 742
+                                    "w": 750
                                 },
                                 {
                                     "all": true,
                                     "optional": true,
-                                    "k": 743
+                                    "k": 751
                                 },
                                 {
-                                    "k": 742
+                                    "k": 750
                                 }
                             ]
                         }
@@ -11998,20 +12148,20 @@
                     [],
                     [
                         {
-                            "e": 744
+                            "e": 752
                         },
                         {
-                            "e": 745
+                            "e": 753
                         }
                     ],
                     [
                         {
-                            "v": 745
+                            "v": 753
                         }
                     ],
                     [
                         {
-                            "c": 745
+                            "c": 753
                         }
                     ],
                     [],
@@ -12026,12 +12176,12 @@
                     [],
                     [
                         {
-                            "e": 752
+                            "e": 1039
                         }
                     ],
                     [
                         {
-                            "v": 753
+                            "v": 1302
                         }
                     ],
                     [
@@ -15550,33 +15700,32 @@
                 [
                     1,
                     "auto_AU_goodmoodprints.com_9fy",
-                    0,
+                    1,
                     "^https?://(www\\.)?goodmoodprints\\.com/",
                     10,
-                    [],
+                    [
+                        1420
+                    ],
                     [
                         {
-                            "e": 2624
+                            "e": 1420
                         }
                     ],
                     [
                         {
-                            "v": 2624
+                            "v": 1420
                         }
                     ],
                     [
                         {
-                            "wait": 500
-                        },
-                        {
-                            "c": 2624
+                            "h": 1420
                         }
                     ],
                     [
                         {
                             "timeout": 1000,
                             "check": "none",
-                            "wv": 2624
+                            "wv": 1420
                         }
                     ],
                     {}
@@ -19611,31 +19760,6 @@
                             "wv": 1183
                         }
                     ],
-                    {}
-                ],
-                [
-                    1,
-                    "auto_AU_urallawoolroom.com.au_3ng",
-                    0,
-                    "^https?://(www\\.)?urallawoolroom\\.com\\.au/",
-                    10,
-                    [],
-                    [
-                        {
-                            "e": 1039
-                        }
-                    ],
-                    [
-                        {
-                            "v": 1039
-                        }
-                    ],
-                    [
-                        {
-                            "c": 1039
-                        }
-                    ],
-                    [],
                     {}
                 ],
                 [
@@ -27771,40 +27895,6 @@
                             "timeout": 1000,
                             "check": "none",
                             "wv": 1505
-                        }
-                    ],
-                    {}
-                ],
-                [
-                    1,
-                    "auto_CH_degussa-goldhandel.ch_mqc",
-                    0,
-                    "^https?://(www\\.)?degussa-goldhandel\\.ch/",
-                    10,
-                    [],
-                    [
-                        {
-                            "e": 1420
-                        }
-                    ],
-                    [
-                        {
-                            "v": 1420
-                        }
-                    ],
-                    [
-                        {
-                            "wait": 500
-                        },
-                        {
-                            "c": 1420
-                        }
-                    ],
-                    [
-                        {
-                            "timeout": 1000,
-                            "check": "none",
-                            "wv": 1420
                         }
                     ],
                     {}
@@ -43065,24 +43155,24 @@
                     ],
                     [
                         {
-                            "e": 746
+                            "e": 1518
                         }
                     ],
                     [
                         {
-                            "v": 746
+                            "v": 1518
                         }
                     ],
                     [
                         {
-                            "c": 747
+                            "c": 2624
                         }
                     ],
                     [
                         {
                             "timeout": 1000,
                             "check": "none",
-                            "wv": 746
+                            "wv": 1518
                         }
                     ],
                     {}
@@ -66901,40 +66991,6 @@
                 ],
                 [
                     1,
-                    "auto_GB_filofax.com_uxo",
-                    0,
-                    "^https?://(www\\.)?filofax\\.com/",
-                    10,
-                    [],
-                    [
-                        {
-                            "e": 1764
-                        }
-                    ],
-                    [
-                        {
-                            "v": 1764
-                        }
-                    ],
-                    [
-                        {
-                            "wait": 500
-                        },
-                        {
-                            "c": 1764
-                        }
-                    ],
-                    [
-                        {
-                            "timeout": 1000,
-                            "check": "none",
-                            "wv": 1764
-                        }
-                    ],
-                    {}
-                ],
-                [
-                    1,
                     "auto_GB_firstclasswatches.co.uk_0",
                     0,
                     "^https?://(www\\.)?firstclasswatches\\.co\\.uk/",
@@ -70222,31 +70278,6 @@
                             "wv": 2744
                         }
                     ],
-                    {}
-                ],
-                [
-                    1,
-                    "auto_GB_musicnotes.com_0",
-                    0,
-                    "^https?://(www\\.)?musicnotes\\.com/",
-                    10,
-                    [],
-                    [
-                        {
-                            "e": 1302
-                        }
-                    ],
-                    [
-                        {
-                            "v": 1302
-                        }
-                    ],
-                    [
-                        {
-                            "c": 1302
-                        }
-                    ],
-                    [],
                     {}
                 ],
                 [
@@ -74257,9 +74288,6 @@
                         }
                     ],
                     [
-                        {
-                            "wait": 500
-                        },
                         {
                             "c": 3015
                         }
@@ -93107,12 +93135,12 @@
                     [],
                     [
                         {
-                            "e": 708
+                            "e": 716
                         }
                     ],
                     [
                         {
-                            "v": 708
+                            "v": 716
                         }
                     ],
                     [
@@ -93120,14 +93148,14 @@
                             "wait": 500
                         },
                         {
-                            "c": 708
+                            "c": 716
                         }
                     ],
                     [
                         {
                             "timeout": 1000,
                             "check": "none",
-                            "wv": 708
+                            "wv": 716
                         }
                     ],
                     {}
@@ -95151,18 +95179,44 @@
                     [],
                     [
                         {
-                            "e": 1518
+                            "exists": [
+                                "#polaris-css-lockdown-container",
+                                ".polaris-consent-widget"
+                            ]
                         }
                     ],
                     [
                         {
-                            "v": 1518
+                            "visible": [
+                                "#polaris-css-lockdown-container",
+                                ".polaris-consent-widget"
+                            ]
                         }
                     ],
                     [
                         {
-                            "text": "Reject",
-                            "c": 1518
+                            "if": {
+                                "exists": [
+                                    "#polaris-css-lockdown-container",
+                                    "[data-testid='oneClickOptOutLink']"
+                                ]
+                            },
+                            "then": [
+                                {
+                                    "waitForThenClick": [
+                                        "#polaris-css-lockdown-container",
+                                        "[data-testid='oneClickOptOutLink']"
+                                    ]
+                                }
+                            ],
+                            "else": [
+                                {
+                                    "hide": [
+                                        "#polaris-css-lockdown-container",
+                                        ".polaris-consent-widget"
+                                    ]
+                                }
+                            ]
                         }
                     ],
                     [],
@@ -96714,7 +96768,7 @@
                     ],
                     [
                         {
-                            "c": 748
+                            "c": 3170
                         }
                     ],
                     [
@@ -98496,12 +98550,12 @@
                     ],
                     [
                         {
-                            "c": 749
+                            "c": 3171
                         }
                     ],
                     [
                         {
-                            "cc": 750
+                            "cc": 3172
                         }
                     ],
                     {}
@@ -98513,21 +98567,21 @@
                     "^https://www\\.samsung\\.com/",
                     22,
                     [
-                        751
+                        3173
                     ],
                     [
                         {
-                            "e": 751
+                            "e": 3173
                         }
                     ],
                     [
                         {
-                            "v": 751
+                            "v": 3173
                         }
                     ],
                     [
                         {
-                            "h": 751
+                            "h": 3173
                         }
                     ],
                     [],
@@ -99403,18 +99457,18 @@
             "index": {
                 "genericRuleRange": [
                     0,
-                    182
+                    185
                 ],
                 "frameRuleRange": [
-                    181,
-                    214
+                    184,
+                    217
                 ],
                 "specificRuleRange": [
-                    182,
-                    2860
+                    185,
+                    2859
                 ],
-                "genericStringEnd": 705,
-                "frameStringEnd": 746
+                "genericStringEnd": 713,
+                "frameStringEnd": 754
             }
         }
     }


### PR DESCRIPTION
Asana Task/Github Issue: https://app.asana.com/1/137249556945/project/1201844467387842/task/1214052492371697

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large update to the `autoconsent` ruleset (selectors and rule indices) may change cookie-banner handling across many sites and could cause regressions in auto-reject/opt-out flows if any selector or action mapping is incorrect.
> 
> **Overview**
> Updates `features/autoconsent.json` to ruleset v14.71.0, expanding and refining generic cookie-banner detection/rejection selectors (notably adding new `didomi` and `consentmo` patterns and broadening some existing matchers).
> 
> Adds new provider-specific automation flows (e.g., `consentmo`, `didomi`, and a Squarespace cookie banner handler) and adjusts several existing site/provider rules (including rewritten steps for `musicnotes.com`, tweaks to an xpath matcher, and removal/retirement of a few site-specific entries).
> 
> Reindexes the ruleset’s string/rule tables (`genericStringEnd`/`frameStringEnd` and related ranges), reflecting the new/removed entries and updated mappings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a2810abf1ec162e8762a5dfa9e5c9301360d6e6c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->