### PR TITLE
Windows: Enable NTP image gen and web search from 0.156

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -1352,6 +1352,14 @@
                 },
                 "omnibarReasoningEffort": {
                     "state": "internal"
+                },
+                "ntpImageGeneration": {
+                    "state": "enabled",
+                    "minSupportedVersion": "0.156.0"
+                },
+                "ntpWebSearch": {
+                    "state": "enabled",
+                    "minSupportedVersion": "0.156.0"
                 }
             },
             "minSupportedVersion": "0.100.0",


### PR DESCRIPTION
Windows: Enable NTP image gen and web search from 0.156

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a configuration-only change that flips feature flags on for Windows clients at a specific minimum version.
> 
> **Overview**
> Enables the `aiChat` subfeatures `ntpImageGeneration` and `ntpWebSearch` in `windows-override.json`, gated to Windows app versions `>= 0.156.0`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 49e33756008a8b95a6373ab5a1a1ad63a1aebacf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->