### PR TITLE
Global hiding rule for certain adblock walls

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -506,6 +506,10 @@
             {
                 "selector": "[class^='DisplayAdvert']",
                 "type": "closest-empty"
+            },
+            {
+                "selector": "div:has(div > div > span > a[href^='https://forms.gle/6M6VTS3mmHXGbFjM8'])",
+                "type": "hide"
             }
         ],
         "styleTagExceptions": [


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/1206670747178362/task/1214134945421847?focus=true

## Description
### Site breakage mitigation process:
#### Brief explanation
- Reported URL: https://variety.com/
- Problems experienced: Adblock wall due to trackers being blocked. Using global rule following discussion with others in site breakage team.
- Platforms affected:
  - [x] iOS
  - [x] Android
  - [x] Windows
  - [x] MacOS
  - [x] Extensions
- Tracker(s) being unblocked: N/A
- Feature being disabled/modified: Element hiding
- [x] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it adds a new *global* element-hiding selector that could match unintended page structures and hide non-ad content across sites. No changes to code execution, auth, or data handling.
> 
> **Overview**
> Adds a new **global** element-hiding rule in `features/element-hiding.json` to `hide` any container matching `div:has(... a[href^='https://forms.gle/6M6VTS3mmHXGbFjM8'])`, intended to mitigate certain adblock-wall overlays.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe8ecd9f385626ab7b5b6d872dfe13679280206f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->