### PR TITLE
Enable some Windows AI features

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -1293,7 +1293,8 @@
                     "minSupportedVersion": "0.150.0"
                 },
                 "ntpChatTools": {
-                    "state": "disabled"
+                    "state": "enabled",
+                    "minSupportedVersion": "0.155.0"
                 },
                 "showHideAiGeneratedImages": {
                     "state": "enabled"
@@ -1313,22 +1314,27 @@
                     "minSupportedVersion": "0.152.0"
                 },
                 "suggestions": {
-                    "state": "internal"
+                    "state": "enabled",
+                    "minSupportedVersion": "0.155.0"
                 },
                 "suggestionsDeletion": {
                     "state": "disabled"
                 },
                 "ntpRecentChats": {
-                    "state": "internal"
+                    "state": "enabled",
+                    "minSupportedVersion": "0.155.0"
                 },
                 "imageGeneration": {
-                    "state": "internal"
+                    "state": "enabled",
+                    "minSupportedVersion": "0.155.0"
                 },
                 "omnibarWebSearch": {
-                    "state": "internal"
+                    "state": "enabled",
+                    "minSupportedVersion": "0.156.0"
                 },
                 "dragAndDropImages": {
-                    "state": "internal"
+                    "state": "enabled",
+                    "minSupportedVersion": "0.155.0"
                 },
                 "viewAllFromRecentChats": {
                     "state": "enabled",


### PR DESCRIPTION
Enable/re-enable the following on Windows:

ntpChatTools
suggestions
ntpRecentChats
imageGeneration
omnibarWebSearch
dragAndDropImages

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change that flips feature flags for Windows builds meeting the new `minSupportedVersion` thresholds; primary risk is unintended exposure of in-progress UI/behavior in eligible versions.
> 
> **Overview**
> Enables several Windows `aiChat` sub-features that were previously `disabled`/`internal`, gating them with new `minSupportedVersion` requirements.
> 
> Specifically turns on `ntpChatTools`, `suggestions`, `ntpRecentChats`, `imageGeneration`, `omnibarWebSearch`, and `dragAndDropImages` for Windows clients at the specified versions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e03764d6baa14b50aa16860fd8f5d80af9cf02c3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->