### PR TITLE
Tracker exception on notebookcheck.net

### DIFF
--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -2357,6 +2357,17 @@
                     }
                 ]
             },
+            "html-load.com": {
+                "rules": [
+                    {
+                        "rule": "html-load.com",
+                        "domains": [
+                            "notebookcheck.net"
+                        ],
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5090"
+                    }
+                ]
+            },
             "hubspot.com": {
                 "rules": [
                     {


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/1206670747178362/task/1214486294551304?focus=true

## Description
### Site breakage mitigation process:
#### Brief explanation
- Reported URL: https://www.notebookcheck.net/
- Problems experienced: Anti-adblock wall, triggered by tracker blocking. Making an exception for the whole domain because of multiple subdomains and files being required by the site.
- Platforms affected:
  - [x] iOS
  - [x] Android
  - [x] Windows
  - [x] MacOS
  - [x] Extensions
- Tracker(s) being unblocked: html-load.com
- Feature being disabled/modified: N/A
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new tracker allowlist exception that will permit requests to `html-load.com` on `notebookcheck.net`, slightly reducing tracker-blocking protections for that site. Risk is limited in scope but impacts privacy/anti-tracking behavior for a specific domain.
> 
> **Overview**
> Mitigates site breakage on `notebookcheck.net` by adding `html-load.com` to `features/tracker-allowlist.json`, allowing that tracker domain to load for this site (with a reference back to the PR for audit trail).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6db0e32f58b4f68eb77e854b04d69058c83d9a50. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->