### PR TITLE
Update content-blocker extension to 2026.4.20

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -4544,7 +4544,7 @@
             "minSupportedVersion": "0.148.0",
             "exceptions": [],
             "settings": {
-                "extensionUrl": "https://staticcdn.duckduckgo.com/extensions/content-blocker/content-blocker-extension-2026.4.13.crx"
+                "extensionUrl": "https://staticcdn.duckduckgo.com/extensions/content-blocker/content-blocker-extension-2026.4.20.crx"
             },
             "features": {
                 "onboardingEnabled": {


### PR DESCRIPTION
Update content-blocker extension to 2026.4.20.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a single config change updates the CDN URL for the Windows `adBlockV2Extension` package, with no code or behavior changes beyond pulling a newer extension build.
> 
> **Overview**
> Updates the Windows overrides configuration to point `adBlockV2Extension.settings.extensionUrl` at the `content-blocker-extension-2026.4.20.crx` package (from `2026.4.13`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff7e75e83585edc36f827a62bc2f456dc90c21ac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->