### PR TITLE
Update content-blocker extension to 2026.5.8

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -4574,7 +4574,7 @@
             "minSupportedVersion": "0.148.0",
             "exceptions": [],
             "settings": {
-                "extensionUrl": "https://staticcdn.duckduckgo.com/extensions/content-blocker/content-blocker-extension-2026.5.3.crx"
+                "extensionUrl": "https://staticcdn.duckduckgo.com/extensions/content-blocker/content-blocker-extension-2026.5.8.crx"
             },
             "features": {
                 "onboardingEnabled": {


### PR DESCRIPTION
Update content-blocker extension to 2026.5.8.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: single configuration change that updates the packaged content-blocker extension URL; main impact is potential runtime behavior differences from the new extension build.
> 
> **Overview**
> Updates the Windows override configuration to point `adBlockV2Extension.settings.extensionUrl` at the `content-blocker-extension-2026.5.8.crx` build (from `2026.5.3`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 028b8eb41366d33b29696a430d5e0c2e9334b54d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->