### PR TITLE
Removed tracker exception for aetna.com

### DIFF
--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -3433,11 +3433,9 @@
                     {
                         "rule": "cdn.quantummetric.com",
                         "domains": [
-                            "aetna.com",
                             "verizon.com"
                         ],
                         "reason": [
-                            "aetna.com - https://github.com/duckduckgo/privacy-configuration/pull/4882",
                             "verizon.com - https://github.com/duckduckgo/privacy-configuration/pull/4969"
                         ]
                     }


### PR DESCRIPTION
Removed 'aetna.com' from the tracker allowlist for cdn.quantummetric.com

**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/1200277586140538/task/1211919371624973?focus=true

## Description
### Site breakage mitigation process:
#### Brief explanation
- Reported URL: aetna.com
- Problems experienced: Previous speculative mitigation had no change so removing.
- Platforms affected:
  - [x] iOS
  - [x] Android
  - [x] Windows
  - [x] MacOS
  - [x] Extensions
- Tracker(s) being unblocked: N/A
- Feature being disabled/modified: N/A
- [x] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change that tightens tracker blocking by removing an allowlist entry; potential risk is site breakage on `aetna.com` if it still depends on `cdn.quantummetric.com`.
> 
> **Overview**
> Removes the `aetna.com` allowlist exception for `cdn.quantummetric.com` from `features/tracker-allowlist.json`, leaving `verizon.com` as the only domain covered by that rule.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9e7e376f3ba47ea1700c8d94e69ac4a2933021b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->