### PR TITLE
Add new disabled flag for aiChat → selectionContext

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -1337,6 +1337,9 @@
                 "menuInApplicationMenu": {
                     "state": "enabled",
                     "minSupportedVersion": "0.154.0"
+                },
+                "selectionContext": {
+                    "state": "disabled"
                 }
             },
             "minSupportedVersion": "0.100.0",


### PR DESCRIPTION
**Asana Task/Github Issue:** [Windows: Selection-aware context attachment](https://app.asana.com/1/137249556945/project/1209292120581622/task/1213651290986341?focus=true)

## Description
Adds a feature flag to gate the selection-aware context attachment feature in the Duck AI Sidebar in the Windows browser.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change that adds a new feature flag defaulted to `disabled`; primary risk is misnaming/miswiring the flag in consumers.
> 
> **Overview**
> Adds a new `aiChat.features.selectionContext` override in `windows-override.json`, defaulting it to **disabled** to gate selection-aware context attachment behavior in the Windows Duck AI Sidebar.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e4d2e5459f40590a85d3d767f1a1199608893ffa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->