### PR TITLE
Enable ad blocking feature availability to everyone - soft launch

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -2940,7 +2940,7 @@
             }
         },
         "adBlockingExtension": {
-            "state": "internal",
+            "state": "enabled",
             "minSupportedVersion": "7.216.0"
         },
         "webDetection": {

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -2608,7 +2608,7 @@
             }
         },
         "adBlockingExtension": {
-            "state": "internal",
+            "state": "enabled",
             "minSupportedVersion": "1.186.0"
         },
         "webDetection": {


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/task/1214423784083397

## Description
Enable ad blocking feature availability to everyone (but not enabled by default) - soft launch

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> This is a configuration-only change, but it expands availability of an ad-blocking capability and could increase exposure to site-compatibility issues for users on the supported versions.
> 
> **Overview**
> Makes the `adBlockingExtension` feature broadly available by changing its override state from `internal` to `enabled` on **iOS** (`overrides/ios-override.json`) and **macOS** (`overrides/macos-override.json`), keeping the existing minimum supported versions intact.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a068ff26b77a239f5b48228e9745a553fa3cdfd1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->