### PR TITLE
Add Admiral detector

### DIFF
--- a/features/event-hub.json
+++ b/features/event-hub.json
@@ -51,6 +51,54 @@
                         }
                     }
                 }
+            },
+            "webTelemetry_admiralAdwalls_day": {
+                "state": "enabled",
+                "trigger": {
+                    "period": {
+                        "days": 1
+                    }
+                },
+                "parameters": {
+                    "admiralAdwallCount": {
+                        "template": "counter",
+                        "source": "admiralAdwall",
+                        "buckets": {
+                            "0": { "gte": 0, "lt": 1 },
+                            "1": { "gte": 1, "lt": 2 },
+                            "2-3": { "gte": 2, "lt": 4 },
+                            "4-7": { "gte": 4, "lt": 8 },
+                            "8-14": { "gte": 8, "lt": 15 },
+                            "15-20": { "gte": 15, "lt": 21 },
+                            "21-39": { "gte": 21, "lt": 40 },
+                            "40+": { "gte": 40 }
+                        }
+                    }
+                }
+            },
+            "webTelemetry_admiralAdwalls_week": {
+                "state": "enabled",
+                "trigger": {
+                    "period": {
+                        "days": 7
+                    }
+                },
+                "parameters": {
+                    "admiralAdwallCount": {
+                        "template": "counter",
+                        "source": "admiralAdwall",
+                        "buckets": {
+                            "0": { "gte": 0, "lt": 1 },
+                            "1": { "gte": 1, "lt": 2 },
+                            "2-3": { "gte": 2, "lt": 4 },
+                            "4-7": { "gte": 4, "lt": 8 },
+                            "8-14": { "gte": 8, "lt": 15 },
+                            "15-20": { "gte": 15, "lt": 21 },
+                            "21-39": { "gte": 21, "lt": 40 },
+                            "40+": { "gte": 40 }
+                        }
+                    }
+                }
             }
         }
     }

--- a/features/web-detection.json
+++ b/features/web-detection.json
@@ -197,6 +197,20 @@
                         "op": "add",
                         "path": "/detectors/adwalls/generic_se/actions",
                         "value": { "fireEvent": { "state": "enabled", "type": "adwall" } }
+                    },
+                    {
+                        "op": "add",
+                        "path": "/detectors/adwalls/admiral/triggers",
+                        "value": { "auto": { "state": "enabled", "when": { "intervalMs": [
+                                        500,
+                                        1000,
+                                        5000
+                                    ] } } }
+                    },
+                    {
+                        "op": "add",
+                        "path": "/detectors/adwalls/admiral/actions",
+                        "value": { "fireEvent": { "state": "enabled", "type": "admiralAdwall" } }
                     }
                 ]
             }

--- a/features/web-detection.json
+++ b/features/web-detection.json
@@ -72,6 +72,16 @@
                             ]
                         }
                     }
+                },
+                "admiral": {
+                    "match": {
+                        "text": {
+                            "pattern": [
+                                "contact support"
+                            ],
+                            "selector": "a[href*='forms.gle/6M6VTS3mmHXGbFjM8']"
+                        }
+                    }
                 }
             },
             "commentsDisabled": {
@@ -79,6 +89,19 @@
                     "match": {
                         "text": {
                             "pattern": "comments are turned off"
+                        }
+                    }
+                }
+            },
+            "other": {
+                "dismissible_en": {
+                    "match": {
+                        "text": {
+                            "pattern": [
+                                "Continue to the site",
+                                "Continue without disabling",
+                                "Continue without supporting"
+                            ]
                         }
                     }
                 }


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/72649045549333/task/1214338807623384?focus=true

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new web detector and enables new telemetry aggregations, which can change event volume and downstream analytics if matching is too broad or misfires.
> 
> **Overview**
> Adds a new `adwalls.admiral` detector in `features/web-detection.json` (text+selector match) and wires it into the Android conditional config to auto-trigger checks and fire a new `admiralAdwall` event.
> 
> Extends `features/event-hub.json` with daily and weekly enabled counters (`webTelemetry_admiralAdwalls_day/week`) that bucket and aggregate the new `admiralAdwall` event source for telemetry reporting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8bab358b5811aae91a866ee2cdee440f16cc7397. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->