### PR TITLE
Add reportStackTrace sub feature for extendedCrashReporting on Windows

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -4751,6 +4751,9 @@
                 },
                 "processStatusTracking": {
                     "state": "enabled"
+                },
+                "reportStackTrace": {
+                    "state": "disabled"
                 }
             }
         },


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/1207390136205919/task/1214148371942816?focus=true

## Description

Adds sub feature for collecting stack traces on demand.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single Windows config change that introduces a new subfeature flag and leaves it disabled by default; risk is limited to consumers that may not yet recognize the new key.
> 
> **Overview**
> Adds a new `reportStackTrace` subfeature under Windows `extendedCrashReporting` in `overrides/windows-override.json`, with the default state set to `disabled` so stack-trace collection can be enabled on demand via configuration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 62abd66452ea3d78803d030e298ac8f3ef3ec602. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->