### PR TITLE
Speculative mitigation for login issues on verizon.com

### DIFF
--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -3397,10 +3397,12 @@
                     {
                         "rule": "cdn.quantummetric.com",
                         "domains": [
-                            "aetna.com"
+                            "aetna.com",
+                            "verizon.com"
                         ],
                         "reason": [
-                            "aetna.com - https://github.com/duckduckgo/privacy-configuration/pull/4882"
+                            "aetna.com - https://github.com/duckduckgo/privacy-configuration/pull/4882",
+                            "verizon.com - https://github.com/duckduckgo/privacy-configuration/pull/4969"
                         ]
                     }
                 ]


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/1200277586140538/task/1214066172775268?focus=true

## Description
### Site breakage mitigation process:
#### Brief explanation
- Reported URL: www.verizon.com & secure.verizon.com
- Problems experienced: Users reporting not being able to log in.
- Platforms affected:
  - [x] iOS
  - [x] Android
  - [x] Windows
  - [x] MacOS
  - [x] Extensions
- Tracker(s) being unblocked: cdn.quantummetric.com
- Feature being disabled/modified: N/A
- [x] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes tracker allowlisting for a high-traffic site, which can impact privacy protections and behavior if the exception is too broad. Scope is small and isolated to a single allowlist entry.
> 
> **Overview**
> Adds `verizon.com` to the existing `quantummetric.com` allowlist rule for `cdn.quantummetric.com`, with an associated reason link, to *speculatively* mitigate login issues on Verizon.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db19cfe4f98c9cf650b93fe1379ccfae0f3c7337. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->