### PR TITLE
Enable suggestions deletion in windows override

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -1318,7 +1318,8 @@
                     "minSupportedVersion": "0.155.0"
                 },
                 "suggestionsDeletion": {
-                    "state": "disabled"
+                    "state": "enabled",
+                    "minSupportedVersion": "0.154.0"
                 },
                 "ntpRecentChats": {
                     "state": "enabled",

--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -1319,7 +1319,7 @@
                 },
                 "suggestionsDeletion": {
                     "state": "enabled",
-                    "minSupportedVersion": "0.154.0"
+                    "minSupportedVersion": "0.155.0"
                 },
                 "ntpRecentChats": {
                     "state": "enabled",


### PR DESCRIPTION
**Asana Task/Github Issue:**

## Description
Enables the **AIChat** → **suggestionsDeletion** flag in windows override

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small configuration-only change that just flips a feature flag with an explicit minimum supported version.
> 
> **Overview**
> Enables the Windows override for `aiChat.features.suggestionsDeletion` by switching it from *disabled* to **enabled** and adding `minSupportedVersion: 0.155.0`, aligning it with the other AI chat suggestions flags.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7d2f3ecbb2e2aa0bb17f0af7ee39e4f6f047d497. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->