### PR TITLE
Skip Dependabot PR automation workflows that require elevated permissions

### DIFF
--- a/.github/workflows/auto-respond-pr.yml
+++ b/.github/workflows/auto-respond-pr.yml
@@ -42,7 +42,7 @@ jobs:
                   ASSIGN_PR_AUTHOR: 'true'
 
     auto_respond:
-        if: github.event.action != 'closed' && !github.event.pull_request.head.repo.fork
+        if: github.event.action != 'closed' && !github.event.pull_request.head.repo.fork && github.event.pull_request.user.login != 'app/dependabot' && github.event.pull_request.user.login != 'dependabot[bot]'
         runs-on: ubuntu-latest
         concurrency: auto-respond-${{ github.event.pull_request.number }}
 

--- a/.github/workflows/auto-respond-pr.yml
+++ b/.github/workflows/auto-respond-pr.yml
@@ -42,7 +42,7 @@ jobs:
                   ASSIGN_PR_AUTHOR: 'true'
 
     auto_respond:
-        if: github.event.action != 'closed' && !github.event.pull_request.head.repo.fork && github.event.pull_request.user.login != 'app/dependabot' && github.event.pull_request.user.login != 'dependabot[bot]'
+        if: github.event.action != 'closed' && !github.event.pull_request.head.repo.fork && github.event.pull_request.user.login != 'dependabot[bot]'
         runs-on: ubuntu-latest
         concurrency: auto-respond-${{ github.event.pull_request.number }}
 

--- a/.github/workflows/publish-test-url.yml
+++ b/.github/workflows/publish-test-url.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
     publish-config:
-        if: github.event.action != 'closed' && github.event.pull_request.user.login != 'dependabot[bot]' && github.event.pull_request.user.login != 'app/dependabot'
+        if: github.event.action != 'closed' && github.event.pull_request.user.login != 'dependabot[bot]'
         runs-on: ubuntu-latest
         concurrency:
             group: preview-pages-branch
@@ -100,7 +100,7 @@ jobs:
                       ❌ Failed to build or publish preview config. Check the [workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for details.
 
     cleanup-preview:
-        if: github.event.action == 'closed' && github.event.pull_request.user.login != 'dependabot[bot]' && github.event.pull_request.user.login != 'app/dependabot'
+        if: github.event.action == 'closed' && github.event.pull_request.user.login != 'dependabot[bot]'
         runs-on: ubuntu-latest
         concurrency:
             group: preview-pages-branch

--- a/.github/workflows/publish-test-url.yml
+++ b/.github/workflows/publish-test-url.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
     publish-config:
-        if: github.event.action != 'closed'
+        if: github.event.action != 'closed' && github.event.pull_request.user.login != 'dependabot[bot]' && github.event.pull_request.user.login != 'app/dependabot'
         runs-on: ubuntu-latest
         concurrency:
             group: preview-pages-branch
@@ -100,7 +100,7 @@ jobs:
                       ❌ Failed to build or publish preview config. Check the [workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for details.
 
     cleanup-preview:
-        if: github.event.action == 'closed'
+        if: github.event.action == 'closed' && github.event.pull_request.user.login != 'dependabot[bot]' && github.event.pull_request.user.login != 'app/dependabot'
         runs-on: ubuntu-latest
         concurrency:
             group: preview-pages-branch


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**Asana Task/Github Issue:**
- N/A

## Description
- skip the `Auto Respond to PR` workflow's `auto_respond` job for Dependabot-authored PRs
- skip the `Publish Test URL` workflow jobs for Dependabot-authored PRs
- avoid the expected 403 failures caused by restricted Dependabot token permissions when those jobs try to comment or otherwise perform write operations

### Feature change process:
- [ ] I have added a schema to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL: N/A
- Problems experienced: Dependabot PR automation jobs fail due to insufficient integration permissions
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked: Dependabot dependency update PRs
- Feature being disabled/modified: GitHub Actions PR automation workflows
- [ ] This change is a speculative mitigation to fix reported breakage.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4fdc9b21-4f90-4506-b086-ce2b50b2c89d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4fdc9b21-4f90-4506-b086-ce2b50b2c89d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

