### PR TITLE
Hide anti-adblock wall on stereogum.com

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -3758,6 +3758,15 @@
                 ]
             },
             {
+                "domain": "stereogum.com",
+                "rules": [
+                    {
+                        "selector": ".AdBlockerGate_overlay__QTKtp",
+                        "type": "hide"
+                    }
+                ]
+            },
+            {
                 "domain": "statesman.com",
                 "rules": [
                     {

--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -3758,19 +3758,19 @@
                 ]
             },
             {
+                "domain": "statesman.com",
+                "rules": [
+                    {
+                        "type": "disable-default"
+                    }
+                ]
+            },
+            {
                 "domain": "stereogum.com",
                 "rules": [
                     {
                         "selector": ".AdBlockerGate_overlay__QTKtp",
                         "type": "hide"
-                    }
-                ]
-            },
-            {
-                "domain": "statesman.com",
-                "rules": [
-                    {
-                        "type": "disable-default"
                     }
                 ]
             },

--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -3769,7 +3769,7 @@
                 "domain": "stereogum.com",
                 "rules": [
                     {
-                        "selector": ".AdBlockerGate_overlay__QTKtp",
+                        "selector": "[class*='AdBlockerGate_overlay']",
                         "type": "hide"
                     }
                 ]


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/1200277586140538/task/1214684195300088?focus=true

## Description
### Site breakage mitigation process:
#### Brief explanation
- Reported URL: https://stereogum.com/
- Problems experienced: Anti-adblock wall triggered by tracker blocking. Need to use `hide` because the element contains text.
- Platforms affected:
  - [x] iOS
  - [x] Android
  - [x] Windows
  - [x] MacOS
  - [x] Extensions
- Tracker(s) being unblocked: N/A
- Feature being disabled/modified: Element hiding
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change that adds a domain-scoped element-hiding rule; potential risk is limited to unintended hiding/layout impact on `stereogum.com` if the selector is too broad.
> 
> **Overview**
> Adds a `stereogum.com` exception to `features/element-hiding.json` to hide the site’s anti-adblock overlay (`[class*='AdBlockerGate_overlay']`), mitigating the adblock wall triggered by tracker blocking.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2200ae3a67d83b47f34834d6ceb7bad14511a3d8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->