### PR TITLE
Enable delayedWebviewPresentation on macOS from 1.186.1

### DIFF
--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -2101,7 +2101,8 @@
             "minSupportedVersion": "1.137.0"
         },
         "delayedWebviewPresentation": {
-            "state": "internal"
+            "state": "enabled",
+            "minSupportedVersion": "1.186.1"
         },
         "tabSuspension": {
             "state": "internal",


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1210995391161861/task/1214150480764506?focus=true

## Description

Flip `delayedWebviewPresentation` from `internal` to `enabled`, gated by `minSupportedVersion: "1.186.1"`.

The feature rolls out to macOS clients on 1.186.1+ and stays off for older versions.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single config toggle gated by minimum app version; no code or schema changes, with limited blast radius to macOS clients on 1.186.1+.
> 
> **Overview**
> Enables the `delayedWebviewPresentation` feature for macOS clients by flipping it from `internal` to **enabled**.
> 
> The rollout is gated with `minSupportedVersion: "1.186.1"`, keeping the feature off for older app versions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 36a15ea2ee3ec2e9893f1216511caf4db6cd6a29. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->