### PR TITLE
Update ad-blocking extension scriptlets for v2026.5.5

### DIFF
--- a/features/ad-blocking-extension.json
+++ b/features/ad-blocking-extension.json
@@ -4,24 +4,24 @@
     },
     "exceptions": [],
     "settings": {
-        "version": "2026.5.3",
+        "version": "2026.5.5",
         "enabledByDefault": false,
         "scriptlets": {
             "scriptlets/isolated/ublock-filters.js": {
                 "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/9ef2ee259997607f891e91448fcbf717e3b9366141b17ee3739bd41bcd7122bc.js",
-                "signature": "MEUCIQChLx4C5CGOuxkT5tETL52A3R/o774Vpa+E1HFEx5HVtAIgQv0x9bwmv8686FJjYxIetPO7O8NAqKTjoe6N/U/wX0M="
+                "signature": "MEUCIBvDVA0YcZA7brG6O/pvIpDTdyWnhZwYdttUXvusjZhkAiEA7y0NHT3EuqDeVhvyqLHEZRm4AMkAKEaTR08AXdVQlvY="
             },
             "scriptlets/main/ublock-filters.js": {
-                "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/e933a69dd186795ebfa0a3f6e86b36862112e4a1c79bcc4bb8797efa1ec2f285.js",
-                "signature": "MEYCIQC46XkDRrt3/+2+NiFst1rb+etbgoN5b4j/IhvoKjbbnwIhAJKtuHlej/5DOcq7PnUnI1543xy2Op2GWjZHHTB+MSXj"
+                "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/dff8b93662f3107f1948383e686078762c2465b28563b1ae73b69cdf14b2bb0d.js",
+                "signature": "MEQCIBspeG3bc0Hi3OzbJZ0Fg/QNhlawvD/DQkDAdx/4UToIAiBypyZY6zR87HM7a1qgeR4Shah79hXaZCPxAltsjlhnYg=="
             },
             "scriptlets/main/ublock-experimental.js": {
                 "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855.js",
-                "signature": "MEUCIQDOuZKvY+DF5+VdiUy26hQ1BSLZrcwUs0guUP8lgHJ0qAIgf+AwXScWq86xiS93S7bqbvobI0/lcMQsCk6lxOR+yw4="
+                "signature": "MEYCIQCodhAqsfV85O3XUrgf2gDYvML5KJn3xLhfOnZo/09jTQIhAMXbRpm4SmG+HRSL+OZa+fi/60nyXjUCwtrncPtL9ISH"
             },
             "scriptlets/isolated/ublock-experimental.js": {
                 "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855.js",
-                "signature": "MEUCIQDvXCvU0xQQvp/uSNddC8474dJoiwykZRRCFo9cxM8tDQIgUq5oI4Qk67Z0VpFT2vtrchy2Wbxnpdsf3PV1Jjk4Yyk="
+                "signature": "MEUCIHcp77Alp7h5ajX+1DnPXFc0uGOfu9l2k7954DHvRBwBAiEAmdNmWBo0ocOLFB6zTWBd7xQNzoP1m2Y43cGRWlce56A="
             }
         }
     }


### PR DESCRIPTION
Update ad-blocking extension scriptlets for v2026.5.5.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk configuration-only change updating CDN URLs and signatures for scriptlet assets; main risk is a bad URL/signature causing scriptlets to fail to load or behavior changes in ad-blocking.
> 
> **Overview**
> Bumps the ad-blocking extension config version to `2026.5.5` and refreshes scriptlet asset references.
> 
> Updates the CDN `url` and/or `signature` entries for the uBlock `filters` and `experimental` scriptlets (both `main` and `isolated` variants) in `features/ad-blocking-extension.json`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1f43714bcbcb54708977b69122c4e5b1ad63f3ec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->