### PR TITLE
Hide blank spaces on apnews.com

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -846,6 +846,10 @@
                     {
                         "selector": ".SovrnAd",
                         "type": "hide-empty"
+                    },
+                    {
+                        "selector": ".FreeStar",
+                        "type": "hide-empty"
                     }
                 ]
             },


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/1200277586140538/task/1214229802847514?focus=true

## Description
### Site breakage mitigation process:
#### Brief explanation
- Reported URL: https://apnews.com/article/russia-ukraine-war-drone-missile-attack-kyiv-10627c3e68677cad65fadd5f2a9f8388
- Problems experienced: Blank spaces caused by trackers being blocked.
- Platforms affected:
  - [x] iOS
  - [x] Android
  - [x] Windows
  - [x] MacOS
  - [x] Extensions
- Tracker(s) being unblocked: N/A
- Feature being disabled/modified: Element hiding
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a single domain-scoped hide rule; low risk aside from potentially hiding non-ad `.FreeStar` containers if the selector is overly broad on apnews.com.
> 
> **Overview**
> Updates `features/element-hiding.json` to additionally hide empty `.FreeStar` elements on `apnews.com`, reducing blank page gaps left behind when ad/tracker content is blocked.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 53ec2732fabc7efad2dee1f5a055297bd8854ede. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->