### PR TITLE
Android: enable NTP Idle for app version 5.278.0

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -1629,9 +1629,9 @@
                     }
                 },
                 "showNTPAfterIdleReturn": {
-                    "state": "disabled",
+                    "state": "enabled",
                     "settings": {
-                        "defaultIdleThresholdSeconds": "300"
+                        "defaultIdleThresholdSeconds": "1800"
                     }
                 },
                 "singleTabFireDialog": {

--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -1630,6 +1630,7 @@
                 },
                 "showNTPAfterIdleReturn": {
                     "state": "enabled",
+                    "minSupportedVersion": 52780000,
                     "settings": {
                         "defaultIdleThresholdSeconds": "1800"
                     }


### PR DESCRIPTION
**Asana Task/Github Issue:**https://app.asana.com/1/137249556945/project/1174433894299346/task/1213910337470388?focus=true

## Description
Enable Show NTP for all users

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes a client-facing feature flag to enabled for all supported Android versions, which could alter tab/launch behavior after inactivity. The change is limited to a remote config override with no security- or data-sensitive logic.
> 
> **Overview**
> **Enables** `androidBrowserConfig.showNTPAfterIdleReturn`, gating it behind `minSupportedVersion: 52780000`.
> 
> Updates the feature’s default idle threshold from `300` to `1800` seconds, changing when the NTP will be shown after returning from idle.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d3b90dbfc7d9fb07392e8daa4df8ce143589924d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->