### PR TITLE
Re-add messageBridge.settings.duckAiNativeStorage

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -2136,6 +2136,7 @@
                 "subscriptions": "disabled",
                 "subscriptionPages": "disabled",
                 "serpSettings": "disabled",
+                "duckAiNativeStorage": "disabled",
                 "domains": [
                     {
                         "domain": [
@@ -2163,17 +2164,10 @@
                                 "op": "replace",
                                 "path": "/serpSettings",
                                 "value": "enabled"
-                            }
-                        ]
-                    },
-                    {
-                        "domain": [
-                            "euw-serp-dev-testing19.duck.ai"
-                        ],
-                        "patchSettings": [
+                            },
                             {
                                 "op": "replace",
-                                "path": "/aiChat",
+                                "path": "/duckAiNativeStorage",
                                 "value": "enabled"
                             }
                         ]

--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -1340,6 +1340,9 @@
                 },
                 "selectionContext": {
                     "state": "disabled"
+                },
+                "nativeStorage": {
+                    "state": "internal"
                 }
             },
             "minSupportedVersion": "0.100.0",
@@ -2133,7 +2136,6 @@
                 "subscriptions": "disabled",
                 "subscriptionPages": "disabled",
                 "serpSettings": "disabled",
-                "duckAiNativeStorage": "internal",
                 "domains": [
                     {
                         "domain": [
@@ -5322,10 +5324,6 @@
         "browserIsInteractiveFix": {
             "exceptions": [],
             "state": "enabled"
-        },
-        "duckAiNativeStorage": {
-            "state": "internal",
-            "exceptions": []
         },
         "multiDownloadPermission": {
             "state": "disabled",

--- a/schema/features/message-bridge.ts
+++ b/schema/features/message-bridge.ts
@@ -5,7 +5,6 @@ export type MessageBridgeSettings = CSSInjectFeatureSettings<{
     subscriptions?: FeatureState;
     subscriptionPages?: FeatureState;
     serpSettings?: FeatureState;
-    duckAiNativeStorage?: FeatureState;
 }>;
 
 export type MessageBridgeFeature<VersionType> = Feature<MessageBridgeSettings, VersionType>;

--- a/schema/features/message-bridge.ts
+++ b/schema/features/message-bridge.ts
@@ -5,6 +5,7 @@ export type MessageBridgeSettings = CSSInjectFeatureSettings<{
     subscriptions?: FeatureState;
     subscriptionPages?: FeatureState;
     serpSettings?: FeatureState;
+    duckAiNativeStorage?: FeatureState;
 }>;
 
 export type MessageBridgeFeature<VersionType> = Feature<MessageBridgeSettings, VersionType>;


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1210407179200832/task/1213984294426946?focus=true

## Description
Re-add messageBridge.settings.duckAiNativeStorage
Enable it only for DDG properties
Remove test URL

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates feature configuration and schema to reintroduce `messageBridge.settings.duckAiNativeStorage` and enable it for DuckDuckGo-owned domains only; risk is moderate because it changes runtime feature gating around AI native storage behavior.
> 
> **Overview**
> Re-adds `messageBridge.settings.duckAiNativeStorage` to the `messageBridge` feature schema and Windows override config.
> 
> Defaults `duckAiNativeStorage` to *disabled* globally, then conditionally enables it via domain patches for DuckDuckGo properties (`duckduckgo.com`, `duck.co`, `duck.ai`), removing the previous test-only domain enablement.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 056f6239ce04ef5a50e1ed1904227499e11d861a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->