### PR TITLE
User agent override to remove error message on iheart.com

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -1517,6 +1517,10 @@
                     {
                         "domain": "sling.com",
                         "reason": "https://github.com/duckduckgo/privacy-configuration/pull/4465"
+                    },
+                    {
+                        "domain": "iheart.com",
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5121"
                     }
                 ],
                 "ddgDefaultSites": [


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/1206670747178362/task/1214598113017841?focus=true

## Description
### Site breakage mitigation process:
#### Brief explanation
- Reported URL: https://www.iheart.com
- Problems experienced: The site doesn’t load. Instead, a “Load cannot follow more than 20 redirections” error message appears.
- Platforms affected:
  - [x] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked: N/A
- Feature being disabled/modified: Disabling the custom user agent.
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change that only alters iOS user-agent override behavior for a single domain (`iheart.com`). Main risk is unintended site-compat impact limited to that site.
> 
> **Overview**
> Adds `iheart.com` to the iOS `customUserAgent` override exceptions (`ddgFixedSites`) so requests to that domain no longer follow the default custom user-agent policy, mitigating the redirect error reported on iheart.com.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc813b0c6ee72f56283d4d164bad158f44c5bd95. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->