### PR TITLE
Change desktopLauncher state from 'internal' to 'preview'

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -5327,6 +5327,7 @@
             "exceptions": [],
             "features": {
                 "desktopLauncher": {
+                    "minSupportedVersion": "0.155.0",
                     "state": "preview"
                 }
             },

--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -5327,7 +5327,7 @@
             "exceptions": [],
             "features": {
                 "desktopLauncher": {
-                    "state": "internal"
+                    "state": "preview"
                 }
             },
             "state": "enabled"


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1205930140120776/task/1214339507055756?focus=true

## Description

Enable Desktop Launcher to Preview channel.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [x] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [x] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [x] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single Windows config change that only adjusts feature rollout state and adds a version gate; no code or security-sensitive logic is modified.
> 
> **Overview**
> Enables the Windows Desktop Launcher under `browserUpdater` for the *preview* channel instead of *internal*.
> 
> Adds a `minSupportedVersion` gate (`0.155.0`) to the `desktopLauncher` feature in `windows-override.json`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3af8668b0fe297b38c6a1f5768f8c38851692053. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->