### PR TITLE
Lucia/enable softlaunch for stable

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -4539,7 +4539,7 @@
                     "state": "enabled"
                 },
                 "stableChannelMigration": {
-                    "state": "disabled"
+                    "state": "enabled"
                 },
                 "softLaunch": {
                     "state": "enabled"

--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -4542,7 +4542,7 @@
                     "state": "disabled"
                 },
                 "softLaunch": {
-                    "state": "preview"
+                    "state": "enabled"
                 }
             }
         },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1205889582400204/task/1213812275773003?focus=true

## Description
Forgot to enable one more feature flag for stable channel migration. 

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> This flips feature flags in the Windows override to enable `stableChannelMigration` and `softLaunch`, which can change rollout behavior for stable users. Risk is limited to configuration but could unintentionally broaden exposure if the flags were meant to remain gated.
> 
> **Overview**
> Enables the Windows `adBlockV2Extension` rollout settings for stable migration by switching `stableChannelMigration` from *disabled* to **enabled** and promoting `softLaunch` from *preview* to **enabled** in `overrides/windows-override.json`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0c0e66a89e8f98b0a93cca7bfeece4c347345204. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->