### PR TITLE
Hide blank spaces on ekstrabladet.dk

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -1584,6 +1584,15 @@
                 ]
             },
             {
+                "domain": "ekstrabladet.dk",
+                "rules": [
+                    {
+                        "selector": "[id^='ebbanner_wrapper_']",
+                        "type": "hide"
+                    }
+                ]
+            },
+            {
                 "domain": "elpais.com",
                 "rules": [
                     {


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/1206670747178362/task/1214168033764377?focus=true

## Description
### Site breakage mitigation process:
#### Brief explanation
- Reported URL: https://ekstrabladet.dk/
- Problems experienced: Big blank spaces caused by trackers being blocked. `hide-empty` and `closest-empty` were ineffective so had to use `hide`.
- Platforms affected:
  - [x] iOS
  - [x] Android
  - [x] Windows
  - [x] MacOS
  - [x] Extensions
- Tracker(s) being unblocked: N/A
- Feature being disabled/modified: Element hiding
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, scoped configuration change affecting only `ekstrabladet.dk`; main risk is unintended hiding of legitimate page elements on that site.
> 
> **Overview**
> Adds a site-specific element-hiding rule for **`ekstrabladet.dk`** to hide banner wrapper elements (`[id^='ebbanner_wrapper_']`) using `type: "hide"` to eliminate large blank spaces left behind when trackers/ads are blocked.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit be7d8d49130c08b29f0393301c7545f7b044e089. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->