### PR TITLE
Hide empty posts on thingiverse.com & zillow.com

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -4474,7 +4474,7 @@
                 "domain": "zillow.com",
                 "rules": [
                     {
-                        "selector": "[data-testid*='-ad']",
+                        "selector": "[data-testid$='-ad']",
                         "type": "hide"
                     }
                 ]

--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -3931,7 +3931,7 @@
                 "domain": "thingiverse.com",
                 "rules": [
                     {
-                        "selector": "[class*='AdCard__leaderboard']",
+                        "selector": "[class*='AdCard__']",
                         "type": "hide-empty"
                     }
                 ]
@@ -4466,6 +4466,15 @@
                     },
                     {
                         "selector": "ytd-in-feed-ad-layout-renderer",
+                        "type": "hide"
+                    }
+                ]
+            },
+            {
+                "domain": "zillow.com",
+                "rules": [
+                    {
+                        "selector": "[data-testid*='-ad']",
                         "type": "hide"
                     }
                 ]


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/1206670747178362/task/1214069025600700?focus=true
https://app.asana.com/1/137249556945/project/1206670747178362/task/1214017590362166?focus=true

## Description
### Site breakage mitigation process:
#### Brief explanation
- Reported URL: https://www.thingiverse.com/ & https://www.zillow.com/los-angeles-ca-90210/rentals/?searchQueryState=%7B%22pagination%22%3A%7B%7D%2C%22isMapVisible%22%3Atrue%2C%22mapBounds%22%3A%7B%22west%22%3A-118.80397971191408%2C%22east%22%3A-118.02807028808596%2C%22south%22%3A33.98154677967599%2C%22north%22%3A34.218077888391356%7D%2C%22usersSearchTerm%22%3A%2290210%22%2C%22regionSelection%22%3A%5B%7B%22regionId%22%3A96086%2C%22regionType%22%3A7%7D%5D%2C%22filterState%22%3A%7B%22fr%22%3A%7B%22value%22%3Atrue%7D%2C%22fsba%22%3A%7B%22value%22%3Afalse%7D%2C%22fsbo%22%3A%7B%22value%22%3Afalse%7D%2C%22nc%22%3A%7B%22value%22%3Afalse%7D%2C%22cmsn%22%3A%7B%22value%22%3Afalse%7D%2C%22auc%22%3A%7B%22value%22%3Afalse%7D%2C%22fore%22%3A%7B%22value%22%3Afalse%7D%7D%2C%22isListVisible%22%3Atrue%7D – need to use `hide` for zillow.com because `hide-empty` and `closest-empty` don’t work.
- Problems experienced: Blank spaces due to trackers being blocked.
- Platforms affected:
  - [x] iOS
  - [x] Android
  - [x] Windows
  - [x] MacOS
  - [x] Extensions
- Tracker(s) being unblocked: N/A
- Feature being disabled/modified: Element hiding
- [ ] This change is a speculative mitigation to fix reported breakage.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk configuration-only change, but the broadened Thingiverse selector may hide additional non-ad elements if they share the `AdCard__` class prefix.
> 
> **Overview**
> Updates element-hiding rules to reduce blank spaces from blocked ads.
> 
> On `thingiverse.com`, broadens the `hide-empty` selector from only leaderboard cards to all `AdCard__*` elements. Adds a new `zillow.com` rule to `hide` elements whose `data-testid` ends with `-ad`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 05e2c2bf01ee66338fdaf360d04f96203c4f8c45. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->