### PR TITLE
Update content-blocker extension to 2026.4.27

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -4553,7 +4553,7 @@
             "minSupportedVersion": "0.148.0",
             "exceptions": [],
             "settings": {
-                "extensionUrl": "https://staticcdn.duckduckgo.com/extensions/content-blocker/content-blocker-extension-2026.4.24.crx"
+                "extensionUrl": "https://staticcdn.duckduckgo.com/extensions/content-blocker/content-blocker-extension-2026.4.27.crx"
             },
             "features": {
                 "onboardingEnabled": {


### PR DESCRIPTION
Update content-blocker extension to 2026.4.27.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a one-line configuration change that only updates the CDN URL for the Windows `adBlockV2Extension` package.
> 
> **Overview**
> Updates the Windows override config to point `adBlockV2Extension.settings.extensionUrl` at the `content-blocker-extension-2026.4.27.crx` build (from `2026.4.24`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9674bc1e03052f4092bf483c819715ea71808a24. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->