### PR TITLE
Allowlist doubleclick.net/ads/preferences/getcookie for google.com

### DIFF
--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -1448,14 +1448,16 @@
                             "rocketnews24.com",
                             "wunderground.com",
                             "community.screwfix.com",
-                            "consent-pref.trustarc.com"
+                            "consent-pref.trustarc.com",
+                            "adssettings.google.com"
                         ],
                         "reason": [
                             "zojirushi.com - https://github.com/duckduckgo/privacy-configuration/issues/2021",
                             "rocketnews24.com - https://github.com/duckduckgo/privacy-configuration/issues/846",
                             "wunderground.com - https://github.com/duckduckgo/privacy-configuration/pull/3096",
                             "community.screwfix.com - https://github.com/duckduckgo/privacy-configuration/pull/4340",
-                            "consent-pref.trustarc.com - https://github.com/duckduckgo/privacy-configuration/pull/4340"
+                            "consent-pref.trustarc.com - https://github.com/duckduckgo/privacy-configuration/pull/4340",
+                            "adssettings.google.com - domain propagation from doubleclick.net/ads/preferences/ rule"
                         ]
                     },
                     {
@@ -1490,6 +1492,19 @@
                             "rocketnews24.com - domain propagation from doubleclick.net catch-all",
                             "wunderground.com - domain propagation from doubleclick.net catch-all",
                             "teamtalk.com to golf365.com - https://github.com/duckduckgo/privacy-configuration/pull/4971"
+                        ]
+                    },
+                    {
+                        "rule": "doubleclick.net/ads/preferences/",
+                        "domains": [
+                            "adssettings.google.com",
+                            "rocketnews24.com",
+                            "wunderground.com"
+                        ],
+                        "reason": [
+                            "adssettings.google.com - https://github.com/duckduckgo/privacy-configuration/pull/5067",
+                            "rocketnews24.com - domain propagation from doubleclick.net catch-all",
+                            "wunderground.com - domain propagation from doubleclick.net catch-all"
                         ]
                     },
                     {


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/11472677167855/task/1214272026419446

## Description
<!-- 
  Please delete either or both process sections below.
-->
Blocking doubleclick break content on https://adssettings.google.com/partnerads

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Expands allowlisting for `doubleclick.net`-related preference endpoints on `adssettings.google.com`, which may increase third-party request/cookie exposure if the rule is broader than intended.
> 
> **Overview**
> Allows `adssettings.google.com` to load Google Ads preference pages by expanding the `doubleclick.net` allowlist.
> 
> This adds `adssettings.google.com` to the existing `googleads.g.doubleclick.net/ads/preferences/naioptout` exception and introduces a new path-specific rule for `doubleclick.net/ads/preferences/` (with propagated coverage for `rocketnews24.com` and `wunderground.com`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8991ba232d2870f820067b53467e1dfb23df7c74. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->