### PR TITLE
Rollout autifill service to 5%, min 5.276.0

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -1289,12 +1289,12 @@
         "autofillService": {
             "state": "enabled",
             "minSupportedVersion": 52760000,
-             "rollout": {
+            "rollout": {
                 "steps": [
                     {
                         "percent": 5
                     }
-                ]      
+                ]
             },
             "features": {
                 "canUpdateAppToDomainDataset": {

--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -1289,13 +1289,6 @@
         "autofillService": {
             "state": "enabled",
             "minSupportedVersion": 52760000,
-            "rollout": {
-                "steps": [
-                    {
-                        "percent": 5
-                    }
-                ]
-            },
             "features": {
                 "canUpdateAppToDomainDataset": {
                     "state": "enabled",
@@ -1308,6 +1301,17 @@
                 "canAutofillInsideDDG": {
                     "state": "enabled",
                     "minSupportedVersion": 52760000
+                },
+                "canProcessSystemFillRequests": {
+                    "state": "enabled",
+                    "minSupportedVersion": 52760000,
+                    "rollout": {
+                        "steps": [
+                            {
+                                "percent": 5
+                            }
+                        ]
+                    }
                 }
             }
         },

--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -1287,20 +1287,27 @@
             }
         },
         "autofillService": {
-            "state": "disabled",
-            "minSupportedVersion": 52290000,
+            "state": "enabled",
+            "minSupportedVersion": 52760000,
+             "rollout": {
+                "steps": [
+                    {
+                        "percent": 5
+                    }
+                ]      
+            },
             "features": {
                 "canUpdateAppToDomainDataset": {
-                    "state": "disabled",
-                    "minSupportedVersion": 52290000
+                    "state": "enabled",
+                    "minSupportedVersion": 52760000
                 },
                 "canMapAppToDomain": {
-                    "state": "disabled",
-                    "minSupportedVersion": 52290000
+                    "state": "enabled",
+                    "minSupportedVersion": 52760000
                 },
                 "canAutofillInsideDDG": {
-                    "state": "disabled",
-                    "minSupportedVersion": 52290000
+                    "state": "enabled",
+                    "minSupportedVersion": 52760000
                 }
             }
         },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1212227266948491/task/1214293383024877?focus=true

## Description
Start autofill service rollout: 5%, min version 5.276.0

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [x] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [x] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it turns on a previously disabled autofill service and expands the set of enabled capabilities, which could affect credential filling behavior for a portion of Android users.
> 
> **Overview**
> Enables `autofillService` on Android and bumps its `minSupportedVersion` to `52760000` (5.276.0).
> 
> Also enables the associated subfeatures (`canUpdateAppToDomainDataset`, `canMapAppToDomain`, `canAutofillInsideDDG`) and introduces a staged 5% rollout for `canProcessSystemFillRequests`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit abfff0ef09d5262f701a6045780cfe00cd0c018e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->