### PR TITLE
Site Breakage: Expand beehiiv mitigation to prevent blocking images

### DIFF
--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -4212,7 +4212,7 @@
                     {
                         "rule": "media.beehiiv.com/cdn-cgi/image/",
                         "domains": [
-                            "thenewthings.com"
+                            "<all>"
                         ],
                         "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5010"
                     }


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/569473074191537/task/1214433794954762?focus=true

## Description
Expand mitigation for media.beehiiv.com/cdn-cgi/image/ to `<all>` as its used to serve images on quite a few sites like thenerve.news


### Site breakage mitigation process:
#### Brief explanation
- Reported URL: https://www.thenerve.news/
- Problems experienced: images don't load
- Platforms affected:
  - [x] iOS
  - [x] Android
  - [x] Windows
  - [x] MacOS
  - [x] Extensions
- Tracker(s) being unblocked: media.beehiiv.com/cdn-cgi/image/
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Expands an allowlist exception from a single site to `<all>`, which could broadly reduce tracker blocking and have wider privacy impact if the rule is overly permissive.
> 
> **Overview**
> Expands the `beehiiv.com` allowlist rule for `media.beehiiv.com/cdn-cgi/image/` from a single domain (`thenewthings.com`) to `<all>`, to prevent images served via Beehiiv’s CDN from being blocked across sites.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 173b27991af15885e5ab2fdceac91e4f76ec92a1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->