### PR TITLE
Enable nativeStorage for Preview and omnibarReasoningEffort for Stable

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -1350,10 +1350,12 @@
                     "minSupportedVersion": "0.156.0"
                 },
                 "nativeStorage": {
-                    "state": "internal"
+                    "state": "preview",
+                    "minSupportedVersion": "0.157.0"
                 },
                 "omnibarReasoningEffort": {
-                    "state": "internal"
+                    "state": "enabled",
+                    "minSupportedVersion": "0.157.0"
                 },
                 "omnibarVoiceChatAccess": {
                     "state": "enabled",


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/task/1214292746604586?focus=true

## Description
Enable nativeStorage for Preview and omnibarReasoningEffort for Stable

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes feature flag states for Windows clients, potentially altering storage and omnibar behavior for users on/after `0.157.0`. Scope is limited to config only.
> 
> **Overview**
> Enables additional Duck AI-related capabilities in `overrides/windows-override.json` by updating feature flag states.
> 
> `aiChat.features.nativeStorage` is moved from *internal* to **preview** (gated by `minSupportedVersion: 0.157.0`), and `aiChat.features.omnibarReasoningEffort` is moved from *internal* to **enabled** (also gated by `0.157.0`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 65fefdbf5d0448f6855949c2ec78dd6b8d711eca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->