### PR TITLE
Disable GPC on petsplace.nl

### DIFF
--- a/features/gpc.json
+++ b/features/gpc.json
@@ -9,10 +9,6 @@
             "reason": "https://github.com/duckduckgo/privacy-configuration/issues/700"
         },
         {
-            "domain": "costco.com",
-            "reason": "https://github.com/duckduckgo/privacy-configuration/issues/644"
-        },
-        {
             "domain": "espn.com",
             "reason": "https://github.com/duckduckgo/privacy-configuration/issues/2003"
         },

--- a/features/gpc.json
+++ b/features/gpc.json
@@ -95,6 +95,10 @@
         {
             "domain": "hawaiiathletics.com",
             "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5071"
+        },
+        {
+            "domain": "petsplace.nl",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5128"
         }
     ],
     "settings": {


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/1206670747178362/task/1214471238254436?focus=true

## Description
### Site breakage mitigation process:
#### Brief explanation
- Reported URL: https://www.petsplace.nl/
- Problems experienced: Dark overlay preventing interaction with the site, caused by GPC and cookie popup mishandling. Disabling CPM (Cookie Popup Management) doesn’t work, but disabling GPC (Global Privacy Control) does.
- Platforms affected:
  - [x] iOS
  - [x] Android
  - [x] Windows
  - [x] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked: N/A
- Feature being disabled/modified: GPC (Global Privacy Control)
- [ ] This change is a speculative mitigation to fix reported breakage.
- Note: Also removed a no-longer-needed GPC exception from three years ago (tested as working now).


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change that adjusts where GPC is disabled; impact is limited to GPC behavior on the affected domains.
> 
> **Overview**
> Updates `features/gpc.json` GPC exceptions by **adding** `petsplace.nl` to disable GPC for reported site breakage.
> 
> Also **removes** the previous `costco.com` GPC exception, indicating it’s no longer needed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f30a15963dba3b255941749ccf9f7ff30eb59e6e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->