### PR TITLE
Enables showAIChatAddressBarChoiceScreen on iOS 7.220.0

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -245,8 +245,8 @@
                     "minSupportedVersion": "7.217.0"
                 },
                 "showAIChatAddressBarChoiceScreen": {
-                    "state": "disabled",
-                    "minSupportedVersion": "7.187.2",
+                    "state": "enabled",
+                    "minSupportedVersion": "7.220.0",
                     "rollout": {
                         "steps": [
                             {


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/1211150618152277/task/1214606799286483

## Description
This PR enables the FF `showAIChatAddressBarChoiceScreen` on iOS, whenever the version is >= 7.220.0.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Enables a user-facing AI Chat choice screen on iOS via remote configuration; while scoped by `minSupportedVersion` and gradual rollout, it can affect onboarding/address bar UX for eligible users.
> 
> **Overview**
> **Enables the `aiChat.showAIChatAddressBarChoiceScreen` feature flag for iOS.**
> 
> The iOS override now sets this flag to `enabled` and bumps its `minSupportedVersion` to `7.220.0`, keeping the existing staged rollout percentages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 16b695ed741136cb47088deba7e53eabf857db1a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->