### PR TITLE
Update ad-blocking extension scriptlets for v2026.4.24

### DIFF
--- a/features/ad-blocking-extension.json
+++ b/features/ad-blocking-extension.json
@@ -4,24 +4,24 @@
     },
     "exceptions": [],
     "settings": {
-        "version": "2026.3.24",
+        "version": "2026.4.24",
         "enabledByDefault": false,
         "scriptlets": {
             "scriptlets/isolated/ublock-filters.js": {
                 "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/982bf709ce6dccf19fe0e273faac43271dcdae440b73461dad3cb56cca9ac4a1.js",
-                "signature": "MEUCIBleAbOazQlaJtCwfyvuo1XM3CQW1NFxo5FdmCgsPqdvAiEA4ZAKMEApCwU2R0iPJ1qJZCr9nXF/AoaA0CV8Az7mods="
+                "signature": "MEUCIQC0LQN0BGW68yNjZk9yiaZvCtB6xQY2W2g0xOTWBQEmNAIgaJBIv6nznMS0S5eA8FRoLYRZ1bSpbDSeV5LY6IHAAIw="
             },
             "scriptlets/main/ublock-filters.js": {
-                "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/fbc57b6303c9be1d728aeae4f3817e8946cf598cdab23322eb5ca2dec8a76507.js",
-                "signature": "MEUCIAogsPOudJ09fZDtiexYp11shHSlbDZeUsJwNCrtl3b8AiEA0qFbneuZ7NZsKqBrVmimFboiXklvA8Sh0seA9VACM3w="
+                "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/8ddaafd49f40be55a0e49aa7e6ede0c1378288999c60decc1470e20d06ac16e9.js",
+                "signature": "MEUCIQCgU5KO2bj0gahMWA9sNy4MZmBqao8st4ToZ50QDGOmEAIgF0bG4zm/CMxd3qNFnhacRD3uzWMfUNb6dEaa9/yRT80="
             },
             "scriptlets/main/ublock-experimental.js": {
                 "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855.js",
-                "signature": "MEUCIGXW1fuc8QECooM3fk74EEA3zjgNNaHlut7XIo7BXuJqAiEA7OhJKQS9fxD82JC2kPDUpuHDZCheqGobRhBNh7rr/c0="
+                "signature": "MEQCIFfyg9MWrZlHc/vfIve6dRJ/1sRTH72gJhc3MqCW+eQXAiAC0ORmCZACbl5RbXfqaX18h0fNElmlR0yuDaZDBJkxzw=="
             },
             "scriptlets/isolated/ublock-experimental.js": {
                 "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855.js",
-                "signature": "MEYCIQDpMg8qnYVPi1lo7554608a6k9ujR9gYsR5vhfy7vUGNwIhAIXxxIHBX2cKF5W40VqsaDIDNdlYnUj1D0diHx0JQnw5"
+                "signature": "MEQCIDsScfZJCR7FhW+Dc7VpNyDVhTzsLQRWutqOio6wNPkJAiA9QN6c0rzXjdoM0g3ikjtdbM9P96r1mJlHAYmJ25795g=="
             }
         }
     }


### PR DESCRIPTION
Update ad-blocking extension scriptlets for v2026.4.24.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only update that changes scriptlet URLs and signatures; impact is limited to which scriptlet bundles are fetched/validated at runtime.
> 
> **Overview**
> Updates `features/ad-blocking-extension.json` to **v`2026.4.24`**.
> 
> Refreshes the referenced scriptlet artifacts by updating the `url`/`signature` pairs for `ublock-filters` (main + isolated) and `ublock-experimental` (main + isolated).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 60ac4ad9e74745177c8e259b78856059e2282329. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->