### PR TITLE
Update content-blocker extension to 2026.4.23

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -4551,7 +4551,7 @@
             "minSupportedVersion": "0.148.0",
             "exceptions": [],
             "settings": {
-                "extensionUrl": "https://staticcdn.duckduckgo.com/extensions/content-blocker/content-blocker-extension-2026.4.20.crx"
+                "extensionUrl": "https://staticcdn.duckduckgo.com/extensions/content-blocker/content-blocker-extension-2026.4.23.crx"
             },
             "features": {
                 "onboardingEnabled": {


### PR DESCRIPTION
Update content-blocker extension to 2026.4.23.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change that updates the CDN URL for the Windows `adBlockV2Extension` CRX; impact is limited to which extension build is fetched.
> 
> **Overview**
> Updates the Windows override config to point `adBlockV2Extension.settings.extensionUrl` at the `content-blocker-extension-2026.4.23.crx` bundle instead of `2026.4.20`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit edc2def4d4c9ae7405385682150190341d6fc63b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->