### PR TITLE
Update ad-blocking extension scriptlets for v2026.5.3

### DIFF
--- a/features/ad-blocking-extension.json
+++ b/features/ad-blocking-extension.json
@@ -4,24 +4,24 @@
     },
     "exceptions": [],
     "settings": {
-        "version": "2026.4.27",
+        "version": "2026.5.3",
         "enabledByDefault": false,
         "scriptlets": {
             "scriptlets/isolated/ublock-filters.js": {
-                "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/982bf709ce6dccf19fe0e273faac43271dcdae440b73461dad3cb56cca9ac4a1.js",
-                "signature": "MEUCIQCa3omQ+7Q1FecHSzOnpynv8dy1Q+6+IBXaiktkZ1ghewIgTCmFumrJn+kSycQaq8sl3LhrGr+BS6figXC6mLFz/xE="
+                "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/9ef2ee259997607f891e91448fcbf717e3b9366141b17ee3739bd41bcd7122bc.js",
+                "signature": "MEUCIQChLx4C5CGOuxkT5tETL52A3R/o774Vpa+E1HFEx5HVtAIgQv0x9bwmv8686FJjYxIetPO7O8NAqKTjoe6N/U/wX0M="
             },
             "scriptlets/main/ublock-filters.js": {
-                "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/425a53d8a8c0a52ecab8a09e805b6b9b95c8aa89287e03a8be288ead2e4d36b5.js",
-                "signature": "MEUCIBtY+HS7Emn8lZ8xm3m79+VpIkXAua4ECY+Vfeew/OqeAiEA023hyBSiF/sKir+uGb7O6whC/hwWRSiwqQNWrsmg3+o="
+                "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/e933a69dd186795ebfa0a3f6e86b36862112e4a1c79bcc4bb8797efa1ec2f285.js",
+                "signature": "MEYCIQC46XkDRrt3/+2+NiFst1rb+etbgoN5b4j/IhvoKjbbnwIhAJKtuHlej/5DOcq7PnUnI1543xy2Op2GWjZHHTB+MSXj"
             },
             "scriptlets/main/ublock-experimental.js": {
                 "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855.js",
-                "signature": "MEUCIQDSTku820Sl2Ab2Mz4Oncanpt14j+cW8n+0ge/XP3vOUQIgZBhV9IcWmaWzZ1i+1gGHlGNe56Vk5x3oSIPh9TPzoJ8="
+                "signature": "MEUCIQDOuZKvY+DF5+VdiUy26hQ1BSLZrcwUs0guUP8lgHJ0qAIgf+AwXScWq86xiS93S7bqbvobI0/lcMQsCk6lxOR+yw4="
             },
             "scriptlets/isolated/ublock-experimental.js": {
                 "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855.js",
-                "signature": "MEUCIQDccLH1ZCmY20vWgyKaJ2wshkQHqkG5Kog0QdLwgNBkIwIgfX4nOtpR77l0kZJjxVz1w2PcsxbTS4TmvbxYgG2jc38="
+                "signature": "MEUCIQDvXCvU0xQQvp/uSNddC8474dJoiwykZRRCFo9cxM8tDQIgUq5oI4Qk67Z0VpFT2vtrchy2Wbxnpdsf3PV1Jjk4Yyk="
             }
         }
     }


### PR DESCRIPTION
Update ad-blocking extension scriptlets for v2026.5.3.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates remote scriptlet URLs and signatures that directly affect ad-blocking behavior; a bad publish/signature mismatch could break content blocking on clients. No code logic changes beyond configuration updates.
> 
> **Overview**
> Bumps the ad-blocking extension configuration to **v`2026.5.3`**.
> 
> Updates the referenced `ublock-filters` scriptlet artifact URLs (main + isolated) and refreshes signatures for both `ublock-filters` and `ublock-experimental` scriptlets to match the new published assets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ba0c58beda56ce9c90603caa07c5ed6d23b8119f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->