### PR TITLE
Add exception to un-break parade.com

### DIFF
--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -1358,7 +1358,7 @@
                             "timesofmalta.com - https://github.com/duckduckgo/privacy-configuration/pull/4646",
                             "hawaiiathletics.com - https://github.com/duckduckgo/privacy-configuration/pull/5071",
                             "vidbox.dev - domain propagation from doubleclick.net catch-all",
-                            "parade.com - https://github.com/duckduckgo/privacy-configuration/pull/5117",
+                            "parade.com - https://github.com/duckduckgo/privacy-configuration/pull/5117"
                         ]
                     },
                     {

--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -1282,6 +1282,7 @@
                             "newschannel9.com",
                             "nytimes.com",
                             "okcfox.com",
+                            "parade.com",
                             "raleighcw.com",
                             "realmadrid.com",
                             "repretel.com",
@@ -1356,7 +1357,8 @@
                             "speedweek.com - https://github.com/duckduckgo/privacy-configuration/pull/4579",
                             "timesofmalta.com - https://github.com/duckduckgo/privacy-configuration/pull/4646",
                             "hawaiiathletics.com - https://github.com/duckduckgo/privacy-configuration/pull/5071",
-                            "vidbox.dev - domain propagation from doubleclick.net catch-all"
+                            "vidbox.dev - domain propagation from doubleclick.net catch-all",
+                            "parade.com - https://github.com/duckduckgo/privacy-configuration/pull/5117",
                         ]
                     },
                     {


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/1204912272578138/task/1214533777876606?focus=true

## Description
### Site breakage mitigation process:
#### Brief explanation
- Reported URL: https://parade.com/tv/the-pitt-season-2-sepideh-moafi-ai-robby-relationship-interview
- Problems experienced: An error message is shown when the site loads.
- Platforms affected:
  - [x] iOS
  - [x] Android
  - [x] Windows
  - [x] MacOS
  - [x] Extensions
- Tracker(s) being unblocked: securepubads.g.doubleclick.net/tag/js/gpt.js
- Feature being disabled/modified: N/A
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Expands the tracker allowlist to unblock `securepubads.g.doubleclick.net/tag/js/gpt.js` on `parade.com`, which may increase third-party ad/tracking exposure for that site. Scope is limited to a single domain and one rule entry.
> 
> **Overview**
> Adds `parade.com` to the allowlisted domains for `securepubads.g.doubleclick.net/tag/js/gpt.js` in `features/tracker-allowlist.json` to mitigate site breakage.
> 
> Updates the corresponding `reason` list to include a reference for the new exception (and fixes the JSON list formatting with a trailing comma on the preceding entry).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 63f4dc19174b0f182c5409ce438ea47f49b3a740. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->