### PR TITLE
Update ad-blocking extension scriptlets for v2026.4.27

### DIFF
--- a/features/ad-blocking-extension.json
+++ b/features/ad-blocking-extension.json
@@ -4,24 +4,24 @@
     },
     "exceptions": [],
     "settings": {
-        "version": "2026.4.24",
+        "version": "2026.4.27",
         "enabledByDefault": false,
         "scriptlets": {
             "scriptlets/isolated/ublock-filters.js": {
                 "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/982bf709ce6dccf19fe0e273faac43271dcdae440b73461dad3cb56cca9ac4a1.js",
-                "signature": "MEUCIQC0LQN0BGW68yNjZk9yiaZvCtB6xQY2W2g0xOTWBQEmNAIgaJBIv6nznMS0S5eA8FRoLYRZ1bSpbDSeV5LY6IHAAIw="
+                "signature": "MEUCIQCa3omQ+7Q1FecHSzOnpynv8dy1Q+6+IBXaiktkZ1ghewIgTCmFumrJn+kSycQaq8sl3LhrGr+BS6figXC6mLFz/xE="
             },
             "scriptlets/main/ublock-filters.js": {
-                "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/8ddaafd49f40be55a0e49aa7e6ede0c1378288999c60decc1470e20d06ac16e9.js",
-                "signature": "MEUCIQCgU5KO2bj0gahMWA9sNy4MZmBqao8st4ToZ50QDGOmEAIgF0bG4zm/CMxd3qNFnhacRD3uzWMfUNb6dEaa9/yRT80="
+                "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/425a53d8a8c0a52ecab8a09e805b6b9b95c8aa89287e03a8be288ead2e4d36b5.js",
+                "signature": "MEUCIBtY+HS7Emn8lZ8xm3m79+VpIkXAua4ECY+Vfeew/OqeAiEA023hyBSiF/sKir+uGb7O6whC/hwWRSiwqQNWrsmg3+o="
             },
             "scriptlets/main/ublock-experimental.js": {
                 "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855.js",
-                "signature": "MEQCIFfyg9MWrZlHc/vfIve6dRJ/1sRTH72gJhc3MqCW+eQXAiAC0ORmCZACbl5RbXfqaX18h0fNElmlR0yuDaZDBJkxzw=="
+                "signature": "MEUCIQDSTku820Sl2Ab2Mz4Oncanpt14j+cW8n+0ge/XP3vOUQIgZBhV9IcWmaWzZ1i+1gGHlGNe56Vk5x3oSIPh9TPzoJ8="
             },
             "scriptlets/isolated/ublock-experimental.js": {
                 "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855.js",
-                "signature": "MEQCIDsScfZJCR7FhW+Dc7VpNyDVhTzsLQRWutqOio6wNPkJAiA9QN6c0rzXjdoM0g3ikjtdbM9P96r1mJlHAYmJ25795g=="
+                "signature": "MEUCIQDccLH1ZCmY20vWgyKaJ2wshkQHqkG5Kog0QdLwgNBkIwIgfX4nOtpR77l0kZJjxVz1w2PcsxbTS4TmvbxYgG2jc38="
             }
         }
     }


### PR DESCRIPTION
Update ad-blocking extension scriptlets for v2026.4.27.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the shipped scriptlet asset URLs/signatures, which can alter content-blocking behavior and potentially impact page compatibility.
> 
> **Overview**
> Updates `features/ad-blocking-extension.json` to **version `2026.4.27`**.
> 
> Refreshes the referenced scriptlet artifacts by updating the `url`/`signature` entries for `ublock-filters.js` (main and isolated) and the signatures for `ublock-experimental.js` (main and isolated).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 19797e85b5aa121fc99593e3c1123e5b0cfa20b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->