### PR TITLE
Roll out TDS experiment to 100%

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -173,8 +173,8 @@
                         ]
                     },
                     "settings": {
-                        "controlUrl": "v5/experiments/202604v2-android-tds-control.json",
-                        "treatmentUrl": "v5/experiments/202604v2-android-tds-treatment.json"
+                        "controlUrl": "v5/experiments/202604v3-android-tds-control.json",
+                        "treatmentUrl": "v5/experiments/202604v3-android-tds-treatment.json"
                     },
                     "cohorts": [
                         {

--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -138,7 +138,7 @@
             "exceptions": [],
             "features": {
                 "tdsNextExperiment007": {
-                    "state": "enabled",
+                    "state": "disabled",
                     "minSupportedVersion": 52361000,
                     "rollout": {
                         "steps": [
@@ -150,6 +150,31 @@
                     "settings": {
                         "controlUrl": "v5/experiments/202604v1-android-tds-control.json",
                         "treatmentUrl": "v5/experiments/202604v1-android-tds-treatment.json"
+                    },
+                    "cohorts": [
+                        {
+                            "name": "control",
+                            "weight": 1
+                        },
+                        {
+                            "name": "treatment",
+                            "weight": 1
+                        }
+                    ]
+                },
+                "tdsNextExperiment008": {
+                    "state": "enabled",
+                    "minSupportedVersion": 52361000,
+                    "rollout": {
+                        "steps": [
+                            {
+                                "percent": 100
+                            }
+                        ]
+                    },
+                    "settings": {
+                        "controlUrl": "v5/experiments/202604v2-android-tds-control.json",
+                        "treatmentUrl": "v5/experiments/202604v2-android-tds-treatment.json"
                     },
                     "cohorts": [
                         {

--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -510,7 +510,7 @@
             "exceptions": [],
             "features": {
                 "tdsNextExperiment007": {
-                    "state": "enabled",
+                    "state": "disabled",
                     "rollout": {
                         "steps": [
                             {
@@ -521,6 +521,30 @@
                     "settings": {
                         "controlUrl": "v5/experiments/202604v1-ios-tds-control.json",
                         "treatmentUrl": "v5/experiments/202604v1-ios-tds-treatment.json"
+                    },
+                    "cohorts": [
+                        {
+                            "name": "control",
+                            "weight": 1
+                        },
+                        {
+                            "name": "treatment",
+                            "weight": 1
+                        }
+                    ]
+                },
+                "tdsNextExperiment008": {
+                    "state": "enabled",
+                    "rollout": {
+                        "steps": [
+                            {
+                                "percent": 100
+                            }
+                        ]
+                    },
+                    "settings": {
+                        "controlUrl": "v5/experiments/202604v2-ios-tds-control.json",
+                        "treatmentUrl": "v5/experiments/202604v2-ios-tds-treatment.json"
                     },
                     "cohorts": [
                         {

--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -543,8 +543,8 @@
                         ]
                     },
                     "settings": {
-                        "controlUrl": "v5/experiments/202604v2-ios-tds-control.json",
-                        "treatmentUrl": "v5/experiments/202604v2-ios-tds-treatment.json"
+                        "controlUrl": "v5/experiments/202604v3-ios-tds-control.json",
+                        "treatmentUrl": "v5/experiments/202604v3-ios-tds-treatment.json"
                     },
                     "cohorts": [
                         {

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -519,7 +519,7 @@
             ],
             "features": {
                 "tdsNextExperiment007": {
-                    "state": "enabled",
+                    "state": "disabled",
                     "rollout": {
                         "steps": [
                             {
@@ -530,6 +530,30 @@
                     "settings": {
                         "controlUrl": "v6/experiments/202604v1-macos-tds-control.json",
                         "treatmentUrl": "v6/experiments/202604v1-macos-tds-treatment.json"
+                    },
+                    "cohorts": [
+                        {
+                            "name": "control",
+                            "weight": 1
+                        },
+                        {
+                            "name": "treatment",
+                            "weight": 1
+                        }
+                    ]
+                },
+                "tdsNextExperiment008": {
+                    "state": "enabled",
+                    "rollout": {
+                        "steps": [
+                            {
+                                "percent": 100
+                            }
+                        ]
+                    },
+                    "settings": {
+                        "controlUrl": "v6/experiments/202604v2-macos-tds-control.json",
+                        "treatmentUrl": "v6/experiments/202604v2-macos-tds-treatment.json"
                     },
                     "cohorts": [
                         {

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -552,8 +552,8 @@
                         ]
                     },
                     "settings": {
-                        "controlUrl": "v6/experiments/202604v2-macos-tds-control.json",
-                        "treatmentUrl": "v6/experiments/202604v2-macos-tds-treatment.json"
+                        "controlUrl": "v6/experiments/202604v3-macos-tds-control.json",
+                        "treatmentUrl": "v6/experiments/202604v3-macos-tds-treatment.json"
                     },
                     "cohorts": [
                         {


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1200811069326255/task/1213611322809655?focus=true

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> This is a config-only change, but it flips which tracker blocklist experiment is active and ramps the new one to 100%, which can materially affect content blocking behavior for all users on supported versions.
> 
> **Overview**
> Updates the platform override configs to stop `tdsNextExperiment007` by setting its `state` to `disabled`.
> 
> Introduces `tdsNextExperiment008` for Android/iOS/macOS content blocking/blocklist, enabled at **100% rollout** and pointing to new `202604v3` control/treatment experiment URLs (with Android keeping the same `minSupportedVersion`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db5f55c863644ecd03cbd8c1d8ed076435f0228c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->