### PR TITLE
Disable product surface telemetry on Android

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -3915,12 +3915,12 @@
             }
         },
         "productSurfaceTelemetry": {
-            "state": "enabled",
+            "state": "disabled",
             "exceptions": [],
             "minSupportedVersion": 52751000,
             "features": {
                 "enableTelemetry": {
-                    "state": "enabled",
+                    "state": "disabled",
                     "minSupportedVersion": 52751000
                 }
             }


### PR DESCRIPTION
**Asana Task/Github Issue:**https://app.asana.com/1/137249556945/project/1211724162604201/task/1213832635704337?focus=true

## Description
Disable the productSurfaceTelemetry flag for Android

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [x] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Simple configuration flip for a single Android feature flag; minimal behavioral surface area beyond reduced telemetry emission.
> 
> **Overview**
> Disables Android `productSurfaceTelemetry` by switching the top-level flag and its `enableTelemetry` subfeature from `enabled` to `disabled` in `overrides/android-override.json`, preventing this telemetry from being collected for supported app versions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 52142dd9a0cefc2f7ffc818efc6457b39d8b5c8d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->