### PR TITLE
Enable omnibarWebSearch aiChat subfeature on macOS

### DIFF
--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -394,7 +394,8 @@
                     "minSupportedVersion": "1.186.0"
                 },
                 "omnibarWebSearch": {
-                    "state": "disabled"
+                    "state": "enabled",
+                    "minSupportedVersion": "1.188.0"
                 }
             },
             "settings": {


### PR DESCRIPTION
**Asana Task/Github Issue:**

## Description

Enable `omnibarWebSearch` (subfeature of `aiChat`) on macOS for app version 1.188.0 and higher.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change that flips on a previously disabled `aiChat` subfeature for macOS, gated by `minSupportedVersion` to limit impact to newer app versions.
> 
> **Overview**
> Enables the `aiChat` subfeature `omnibarWebSearch` for macOS by switching it from **disabled** to **enabled** and adding `minSupportedVersion: 1.188.0` in `overrides/macos-override.json`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e238c2ded6c58e82db17a43c4231f17a9f167751. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->