### PR TITLE
Disable adwall pixels

### DIFF
--- a/features/event-hub.json
+++ b/features/event-hub.json
@@ -7,7 +7,7 @@
     "settings": {
         "telemetry": {
             "webTelemetry_adwalls_day": {
-                "state": "enabled",
+                "state": "disabled",
                 "trigger": {
                     "period": {
                         "days": 1
@@ -30,7 +30,7 @@
                 }
             },
             "webTelemetry_adwalls_week": {
-                "state": "enabled",
+                "state": "disabled",
                 "trigger": {
                     "period": {
                         "days": 7


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1205278999335242/task/1212694657846349?focus=true

## Description

Disables adwall pixel on Android.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change that disables two adwall telemetry/pixel events; main impact is reduced analytics/pixel firing rather than runtime behavior.
> 
> **Overview**
> Disables adwall-related telemetry/pixel firing by switching `webTelemetry_adwalls_day` and `webTelemetry_adwalls_week` from **enabled** to **disabled** in `features/event-hub.json`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 67c60c1298af8f3c1754734a782eeff643280a89. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->