### PR TITLE
Update content-blocker extension to 2026.4.24

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -4547,7 +4547,7 @@
             "minSupportedVersion": "0.148.0",
             "exceptions": [],
             "settings": {
-                "extensionUrl": "https://staticcdn.duckduckgo.com/extensions/content-blocker/content-blocker-extension-2026.4.23.crx"
+                "extensionUrl": "https://staticcdn.duckduckgo.com/extensions/content-blocker/content-blocker-extension-2026.4.24.crx"
             },
             "features": {
                 "onboardingEnabled": {


### PR DESCRIPTION
Update content-blocker extension to 2026.4.24.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change that updates the CDN URL for the Windows content-blocker extension; main risk is a bad/invalid URL or regression in the new extension build.
> 
> **Overview**
> Updates `overrides/windows-override.json` to point `adBlockV2Extension.settings.extensionUrl` at the `content-blocker-extension-2026.4.24.crx` build (from `2026.4.23`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 67aad03ba862ba6ea55c9ac397dc885f8b7dec30. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->