### PR TITLE
Apple native storage internal

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -135,6 +135,7 @@
                 "aiChat": "disabled",
                 "subscriptions": "disabled",
                 "serpSettings": "disabled",
+                "duckAiNativeStorage": "disabled",
                 "domains": [
                     {
                         "domain": [
@@ -156,6 +157,11 @@
                             {
                                 "op": "replace",
                                 "path": "/serpSettings",
+                                "value": "enabled"
+                            },
+                            {
+                                "op": "replace",
+                                "path": "/duckAiNativeStorage",
                                 "value": "enabled"
                             }
                         ]
@@ -213,6 +219,9 @@
                 "experimentalAddressBar": {
                     "state": "enabled",
                     "minSupportedVersion": "7.181.0"
+                },
+                "nativeStorage": {
+                    "state": "internal"
                 },
                 "showAIChatAddressBarChoiceScreen": {
                     "state": "enabled",

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -245,6 +245,7 @@
                 "aiChat": "disabled",
                 "subscriptions": "disabled",
                 "serpSettings": "disabled",
+                "duckAiNativeStorage": "disabled",
                 "domains": [
                     {
                         "domain": [
@@ -266,6 +267,11 @@
                             {
                                 "op": "replace",
                                 "path": "/serpSettings",
+                                "value": "enabled"
+                            },
+                            {
+                                "op": "replace",
+                                "path": "/duckAiNativeStorage",
                                 "value": "enabled"
                             }
                         ]
@@ -311,6 +317,9 @@
                 },
                 "applicationMenuShortcut": {
                     "state": "enabled"
+                },
+                "nativeStorage": {
+                    "state": "internal"
                 },
                 "sidebar": {
                     "state": "enabled",


### PR DESCRIPTION

**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/task/1214133762060150?focus=true

## Description
Apple native storage internal

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Apple (iOS/macOS) remote config to introduce a new `messageBridge` setting and mark `aiChat.nativeStorage` as `internal`, which can alter Duck.ai storage behavior during internal testing. Risk is moderate because it affects feature-gating and persistence behavior, but remains limited to internal rollout states/domains.
> 
> **Overview**
> **Adds Apple config gating for Duck.ai native storage.**
> 
> Updates iOS and macOS overrides to introduce a new `messageBridge` setting (`duckAiNativeStorage`) defaulting to disabled but enabled for DuckDuckGo/Duck.ai domains via patch rules. Separately sets `aiChat.features.nativeStorage` to `internal` on both platforms, making native storage behavior available only to internal builds/users per config.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c261dc8a437f8eda086dd27e6e204a9467916cf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->