### PR TITLE
Add adwall mitigations

### DIFF
--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -4294,6 +4294,95 @@
                         "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5010"
                     }
                 ]
+            },
+            "cloudchickens.com": {
+                "rules": [
+                    {
+                        "rule": "cloudchickens.com",
+                        "domains": [
+                            "nbcsports.com"
+                        ],
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5114"
+                    }
+                ]
+            },
+            "haikusoap.com": {
+                "rules": [
+                    {
+                        "rule": "haikusoap.com",
+                        "domains": [
+                            "pagesix.com"
+                        ],
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5114"
+                    }
+                ]
+            },
+            "hamsterspot.com": {
+                "rules": [
+                    {
+                        "rule": "hamsterspot.com",
+                        "domains": [
+                            "billboard.com"
+                        ],
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5114"
+                    }
+                ]
+            },
+            "kindhush.com": {
+                "rules": [
+                    {
+                        "rule": "kindhush.com",
+                        "domains": [
+                            "<all>"
+                        ],
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5114"
+                    }
+                ]
+            },
+            "merequartz.com": {
+                "rules": [
+                    {
+                        "rule": "merequartz.com",
+                        "domains": [
+                            "nbcsports.com",
+                            "pagesix.com"
+                        ],
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5114"
+                    }
+                ]
+            },
+            "phoneresult.com": {
+                "rules": [
+                    {
+                        "rule": "phoneresult.com",
+                        "domains": [
+                            "indiewire.com"
+                        ],
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5114"
+                    }
+                ]
+            },
+            "slimesupplies.net": {
+                "rules": [
+                    {
+                        "rule": "slimesupplies.net",
+                        "domains": [
+                            "rollingstone.com"
+                        ],
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5114"
+                    }
+                ]
+            },
+            "successbuffet.com": {
+                "rules": [
+                    {
+                        "rule": "successbuffet.com",
+                        "domains": [
+                            "variety.com"
+                        ],
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5114"
+                    }
+                ]
             }
         }
     },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/72649045549333/task/1214295430255967?focus=true

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it expands the tracker allowlist, which can reduce blocking protections and may have privacy impact if the new exceptions are overly broad or mis-scoped.
> 
> **Overview**
> Adds new `allowlistedTrackers` entries in `features/tracker-allowlist.json` to mitigate adwall breakage by allowing requests to several additional domains (e.g., `cloudchickens.com`, `haikusoap.com`, `merequartz.com`) on specific publisher sites like `nbcsports.com`, `pagesix.com`, `billboard.com`, `rollingstone.com`, `variety.com`, and `indiewire.com` (plus one `<all>` exception).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d96830d856be0e5c4b6232e2381710fcc53c7f4a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->