### PR TITLE
Enable processStatusTracking in windows-override

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -4746,6 +4746,9 @@
                             2
                         ]
                     }
+                },
+                "processStatusTracking": {
+                    "state": "enabled"
                 }
             }
         },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/72649045549333/task/1214335058045539?focus=true

Enable processStatusTracking for debugging `BrowserProcessStartException` `PROFILE_IN_USE` crashes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change that enables additional crash/process status diagnostics on Windows; main impact is potentially increased telemetry/logging volume.
> 
> **Overview**
> **Windows override config change:** turns on `extendedCrashReporting.features.processStatusTracking` by setting its `state` to `enabled`, to allow collecting process status information for debugging Windows startup/profile-related crashes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 89953ad60ba35e38ebe4edd4481efc866384a18e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->