### PR TITLE
Update content-blocker extension to 2026.5.3

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -4568,7 +4568,7 @@
             "minSupportedVersion": "0.148.0",
             "exceptions": [],
             "settings": {
-                "extensionUrl": "https://staticcdn.duckduckgo.com/extensions/content-blocker/content-blocker-extension-2026.4.27.crx"
+                "extensionUrl": "https://staticcdn.duckduckgo.com/extensions/content-blocker/content-blocker-extension-2026.5.3.crx"
             },
             "features": {
                 "onboardingEnabled": {


### PR DESCRIPTION
Update content-blocker extension to 2026.5.3.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change that updates the CDN URL for the Windows `adBlockV2Extension` package; main risk is a bad URL/version causing extension download or rollout issues.
> 
> **Overview**
> Updates the Windows override configuration to point `adBlockV2Extension.settings.extensionUrl` at the `content-blocker-extension-2026.5.3.crx` package (from `2026.4.27`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a40132faff935be46860d725b77cc5c8021b3ab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->