### PR TITLE
testing 

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -2173,6 +2173,31 @@
                 ]
             },
             {
+                "domain": "idahonews.com",
+                "rules": [
+                    {
+                        "selector": "[class*='DisplayAd_']",
+                        "type": "closest-empty"
+                    },
+                    {
+                        "selector": "[class*='AdBlock__']",
+                        "type": "closest-empty"
+                    },
+                    {
+                        "selector": "[class*='Taboola']",
+                        "type": "closest-empty"
+                    },
+                    {
+                        "selector": "[class*='openwebAd']",
+                        "type": "hide-empty"
+                    },
+                    {
+                        "selector": "[class*='PrimisMidArticle']",
+                        "type": "closest-empty"
+                    }
+                ]
+            },
+            {
                 "domain": "ieee.org",
                 "rules": [
                     {

--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -731,6 +731,13 @@
                         "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1107"
                     },
                     {
+                        "rule": "cdnjs.cloudflare.com/ajax/libs/fingerprintjs2/",
+                        "domains": [
+                            "<all>"
+                        ],
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1107"
+                    },
+                    {
                         "rule": "cdnjs.cloudflare.com/ajax/libs/fingerprintjs2/1.8.6/fingerprint2.min.js",
                         "domains": [
                             "<all>"
@@ -743,13 +750,6 @@
                             "<all>"
                         ],
                         "reason": "https://github.com/duckduckgo/privacy-configuration/issues/641"
-                    },
-                    {
-                        "rule": "cdnjs.cloudflare.com/ajax/libs/fingerprintjs2/",
-                        "domains": [
-                            "<all>"
-                        ],
-                        "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1107"
                     }
                 ]
             },
@@ -1776,14 +1776,14 @@
             "google.com": {
                 "rules": [
                     {
-                        "rule": "accounts.google.com/o/oauth2/iframerpc",
+                        "rule": "accounts.google.com/o/oauth2/iframe",
                         "domains": [
                             "<all>"
                         ],
                         "reason": "https://github.com/duckduckgo/privacy-configuration/issues/489"
                     },
                     {
-                        "rule": "accounts.google.com/o/oauth2/iframe",
+                        "rule": "accounts.google.com/o/oauth2/iframerpc",
                         "domains": [
                             "<all>"
                         ],
@@ -1986,8 +1986,7 @@
                         "domains": [
                             "speedweek.com",
                             "rocketnews24.com",
-                            "zefoy.com",
-                            "nytimes.com"
+                            "zefoy.com"
                         ],
                         "reason": [
                             "speedweek.com - https://github.com/duckduckgo/privacy-configuration/pull/4579",

--- a/pir/data-broker-rubric.md
+++ b/pir/data-broker-rubric.md
@@ -1,0 +1,91 @@
+# Data Broker Rubric
+
+This rubric represents the rules we use to evaluate whether Personal Information Removal (PIR) can support certain brokers, developed around core rules (like over-sharing personal data to brokers) and core functionality (supported CAPTCHAs, etc).
+
+All past and current broker sites that were and are being evaluated are listed in [Unsupported Data Broker Sites](./unsupported-data-broker-sites.md).
+
+> **Warning**
+> This is a living document, and intended to change over time to reflect the updates we make to the product, and the evolution of the brokers themselves.
+
+## How to Evaluate
+
+The evaluation should center on end-to-end manual scans and removals, confirming the broker is actually honouring them before any code is written.
+
+When testing:
+
+- Ensure you're using **multiple states**, since the CCPA can make the opt-out rules (and thereby the opt-out steps) different.
+- Use a **variety of email domains** including:
+  - Major email providers (Outlook, Gmail, etc.)
+  - Temporary email domains (duck.com)
+  - Custom domains (official for this within DuckDuckGo is TBD)
+- Work through the tiers below. If any required criterion fails, document the reason in [Unsupported Data Broker Sites](./unsupported-data-broker-sites.md).
+
+---
+
+## Tier 1
+
+### Connectivity
+
+| Criterion | Description |
+|---|---|
+| **Broker Loads** | Does the broker URL load in the browser? |
+| **Same Search Domain** | Does a search results page load with the same URL? |
+
+> **Note:** If not the same domain, this is likely a mirror site.
+
+### Search Results
+
+| Criterion | Description |
+|---|---|
+| **Allows Search** | Allows searching people by name, city, state (and optional age) |
+
+> **Note:** PIR only allows searching by name, city, state (and optional age range).
+
+### Opt Out
+
+| Criterion | Description |
+|---|---|
+| **Non-sensitive** | Broker has an opt-out form that only uses non-sensitive information: name, email, city, state, profile URL, or any of the data we can generate (see below) |
+
+PIR can generate the following data for opt-out forms:
+
+- A fake phone number
+- A fake zip code
+- A fake street address
+- A 1x1px fake image
+
+> **Note:** PIR only has limited info about the user and we aren't willing to hand over a lot of user information to data brokers.
+
+---
+
+## Tier 2
+
+### Opt Out
+
+| Criterion | Description |
+|---|---|
+| **Form or Search** | Opt out can be accessed as a standalone page, or by searching with non-sensitive info (name, email, city, state) |
+| **Supported Captcha** | Uses a captcha we support (reCAPTCHA, reCAPTCHA Enterprise) |
+| **Accepts Generated Info** | If the opt out requires a phone number or ID, confirm that a non-valid ID (e.g. 1x1 pixel JPG) works |
+
+> **Note:** PIR only supports reCAPTCHA and reCAPTCHA Enterprise.
+
+> **Note:** PIR generates images and random phone numbers when needed — verify with the broker that these work for opt out.
+
+### Confirmation
+
+| Criterion | Description |
+|---|---|
+| **Sends Confirmation** | If a confirmation email is promised, confirm we actually receive an email |
+| **Confirmation Click** | If the email requires clicking a link, ensure the link actually allows the user to complete the opt out |
+| **Supported Confirmation** | If after clicking the confirmation link the broker requires more info, ensure the info is non-sensitive and uses a supported captcha |
+
+> **Note:** PIR only supports reCAPTCHA and reCAPTCHA Enterprise.
+
+> **Note:** PIR only has limited info about the user and we aren't willing to hand over a lot of user information to data brokers.
+
+### Validation
+
+| Criterion | Description |
+|---|---|
+| **Record Removed** | Confirm that the record is actually removed |

--- a/pir/unsupported-data-broker-sites.md
+++ b/pir/unsupported-data-broker-sites.md
@@ -1,0 +1,26 @@
+# Unsupported Data Broker Sites
+
+## What is this project?
+
+This project contains lists of data broker sites that:
+
+- Are waiting to be tested (**Backlog** section)
+- Were verified positively and are waiting to be supported (**Approved**)
+- Were rejected (**Rejected**)
+
+### Rejection Reasons
+
+| Reason | Description |
+|---|---|
+| **Blind optout** | We can't validate if the data broker has user data (no scanning or paid scanning) |
+| **Broken optout** | We can't opt out as the process is broken right now (e.g. form doesn't load) |
+| **Doesn't comply** | Site allows opt out, but is not performing any data removals |
+| **Partial removal** | Site allows opt out, but doesn't remove all user data (e.g. only address) |
+| **Site dead** | Site doesn't load, redirects elsewhere, or says service was discontinued |
+| **Invalid data broker** | Site doesn't deal with personal data of individuals but rather with data of professionals, vehicles, or companies |
+| **PIR technical limitations** | PIR currently can't support this site due to limitations (e.g. would require sending emails or passing a captcha we don't support) |
+
+## How to evaluate a new data broker site?
+
+Follow instructions in the [Data Broker Rubric](./data-broker-rubric.md).
+


### PR DESCRIPTION
**Asana Task/Github Issue:**

## Description
<!-- 
  Please delete either or both process sections below.
-->

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes tracker allowlisting and site-specific element-hiding behavior, which can impact blocking effectiveness or cause site breakage if selectors/rules are too broad. The added PIR markdown docs are low risk.
> 
> **Overview**
> Adds a new `idahonews.com` entry to `features/element-hiding.json` to remove several ad/recirculation components using `closest-empty`/`hide-empty` selectors.
> 
> Updates `features/tracker-allowlist.json` by broadening the Cloudflare `fingerprintjs2` CDN allowlist rule, reordering/retaining related rules, swapping the two Google OAuth iframe allowlist paths, and removing `nytimes.com` from the `tpc.googlesyndication.com/sodar/sodar2.js` domain list.
> 
> Introduces PIR process documentation via new markdown files: `pir/data-broker-rubric.md` (evaluation criteria) and `pir/unsupported-data-broker-sites.md` (tracking backlog/approved/rejected brokers and rejection reasons).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ffc52fbf84113a972fc7ab73ee54923b9ebc9fb1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->