### PR TITLE
Fix malformed rendering on apple checkout

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -854,6 +854,21 @@
                 ]
             },
             {
+                "domain": "apple.com",
+                "rules": [
+                    {
+                        "selector": ".rf-paymentoptions-image",
+                        "type": "modify-style",
+                        "values": [
+                            {
+                                "property": "background-image",
+                                "value": "none"
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
                 "domain": "asuracomic.net",
                 "rules": [
                     {


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1206777341262243/task/1214442146838785?focus=true

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a single, domain-scoped element-hiding rule changes only CSS for `apple.com`, with limited blast radius but potential for minor site-specific UI regressions if the selector matches unexpectedly.
> 
> **Overview**
> Fixes malformed rendering on Apple checkout by adding an `apple.com`-scoped element-hiding rule that **removes the `background-image`** from `.rf-paymentoptions-image` via `modify-style`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3f99691e1f024be96d323c7900f43626a85643ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->