### PR TITLE
Fix email form not displaying on theaestheticcity.com

### DIFF
--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -879,14 +879,6 @@
             "convertkit.com": {
                 "rules": [
                     {
-                        "rule": "the-aesthetic-city.kit.com",
-                        "domains": [
-                            "convertkit.com",
-                            "theaestheticcity.com"
-                        ],
-                        "reason": "theaestheticcity.com - https://github.com/duckduckgo/privacy-configuration/pull/4958"
-                    },
-                    {
                         "rule": "convertkit.com",
                         "domains": [
                             "kit.com"
@@ -4053,6 +4045,14 @@
             },
             "kit.com": {
                 "rules": [
+                    {
+                        "rule": "the-aesthetic-city.kit.com",
+                        "domains": [
+                            "convertkit.com",
+                            "theaestheticcity.com"
+                        ],
+                        "reason": "theaestheticcity.com - https://github.com/duckduckgo/privacy-configuration/pull/4958"
+                    },
                     {
                         "rule": "kit.com",
                         "domains": [

--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -879,6 +879,14 @@
             "convertkit.com": {
                 "rules": [
                     {
+                        "rule": "the-aesthetic-city.kit.com",
+                        "domains": [
+                            "convertkit.com",
+                            "theaestheticcity.com"
+                        ],
+                        "reason": "theaestheticcity.com - https://github.com/duckduckgo/privacy-configuration/pull/4958"
+                    },
+                    {
                         "rule": "convertkit.com",
                         "domains": [
                             "kit.com"


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/1204912272578138/task/1214052658908125?focus=true

## Description
### Site breakage mitigation process:
#### Brief explanation
- Reported URL: https://theaestheticcity.com/foundations
- Problems experienced: Email signup form not displaying.
- Platforms affected:
  - [x] iOS
  - [x] Android
  - [x] Windows
  - [x] MacOS
  - [x] Extensions
- Tracker(s) being unblocked: kit.com
- Feature being disabled/modified: N/A
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new tracker allowlist exception that relaxes blocking for a specific `kit.com` host on `theaestheticcity.com`, which could increase tracking exposure if overly broad. Scope is limited to one host/domain pair, reducing blast radius.
> 
> **Overview**
> Fixes a site-breakage case where an email signup form was not rendering on `theaestheticcity.com` by allowlisting requests to `the-aesthetic-city.kit.com`.
> 
> This adds a host-specific rule under `kit.com` that permits the tracker only when embedded by `theaestheticcity.com` (and `convertkit.com`), while keeping the existing broader `kit.com` allowlist rule intact.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 471d0b133253be8c6308c4c6fb52142a2b49f41a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->