### PR TITLE
Enable stableChannelMigration to show AdBlock settings to stable users as well

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -4560,7 +4560,7 @@
                     "state": "enabled"
                 },
                 "stableChannelMigration": {
-                    "state": "disabled"
+                    "state": "enabled"
                 },
                 "softLaunch": {
                     "state": "enabled"


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1205889582400204/task/1213812275773003?focus=true

## Description
Forgot to enable the feature flag for stable channel migration

### Feature change process:

- [x] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [x] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [x] This feature was covered by a tech design.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change that flips a single Windows override feature flag from disabled to enabled; main risk is unintended rollout if consumers read this flag immediately.
> 
> **Overview**
> Enables the `adBlockV2Extension.features.stableChannelMigration` flag in `overrides/windows-override.json`, switching it from **disabled** to **enabled** for Windows configuration overrides.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 74ce55b5b4cd40fdf8ff8a25c08c96112965ca41. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->