### PR TITLE
Disable GPC on metaux-precieux.fr & 24.energa.pl

### DIFF
--- a/features/gpc.json
+++ b/features/gpc.json
@@ -85,7 +85,7 @@
             "reason": "https://github.com/duckduckgo/privacy-configuration/pull/4965"
         },
         {
-            "domain": "24.energa.pl",
+            "domain": "energa.pl",
             "reason": "https://github.com/duckduckgo/privacy-configuration/pull/4965"
         }
     ],

--- a/features/gpc.json
+++ b/features/gpc.json
@@ -79,6 +79,14 @@
         {
             "domain": "arhaus.com",
             "reason": "https://github.com/duckduckgo/privacy-configuration/pull/4819"
+        },
+        {
+            "domain": "metaux-precieux.fr",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/pull/4965"
+        },
+        {
+            "domain": "24.energa.pl",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/pull/4965"
         }
     ],
     "settings": {


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/1206670747178362/task/1214029604797248?focus=true
https://app.asana.com/1/137249556945/project/1206670747178362/task/1214022753924527?focus=true

## Description
### Site breakage mitigation process:
#### Brief explanation
- Reported URL: https://www.energa.pl/dom/oferty/ & https://www.metaux-precieux.fr/informations/cours-acheteurs-actuels/or/
- Problems experienced: Dark overlay after page loads. Cause: When GPC is enabled, some sites' cookie consent banners auto-dismiss without removing their dark background overlay, leaving the page blocked. In other words, GPC causes the cookie popup to skip its own UI flow entirely, and that skip path can leave an overlay on the page.
- Platforms affected:
  - [x] iOS
  - [x] Android
  - [x] Windows
  - [x] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked: N/A
- Feature being disabled/modified: Global Privacy Control (GPC)
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change that disables GPC on two specific domains to mitigate site breakage; no code or logic changes beyond the exception list.
> 
> **Overview**
> Adds `metaux-precieux.fr` and `energa.pl` to the `features/gpc.json` exceptions list, disabling Global Privacy Control on those sites to prevent reported page-blocking overlay issues when GPC is enabled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a0e9ff2e02236a450afc82853ad27d9c9b8e69c3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->