### PR TITLE
Bump native storage release to 20%

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -227,6 +227,9 @@
                         "steps": [
                             {
                                 "percent": 5
+                            },
+                            {
+                                "percent": 20
                             }
                         ]
                     }

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -325,6 +325,9 @@
                         "steps": [
                             {
                                 "percent": 5
+                            },
+                            {
+                                "percent": 20
                             }
                         ]
                     }


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/72649045549333/task/1214486857936919?focus=true

## Description
Bump native storage release to 20%

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change that expands the `aiChat.nativeStorage` rollout cohort from 5% to 20% for iOS and macOS; primary risk is increased exposure to any latent native storage issues.
> 
> **Overview**
> Increases the incremental rollout for `aiChat.nativeStorage` from **5% to 20%** in the override configs for **iOS** and **macOS**, expanding the enabled population while keeping existing minimum supported versions unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b4940f9742df824a232295e4b29a8ad0aed63f30. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->