### PR TITLE
[iOS] Bump rollout for autoplayBlocking to 25%

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -2478,6 +2478,9 @@
                         "steps": [
                             {
                                 "percent": 10
+                            },
+                            {
+                                "percent": 25
                             }
                         ]
                     }


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1210594645375461/task/1213572666967579?focus=true

## Description
Bump rollout for `autoplayBlocking` remote feature flag to 25%. On top of #4991 

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [X] I have tested this change locally in all supported browsers.
- [X] This code for the config change is ready to merge.
- [X] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change that increases exposure of the `autoplayBlocking` remote flag on iOS; main risk is potential site playback regressions for a larger cohort.
> 
> **Overview**
> In `overrides/ios-override.json`, increases the iOS `iOSBrowserConfig.autoplayBlocking` feature rollout by adding a new `25%` step (after the existing `10%` step), expanding the enabled cohort while keeping the feature state and minimum supported version unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b42e0f035790c0b77a3146f5687ff14c357e793. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->