### PR TITLE
Added notebookcheck.com alongside notebookcheck.net mitigation

### DIFF
--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -2433,7 +2433,7 @@
                         ],
                         "reason": [
                             "notebookcheck.net - https://github.com/duckduckgo/privacy-configuration/pull/5090",
-                            "notebookcheck.net - https://github.com/duckduckgo/privacy-configuration/pull/5129"
+                            "notebookcheck.com - https://github.com/duckduckgo/privacy-configuration/pull/5129"
                         ]
                     }
                 ]

--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -2428,9 +2428,13 @@
                     {
                         "rule": "html-load.com",
                         "domains": [
-                            "notebookcheck.net"
+                            "notebookcheck.net",
+                            "notebookcheck.com"
                         ],
-                        "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5090"
+                        "reason": [
+                            "notebookcheck.net - https://github.com/duckduckgo/privacy-configuration/pull/5090",
+                            "notebookcheck.net - https://github.com/duckduckgo/privacy-configuration/pull/5129"
+                        ]
                     }
                 ]
             },


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/1206670747178362/task/1214486294551304?focus=true

## Description
### Site breakage mitigation process:
#### Brief explanation
- Reported URL: https://www.notebookcheck.com/
- Problems experienced: Anti-adblock wall, triggered by tracker blocking. Making an exception for the whole domain because of multiple subdomains and files being required by the site. Same approach as #5090 
- Platforms affected:
  - [x] iOS
  - [x] Android
  - [x] Windows
  - [x] MacOS
  - [x] Extensions
- Tracker(s) being unblocked: html-load.com
- Feature being disabled/modified: N/A
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Expands a tracker allowlist exception to an additional domain, which can increase tracking surface if applied too broadly or if the rule matches more requests than intended.
> 
> **Overview**
> Extends the existing `html-load.com` allowlist mitigation to also apply to `notebookcheck.com` (in addition to `notebookcheck.net`) to address site breakage/anti-adblock behavior.
> 
> Updates the rule metadata to record separate justification links per domain by switching `reason` from a single string to a list.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 39978ca14752990b03422c43b8d9acbebf6f6c47. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->