### PR TITLE
Disables showAIChatAddressBarChoiceScreen on iOS

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -245,7 +245,7 @@
                     "minSupportedVersion": "7.217.0"
                 },
                 "showAIChatAddressBarChoiceScreen": {
-                    "state": "enabled",
+                    "state": "disabled",
                     "minSupportedVersion": "7.187.2",
                     "rollout": {
                         "steps": [


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/1211150618152277/task/1214561883505111?focus=true

## Description
In this PR we're disabling `showAIChatAddressBarChoiceScreen` on iOS.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a config-only change that flips a single iOS feature flag from enabled to disabled, with no code or data-handling changes.
> 
> **Overview**
> Disables the iOS `aiChat.showAIChatAddressBarChoiceScreen` feature flag in `overrides/ios-override.json`, turning the choice screen off for supported app versions while leaving the existing min version and rollout metadata unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f6335676c1433084d5fe3e1b97bc254a1499d035. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->