### PR TITLE
Enable tabSuspension feature flag on macOS

### DIFF
--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -2110,6 +2110,7 @@
             "features": {
                 "memoryPressureTrigger": {
                     "state": "enabled",
+                    "minSupportedVersion": "1.186.1",
                     "settings": {
                         "tabInactivityPeriod": 600
                     }

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -2105,10 +2105,10 @@
             "minSupportedVersion": "1.186.1"
         },
         "tabSuspension": {
-            "state": "internal",
+            "state": "enabled",
             "features": {
                 "memoryPressureTrigger": {
-                    "state": "internal",
+                    "state": "enabled",
                     "settings": {
                         "tabInactivityPeriod": 600
                     }

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -2106,6 +2106,7 @@
         },
         "tabSuspension": {
             "state": "enabled",
+            "minSupportedVersion": "1.186.1",
             "features": {
                 "memoryPressureTrigger": {
                     "state": "enabled",


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/0/1201899738287924/1212783484938405/f

## Description

Enable the `tabSuspension` feature flag and its `memoryPressureTrigger` subfeature on macOS by changing their state from `internal` to `enabled`.

### Feature change process:

- [x] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [x] This feature was covered by a tech design.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes runtime behavior on macOS by enabling tab suspension and memory-pressure-triggered suspension, which could impact tab lifecycle/UX and stability if edge cases exist.
> 
> **Overview**
> Enables the `tabSuspension` feature flag for macOS (previously `internal`) and turns on its `memoryPressureTrigger` subfeature.
> 
> Both flags now require `minSupportedVersion` `1.186.1`, while keeping the existing `tabInactivityPeriod` (600s) and `inputFieldFocusDetection` settings unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0edbc94e56dc0030b1505ff48b3e45f07a38027c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->