### PR TITLE
Re-enabling 'autocompleteTabs' for Windows as not all checks have been removed in the browser

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -1383,6 +1383,9 @@
                 "maxHistoryCount": 5
             }
         },
+        "autocompleteTabs": {
+            "state": "enabled"
+        },
         "duckAiDataClearing": {
             "exceptions": [],
             "state": "enabled",

--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -1384,7 +1384,8 @@
             }
         },
         "autocompleteTabs": {
-            "state": "enabled"
+            "state": "enabled",
+            "exceptions": []
         },
         "duckAiDataClearing": {
             "exceptions": [],


### PR DESCRIPTION
…n removed in the browser

**Asana Task/Github Issue:**

## Description
<!-- 
  Please delete either or both process sections below.
-->

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change that enables an existing feature flag for Windows; main risk is unintended UI/behavior change if the feature is not fully supported yet.
> 
> **Overview**
> Re-enables the `autocompleteTabs` feature flag in `overrides/windows-override.json` for Windows by adding it back as `state: enabled` with no exceptions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e713aa0ba9cb5d48550f39e789fa6b6db1b64ccc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->