### PR TITLE
Remove obsolete duckAiNativeStorage flags, add aiChat.nativeStorage

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -1340,6 +1340,9 @@
                 },
                 "selectionContext": {
                     "state": "disabled"
+                },
+                "nativeStorage": {
+                    "state": "internal"
                 }
             },
             "minSupportedVersion": "0.100.0",
@@ -2133,7 +2136,6 @@
                 "subscriptions": "disabled",
                 "subscriptionPages": "disabled",
                 "serpSettings": "disabled",
-                "duckAiNativeStorage": "internal",
                 "domains": [
                     {
                         "domain": [
@@ -5322,10 +5324,6 @@
         "browserIsInteractiveFix": {
             "exceptions": [],
             "state": "enabled"
-        },
-        "duckAiNativeStorage": {
-            "state": "internal",
-            "exceptions": []
         },
         "multiDownloadPermission": {
             "state": "disabled",

--- a/schema/features/message-bridge.ts
+++ b/schema/features/message-bridge.ts
@@ -5,7 +5,6 @@ export type MessageBridgeSettings = CSSInjectFeatureSettings<{
     subscriptions?: FeatureState;
     subscriptionPages?: FeatureState;
     serpSettings?: FeatureState;
-    duckAiNativeStorage?: FeatureState;
 }>;
 
 export type MessageBridgeFeature<VersionType> = Feature<MessageBridgeSettings, VersionType>;


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1210407179200832/task/1213984294426946

## Description
Removed obsolete duckAiNativeStorage flag
Added aiChat.nativeStorage flag

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: config/schema cleanup that removes an unused message-bridge flag and introduces a new `aiChat.nativeStorage` subfeature toggle; main risk is client compatibility if any consumer still expects the old key.
> 
> **Overview**
> Adds a new `aiChat.nativeStorage` subfeature flag (set to `internal` in `windows-override.json`) to control AI Chat native storage behavior.
> 
> Removes the obsolete `duckAiNativeStorage` flag from both the Windows override configuration and the `MessageBridgeSettings` schema (`schema/features/message-bridge.ts`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c500689801453d0de76294ce396ac066c68b72a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->