### PR TITLE
Allow ad.doubleclick.net favicon on Planet Sport sites 

### DIFF
--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -1457,6 +1457,27 @@
                         ]
                     },
                     {
+                        "rule": "ad.doubleclick.net/favicon.ico",
+                        "domains": [
+                            "rocketnews24.com",
+                            "wunderground.com",
+                            "teamtalk.com",
+                            "loverugbyleague.com",
+                            "planetrugby.com",
+                            "planetf1.com",
+                            "planetfootball.com",
+                            "football365.com",
+                            "tennis365.com",
+                            "cricket365.com",
+                            "golf365.com"
+                        ],
+                        "reason": [
+                            "rocketnews24.com - domain propagation from doubleclick.net catch-all",
+                            "wunderground.com - domain propagation from doubleclick.net catch-all",
+                            "teamtalk.com to golf365.com - https://github.com/duckduckgo/privacy-configuration/pull/4970",
+                        ]
+                    },
+                    {
                         "rule": "doubleclick.net",
                         "domains": [
                             "rocketnews24.com",

--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -1474,7 +1474,7 @@
                         "reason": [
                             "rocketnews24.com - domain propagation from doubleclick.net catch-all",
                             "wunderground.com - domain propagation from doubleclick.net catch-all",
-                            "teamtalk.com to golf365.com - https://github.com/duckduckgo/privacy-configuration/pull/4971",
+                            "teamtalk.com to golf365.com - https://github.com/duckduckgo/privacy-configuration/pull/4971"
                         ]
                     },
                     {

--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -1474,7 +1474,7 @@
                         "reason": [
                             "rocketnews24.com - domain propagation from doubleclick.net catch-all",
                             "wunderground.com - domain propagation from doubleclick.net catch-all",
-                            "teamtalk.com to golf365.com - https://github.com/duckduckgo/privacy-configuration/pull/4970",
+                            "teamtalk.com to golf365.com - https://github.com/duckduckgo/privacy-configuration/pull/4971",
                         ]
                     },
                     {


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/1206670747178362/task/1214066383705634?focus=true

## Description
### Site breakage mitigation process: 
#### Brief explanation
- Reported URLs:
  - https://www.planetf1.com/
  - https://www.planetrugby.com/
  - https://www.planetfootball.com/
  - https://www.teamtalk.com/
  - https://www.loverugbyleague.com/
  - https://www.football365.com/
  - https://www.tennis365.com/
  - https://www.cricket365.com/
  - https://www.golf365.com/
- Problems experienced: Adblock wall on all the listed sites (identical pattern), caused by tracker blocking.
- Platforms affected:
  - [x] iOS
  - [x] Android
  - [x] Windows
  - [x] MacOS
  - [x] Extensions
- Tracker(s) being unblocked: ad.doubleclick.net/favicon.ico
- Feature being disabled/modified: N/A
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Expands tracker allowlisting for a Google/DoubleClick endpoint, which can weaken blocking protections if the exception is broader than intended, though it is scoped to `favicon.ico` and specific domains.
> 
> **Overview**
> Mitigates adblock-wall breakage by adding an allowlist exception for `ad.doubleclick.net/favicon.ico` on several Planet Sport domains (e.g., `planetf1.com`, `planetrugby.com`, `planetfootball.com`, `football365.com`, and related sites).
> 
> The new rule is added under the existing `doubleclick.net` allowlist entries with updated reasons referencing the associated propagation/breakage investigation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7f0e6edf070f7be674809e2c022b992cf4c57eb7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->