### PR TITLE
Enable voice chat entry points in Windows starting in 0.157.0

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -1356,7 +1356,8 @@
                     "state": "internal"
                 },
                 "omnibarVoiceChatAccess": {
-                    "state": "internal"
+                    "state": "enabled",
+                    "minSupportedVersion": "0.157.0"
                 },
                 "ntpImageGeneration": {
                     "state": "enabled",


### PR DESCRIPTION
https://app.asana.com/1/137249556945/project/1209072953775241/task/1213684472445446?focus=true

## Description

Enable voice chat entry points in Windows starting in 0.157.0

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change that flips a Windows feature flag; main risk is unintended exposure of voice chat entry points on versions >= 0.157.0.
> 
> **Overview**
> Enables the Windows `aiChat` subfeature `omnibarVoiceChatAccess`, gating it to clients with `minSupportedVersion` `0.157.0` (previously `internal`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c8ff40dc061a088683e62747d57ab73544d284b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->