### PR TITLE
Enable nativeRequestInterception for preview

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -5302,7 +5302,8 @@
                     "state": "disabled"
                 },
                 "enableNativeRequestInterception": {
-                    "state": "preview"
+                    "state": "preview",
+                    "minSupportedVersion": "0.155.4"
                 }
             }
         },

--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -5294,11 +5294,15 @@
             "state": "disabled"
         },
         "nativeRequestInterception": {
-            "state": "disabled",
+            "state": "preview",
+            "minSupportedVersion": "0.155.4",
             "exceptions": [],
             "features": {
                 "disableFirstAboutBlankNavigation": {
                     "state": "disabled"
+                },
+                "enableNativeRequestInterception": {
+                    "state": "preview"
                 }
             }
         },


### PR DESCRIPTION
**Asana Task/Github Issue:**

## Description
<!-- 
  Please delete either or both process sections below.
-->

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes a network-interception-related feature flag from off to preview, which can affect request handling and site compatibility for preview users. Risk is limited by the preview state and minimum supported version gating.
> 
> **Overview**
> Enables `nativeRequestInterception` as a **preview** feature for Windows by switching it from `disabled` to `preview`, gating it behind `minSupportedVersion: 0.155.4`.
> 
> Adds a nested `enableNativeRequestInterception` subfeature (also **preview**, `minSupportedVersion: 0.155.4`) under the `nativeRequestInterception` feature config.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 067f7090e8157e6d9f5b1f8da72d1dbc72d17ad2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->