### PR TITLE
Disable device enumeration google meet and teams

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -4243,6 +4243,16 @@
                                 }
                             }
                         ]
+                    },
+                    {
+                        "domain": "meet.google.com",
+                        "patchSettings": [
+                            {
+                                "op": "replace",
+                                "path": "/enumerateDevices",
+                                "value": "disabled"
+                            }
+                        ]
                     }
                 ]
             }

--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -4253,6 +4253,16 @@
                                 "value": "disabled"
                             }
                         ]
+                    },
+                    {
+                        "domain": "teams.microsoft.com",
+                        "patchSettings": [
+                            {
+                                "op": "replace",
+                                "path": "/enumerateDevices",
+                                "value": "disabled"
+                            }
+                        ]
                     }
                 ]
             }


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/task/1214683287286981?focus=true

## Description
<!-- 
  Please delete either or both process sections below.
-->

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes `enumerateDevices` behavior for two major video-conferencing domains, which could impact camera/mic selection or call setup if the mitigation is too broad.
> 
> **Overview**
> Updates Windows `webCompat` overrides to **disable `enumerateDevices`** specifically on `meet.google.com` and `teams.microsoft.com` via domain-scoped `patchSettings`, while leaving the global setting unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b2508a03b5014f215032676d6dec7e52b4d52c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1214683287286981