### PR TITLE
Update content-blocker extension to 2026.5.5

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -4571,7 +4571,7 @@
             "minSupportedVersion": "0.148.0",
             "exceptions": [],
             "settings": {
-                "extensionUrl": "https://staticcdn.duckduckgo.com/extensions/content-blocker/content-blocker-extension-2026.5.3.crx"
+                "extensionUrl": "https://staticcdn.duckduckgo.com/extensions/content-blocker/content-blocker-extension-2026.5.5.crx"
             },
             "features": {
                 "onboardingEnabled": {


### PR DESCRIPTION
Update content-blocker extension to 2026.5.5.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change that updates the CDN URL for the Windows `adBlockV2Extension` package; main risk is rollout issues if the referenced CRX is missing or incompatible.
> 
> **Overview**
> Updates `overrides/windows-override.json` to bump the `adBlockV2Extension` `extensionUrl` from `content-blocker-extension-2026.5.3.crx` to `content-blocker-extension-2026.5.5.crx`, changing which content-blocker extension build Windows clients download.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 817183ffc7ab5c778af8d3731edb034a9ed2e751. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->