### PR TITLE
Feature flag for Ad Block Partial Rollout

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -4566,15 +4566,7 @@
                     "state": "enabled"
                 },
                 "partialLaunch": {
-                    "state": "disabled",
-                    "minSupportedVersion": "0.155.0",
-                    "rollout": {
-                        "steps": [
-                            {
-                                "percent": 10
-                            }
-                        ]
-                    }
+                    "state": "disabled"
                 }
             }
         },

--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -4564,6 +4564,17 @@
                 },
                 "softLaunch": {
                     "state": "enabled"
+                },
+                "partialLaunch": {
+                    "state": "disabled",
+                    "minSupportedVersion": "0.155.0",
+                    "rollout": {
+                        "steps": [
+                            {
+                                "percent": 10
+                            }
+                        ]
+                    }
                 }
             }
         },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1205889582400204/task/1213913251276761?focus=true

## Description
Added a feature flag for the partial rollout of ad block.
When it's ready as part of the next project I will add a `rollout` -> `steps` setting.

### Feature change process:

- [x] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [x] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [x] This feature was covered by a tech design.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only change that introduces a disabled feature flag; low risk aside from potential downstream consumers expecting a stable schema.
> 
> **Overview**
> Adds a new `partialLaunch` feature flag under `adBlockV2Extension.features` in `overrides/windows-override.json`, defaulting to `disabled`, to support a future partial rollout of the ad blocker extension.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 37c40f74bf265472c71a9a56d043115eba5e2784. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->