### PR TITLE
Enable new tab progress for Windows in stable

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -4834,17 +4834,17 @@
         },
         "tabProgressIndicator": {
             "minSupportedVersion": "0.151.0",
-            "state": "preview",
+            "state": "enabled",
             "exceptions": []
         },
         "tabLabelTransition": {
             "minSupportedVersion": "0.155.0",
-            "state": "preview",
+            "state": "enabled",
             "exceptions": []
         },
         "faviconTransitions": {
             "minSupportedVersion": "0.155.0",
-            "state": "preview",
+            "state": "enabled",
             "exceptions": []
         },
         "tabNavigationHistoryRestore": {


### PR DESCRIPTION
**Asana Task/Github Issue:**

## Description
<!-- 
  Please delete either or both process sections below.
-->

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a config-only change that flips Windows feature flags from `preview` to `enabled` without touching runtime code paths beyond feature gating.
> 
> **Overview**
> **Enables several tab UI enhancements on Windows stable** by switching `tabProgressIndicator`, `tabLabelTransition`, and `faviconTransitions` in `overrides/windows-override.json` from `preview` to `enabled` (with the same minimum supported versions and no new exceptions).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b7b207af2b2f88891ceb2ecfb9e523e5829fd573. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->