### PR TITLE
Disable autoconsent (CPM) on theguardian.com for iOS

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -680,6 +680,10 @@
                 {
                     "domain": "newrepublic.com",
                     "reason": "https://github.com/duckduckgo/privacy-configuration/pull/4652"
+                },
+                {
+                    "domain": "theguardian.com",
+                    "reason": "https://github.com/duckduckgo/privacy-configuration/pull/4985"
                 }
             ],
             "features": {


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/1206670747178362/task/1214104976237392?focus=true

## Description
### Site breakage mitigation process:
#### Brief explanation
- Reported URL: https://www.theguardian.com/au
- Problems experienced: Unable to scroll due to the cookie popup repeatedly appearing. Seems to be iOS only.
- Platforms affected:
  - [x] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked: N/A
- Feature being disabled/modified: Cookie Popup Management (CPM)
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-domain configuration change limited to iOS that only disables one feature for `theguardian.com`.
> 
> **Overview**
> Adds `theguardian.com` to the iOS `autoconsent` exception list in `overrides/ios-override.json`, effectively disabling Cookie Popup Management for that domain to mitigate reported site breakage (cookie popup loop/scroll lock).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 26e419c12740d7fb91cc39113f1e93d2b78f5836. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->