### PR TITLE
Add cpm exception for doublelist.com

### DIFF
--- a/features/autoconsent.json
+++ b/features/autoconsent.json
@@ -830,6 +830,10 @@
         {
             "domain": "milesplit.live",
             "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5079"
+        },
+        {
+            "domain": "doublelist.com",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5137"
         }
     ],
     "settings": {


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1206670747178362/task/1213975538486298?focus=true

### Site breakage mitigation process:
#### Brief explanation
- Reported URL: doublelist.com
- Problems experienced: CPM mistakenly handles age-verification pop-up
- Platforms affected:
  - [x] iOS
  - [x] Android
  - [x] Windows
  - [x] MacOS
  - [ ] Extensions
- Feature being disabled/modified: autoconsent