### PR TITLE
Add adwall mitigation

### DIFF
--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -4194,6 +4194,17 @@
                     }
                 ]
             },
+            "monkeyapes.com": {
+                "rules": [
+                    {
+                        "rule": "monkeyapes.com",
+                        "domains": [
+                            "thegatewaypundit.com"
+                        ],
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5078"
+                    }
+                ]
+            },
             "asapp.com": {
                 "rules": [
                     {


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1200277586140538/task/1214442050950427?focus=true

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Small config-only change but it relaxes tracker blocking for `monkeyapes.com` on `thegatewaypundit.com`, which could impact privacy protections if overly broad.
> 
> **Overview**
> Adds a new allowlist entry in `features/tracker-allowlist.json` to permit requests to `monkeyapes.com` when triggered on `thegatewaypundit.com` (linked to privacy-configuration PR #5078).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1359656920122770186b8fa1f4cf874a2255441d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->