### PR TITLE
Add milesplit.live to autoconsent exceptions

### DIFF
--- a/features/autoconsent.json
+++ b/features/autoconsent.json
@@ -826,6 +826,10 @@
         {
             "domain": "condor.com",
             "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5073"
+        },
+        {
+            "domain": "milesplit.live",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5079"
         }
     ],
     "settings": {


### PR DESCRIPTION


**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/inbox/11472677167854/item/1214372763692536/story/1214449619130636
## Description
<!-- 
  Please delete either or both process sections below.
-->
Menu bar not loading

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change that adds a single domain to the Auto Consent exception list; impact is limited to consent handling behavior on `milesplit.live`.
> 
> **Overview**
> Adds `milesplit.live` to the Auto Consent exceptions list in `features/autoconsent.json` (with reference to PR `#5079`), exempting that site from the standard autoconsent behavior to mitigate site breakage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d3aca95994bc94ffa816b58ccb1d8377055fe4b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->