### PR TITLE
Add searchserverapi1.com to tracker allowlist

### DIFF
--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -3589,7 +3589,7 @@
                         "domains": [
                             "<all>"
                         ],
-                        "reason": "TODO: fill in PR link"
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5015"
                     }
                 ]
             },

--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -3582,6 +3582,17 @@
                     }
                 ]
             },
+            "searchserverapi1.com": {
+                "rules": [
+                    {
+                        "rule": "searchserverapi1.com",
+                        "domains": [
+                            "<all>"
+                        ],
+                        "reason": "TODO: fill in PR link"
+                    }
+                ]
+            },
             "searchspring.io": {
                 "rules": [
                     {


### PR DESCRIPTION


**Asana Task/Github Issue:**

## Description
<!-- 
  Please delete either or both process sections below.
-->
False positive in our tracker detection and blocking breaks product recommendations on sites like https://oesd.com. 

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new global allowlist entry for `searchserverapi1.com`, which could increase tracking exposure if the domain is misclassified. Impact is limited to this single domain/rule change in configuration.
> 
> **Overview**
> Updates `features/tracker-allowlist.json` to **allowlist `searchserverapi1.com` across all domains** (rule: `searchserverapi1.com`), referencing PR `#5015` as the justification.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 35cb88de83e874dc2fc6d9833c63e2b263206595. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->