### PR TITLE
Roll nativeRequestInterception out to 15% of stable

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -5318,6 +5318,9 @@
                         "steps": [
                             {
                                 "percent": 5
+                            },
+                            {
+                                "percent": 15
                             }
                         ]
                     }


### PR DESCRIPTION
Bumps the `enableNativeRequestInterception` rollout to 15% of stable by appending a new step:

```diff
 "rollout": {
     "steps": [
         { "percent": 5 }
+      , { "percent": 15 }
     ]
 }
```

Appending a step (rather than replacing the existing one) preserves stickiness for users already sampled at 5% and recruits new users using the conditional probability between the two steps.