### PR TITLE
Enable selectionContext state in windows-override.json

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -1345,7 +1345,8 @@
                     "minSupportedVersion": "0.154.0"
                 },
                 "selectionContext": {
-                    "state": "disabled"
+                    "state": "enabled",
+                    "minSupportedVersion": "0.156.0"
                 },
                 "nativeStorage": {
                     "state": "internal"


### PR DESCRIPTION
**Asana Task/Github Issue:**

## Description
Enables the **AIChat** → **selectionContext** flag in windows override

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single feature-flag config change gated by a minimum supported version; no code or data-handling logic changes.
> 
> **Overview**
> Enables the `aiChat.features.selectionContext` flag in `overrides/windows-override.json`, switching it from `disabled` to **enabled**.
> 
> Adds `minSupportedVersion: 0.156.0` for this flag to gate rollout to compatible Windows app versions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 061440c49e30da8b694d15a3cc400c31e0890700. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->