### PR TITLE
Android/Duck.Ai/Voice chat: Enable duck.ai voice chat entry and digital assistant

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -485,6 +485,14 @@
                 "useNativeStorageChatData": {
                     "state": "enabled",
                     "minSupportedVersion": 52780000
+                },
+                "duckAiVoiceEntryPoint": {
+                    "state": "enabled",
+                    "minSupportedVersion": 52780000
+                },
+                "digitalAssistantDuckAi": {
+                    "state": "enabled",
+                    "minSupportedVersion": 52780000
                 }
             }
         },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/task/1214492822707046?focus=true

## Description
Enables the new Duck.Ai voice chat entries and also Voice chat as Digital assistant

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [x] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change that enables two existing feature flags for Android starting at `minSupportedVersion` 52780000; main risk is unintended rollout/UX exposure if the app-side implementation is not fully ready.
> 
> **Overview**
> Enables Duck.ai voice-related functionality in the Android override config by turning on two new `aiChat` sub-features: `duckAiVoiceEntryPoint` and `digitalAssistantDuckAi` (both gated behind `minSupportedVersion` 52780000).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd531a82c8f176a5575dd271e4b1f0fcddf69606. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->