### PR TITLE
yt detection overrides for apple

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -2901,7 +2901,8 @@
                             "adBlocker": true,
                             "playabilityError": true,
                             "videoAd": true,
-                            "staticAd": true
+                            "staticAd": true,
+                            "buffering": true
                         }
                     }
                 }

--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -2896,10 +2896,19 @@
                             "signInButton": "a[href*=\"accounts.google.com/ServiceLogin\"]",
                             "avatarButton": "#avatar-btn",
                             "premiumLogo": "ytd-topbar-logo-renderer a[title*=\"Premium\"]"
+                        },
+                        "fireDetectionEvents": {
+                            "adBlocker": true,
+                            "playabilityError": true,
+                            "videoAd": true,
+                            "staticAd": true
                         }
                     }
                 }
             }
+        },
+        "webEvents": {
+            "state": "enabled"
         },
         "hover": {
             "state": "disabled"

--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -2909,7 +2909,8 @@
             }
         },
         "webEvents": {
-            "state": "enabled"
+            "state": "enabled",
+            "minSupportedVersion": "7.219.0"
         },
         "hover": {
             "state": "disabled"

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -2551,7 +2551,8 @@
                             "adBlocker": true,
                             "playabilityError": true,
                             "videoAd": true,
-                            "staticAd": true
+                            "staticAd": true,
+                            "buffering": true
                         }
                     }
                 }

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -2546,10 +2546,19 @@
                             "signInButton": "a[href*=\"accounts.google.com/ServiceLogin\"]",
                             "avatarButton": "#avatar-btn",
                             "premiumLogo": "ytd-topbar-logo-renderer a[title*=\"Premium\"]"
+                        },
+                        "fireDetectionEvents": {
+                            "adBlocker": true,
+                            "playabilityError": true,
+                            "videoAd": true,
+                            "staticAd": true
                         }
                     }
                 }
             }
+        },
+        "webEvents": {
+            "state": "enabled"
         },
         "hover": {
             "state": "enabled"

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -2559,7 +2559,8 @@
             }
         },
         "webEvents": {
-            "state": "enabled"
+            "state": "enabled",
+            "minSupportedVersion": "1.189.0"
         },
         "hover": {
             "state": "enabled"

--- a/schema/features/web-interference-detection.ts
+++ b/schema/features/web-interference-detection.ts
@@ -47,6 +47,12 @@ type YoutubeAdsDetector = {
         avatarButton?: string;
         premiumLogo?: string;
     };
+    fireDetectionEvents?: {
+        adBlocker?: boolean;
+        playabilityError?: boolean;
+        videoAd?: boolean;
+        staticAd?: boolean;
+    };
 };
 
 type WebInterferenceDetectionSettings = CSSInjectFeatureSettings<{

--- a/schema/features/web-interference-detection.ts
+++ b/schema/features/web-interference-detection.ts
@@ -52,6 +52,7 @@ type YoutubeAdsDetector = {
         playabilityError?: boolean;
         videoAd?: boolean;
         staticAd?: boolean;
+        buffering?: boolean;
     };
 };
 


### PR DESCRIPTION
**Asana Task/Github Issue:**

## Description
<!-- 
  Please delete either or both process sections below.
-->

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Enables `webEvents` for iOS/macOS and adds new configurable `fireDetectionEvents` flags for YouTube interference detection, which could change what detection/telemetry signals are emitted on Apple platforms. Risk is moderate because it alters runtime event behavior but is gated by `minSupportedVersion` and config.
> 
> **Overview**
> Turns on the `webEvents` feature in the Apple overrides (iOS `>=7.219.0`, macOS `>=1.189.0`).
> 
> Extends `webInterferenceDetection`’s YouTube detector with a new optional `fireDetectionEvents` config (ad blocker, playability error, video/static ads, buffering) and sets these flags to `true` in both iOS and macOS overrides to control which detection events are emitted.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 88398a1a935ee02288a0aef72cf530d15c393c6c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->