### PR TITLE
[iOS] Start rollout for autoplayBlocking at 10%

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -2464,6 +2464,7 @@
                 },
                 "autoplayBlocking": {
                     "state": "enabled",
+                    "minSupportedVersion": "7.216.0",
                     "rollout": {
                         "steps": [
                             {

--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -2463,7 +2463,14 @@
                     "state": "disabled"
                 },
                 "autoplayBlocking": {
-                    "state": "internal"
+                    "state": "enabled",
+                    "rollout": {
+                        "steps": [
+                            {
+                                "percent": 10
+                            }
+                        ]
+                    }
                 },
                 "showNTPAfterIdleReturn": {
                     "state": "enabled",


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/task/1213639734241586?focus=true

## Description
Start rollout for `autoplayBlocking` remote feature flag at 10%. This enables the media autoplay blocking menu and configuration.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [X] I have tested this change locally in all supported browsers.
- [X] This code for the config change is ready to merge.
- [X] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Enables a user-facing media autoplay blocking feature for a subset of iOS users, which could impact video/audio playback behavior on some sites. Rollout is limited to 10% and gated by `minSupportedVersion`, reducing blast radius but still affecting core browsing UX.
> 
> **Overview**
> Starts a staged rollout of the iOS `autoplayBlocking` remote feature by switching it from `internal` to **enabled** and adding a `minSupportedVersion` of `7.216.0`.
> 
> Introduces an initial rollout step of **10%**, turning on the autoplay blocking menu/configuration for a small cohort.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 76b434e74060b918fa4ea60e43c48207a1b4fa99. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->