### PR TITLE
Enable videos to play on 247sports.com

### DIFF
--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -3781,10 +3781,12 @@
                         "rule": "tags.tiqcdn.com/utag/cbsi/",
                         "domains": [
                             "paramountplus.com",
-                            "cbs.com"
+                            "cbs.com",
+                            "247sports.com"
                         ],
                         "reason": [
-                            "paramountplus.com, cbs.com - https://github.com/duckduckgo/privacy-configuration/pull/2435"
+                            "paramountplus.com, cbs.com - https://github.com/duckduckgo/privacy-configuration/pull/2435",
+                            "247sports.com - https://github.com/duckduckgo/privacy-configuration/pull/5042"
                         ]
                     }
                 ]


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/1200277586140538/task/1214291895418248?focus=true

## Description
### Site breakage mitigation process:
#### Brief explanation
- Reported URL: https://247sports.com/article/florida-helps-itself-during-visit-with-top247-safety-jayden-aparicio-bailey-282959025/
- Problems experienced: Videos not playing due to tracker blocking.
- Platforms affected:
  - [x] iOS
  - [x] Android
  - [x] Windows
  - [x] MacOS
  - [x] Extensions
- Tracker(s) being unblocked: tiqcdn.com
- Feature being disabled/modified: N/A
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new tracker allowlist exception for `247sports.com`, which may increase third-party tracking surface on that site and should be verified to only unblock what’s required for video playback.
> 
> **Overview**
> Expands the `tiqcdn.com` allowlist entry for `tags.tiqcdn.com/utag/cbsi/` to include `247sports.com`, with an associated justification link, to mitigate video playback breakage caused by tracker blocking.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b22c68f6c4baf79d57734e4861a3176c06c17539. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->