### PR TITLE
Disable browserUiLock (Android)

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -2148,7 +2148,7 @@
             }
         },
         "browserUiLock": {
-            "state": "enabled",
+            "state": "disabled",
             "minSupportedVersion": 52700000,
             "exceptions": [],
             "settings": {


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1202552961248957/task/1214156122159512?focus=true

## Description

- `browserUiLock` is causing issues with pull-to-refresh, disabling it fixes the issue.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [x] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced: Pull-to-refresh is inconsistent
- Platforms affected:
  - [ ] iOS
  - [x] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a single Android remote-config flag is flipped from enabled to disabled, with no code changes; impact is limited to UI behavior for supported versions.
> 
> **Overview**
> Disables the Android `browserUiLock` feature flag (from `enabled` to `disabled`) in `overrides/android-override.json` for `minSupportedVersion` `52700000`, intended to mitigate pull-to-refresh issues.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e2e9f6723135889d8510adba255d28f79c1c12a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->