### PR TITLE
[iOS][Onboarding] Stop assigning users of Duck.ai Onboarding experiment to treatment cohorts

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -290,11 +290,11 @@
                         },
                         {
                             "name": "treatmentA",
-                            "weight": 1
+                            "weight": 0
                         },
                         {
                             "name": "treatmentB",
-                            "weight": 1
+                            "weight": 0
                         }
                     ]
                 },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/task/1214515502292474?focus=true

## Description
This PR stops assigning users to treatment cohorts for the Duck.ai onboarding experiment

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change that stops new users being assigned to the `treatmentA`/`treatmentB` cohorts for the Duck.ai onboarding experiment; impact is limited to experiment rollout/metrics on iOS.
> 
> **Overview**
> Disables assignment to the Duck.ai onboarding query experiment treatment cohorts on iOS by setting `onboardingDuckAIQueryExperiment` cohort weights for `treatmentA` and `treatmentB` to `0` (leaving only the `control` cohort active).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 173721dc74625c60ae6a597d1f029af1650c89b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->