### PR TITLE
Update Osano dsar domain

### DIFF
--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -3154,11 +3154,11 @@
             "osano.com": {
                 "rules": [
                     {
-                        "rule": "dsar.api.osano.com/",
+                        "rule": "dsar-public.api.osano.com/",
                         "domains": [
                             "<all>"
                         ],
-                        "reason": "https://github.com/duckduckgo/privacy-configuration/issues/529"
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/issues/4920"
                     },
                     {
                         "rule": "cmp.osano.com",


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1200890834746050/task/1214246538565122?focus=true

## Description
Update Osano allowlist rule to point at updated api endpoint.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk configuration-only change; the main risk is unblocking an incorrect Osano endpoint (or failing to unblock the new one), which could affect site functionality for DSAR flows.
> 
> **Overview**
> Updates the `osano.com` tracker allowlist entry to permit the new DSAR endpoint by changing the rule from `dsar.api.osano.com/` to `dsar-public.api.osano.com/`, and refreshes the linked tracking issue reference.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 072e7bef869ecd8d020f84a107f7f7b56bd2b29d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->