### PR TITLE
Add dmv.ny.gov to popup blocking allowlist on macOS

### DIFF
--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -2223,6 +2223,7 @@
                     "becu.org",
                     "capitalone.com",
                     "chase.com",
+                    "dmv.ny.gov",
                     "github.com",
                     "google.com",
                     "googleusercontent.com",


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/1202406491309510/task/1213832268661772?focus=true

## Description
### Site breakage mitigation process:
#### Brief explanation
- Reported URL: https://dmv.ny.gov
- Problems experienced: Unable to download DMV records — site shows "your browser has blocked us from getting popups", preventing the download popup from opening.
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [x] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked: N/A
- Feature being disabled/modified: Added `dmv.ny.gov` to the `popupBlocking` allowlist in `overrides/macos-override.json`
- [x] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-domain configuration tweak limited to macOS popup blocking behavior; no code or security-sensitive logic changes.
> 
> **Overview**
> Updates macOS privacy configuration to *allow popups on* `dmv.ny.gov` by adding it to the `popupBlocking` allowlist, mitigating download flows that rely on pop-up windows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 33b3bcc3672bffdbbd643b904c80b1ba51a62a88. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->