### PR TITLE
Element hiding: hide "experiencing interruptions" toast on youtube that's causing confusion

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -4347,15 +4347,6 @@
                 ]
             },
             {
-                "domain": "youtube.com",
-                "rules": [
-                    {
-                        "selector": "#toast[role='region']:has(yt-button-shape > a[href='https://support.google.com/youtube/answer/3037019#check_ad_blockers&zippy=%2Ccheck-your-extensions-including-ad-blockers'])",
-                        "type": "hide"
-                    }
-                ]
-            },
-            {
                 "domain": "gazeta.pl",
                 "rules": [
                     {
@@ -4484,6 +4475,10 @@
                     },
                     {
                         "selector": "ytd-in-feed-ad-layout-renderer",
+                        "type": "hide"
+                    },
+                    {
+                        "selector": "#toast[role='region']:has(yt-button-shape > a[href='https://support.google.com/youtube/answer/3037019#check_ad_blockers&zippy=%2Ccheck-your-extensions-including-ad-blockers'])",
                         "type": "hide"
                     }
                 ]

--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -4347,6 +4347,15 @@
                 ]
             },
             {
+                "domain": "youtube.com",
+                "rules": [
+                    {
+                        "selector": "#toast[role='region']:has(yt-button-shape > a[href='https://support.google.com/youtube/answer/3037019#check_ad_blockers&zippy=%2Ccheck-your-extensions-including-ad-blockers'])",
+                        "type": "hide"
+                    }
+                ]
+            },
+            {
                 "domain": "gazeta.pl",
                 "rules": [
                     {


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/246491496396031/task/1214189847446852?focus=true

## Description
Youtube is showing this message intermittently for our users, which is causing confusion. This hides specifically the toast that links to the check ad blockers page.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a single, highly specific `youtube.com` element-hiding selector is added and only affects cosmetic UI removal on that site.
> 
> **Overview**
> Updates `features/element-hiding.json` to **hide a specific YouTube toast** (`#toast[role='region']`) that links users to the "check your extensions including ad blockers" support page, reducing confusion from the intermittent "experiencing interruptions" message.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e638f590edd67a76e0c8ff4694d4bfc4d07b5818. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->