### PR TITLE
Add Windows UI responsiveness SLO feature flag

### DIFF
--- a/features/ui-responsiveness.json
+++ b/features/ui-responsiveness.json
@@ -1,0 +1,7 @@
+{
+    "_meta": {
+        "description": "Controls UI responsiveness SLO instrumentation."
+    },
+    "state": "disabled",
+    "exceptions": []
+}

--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -4679,7 +4679,7 @@
             }
         },
         "uiResponsiveness": {
-            "state": "enabled",
+            "state": "internal",
             "features": {
                 "keypressToCharacterRender": {
                     "state": "internal"

--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -4678,6 +4678,17 @@
                 }
             }
         },
+        "uiResponsiveness": {
+            "state": "enabled",
+            "features": {
+                "keypressToCharacterRender": {
+                    "state": "internal"
+                },
+                "keypressToSuggestionRender": {
+                    "state": "internal"
+                }
+            }
+        },
         "diskSpaceMonitoring": {
             "state": "enabled",
             "exceptions": [],


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1212377141129925/task/1213904343638504

## Description
Adds UI responsiveness SLO feature flag, enables internally on Windows

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk configuration-only change that adds a new feature flag and enables it only for internal Windows builds; main risk is unintended telemetry/instrumentation toggling if consumed differently than expected.
> 
> **Overview**
> Adds a new `uiResponsiveness` feature-flag definition (`features/ui-responsiveness.json`) to control UI responsiveness SLO instrumentation (default **disabled**).
> 
> Updates `overrides/windows-override.json` to enable this flag for **internal** Windows users, including two internal sub-features: `keypressToCharacterRender` and `keypressToSuggestionRender`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d849c0bf4de486ee8e71b083704791f9e91b38b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->