### PR TITLE
Enable nativeRequestInterception for internal users

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -5275,7 +5275,7 @@
             "state": "disabled"
         },
         "nativeRequestInterception": {
-            "state": "disabled",
+            "state": "internal",
             "exceptions": [],
             "features": {
                 "disableFirstAboutBlankNavigation": {


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/72649045549333/task/1214148525962211?focus=true

## Description
Enable nativeRequestInterception for internal users

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the rollout state of `nativeRequestInterception` on Windows from disabled to `internal`, which could affect request handling behavior for internal users and potentially surface networking/regression issues early.
> 
> **Overview**
> Updates `overrides/windows-override.json` to switch `nativeRequestInterception` from **disabled** to **internal**, enabling the feature for internal Windows users while leaving existing exceptions and sub-feature flags unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 11138abda074cd21ae68b0872b0d310363c01e97. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->