### PR TITLE
Disable omnibarWebSearch aiChat subfeature on macOS

### DIFF
--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -368,6 +368,9 @@
                 "ntpChatTools": {
                     "state": "enabled",
                     "minSupportedVersion": "1.186.0"
+                },
+                "omnibarWebSearch": {
+                    "state": "disabled"
                 }
             },
             "settings": {


### PR DESCRIPTION
**Asana Task/Github Issue:**

## Description

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

Disables the `omnibarWebSearch` subfeature of `aiChat` on macOS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single config-only feature-flag tweak scoped to macOS; low risk aside from potentially disabling expected functionality for users relying on `omnibarWebSearch`.
> 
> **Overview**
> Disables the `aiChat` subfeature `omnibarWebSearch` in the macOS override configuration by explicitly setting it to `disabled`.
> 
> This changes macOS feature-flag behavior only (no code logic changes), preventing the omnibar web search capability from being enabled via `aiChat` on macOS builds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4597e00354fb2aaab1e1a17688a342e18908402f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->