### PR TITLE
Disable GPC for claude.com on macOS

### DIFF
--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -639,7 +639,13 @@
             ]
         },
         "gpc": {
-            "state": "enabled"
+            "state": "enabled",
+            "exceptions": [
+                {
+                    "domain": "claude.com",
+                    "reason": "https://github.com/duckduckgo/privacy-configuration/pull/4970"
+                }
+            ]
         },
         "webCompat": {
             "state": "enabled",


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/1206670747178362/task/1214066383825400?focus=true

## Description
### Site breakage mitigation process:
#### Brief explanation
- Reported URL: https://claude.com/product/cowork
- Problems experienced: Blank page on first load on macOS. See attached screenshot.
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [x] macOS
  - [ ] Extensions
- Tracker(s) being unblocked: N/A
- Feature being disabled/modified: Disabled GPC (Global Privacy Control) on macOS only.
- [ ] This change is a speculative mitigation to fix reported breakage.

<img width="3024" height="1806" alt="claude-com_2026-04-15" src="https://github.com/user-attachments/assets/ae6e3675-e1b1-4515-a882-3aa455507790" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, data-only configuration change limited to macOS that adds a single domain exception to `gpc` behavior. Main risk is unintended privacy/compatibility impact for `claude.com` if the exception scope is broader than needed.
> 
> **Overview**
> Disables Global Privacy Control (GPC) specifically for `claude.com` on macOS by adding a `gpc.exceptions` entry in `overrides/macos-override.json` (with a linked rationale) while keeping GPC enabled globally.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c79751ec3c5cc1bcee65dc22be100efdc5679d24. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->