### PR TITLE
Enable progressBarUpgrade and update minSupportedVersion

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -4169,26 +4169,13 @@
             "minSupportedVersion": 52720000
         },
         "progressBarUpgrade": {
-            "state": "disabled",
-            "minSupportedVersion": 52760000,
+            "state": "enabled",
+            "minSupportedVersion": 52781000,
             "exceptions": [],
             "features": {
                 "behaviourUpdate": {
-                    "state": "disabled",
-                    "minSupportedVersion": 52760000,
-                    "rollout": {
-                        "steps": [
-                            {
-                                "percent": 10
-                            },
-                            {
-                                "percent": 50
-                            },
-                            {
-                                "percent": 100
-                            }
-                        ]
-                    }
+                    "state": "enabled",
+                    "minSupportedVersion": 52781000,
                 }
             }
         },

--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -4175,7 +4175,7 @@
             "features": {
                 "behaviourUpdate": {
                     "state": "enabled",
-                    "minSupportedVersion": 52781000,
+                    "minSupportedVersion": 52781000
                 }
             }
         },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1202552961248957/task/1214172338559653

## Description
Re-enabled after bugfix in 5.278.1 is rolled out to 100%

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [x] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [x] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Enables a previously disabled Android feature flag, which could affect user-visible UI/behavior for all clients at/above the new minimum app version. Risk is mitigated by gating to `minSupportedVersion` 52781000 but still broad once clients upgrade.
> 
> **Overview**
> Re-enables the Android `progressBarUpgrade` feature (and its `behaviourUpdate` subfeature) by switching their `state` to `enabled`.
> 
> Raises the `minSupportedVersion` gate from `52760000` to `52781000` and removes the prior stepped rollout configuration, making the feature fully on for supported versions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb485eb09c3132b1d4360723cfa2fb1783a114f3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->