### PR TITLE
Update ad-blocking extension scriptlets for v2026.5.8

### DIFF
--- a/features/ad-blocking-extension.json
+++ b/features/ad-blocking-extension.json
@@ -4,24 +4,24 @@
     },
     "exceptions": [],
     "settings": {
-        "version": "2026.5.3",
+        "version": "2026.5.8",
         "enabledByDefault": false,
         "scriptlets": {
             "scriptlets/isolated/ublock-filters.js": {
                 "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/9ef2ee259997607f891e91448fcbf717e3b9366141b17ee3739bd41bcd7122bc.js",
-                "signature": "MEUCIQChLx4C5CGOuxkT5tETL52A3R/o774Vpa+E1HFEx5HVtAIgQv0x9bwmv8686FJjYxIetPO7O8NAqKTjoe6N/U/wX0M="
+                "signature": "MEUCIF29f3XY7GA8VgB9UbCzUG++LxwCsHdFbjaJAsywdvHEAiEAxvB54M+38SoexE9Udj/ba+zTTg/Q8mSg3fYn0DIzuMQ="
             },
             "scriptlets/main/ublock-filters.js": {
-                "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/e933a69dd186795ebfa0a3f6e86b36862112e4a1c79bcc4bb8797efa1ec2f285.js",
-                "signature": "MEYCIQC46XkDRrt3/+2+NiFst1rb+etbgoN5b4j/IhvoKjbbnwIhAJKtuHlej/5DOcq7PnUnI1543xy2Op2GWjZHHTB+MSXj"
+                "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/75d3e03a27ebf119537fcdc94735d98355f495d5cb1cf1a76d7f26fe16874df6.js",
+                "signature": "MEYCIQDfnpczIJJtjrTXBUgo18PeIG6UFmWF/O1KfpdbbRyq8gIhAOYASdN/jSGA5d/UxALzicWks2omLK8fd22Vv4CeHMwi"
             },
             "scriptlets/main/ublock-experimental.js": {
                 "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855.js",
-                "signature": "MEUCIQDOuZKvY+DF5+VdiUy26hQ1BSLZrcwUs0guUP8lgHJ0qAIgf+AwXScWq86xiS93S7bqbvobI0/lcMQsCk6lxOR+yw4="
+                "signature": "MEYCIQCDwOT4aNfrOfbVdJxMZrjyRRpm9WRb2gf9xE4le7UhUwIhAPFkBT/lPa6Tx915NpcGELtwXUaK4HgT7l/qOtIqBP2x"
             },
             "scriptlets/isolated/ublock-experimental.js": {
                 "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855.js",
-                "signature": "MEUCIQDvXCvU0xQQvp/uSNddC8474dJoiwykZRRCFo9cxM8tDQIgUq5oI4Qk67Z0VpFT2vtrchy2Wbxnpdsf3PV1Jjk4Yyk="
+                "signature": "MEUCIQDx68lVUgkK/u5ZuDzmffVccmfjhatnXKkPOghpKWyCBAIgbFo/UqyjJf3bi+ymJuxzErsT1TyuYxLlSe1WQh0XFY8="
             }
         }
     }


### PR DESCRIPTION
Update ad-blocking extension scriptlets for v2026.5.8.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates version metadata and CDN URLs/signatures for scriptlet assets; no code or logic changes in-repo.
> 
> **Overview**
> Updates `features/ad-blocking-extension.json` to **v2026.5.8**, including refreshed CDN `url` and `signature` values for the uBlock scriptlets (notably `scriptlets/main/ublock-filters.js` and updated signatures for the other entries).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef0b49d8d201d602ff68d87026325368b7a7e6c6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->