### PR TITLE
Disable CPM on mumsnet.com on macOS and iOS

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -738,6 +738,10 @@
                 {
                     "domain": "theguardian.com",
                     "reason": "https://github.com/duckduckgo/privacy-configuration/pull/4985"
+                },
+                {
+                    "domain": "mumsnet.com",
+                    "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5119"
                 }
             ],
             "features": {

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -771,6 +771,10 @@
                 {
                     "domain": "newrepublic.com",
                     "reason": "https://github.com/duckduckgo/privacy-configuration/pull/4652"
+                },
+                {
+                    "domain": "mumsnet.com",
+                    "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5119"
                 }
             ],
             "features": {


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/1204912272578138/task/1214600822518478?focus=true

## Description
### Site breakage mitigation process:
#### Brief explanation
- Reported URL: https://www.mumsnet.com/
- Problems experienced: Page occasionally freezes.
- Platforms affected:
  - [x] iOS
  - [ ] Android
  - [ ] Windows
  - [x] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked: N/A
- Feature being disabled/modified: CPM (Cookie Popup Management)
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change that adds a single domain exception; main impact is reduced cookie-popup management coverage on `mumsnet.com` for iOS/macOS users.
> 
> **Overview**
> Adds `mumsnet.com` to the `autoconsent.exceptions` lists in `ios-override.json` and `macos-override.json`, effectively disabling Cookie Popup Management on that site for those platforms to mitigate reported breakage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e4dc201f3aa0aa6dea0a8df0c5b72f0ba7823f5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->