### PR TITLE
Rollout duck.ai native storage to 5% of users

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -472,12 +472,19 @@
                     "minSupportedVersion": 52760000
                 },
                 "duckAiNativeStorage": {
-                    "state": "internal",
-                    "minSupportedVersion": 52770000
+                    "state": "enabled",
+                    "minSupportedVersion": 52780000,
+                    "rollout": {
+                        "steps": [
+                            {
+                                "percent": 5
+                            }
+                        ]
+                    }
                 },
                 "useNativeStorageChatData": {
-                    "state": "disabled",
-                    "minSupportedVersion": 52770000
+                    "state": "enabled",
+                    "minSupportedVersion": 52780000
                 }
             }
         },


### PR DESCRIPTION
**Asana Task/Github Issue:**https://app.asana.com/1/137249556945/project/72649045549333/task/1214550267233324?focus=true

## Description
Rollout the duck.ai data migration to native for Android to 5% of users.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [x] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [x] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [x] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Enables Duck.ai chat data migration to native storage for a small Android cohort, which can affect persistence and data migration behavior. Risk is limited by a 5% rollout gate but failures could impact chat history integrity for those users.
> 
> **Overview**
> Rolls out Duck.ai native storage on Android by switching `aiChat.features.duckAiNativeStorage` from *internal* to **enabled** with a **5% rollout** and bumping `minSupportedVersion` to `52780000`.
> 
> Also enables `aiChat.features.useNativeStorageChatData` (previously disabled) at `minSupportedVersion` `52780000`, aligning chat data reads/writes with the native storage migration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1f13729ee8043742c70938f047f5de534f5647b9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->