### PR TITLE
Update ad-blocking extension scriptlets for v2026.4.23

### DIFF
--- a/features/ad-blocking-extension.json
+++ b/features/ad-blocking-extension.json
@@ -9,19 +9,19 @@
         "scriptlets": {
             "scriptlets/isolated/ublock-filters.js": {
                 "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/982bf709ce6dccf19fe0e273faac43271dcdae440b73461dad3cb56cca9ac4a1.js",
-                "signature": "MEUCIBleAbOazQlaJtCwfyvuo1XM3CQW1NFxo5FdmCgsPqdvAiEA4ZAKMEApCwU2R0iPJ1qJZCr9nXF/AoaA0CV8Az7mods="
+                "signature": "MEUCIQC86FlCPDSjNe5IaQa/DrGTXZPn0AHnIASQI7XTUZS1pwIgBqLmsFa1/Rc3Uz2xX3p1esxwYbMlgKxvLJvRl9svDGs="
             },
             "scriptlets/main/ublock-filters.js": {
-                "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/fbc57b6303c9be1d728aeae4f3817e8946cf598cdab23322eb5ca2dec8a76507.js",
-                "signature": "MEUCIAogsPOudJ09fZDtiexYp11shHSlbDZeUsJwNCrtl3b8AiEA0qFbneuZ7NZsKqBrVmimFboiXklvA8Sh0seA9VACM3w="
+                "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/4f83f683712d24096858db7e209b07f32aabcfd07285e0075b4853311ef8af7a.js",
+                "signature": "MEUCIFrR32w8CmNyRUQwVRu7oEmVfnKlixHff0n+GIhANPf+AiEA2Q2c/aA/3e58N20ib0kPAY8LdAcUsiv8cf+TczIEgCU="
             },
             "scriptlets/main/ublock-experimental.js": {
                 "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855.js",
-                "signature": "MEUCIGXW1fuc8QECooM3fk74EEA3zjgNNaHlut7XIo7BXuJqAiEA7OhJKQS9fxD82JC2kPDUpuHDZCheqGobRhBNh7rr/c0="
+                "signature": "MEYCIQD8X91R+BkJqYlLAnUDcao4+SevJiJYdnlcrJTr09iEUwIhANaYaX6tY+eVvvYjhvkTVa9vbsxzocnwVAI2clmiexXE"
             },
             "scriptlets/isolated/ublock-experimental.js": {
                 "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855.js",
-                "signature": "MEYCIQDpMg8qnYVPi1lo7554608a6k9ujR9gYsR5vhfy7vUGNwIhAIXxxIHBX2cKF5W40VqsaDIDNdlYnUj1D0diHx0JQnw5"
+                "signature": "MEUCIQC38+N4rZqpX8lesVZq+xy9+RVmP5Wk+YWX0j2v9lNCdAIgUBWKvOLBIhLrGEo1S/L0VMmVjmzfy78BEAEwKOmJ1hM="
             }
         }
     }


### PR DESCRIPTION
Update ad-blocking extension scriptlets for v2026.4.23.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates the remote scriptlet asset referenced by the ad-blocking extension; incorrect URLs/signatures could break scriptlet loading and affect blocking behavior.
> 
> **Overview**
> Refreshes the ad-blocking extension’s scriptlet configuration by updating the `scriptlets/main/ublock-filters.js` CDN URL and rotating signatures for all listed scriptlets to match the current hosted artifacts.
> 
> No other settings or feature flags are changed (e.g., `enabledByDefault` and the configured version string remain the same).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a9d41c94437d7ca42584dd3a6da65c85684324b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->