### PR TITLE
Enable `webNotifications` on Windows

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -4203,7 +4203,8 @@
             "state": "enabled",
             "features": {
                 "showNotifications": {
-                    "state": "enabled"
+                    "state": "enabled",
+                    "minSupportedVersion": "0.156.0"
                 }
             },
             "exceptions": []

--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -4202,11 +4202,8 @@
         "webNotifications": {
             "state": "enabled",
             "features": {
-                "permissionRequests": {
-                    "state": "internal"
-                },
                 "showNotifications": {
-                    "state": "internal"
+                    "state": "enabled"
                 }
             },
             "exceptions": []


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1213311565674947/task/1211395954816929?focus=true

## Description
Enables `webNotifications` including its sub-feature for every user on Windows. This enables web notifications on Windows publicly.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [x] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [x] This feature was covered by a tech design.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Enables a user-facing capability (web notifications) for Windows users, which could affect permission/notification behavior and trigger new OS-level prompts if client gating is incorrect.
> 
> **Overview**
> Enables `webNotifications` for all Windows users by promoting the `showNotifications` sub-feature from *internal* to **enabled**, gated to app versions `>= 0.156.0`.
> 
> Removes the previously internal-only `permissionRequests` sub-feature entry from the Windows override config.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 22ebc9176dce6e36dea1fb90c5316b099d60243c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->