### PR TITLE
Disable minimal chrome in landscape on iOS

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -2496,7 +2496,7 @@
                     "minSupportedVersion": "7.215.0"
                 },
                 "minimalChromeInLandscape": {
-                    "state": "enabled",
+                    "state": "disabled",
                     "minSupportedVersion": "7.215.0"
                 }
             }


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/414709148257752/task/1214167742861334?focus=true

cc: @bwaresiak @edulpn 

## Description
We’ve found a critical bug caused by this feature. Disabling the feature as a mitigation measure.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [x] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, single config flag change in `ios-override.json` that disables a UI experiment; impact is limited to iOS clients >= `7.215.0` and is easily reversible.
> 
> **Overview**
> Disables the `iOSBrowserConfig.minimalChromeInLandscape` feature flag in `overrides/ios-override.json` (from `enabled` to `disabled`) for iOS versions >= `7.215.0` as a mitigation for a critical issue.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 776ad7b7a19ff63fea953c703a23066ff3a4001e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->