### PR TITLE
Enable adBlockingExtension for internal users on iOS and macOS

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -2877,8 +2877,8 @@
             }
         },
         "adBlockingExtension": {
-            "state": "disabled",
-            "minSupportedVersion": "7.210.0"
+            "state": "internal",
+            "minSupportedVersion": "7.216.0"
         },
         "webDetection": {
             "state": "enabled",

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -2541,8 +2541,8 @@
             }
         },
         "adBlockingExtension": {
-            "state": "disabled",
-            "minSupportedVersion": "1.183.0"
+            "state": "internal",
+            "minSupportedVersion": "1.186.0"
         },
         "webDetection": {
             "state": "enabled",


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1163321984198618/task/1213458589159294?focus=true

## Description
Enable adBlockingExtension for internal users on iOS and macOS

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change that exposes `adBlockingExtension` to internal users only, but could impact internal browsing behavior on supported app versions.
> 
> **Overview**
> Enables the `adBlockingExtension` feature in the iOS and macOS override configs by switching it from `disabled` to **`internal`**.
> 
> Also bumps the feature’s `minSupportedVersion` to `7.216.0` (iOS) and `1.186.0` (macOS) so it only applies to newer builds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5cdbcf7e776c257515c62ae60e490abf701f6eee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->