### PR TITLE
Enable omnibar voice chat access on Windows

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -1355,6 +1355,9 @@
                 "omnibarReasoningEffort": {
                     "state": "internal"
                 },
+                "omnibarVoiceChatAccess": {
+                    "state": "internal"
+                },
                 "ntpImageGeneration": {
                     "state": "enabled",
                     "minSupportedVersion": "0.156.0"


### PR DESCRIPTION
https://app.asana.com/1/137249556945/project/1211654189969294/task/1213684472445446

## Description

Enable omnibar voice chat access on Windows (internal).


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change that gates an internal feature; main risk is unintentionally exposing the flag to broader Windows builds if consumed incorrectly.
> 
> **Overview**
> Enables the `aiChat` sub-feature flag `omnibarVoiceChatAccess` in `overrides/windows-override.json` with `state: internal`, allowing internal Windows builds to access omnibar voice chat functionality.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fae432fed61f60e5b7375a5a415664d387be06f5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->