### PR TITLE
[iOS] Enable fire mode to 10% of users

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -2550,12 +2550,19 @@
                     }
                 },
                 "fireButtonRefinements": {
-                    "state": "internal",
-                    "minSupportedVersion": "7.215.0"
+                    "state": "enabled",
+                    "minSupportedVersion": "7.218.0"
                 },
                 "fireMode": {
-                    "state": "internal",
-                    "minSupportedVersion": "7.215.0"
+                    "state": "enabled",
+                    "minSupportedVersion": "7.218.0",
+                    "rollout": {
+                        "steps": [
+                            {
+                                "percent": 10
+                            }
+                        ]
+                    }
                 },
                 "minimalChromeInLandscape": {
                     "state": "enabled",


### PR DESCRIPTION
**Asana Task/Github Issue: https://app.asana.com/1/137249556945/project/1211767540372501/task/1214227958592923?focus=true**

## Description
Enabling the fire mode feature for 10% of users and the fire button refinements feature for all users.
Note: In the iOS code, fire button refinements is dependent on fire mode, meaning this change will effectively roll out both features to the same cohort of users.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change, but it enables a user-facing feature for a new cohort and bumps `minSupportedVersion`, so misconfiguration could unexpectedly expose/withhold the feature.
> 
> **Overview**
> Enables `iOSBrowserConfig.fireMode` (previously `internal`) with a **10% rollout** and raises `minSupportedVersion` to `7.218.0`.
> 
> Also switches `fireButtonRefinements` from `internal` to **enabled for all supported users**, with the same `minSupportedVersion` bump to `7.218.0`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 572e9825cb3775c923b1acac18b2a9f18873ab45. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->