### PR TITLE
Enable multiDownloadPermission for internal users

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -5356,7 +5356,7 @@
             "state": "enabled"
         },
         "multiDownloadPermission": {
-            "state": "disabled",
+            "state": "internal",
             "exceptions": []
         }
     },


### PR DESCRIPTION
**Asana Task/Github Issue:**

## Description
Enable multiDownloadPermission for internal users

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [X] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change that widens `multiDownloadPermission` availability from disabled to internal on Windows; impact is limited to internal builds/users.
> 
> **Overview**
> Switches the Windows override for `multiDownloadPermission` from `disabled` to **`internal`**, enabling the feature for internal users while leaving exceptions unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9fa89050d82b38d5d2be7377e168722a3d4bc23f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->