### PR TITLE
Enable duck.ai migration for internal users only

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -2130,6 +2130,7 @@
                 "aiChat": "disabled",
                 "subscriptions": "disabled",
                 "serpSettings": "disabled",
+                "duckAiNativeStorage": "disabled",
                 "domains": [
                     {
                         "domain": [
@@ -2151,6 +2152,11 @@
                             {
                                 "op": "replace",
                                 "path": "/serpSettings",
+                                "value": "enabled"
+                            },
+                            {
+                                "op": "replace",
+                                "path": "/duckAiNativeStorage",
                                 "value": "enabled"
                             }
                         ]

--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -445,6 +445,12 @@
                 "rememberTogglePosition": {
                     "state": "enabled",
                     "minSupportedVersion": 52760000
+                },
+                "duckAiNativeStorage": {
+                    "state": "internal"
+                },
+                "useNativeStorageChatData": {
+                    "state": "disabled"
                 }
             }
         },

--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -447,10 +447,12 @@
                     "minSupportedVersion": 52760000
                 },
                 "duckAiNativeStorage": {
-                    "state": "internal"
+                    "state": "internal",
+                    "minSupportedVersion": 52770000
                 },
                 "useNativeStorageChatData": {
-                    "state": "disabled"
+                    "state": "disabled",
+                    "minSupportedVersion": 52770000
                 }
             }
         },


### PR DESCRIPTION
- **Android: Enable duckAiNativeStorage for messageBridge on DDG domains**
- **Android: Add duckAiNativeStorage and useNativeStorageChatData sub-features to aiChat as disabled**

**Asana Task/Github Issue:**https://app.asana.com/1/137249556945/project/1198194956794324/task/1214331584770077?focus=true

## Description
Enable the `messageBridge.duckAiNativeStorage` to make the duck.ai native storage API availble to JS
Enable the `aiChat.duckAiNativeStorage` for internal users
Disable the `aiChat.useNativeStorageChatData` for all users

_Test_
* install android playDebug
* enable duck.ai and create some chats, normal, image, voice etc.
* under settings -> dev settings set a custom privacy config to https://duckduckgo.github.io/privacy-configuration/pr-5051/v4/android-config.json
* force close and re-open the app
* verify the migration does not happen
* repeat this test with internalDebug
* verify the migration does happen
* verify chat suggestions, delete/burn chat continue to work as expected

### Feature change process:

- [X] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [X] I have tested this change locally in all supported browsers.
- [X] This code for the config change is ready to merge.
- [X] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [X] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Config-only change, but it touches Duck.ai chat storage/migration flags and message bridge exposure; mistakes could impact chat persistence or trigger unintended migrations even if scoped to internal users.
> 
> **Overview**
> Enables the `messageBridge` capability `duckAiNativeStorage` on DDG-owned domains (`duckduckgo.com`, `duck.co`, `duck.ai`) so Duck.ai JS can call into the native storage API.
> 
> Adds two new `aiChat` sub-features: **`duckAiNativeStorage`** (set to `internal`) and **`useNativeStorageChatData`** (set to `disabled`), both gated to `minSupportedVersion` `52770000`, to control rollout of native-storage-backed chat data/migration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d0f281a47c589954cbfa0b84ed11a3be01258b1f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->