### PR TITLE
Add more adwall detection patterns

### DIFF
--- a/features/web-detection.json
+++ b/features/web-detection.json
@@ -79,7 +79,11 @@
                             "pattern": [
                                 "contact support"
                             ],
-                            "selector": "a[href*='forms.gle/6M6VTS3mmHXGbFjM8']"
+                            "selector": [
+                                "a[href*='forms.gle/6M6VTS3mmHXGbFjM8']",
+                                "a[href^='http://forms.gle/6M6VTS3mmHXGbFjM8']",
+                                "a[href^='https://forms.gle/6M6VTS3mmHXGbFjM8']"
+                            ]
                         }
                     }
                 }


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/72649045549333/task/1214338807623384?focus=true

## Description
<!-- 
  Please delete either or both process sections below.
-->

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Low-scope config-only change, but it changes `selector` from a string to an array for the `adwalls.admiral` detector, which could break consumers if they assume a single selector value.
> 
> **Overview**
> Expands the `adwalls.admiral` detection rule in `features/web-detection.json` by allowing multiple link selectors for the same “contact support” text, covering `forms.gle` URLs matched via substring and explicit `http://`/`https://` prefixes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 79d56a3ebdfca7c7c8b0becac8ea200360d6f833. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->