### PR TITLE
[MacOS] [Fire Window Subscription Promo] Enable subscriptionPromoFireWindow

### DIFF
--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -2070,6 +2070,16 @@
                 "allowProTierPurchase": {
                     "state": "enabled",
                     "minSupportedVersion": "1.180.0"
+                },
+                "subscriptionPromoFireWindow": {
+                    "state": "enabled",
+                    "minSupportedVersion": "1.189.0",
+                    "targets": [
+                        {
+                            "localeLanguage": "en",
+                            "localeCountry": "US"
+                        }
+                    ]
                 }
             }
         },


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/1211834678943996/task/1213996219850960?focus=true

## Description
Enables the `subscriptionPromoFireWindow` subfeature under `privacyPro` in the macOS override config. This gates the new VPN subscription promo card on the Fire Window home page.

- `state: enabled`
- `minSupportedVersion: 1.189.0` — first macOS release containing the flag (verified: included in `release/macos/1.189.0`, not in `1.188.0`)
- `targets: [{ localeLanguage: "en", localeCountry: "US" }]` — matches the client-side `en_US` locale gate in `SubscriptionPromoViewModel`

Client implementation lives on the apple-browsers branch `htang/macos/Subscription-promo-on-fire-window` (PR #4368). The flag is consumed by `SubscriptionPromoViewModel.init` and `TabCollectionViewModel.append(tab:)`; both default to disabled when the flag is off.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [x] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [x] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.