### PR TITLE
Add featureEnabled subfeature to adBlockingExtension

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -2956,7 +2956,7 @@
             "state": "enabled",
             "minSupportedVersion": "7.216.0",
             "features": {
-                "isEnabled": {
+                "featureEnabled": {
                     "state": "enabled",
                     "minSupportedVersion": "7.216.0"
                 }

--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -2954,7 +2954,13 @@
         },
         "adBlockingExtension": {
             "state": "enabled",
-            "minSupportedVersion": "7.216.0"
+            "minSupportedVersion": "7.216.0",
+            "features": {
+                "isEnabled": {
+                    "state": "enabled",
+                    "minSupportedVersion": "7.216.0"
+                }
+            }
         },
         "webDetection": {
             "state": "enabled",

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -2613,7 +2613,13 @@
         },
         "adBlockingExtension": {
             "state": "enabled",
-            "minSupportedVersion": "1.186.0"
+            "minSupportedVersion": "1.186.0",
+            "features": {
+                "featureEnabled": {
+                    "state": "enabled",
+                    "minSupportedVersion": "1.186.0"
+                }
+            }
         },
         "webDetection": {
             "state": "enabled",


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1200194497630846/task/1214004790021021?focus=true

## Description
Add featureEnabled subfeature to adBlockingExtension

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change that adds a nested flag under `adBlockingExtension` for iOS and macOS; main risk is clients that strictly validate schema may reject the new `features` shape.
> 
> **Overview**
> Adds a new `adBlockingExtension.features.featureEnabled` subfeature to both `ios-override.json` and `macos-override.json`, enabled with the same `minSupportedVersion` as the parent feature.
> 
> This allows the ad blocking extension to be toggled via a dedicated nested flag without changing the overall `adBlockingExtension` rollout/version gating.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit acd85b66b4ffd685508d5c5ebd380cc0e0e173d9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->