### PR TITLE
remove auto from overflowTypes for browserUiLock check

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -2140,7 +2140,9 @@
             "state": "enabled",
             "minSupportedVersion": 52700000,
             "exceptions": [],
-            "settings": {}
+            "settings": {
+                "overflowTypes": ["hidden", "clip"]
+            }
         },
         "navigatorInterface": {
             "state": "enabled",

--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -2141,7 +2141,10 @@
             "minSupportedVersion": 52700000,
             "exceptions": [],
             "settings": {
-                "overflowTypes": ["hidden", "clip"]
+                "overflowTypes": [
+                    "hidden",
+                    "clip"
+                ]
             }
         },
         "navigatorInterface": {


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1212608036467427/task/1214085645307212?focus=true

## Description
- Remove 'auto' from list of overflow types checked for scrollbar visibility. 
- This was added tentatively initially to match iOS behavior on some sites e.g. puzzlist.com, but it causes unexpected lock on SERP, so reverting. 

Test with a custom config: https://duckduckgo.github.io/privacy-configuration/pr-4974/v4/android-config.json override via dev tools.
### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [x] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [x] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, Android-only config tweak that narrows when `browserUiLock` triggers; primary risk is minor site-specific behavior changes (under/over-locking UI).
> 
> **Overview**
> Updates Android `browserUiLock` feature config to explicitly set `settings.overflowTypes` to `hidden` and `clip` (replacing the previously empty settings block), removing `auto` from the overflow types considered when determining scrollbar visibility/lock behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d3bbca69149e870f8a9dd307d6572c3b4ce661eb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->