### PR TITLE
Exceptions to remove anti-adblock wall on vidbox.dev

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -4137,15 +4137,6 @@
                 ]
             },
             {
-                "domain": "vinted.fr",
-                "rules": [
-                    {
-                        "selector": ".ad-container--leaderboard",
-                        "type": "hide"
-                    }
-                ]
-            },
-            {
                 "domain": "vice.com",
                 "rules": [
                     {
@@ -4158,6 +4149,27 @@
                     },
                     {
                         "selector": ".fixed-slot",
+                        "type": "hide"
+                    }
+                ]
+            },
+            {
+                "domain": "vidbox.dev",
+                "rules": [
+                    {
+                        "type": "disable-default"
+                    },
+                    {
+                        "selector": "[aria-label='Sponsored content']",
+                        "type": "hide-empty"
+                    }
+                ]
+            },
+            {
+                "domain": "vinted.fr",
+                "rules": [
+                    {
+                        "selector": ".ad-container--leaderboard",
                         "type": "hide"
                     }
                 ]

--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -1046,12 +1046,14 @@
                             "history.com",
                             "10play.com.au",
                             "rocketnews24.com",
-                            "wunderground.com"
+                            "wunderground.com",
+                            "vidbox.dev"
                         ],
                         "reason": [
                             "history.com, 10play.com.au - https://github.com/duckduckgo/privacy-configuration/issues/1185",
                             "rocketnews24.com - https://github.com/duckduckgo/privacy-configuration/issues/846",
-                            "wunderground.com - https://github.com/duckduckgo/privacy-configuration/pull/3096"
+                            "wunderground.com - https://github.com/duckduckgo/privacy-configuration/pull/3096",
+                            "vidbox.dev - domain propagation from doubleclick.net catch-all"
                         ]
                     },
                     {
@@ -1060,12 +1062,14 @@
                             "cbs.com",
                             "paramountplus.com",
                             "rocketnews24.com",
-                            "wunderground.com"
+                            "wunderground.com",
+                            "vidbox.dev"
                         ],
                         "reason": [
                             "cbs.com, paramountplus.com - https://github.com/duckduckgo/privacy-configuration/pull/2410",
                             "rocketnews24.com - https://github.com/duckduckgo/privacy-configuration/issues/846",
-                            "wunderground.com - https://github.com/duckduckgo/privacy-configuration/pull/3096"
+                            "wunderground.com - https://github.com/duckduckgo/privacy-configuration/pull/3096",
+                            "vidbox.dev - domain propagation from doubleclick.net catch-all"
                         ]
                     },
                     {
@@ -1076,7 +1080,8 @@
                             "rocketnews24.com",
                             "servustv.com",
                             "wunderground.com",
-                            "modernhoney.com"
+                            "modernhoney.com",
+                            "vidbox.dev"
                         ],
                         "reason": [
                             "ah.nl - 'Bonus offer' elements do not render and are not clickable.",
@@ -1084,7 +1089,8 @@
                             "rocketnews24.com - https://github.com/duckduckgo/privacy-configuration/issues/846",
                             "servustv.com - https://github.com/duckduckgo/privacy-configuration/issues/2188",
                             "wunderground.com - https://github.com/duckduckgo/privacy-configuration/issues/2885",
-                            "modernhoney.com - https://github.com/duckduckgo/privacy-configuration/pull/4111"
+                            "modernhoney.com - https://github.com/duckduckgo/privacy-configuration/pull/4111",
+                            "vidbox.dev - domain propagation from doubleclick.net catch-all"
                         ]
                     },
                     {
@@ -1096,7 +1102,8 @@
                             "crunchyroll.com",
                             "pch.com",
                             "iheart.com",
-                            "wunderground.com"
+                            "wunderground.com",
+                            "vidbox.dev"
                         ],
                         "reason": [
                             "https://github.com/duckduckgo/privacy-configuration/issues/1185",
@@ -1104,7 +1111,8 @@
                             "crunchyroll.com - https://github.com/duckduckgo/privacy-configuration/issues/1140",
                             "pch.com - https://github.com/duckduckgo/privacy-configuration/pull/2793",
                             "iheart.com - https://github.com/duckduckgo/privacy-configuration/pull/3040",
-                            "wunderground.com - https://github.com/duckduckgo/privacy-configuration/pull/3096"
+                            "wunderground.com - https://github.com/duckduckgo/privacy-configuration/pull/3096",
+                            "vidbox.dev - domain propagation from doubleclick.net catch-all"
                         ]
                     },
                     {
@@ -1113,13 +1121,15 @@
                             "cc.com",
                             "paramountplus.com",
                             "rocketnews24.com",
-                            "wunderground.com"
+                            "wunderground.com",
+                            "vidbox.dev"
                         ],
                         "reason": [
                             "cc.com - https://github.com/duckduckgo/privacy-configuration/pull/3508",
                             "paramount - https://github.com/duckduckgo/privacy-configuration/pull/3534",
                             "rocketnews24.com - https://github.com/duckduckgo/privacy-configuration/issues/846",
-                            "wunderground.com - https://github.com/duckduckgo/privacy-configuration/pull/3096"
+                            "wunderground.com - https://github.com/duckduckgo/privacy-configuration/pull/3096",
+                            "vidbox.dev - domain propagation from doubleclick.net catch-all"
                         ]
                     },
                     {
@@ -1127,12 +1137,14 @@
                         "domains": [
                             "cbssports.com",
                             "rocketnews24.com",
-                            "wunderground.com"
+                            "wunderground.com",
+                            "vidbox.dev"
                         ],
                         "reason": [
                             "cbssports.com - Live videos do not load or render.",
                             "rocketnews24.com - https://github.com/duckduckgo/privacy-configuration/issues/846",
-                            "wunderground.com - https://github.com/duckduckgo/privacy-configuration/pull/3096"
+                            "wunderground.com - https://github.com/duckduckgo/privacy-configuration/pull/3096",
+                            "vidbox.dev - domain propagation from doubleclick.net catch-all"
                         ]
                     },
                     {
@@ -1140,12 +1152,14 @@
                         "domains": [
                             "foxweather.com",
                             "rocketnews24.com",
-                            "wunderground.com"
+                            "wunderground.com",
+                            "vidbox.dev"
                         ],
                         "reason": [
                             "foxweather.com - https://github.com/duckduckgo/privacy-configuration/issues/1541",
                             "rocketnews24.com - https://github.com/duckduckgo/privacy-configuration/issues/846",
-                            "wunderground.com - https://github.com/duckduckgo/privacy-configuration/pull/3096"
+                            "wunderground.com - https://github.com/duckduckgo/privacy-configuration/pull/3096",
+                            "vidbox.dev - domain propagation from doubleclick.net catch-all"
                         ]
                     },
                     {
@@ -1314,7 +1328,8 @@
                             "nationalreview.com",
                             "supermarketperimeter.com",
                             "speedweek.com",
-                            "timesofmalta.com"
+                            "timesofmalta.com",
+                            "vidbox.dev"
                         ],
                         "reason": [
                             "ah.nl - 'Bonus offer' elements do not render and are not clickable.",
@@ -1340,7 +1355,8 @@
                             "supermarketperimeter.com - https://github.com/duckduckgo/privacy-configuration/pull/4519",
                             "speedweek.com - https://github.com/duckduckgo/privacy-configuration/pull/4579",
                             "timesofmalta.com - https://github.com/duckduckgo/privacy-configuration/pull/4646",
-                            "hawaiiathletics.com - https://github.com/duckduckgo/privacy-configuration/pull/5071"
+                            "hawaiiathletics.com - https://github.com/duckduckgo/privacy-configuration/pull/5071",
+                            "vidbox.dev - domain propagation from doubleclick.net catch-all"
                         ]
                     },
                     {
@@ -1348,12 +1364,14 @@
                         "domains": [
                             "ah.nl",
                             "wunderground.com",
-                            "rocketnews24.com"
+                            "rocketnews24.com",
+                            "vidbox.dev"
                         ],
                         "reason": [
                             "ah.nl - 'Bonus offer' elements do not render and are not clickable.",
                             "wunderground.com - Video element does not display.",
-                            "rocketnews24.com - https://github.com/duckduckgo/privacy-configuration/issues/846"
+                            "rocketnews24.com - https://github.com/duckduckgo/privacy-configuration/issues/846",
+                            "vidbox.dev - domain propagation from doubleclick.net catch-all"
                         ]
                     },
                     {
@@ -1362,13 +1380,15 @@
                             "rocketnews24.com",
                             "weather.com",
                             "wunderground.com",
-                            "repretel.com"
+                            "repretel.com",
+                            "vidbox.dev"
                         ],
                         "reason": [
                             "https://github.com/duckduckgo/privacy-configuration/issues/415",
                             "rocketnews24.com - https://github.com/duckduckgo/privacy-configuration/issues/846",
                             "wunderground.com - https://github.com/duckduckgo/privacy-configuration/issues/956",
-                            "repretel.com - broken videos"
+                            "repretel.com - broken videos",
+                            "vidbox.dev - domain propagation from doubleclick.net catch-all"
                         ]
                     },
                     {
@@ -1376,12 +1396,14 @@
                         "domains": [
                             "sbs.com.au",
                             "rocketnews24.com",
-                            "wunderground.com"
+                            "wunderground.com",
+                            "vidbox.dev"
                         ],
                         "reason": [
                             "sbs.com.au - https://github.com/duckduckgo/privacy-configuration/pull/2436",
                             "rocketnews24.com - https://github.com/duckduckgo/privacy-configuration/issues/846",
-                            "wunderground.com - https://github.com/duckduckgo/privacy-configuration/pull/3096"
+                            "wunderground.com - https://github.com/duckduckgo/privacy-configuration/pull/3096",
+                            "vidbox.dev - domain propagation from doubleclick.net catch-all"
                         ]
                     },
                     {
@@ -1397,7 +1419,8 @@
                             "nationalpost.com",
                             "modernhoney.com",
                             "rocketnews24.com",
-                            "nytimes.com"
+                            "nytimes.com",
+                            "vidbox.dev"
                         ],
                         "reason": [
                             "applesfera.com - https://github.com/duckduckgo/privacy-configuration/issues/1723",
@@ -1410,7 +1433,8 @@
                             "nationalpost.com - https://github.com/duckduckgo/privacy-configuration/pull/3969",
                             "modernhoney.com - https://github.com/duckduckgo/privacy-configuration/pull/4111",
                             "rocketnews24.com - https://github.com/duckduckgo/privacy-configuration/issues/846",
-                            "nytimes.com - https://github.com/duckduckgo/privacy-configuration/pull/4549"
+                            "nytimes.com - https://github.com/duckduckgo/privacy-configuration/pull/4549",
+                            "vidbox.dev - domain propagation from doubleclick.net catch-all"
                         ]
                     },
                     {
@@ -1419,13 +1443,15 @@
                             "rocketnews24.com",
                             "wunderground.com",
                             "comexlive.org",
-                            "3dzip.info"
+                            "3dzip.info",
+                            "vidbox.dev"
                         ],
                         "reason": [
                             "rocketnews24.com - domain propagation from doubleclick.net catch-all",
                             "wunderground.com - domain propagation from doubleclick.net catch-all",
                             "comexlive.org - https://github.com/duckduckgo/privacy-configuration/pull/4690",
-                            "3dzip.info - https://github.com/duckduckgo/privacy-configuration/pull/4733"
+                            "3dzip.info - https://github.com/duckduckgo/privacy-configuration/pull/4733",
+                            "vidbox.dev - domain propagation from doubleclick.net catch-all"
                         ]
                     },
                     {
@@ -1434,13 +1460,15 @@
                             "sbs.com.au",
                             "rocketnews24.com",
                             "wunderground.com",
-                            "business-standard.com"
+                            "business-standard.com",
+                            "vidbox.dev"
                         ],
                         "reason": [
                             "www.sbs.com.au - https://github.com/duckduckgo/privacy-configuration/issues/1761",
                             "rocketnews24.com - https://github.com/duckduckgo/privacy-configuration/issues/846",
                             "wunderground.com - https://github.com/duckduckgo/privacy-configuration/pull/3096",
-                            "business-standard.com - domain propagation from www3.doubleclick.net rule"
+                            "business-standard.com - domain propagation from www3.doubleclick.net rule",
+                            "vidbox.dev - domain propagation from doubleclick.net catch-all"
                         ]
                     },
                     {
@@ -1451,7 +1479,8 @@
                             "wunderground.com",
                             "community.screwfix.com",
                             "consent-pref.trustarc.com",
-                            "adssettings.google.com"
+                            "adssettings.google.com",
+                            "vidbox.dev"
                         ],
                         "reason": [
                             "zojirushi.com - https://github.com/duckduckgo/privacy-configuration/issues/2021",
@@ -1459,7 +1488,8 @@
                             "wunderground.com - https://github.com/duckduckgo/privacy-configuration/pull/3096",
                             "community.screwfix.com - https://github.com/duckduckgo/privacy-configuration/pull/4340",
                             "consent-pref.trustarc.com - https://github.com/duckduckgo/privacy-configuration/pull/4340",
-                            "adssettings.google.com - domain propagation from doubleclick.net/ads/preferences/ rule"
+                            "adssettings.google.com - domain propagation from doubleclick.net/ads/preferences/ rule",
+                            "vidbox.dev - domain propagation from doubleclick.net catch-all"
                         ]
                     },
                     {
@@ -1467,12 +1497,14 @@
                         "domains": [
                             "rocketnews24.com",
                             "wunderground.com",
-                            "business-standard.com"
+                            "business-standard.com",
+                            "vidbox.dev"
                         ],
                         "reason": [
                             "rocketnews24.com - https://github.com/duckduckgo/privacy-configuration/issues/846",
                             "wunderground.com - https://github.com/duckduckgo/privacy-configuration/pull/3096",
-                            "business-standard.com - https://github.com/duckduckgo/privacy-configuration/pull/4740"
+                            "business-standard.com - https://github.com/duckduckgo/privacy-configuration/pull/4740",
+                            "vidbox.dev - domain propagation from doubleclick.net catch-all"
                         ]
                     },
                     {
@@ -1488,12 +1520,14 @@
                             "football365.com",
                             "tennis365.com",
                             "cricket365.com",
-                            "golf365.com"
+                            "golf365.com",
+                            "vidbox.dev"
                         ],
                         "reason": [
                             "rocketnews24.com - domain propagation from doubleclick.net catch-all",
                             "wunderground.com - domain propagation from doubleclick.net catch-all",
-                            "teamtalk.com to golf365.com - https://github.com/duckduckgo/privacy-configuration/pull/4971"
+                            "teamtalk.com to golf365.com - https://github.com/duckduckgo/privacy-configuration/pull/4971",
+                            "vidbox.dev - domain propagation from doubleclick.net catch-all"
                         ]
                     },
                     {
@@ -1501,23 +1535,27 @@
                         "domains": [
                             "adssettings.google.com",
                             "rocketnews24.com",
-                            "wunderground.com"
+                            "wunderground.com",
+                            "vidbox.dev"
                         ],
                         "reason": [
                             "adssettings.google.com - https://github.com/duckduckgo/privacy-configuration/pull/5067",
                             "rocketnews24.com - domain propagation from doubleclick.net catch-all",
-                            "wunderground.com - domain propagation from doubleclick.net catch-all"
+                            "wunderground.com - domain propagation from doubleclick.net catch-all",
+                            "vidbox.dev - domain propagation from doubleclick.net catch-all"
                         ]
                     },
                     {
                         "rule": "doubleclick.net",
                         "domains": [
                             "rocketnews24.com",
-                            "wunderground.com"
+                            "wunderground.com",
+                            "vidbox.dev"
                         ],
                         "reason": [
                             "rocketnews24.com - https://github.com/duckduckgo/privacy-configuration/issues/846",
-                            "wunderground.com - https://github.com/duckduckgo/privacy-configuration/pull/3096"
+                            "wunderground.com - https://github.com/duckduckgo/privacy-configuration/pull/3096",
+                            "vidbox.dev - https://github.com/duckduckgo/privacy-configuration/pull/5098"
                         ]
                     }
                 ]
@@ -1923,13 +1961,15 @@
                             "easyjet.com",
                             "worlddutyfree.com",
                             "saplinglearning.com",
-                            "bswift.com"
+                            "bswift.com",
+                            "vidbox.dev"
                         ],
                         "reason": [
                             "doterra.com - For doterra.com/login/loading, the page shows a loading indicator and never redirects.",
                             "easyjet.com - Clicking 'Show Worldwide flights' after entering parameters for a worldwide flight in the flight viewing form does nothing.",
                             "worlddutyfree.com - https://github.com/duckduckgo/privacy-configuration/issues/1380",
-                            "bswift.com - https://github.com/duckduckgo/privacy-configuration/pull/2630"
+                            "bswift.com - https://github.com/duckduckgo/privacy-configuration/pull/2630",
+                            "vidbox.dev - https://github.com/duckduckgo/privacy-configuration/pull/5098"
                         ]
                     },
                     {


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/1200277586140538/task/1214519753987175?focus=true

## Description
### Site breakage mitigation process:
#### Brief explanation
- Reported URL: https://vidbox.dev/
- Problems experienced: Anti-adblock wall triggered by tracker blocking. Also fixed small re-ordering issue in `element-hiding.json`
- Platforms affected:
  - [x] iOS
  - [x] Android
  - [x] Windows
  - [x] MacOS
  - [x] Extensions
- Tracker(s) being unblocked: `google-analytics.com`, `doubleclick.net`
- Feature being disabled/modified: N/A
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds tracker allowlist exceptions for `vidbox.dev` (notably `doubleclick.net` and `google-analytics.com`), which can impact blocking/privacy behavior if overly broad. Element-hiding changes are localized but disabling defaults on `vidbox.dev` could affect ad removal behavior on that site.
> 
> **Overview**
> Mitigates `vidbox.dev` anti-adblock breakage by **allowlisting** `google-analytics.com/analytics.js` and propagating `vidbox.dev` across multiple `doubleclick.net` allowlist rules in `tracker-allowlist.json`.
> 
> Updates `element-hiding.json` domain rules: reorders the `vice.com`/`vinted.fr` entries and adds a new `vidbox.dev` override that **disables default element-hiding** and only hides empty *Sponsored content* containers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de0aeee432175cb6bf1bc4fd2eb6f77aca83d081. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->