### PR TITLE
Skip privileged PR workflows on forks

### DIFF
--- a/.github/workflows/auto-respond-pr.yml
+++ b/.github/workflows/auto-respond-pr.yml
@@ -29,7 +29,7 @@ jobs:
     # Closes tasks for both merged PRs and abandoned PRs to clean up dead tasks
     # Runs independently of the main workflow
     sync_asana_on_close:
-        if: github.event.action == 'closed'
+        if: github.event.action == 'closed' && !github.event.pull_request.head.repo.fork
         runs-on: ubuntu-latest
         steps:
             - uses: duckduckgo/action-asana-sync@v11
@@ -42,7 +42,7 @@ jobs:
                   ASSIGN_PR_AUTHOR: 'true'
 
     auto_respond:
-        if: github.event.action != 'closed'
+        if: github.event.action != 'closed' && !github.event.pull_request.head.repo.fork
         runs-on: ubuntu-latest
         concurrency: auto-respond-${{ github.event.pull_request.number }}
 


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1204023833050360/task/1214178616039048?focus=true

## Description
<!-- 
  Please delete either or both process sections below.
-->

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only adds fork checks to GitHub Actions job conditions, reducing exposure of secret-dependent steps on forked PR events.
> 
> **Overview**
> Prevents the `auto-respond-pr.yml` workflow from running its Asana sync and auto-response jobs on PRs originating from forks by adding `!github.event.pull_request.head.repo.fork` to the job `if` conditions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9295114b872402736ad372e2fa964287dfa239c8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->