### PR TITLE
Remove autocompleteTabs feature flag from privacy config

### DIFF
--- a/features/autocomplete-tabs.json
+++ b/features/autocomplete-tabs.json
@@ -1,7 +1,0 @@
-{
-    "_meta": {
-        "description": "Allow tabs to be included in autocomplete suggestions"
-    },
-    "state": "enabled",
-    "exceptions": []
-}

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -410,9 +410,6 @@
                 "maxHistoryCount": 5
             }
         },
-        "autocompleteTabs": {
-            "minSupportedVersion": "1.134.0"
-        },
         "serp": {
             "state": "enabled",
             "exceptions": [],


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/0/0/1212810445481107

## Description
Removes the `autocompleteTabs` feature from the privacy configuration. The feature flag was dropped from the macOS app codebase in [PR #3196](https://github.com/duckduckgo/apple-browsers/pull/3196) (January 2026), permanently enabling the feature in code. No app version currently reads this key from the config.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [x] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config cleanup that deletes an unused feature flag entry; impact is limited to clients that might still read this key.
> 
> **Overview**
> Removes the `autocompleteTabs` privacy-config feature flag by deleting `features/autocomplete-tabs.json` and dropping the corresponding `minSupportedVersion` override from `overrides/macos-override.json`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9d8698a82830b49b96d68b6fb89ad8517176a1fd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->