### PR TITLE
Add more adwall mitigations

### DIFF
--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -4392,6 +4392,28 @@
                         "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5114"
                     }
                 ]
+            },
+            "oceancloudhosts.com": {
+                "rules": [
+                    {
+                        "rule": "oceancloudhosts.com",
+                        "domains": [
+                            "nationalpost.com"
+                        ],
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5127"
+                    }
+                ]
+            },
+            "toolforthought.com": {
+                "rules": [
+                    {
+                        "rule": "toolforthought.com",
+                        "domains": [
+                            "deadline.com"
+                        ],
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5127"
+                    }
+                ]
             }
         }
     },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/72649045549333/task/1214295430255967?focus=true

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk configuration-only change that broadens allowlisting for two trackers, which could slightly reduce blocking coverage on the specified sites.
> 
> **Overview**
> Adds new `allowlistedTrackers` rules in `features/tracker-allowlist.json` for `oceancloudhosts.com` on `nationalpost.com` and `toolforthought.com` on `deadline.com` (referencing PR `#5127`) to mitigate adwall-related site breakage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd1d7dc9d13a10b94b484a38606a78bbd839d407. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->