### PR TITLE
Enable minimal chrome in landscape on iOS

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -2492,7 +2492,7 @@
                     "minSupportedVersion": "7.215.0"
                 },
                 "minimalChromeInLandscape": {
-                    "state": "internal",
+                    "state": "enabled",
                     "minSupportedVersion": "7.215.0"
                 }
             }


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1206226850447395/task/1214133892463435?focus=true

## Description
Enable minimal chrome in landscape on iOS for all users.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [x] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single iOS remote-config flag change (from `internal` to `enabled`) gated by an existing `minSupportedVersion`, with no code or data-handling logic changes.
> 
> **Overview**
> Enables the `iOSBrowserConfig.minimalChromeInLandscape` feature flag for all supported iOS users by switching its `state` from `internal` to `enabled` in `overrides/ios-override.json` (still gated by `minSupportedVersion: 7.215.0`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 54d11052d71e4ace5c83a3b55b34b9f5a0edb11c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->