### PR TITLE
Update request-blocklist.json

### DIFF
--- a/features/request-blocklist.json
+++ b/features/request-blocklist.json
@@ -5,6 +5,18 @@
     "state": "disabled",
     "settings": {
         "blockedRequests": {
+            "youtube.com": {
+                "rules": [
+                    {
+                        "rule": "youtube.com/youtubei/v1/player/ad_break",
+                        "domains": [
+                            "youtube.com",
+                            "youtube-nocookie.com"
+                        ],
+                        "reason": "YT midroll ads"
+                    }
+                ]
+            },
             "privacy-test-pages.site": {
                 "rules": [
                     {


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/246491496396031/task/1214167733596582?focus=true

## Description
Testing

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Config-only change, but if/when `request-blocklist` is enabled it may affect YouTube playback by blocking `youtubei/v1/player/ad_break` requests across `youtube.com` and `youtube-nocookie.com`. Scope is small and isolated to one rule addition.
> 
> **Overview**
> Adds a new `youtube.com` entry to `features/request-blocklist.json` that blocks `youtube.com/youtubei/v1/player/ad_break` (midroll ad-related) for `youtube.com` and `youtube-nocookie.com`.
> 
> No other logic changes; this is a targeted update to the request-blocking ruleset (feature remains `disabled` in the config).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d2a31780b6e66948095d5fcb4e7b1745cdfa8155. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->