### PR TITLE
Disable GPC on ernestjones.co.uk

### DIFF
--- a/features/gpc.json
+++ b/features/gpc.json
@@ -87,6 +87,10 @@
         {
             "domain": "energa.pl",
             "reason": "https://github.com/duckduckgo/privacy-configuration/pull/4965"
+        },
+        {
+            "domain": "ernestjones.co.uk",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/pull/4996"
         }
     ],
     "settings": {


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/1206670747178362/task/1213987912947922?focus=true

## Description
### Site breakage mitigation process:
#### Brief explanation
- Reported URL: https://www.ernestjones.co.uk/
- Problems experienced: Unresponsive buttons on the cookie popup due to a clash between the site’s cookie popup and Global Privacy Control (GPC). Disabling CPM is not effective.
- Platforms affected:
  - [x] iOS
  - [x] Android
  - [x] Windows
  - [x] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked: N/A
- Feature being disabled/modified: Global Privacy Control (GPC)
- [ ] This change is a speculative mitigation to fix reported breakage.