### PR TITLE
Remove onboardingSearchExperience iOS feature flag

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -272,11 +272,6 @@
                 "standaloneMigration": {
                     "state": "enabled"
                 },
-                "onboardingSearchExperience": {
-                    "state": "enabled",
-                    "description": "Toggle Choice Screen during onboarding",
-                    "minSupportedVersion": "7.197.0"
-                },
                 "onboardingDuckAIQueryExperiment": {
                     "state": "enabled",
                     "description": "Duck.ai onboarding query experiment cohorts",


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1205842942115003/task/1214429872428971

## Description

Removes the `onboardingSearchExperience` feature flag from `overrides/ios-override.json`.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.