### PR TITLE
Add freemiumPIR subfeature on iOS

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -2547,6 +2547,9 @@
                 },
                 "goToMarket": {
                     "state": "disabled"
+                },
+                "freemiumPIR": {
+                    "state": "disabled"
                 }
             },
             "minSupportedVersion": "7.201.1"


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/72649045549333/task/1210938375848292

## Description
This PR adds a new flag that controls freemium PIR availability on iOS (currently off)

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [x] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only change that adds a new disabled feature flag; low blast radius unless clients start reading the flag incorrectly.
> 
> **Overview**
> Introduces a new `dbp` subfeature flag, `freemiumPIR`, in `overrides/ios-override.json` to control freemium PIR availability on iOS. The flag is added alongside other `dbp` subfeatures and is set to **disabled** by default.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e183e4242c701238adf9dc91fcedb8721b728b0b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->