### PR TITLE
Mitigate more adwalls

### DIFF
--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -250,6 +250,13 @@
             "adsafeprotected.com": {
                 "rules": [
                     {
+                        "rule": "dt.adsafeprotected.com/dt",
+                        "domains": [
+                            "<all>"
+                        ],
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5116"
+                    },
+                    {
                         "rule": "static.adsafeprotected.com/favicon.ico",
                         "domains": [
                             "tf1info.fr"
@@ -408,12 +415,12 @@
                     {
                         "rule": "aax.amazon-adsystem.com/e/dtb/bid",
                         "domains": [
-                            "cleveland.com",
-                            "foxnews.com"
+                            "<all>"
                         ],
                         "reason": [
                             "cleveland.com - https://github.com/duckduckgo/privacy-configuration/issues/3006",
-                            "foxnews.com - https://github.com/duckduckgo/privacy-configuration/pull/3785"
+                            "foxnews.com - https://github.com/duckduckgo/privacy-configuration/pull/3785",
+                            "<all> - https://github.com/duckduckgo/privacy-configuration/pull/5116"
                         ]
                     },
                     {


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/72649045549333/task/1214295430255967?focus=true

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Widens two tracker allowlist rules to apply to `<all>` sites, which can reduce blocking protections broadly if the patterns are overly permissive or abused.
> 
> **Overview**
> Mitigates additional adwalls by expanding `features/tracker-allowlist.json`.
> 
> Adds a new global allowlist for `adsafeprotected.com` (`dt.adsafeprotected.com/dt`) and broadens the existing `amazon-adsystem.com` allowlist for `aax.amazon-adsystem.com/e/dtb/bid` from specific domains to `<all>`, updating the associated reasons accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a99c4d8089f6fce4bfccbd2d227e8fd8b05dd5a2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->