### PR TITLE
Mitigate adblock wall on biancazapatka.com

### DIFF
--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -216,7 +216,7 @@
                         ],
                         "reason": [
                             "biancazapatka.com - https://github.com/duckduckgo/privacy-configuration/pull/4995",
-                            "gardeningknowhow.com, adamtheautomator.com, packhacker.com, cookingclassy.com, modernhoney.com - domain propagation from adthrive.com rule",
+                            "gardeningknowhow.com, adamtheautomator.com, packhacker.com, cookingclassy.com, modernhoney.com - domain propagation from adthrive.com rule"
                         ]
                     },
                     {

--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -205,6 +205,21 @@
             "adthrive.com": {
                 "rules": [
                     {
+                        "rule": "ads.adthrive.com/abd/abd.js",
+                        "domains": [
+                            "biancazapatka.com",
+                            "gardeningknowhow.com",
+                            "adamtheautomator.com",
+                            "packhacker.com",
+                            "cookingclassy.com",
+                            "modernhoney.com"
+                        ],
+                        "reason": [
+                            "biancazapatka.com - https://github.com/duckduckgo/privacy-configuration/pull/4995",
+                            "gardeningknowhow.com, adamtheautomator.com, packhacker.com, cookingclassy.com, modernhoney.com - domain propagation from adthrive.com rule",
+                        ]
+                    },
+                    {
                         "rule": "adthrive.com",
                         "domains": [
                             "gardeningknowhow.com",


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/1206670747178362/task/1213945779917405?focus=true

## Description
### Site breakage mitigation process:
#### Brief explanation
- Reported URL: https://biancazapatka.com/en/
- Problems experienced: Adblock wall on biancazapatka.com due to tracker blocking.
- Platforms affected:
  - [x] iOS
  - [x] Android
  - [x] Windows
  - [x] MacOS
  - [x] Extensions
- Tracker(s) being unblocked: adthrive.com
- Feature being disabled/modified: N/A
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new tracker allowlist exception for an AdThrive script on several domains, which can impact tracking protections on those sites if overly broad or mis-scoped.
> 
> **Overview**
> Adds a new allowlist rule for `ads.adthrive.com/abd/abd.js` under `adthrive.com`, enabling this script on `biancazapatka.com` (to mitigate an adblock wall) and propagating the same exception to several existing AdThrive-affected domains.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bb52f9ef300cbe9d5e660669e7124725a4f9c1ab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->