### PR TITLE
Re-enable minimal chrome in landscape for 7.217.0

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -2513,8 +2513,8 @@
                     "minSupportedVersion": "7.215.0"
                 },
                 "minimalChromeInLandscape": {
-                    "state": "disabled",
-                    "minSupportedVersion": "7.215.0"
+                    "state": "enabled",
+                    "minSupportedVersion": "7.217.0"
                 }
             }
         },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/task/1214260512532004?focus=true

## Description
Enable minimal chrome in landscape on iOS (7.217.0)

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [x] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change that toggles a single iOS UI feature flag; impact is limited to devices on/above the new minimum supported version.
> 
> **Overview**
> Re-enables the iOS `iOSBrowserConfig.minimalChromeInLandscape` feature flag by switching it from `disabled` to `enabled` and bumping its `minSupportedVersion` from `7.215.0` to `7.217.0`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b6c3c763aad11b1e88bccb4134581b21c1d206a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->