### PR TITLE
Add maxUrlSuggestions setting to duckAiChatHistory 

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -451,7 +451,8 @@
                 "chatsLocalStorageKeys": [
                     "savedAIChats"
                 ],
-                "maxHistoryCount": 10
+                "maxHistoryCount": 10,
+                "maxUrlSuggestions": 3
             }
         },
         "duckAiDataClearing": {


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/1212810093780571/task/1213905632238249?focus=true

## Description
Adds a new maxUrlSuggestions setting (value: 3) under duckAiChatHistory.settings in the Android override.
This allows the Android client to read the URL suggestions limit (Displayed in Duck.ai mode) from the privacy config. 

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [x] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small config-only change that adds a new numeric setting and should not affect existing behavior unless the Android client opts into reading it.
> 
> **Overview**
> Adds a new `duckAiChatHistory.settings.maxUrlSuggestions` value (`3`) to `overrides/android-override.json`, allowing the Android client to read a configurable limit for Duck.ai URL suggestions (alongside the existing `maxHistoryCount`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ef3109913db41e9f3e322c0341a87778adf1a9a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->