### PR TITLE
iOS: Increase showNTPAfterIdleReturn default to 30 minutes

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -2523,7 +2523,10 @@
                 },
                 "showNTPAfterIdleReturn": {
                     "state": "enabled",
-                    "minSupportedVersion": "7.212.0"
+                    "minSupportedVersion": "7.212.0",
+                    "settings": {
+                        "idleThresholdSeconds": 1800
+                    }
                 },
                 "onboardingRebranding": {
                     "state": "enabled",

--- a/schema/config.ts
+++ b/schema/config.ts
@@ -33,6 +33,7 @@ import { WebEventsFeature } from './features/web-events';
 import { WebInterferenceDetectionFeature } from './features/web-interference-detection';
 import { ExtendedCrashReporting } from './features/extendedCrashReporting';
 import { MacOSBrowserConfig } from './features/macos-browser-config';
+import { IOSBrowserConfig } from './features/ios-browser-config';
 import { DownloadManager } from './features/downloadManager';
 import { WebExtensionsConfig } from './features/web-extensions';
 import { AdBlockingExtensionConfig } from './features/ad-blocking-extension';
@@ -95,6 +96,7 @@ export type ConfigV5<VersionType> = {
         webInterferenceDetection?: WebInterferenceDetectionFeature<VersionType>;
         extendedCrashReporting?: ExtendedCrashReporting<VersionType>;
         macOSBrowserConfig?: MacOSBrowserConfig<VersionType>;
+        iOSBrowserConfig?: IOSBrowserConfig<VersionType>;
         tabSuspension?: TabSuspension<VersionType>;
         webExtensions?: WebExtensionsConfig<VersionType>;
     };

--- a/schema/features/ios-browser-config.ts
+++ b/schema/features/ios-browser-config.ts
@@ -1,0 +1,21 @@
+import { Feature, SubFeature } from '../feature';
+
+type SettingsType = {
+    promptCooldownInterval?: number;
+};
+
+type SubFeatures<VersionType> = {
+    showNTPAfterIdleReturn?: SubFeature<
+        VersionType,
+        {
+            // Seconds the app must be in the background before returning to the New Tab Page on foreground
+            idleThresholdSeconds: number;
+        }
+    >;
+};
+
+export type IOSBrowserConfig<VersionType> = Feature<
+    SettingsType,
+    VersionType,
+    SubFeatures<VersionType> & Record<string, SubFeature<VersionType>>
+>;


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/0/0/1214420688003519

## Description

Sets `idleThresholdSeconds` to `1800` (30 minutes) on the iOS `showNTPAfterIdleReturn` subfeature in `overrides/ios-override.json`.

The iOS client previously had no `settings` block for this subfeature, so it was falling back to its hard-coded 5-minute default. With the upcoming user-facing setting that lets users pick their own inactivity timer, we want the remote default to be 30 minutes for users who never change it.

Also adds a typed `IOSBrowserConfig` schema (`schema/features/ios-browser-config.ts`) and wires it into `ConfigV5`. Without this, subfeature settings on `iOSBrowserConfig` defaulted to `Record<string, string>` and the integer setting failed schema validation. macOS and Android already have equivalent typed schemas.

Companion iOS PR: https://github.com/duckduckgo/apple-browsers/pull/4669

### Feature change process:

- [x] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [x] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.