### PR TITLE
Set voiceShortcut to enabled

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -316,8 +316,8 @@
                     "minSupportedVersion": "7.214.0"
                 },
                 "voiceShortcut": {
-                    "state": "internal",
-                    "minSupportedVersion": "7.212.0"
+                    "state": "enabled",
+                    "minSupportedVersion": "7.216.0"
                 }
             },
             "settings": {


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1210947754188321/task/1213614137783999?focus=true

## Description
Sets voiceShortcut flag to enabled for version 7.216.0

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [x] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk configuration-only change that flips a single feature flag and raises its minimum supported iOS app version.
> 
> **Overview**
> Enables the `aiChat.features.voiceShortcut` flag in `overrides/ios-override.json` and bumps its `minSupportedVersion` to `7.216.0`, moving it from an internal-only rollout to enabled for supported clients.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a1dbed152125b2258b55e7e1b4f19c8749cc83e3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->