### PR TITLE
AdBlock Analytics Pixel

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -4594,9 +4594,6 @@
                 },
                 "partialLaunch": {
                     "state": "disabled"
-                },
-                "analyticsPixel": {
-                    "state": "disabled"
                 }
             }
         },

--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -4594,6 +4594,9 @@
                 },
                 "partialLaunch": {
                     "state": "disabled"
+                },
+                "analyticsPixel": {
+                    "state": "disabled"
                 }
             }
         },

--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -5292,7 +5292,6 @@
                             "staticAd": true,
                             "buffering": true
                         }
-                        
                     }
                 }
             }

--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -5284,7 +5284,15 @@
                             "signInButton": "a[href*=\"accounts.google.com/ServiceLogin\"]",
                             "avatarButton": "#avatar-btn",
                             "premiumLogo": "ytd-topbar-logo-renderer a[title*=\"Premium\"]"
+                        },
+                        "fireDetectionEvents": {
+                            "adBlocker": true,
+                            "playabilityError": true,
+                            "videoAd": true,
+                            "staticAd": true,
+                            "buffering": true
                         }
+                        
                     }
                 }
             }


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/72649045549333/task/1214097468178147?focus=true

## Description
Added a feature flag just for the pixel being sent, separate from the opt in yet. Default to false as we don't yet know if we want to send this. 

### Feature change process:

- [x] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [x] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk configuration-only change that enables emitting several `youtubeAds` detection events; main risk is increased telemetry/event volume or unexpected downstream handling if consumers assume defaults.
> 
> **Overview**
> Adds `fireDetectionEvents` to the Windows `webInterferenceDetection` `youtubeAds` config, explicitly enabling event firing for `adBlocker`, `playabilityError`, `videoAd`, `staticAd`, and `buffering` detections.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 41ebbe8b15c24df6ab1e3605dd4c0c2f5c2f4cd6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->