### PR TITLE
Roll nativeRequestInterception out to 5% of stable

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -5301,16 +5301,23 @@
             "state": "disabled"
         },
         "nativeRequestInterception": {
-            "state": "preview",
-            "minSupportedVersion": "0.155.4",
+            "state": "enabled",
+            "minSupportedVersion": "0.155.5",
             "exceptions": [],
             "features": {
                 "disableFirstAboutBlankNavigation": {
                     "state": "disabled"
                 },
                 "enableNativeRequestInterception": {
-                    "state": "preview",
-                    "minSupportedVersion": "0.155.4"
+                    "state": "enabled",
+                    "minSupportedVersion": "0.155.5",
+                    "rollout": {
+                        "steps": [
+                            {
+                                "percent": 5
+                            }
+                        ]
+                    }
                 }
             }
         },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/72649045549333/task/1213842661987429?focus=true

## Description

The feature used to be controlled by the main feature state but it was switched to sub feature in 0.155.5.
Enable the sub feature for 5% of stable.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Enables a network/request interception feature on Windows stable (5% rollout), which could introduce site-compat or networking regressions for that cohort.
> 
> **Overview**
> Updates Windows override config to **enable** `nativeRequestInterception` (and its `enableNativeRequestInterception` subfeature) starting at version `0.155.5`.
> 
> Adds a **5% rollout** for the subfeature, shifting it from `preview` to `enabled` and bumping the minimum supported version from `0.155.4` to `0.155.5`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9f350ae1f71da055c06521d1ffbb98b1b13b58ba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->