### PR TITLE
[Android] Enable "defaultBrowserChangedSurvey" feature flag

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -4139,6 +4139,10 @@
                     }
                 }
             }
+        },
+        "defaultBrowserChangedSurvey": {
+            "state": "enabled",
+            "exceptions": []
         }
     },
     "unprotectedTemporary": [],

--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -4142,6 +4142,7 @@
         },
         "defaultBrowserChangedSurvey": {
             "state": "enabled",
+            "minSupportedVersion": 52770000,
             "exceptions": []
         }
     },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/task/1214359748758911?focus=true

## Description
<!-- 
  Please delete either or both process sections below.
-->
Added `defaultBrowserChangedSurvey` flag with state enabled.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change that enables a new Android feature flag gated by `minSupportedVersion`; main risk is unintended survey rollout to eligible versions if the flag name/version is incorrect.
> 
> **Overview**
> **Enables the Android `defaultBrowserChangedSurvey` remote feature flag** by adding it to `overrides/android-override.json` with `state: "enabled"`, `minSupportedVersion: 52770000`, and no exceptions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3e4af8acc824ff3d7efde4a2b939a4b7d7d22b1f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->