### PR TITLE
Enable native storage for Apple AI Chat

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -221,7 +221,11 @@
                     "minSupportedVersion": "7.181.0"
                 },
                 "nativeStorage": {
-                    "state": "internal"
+                    "state": "enabled",
+                    "minSupportedVersion": "7.217.0"
+                },
+                "nativeDataAccess": {
+                    "state": "enabled"
                 },
                 "showAIChatAddressBarChoiceScreen": {
                     "state": "enabled",

--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -232,7 +232,8 @@
                     }
                 },
                 "nativeDataAccess": {
-                    "state": "enabled"
+                    "state": "enabled",
+                    "minSupportedVersion": "7.217.0"
                 },
                 "showAIChatAddressBarChoiceScreen": {
                     "state": "enabled",

--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -222,7 +222,14 @@
                 },
                 "nativeStorage": {
                     "state": "enabled",
-                    "minSupportedVersion": "7.217.0"
+                    "minSupportedVersion": "7.217.0",
+                    "rollout": {
+                        "steps": [
+                            {
+                                "percent": 5
+                            }
+                        ]
+                    }
                 },
                 "nativeDataAccess": {
                     "state": "enabled"

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -319,7 +319,11 @@
                     "state": "enabled"
                 },
                 "nativeStorage": {
-                    "state": "internal"
+                    "state": "enabled",
+                    "minSupportedVersion": "1.187.0"
+                },
+                "nativeDataAccess": {
+                    "state": "enabled"
                 },
                 "sidebar": {
                     "state": "enabled",

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -330,7 +330,8 @@
                     }
                 },
                 "nativeDataAccess": {
-                    "state": "enabled"
+                    "state": "enabled",
+                    "minSupportedVersion": "1.187.0"
                 },
                 "sidebar": {
                     "state": "enabled",

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -320,7 +320,14 @@
                 },
                 "nativeStorage": {
                     "state": "enabled",
-                    "minSupportedVersion": "1.187.0"
+                    "minSupportedVersion": "1.187.0",
+                    "rollout": {
+                        "steps": [
+                            {
+                                "percent": 5
+                            }
+                        ]
+                    }
                 },
                 "nativeDataAccess": {
                     "state": "enabled"


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/72649045549333/task/1214381431904523?focus=true

## Description
Enable native storage for Apple AI Chat

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [x] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Although this is a config-only change, it enables new on-device persistence paths for AI Chat on iOS/macOS, so misconfiguration could impact data handling and user experience during rollout.
> 
> **Overview**
> Enables **AI Chat native storage** on Apple platforms by switching `aiChat.features.nativeStorage` from `internal` to `enabled` in both `ios-override.json` and `macos-override.json`, gated by new `minSupportedVersion` values and a 5% rollout step.
> 
> Also turns on `aiChat.features.nativeDataAccess` for the same minimum versions, aligning data access behavior with the new native-storage rollout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2cc4c7dc9936826ce77043ee67aa606753b1d89b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->