### PR TITLE
disable ios telemetry

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -2392,7 +2392,7 @@
                     }
                 },
                 "productTelemetrySurfaceUsage": {
-                    "state": "enabled",
+                    "state": "disabled",
                     "minSupportedVersion": "7.199.0",
                     "description": "Temporarily gather telemetry around product surfaces being used."
                 },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/task/1213832635704339?focus=true

## Description
Disable product telemetry on iOS.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change that disables an iOS telemetry feature flag; no code or data-processing logic is modified.
> 
> **Overview**
> Disables the iOS `iOSBrowserConfig.productTelemetrySurfaceUsage` feature flag by switching its `state` from `enabled` to `disabled`, stopping this telemetry collection for supported app versions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e55a13440c6baf441ff8d352a17f6051f9e2337. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->