### PR TITLE
Disable webViewUserAgent for macOS for experiment

### DIFF
--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -512,7 +512,7 @@
                     "minSupportedVersion": "1.171.0"
                 },
                 "webViewUserAgent": {
-                    "state": "enabled",
+                    "state": "disabled",
                     "minSupportedVersion": "1.182.0"
                 }
             },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1206873150423133/task/1214450629603349?focus=true

## Description
<!-- 
  Please delete either or both process sections below.
—>

Temporarily disable webViewUserAgent

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change that flips a single macOS override flag; impact is limited to sites/flows dependent on the `webViewUserAgent` behavior for macOS builds >= `1.182.0`.
> 
> **Overview**
> Disables the `webViewUserAgent` feature flag in `overrides/macos-override.json` (previously enabled) for macOS versions `>= 1.182.0`, effectively turning off that experiment/behavior via configuration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 474e01f7fbce17c1ccc7aad2bd2df1dd8f520273. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->