### PR TITLE
[iOS] Enable fire mode to 25% of users

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -2595,6 +2595,9 @@
                         "steps": [
                             {
                                 "percent": 10
+                            },
+                            {
+                                "percent": 25
                             }
                         ]
                     }


### PR DESCRIPTION
**Asana Task/Github Issue: https://app.asana.com/1/137249556945/project/1211767540372501/task/1214227958592924**

## Description
Enabling the fire mode feature for 25% of users.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change that expands `fireMode` feature exposure on iOS; main risk is increased user-facing impact if the feature has issues at scale.
> 
> **Overview**
> Expands the iOS `fireMode` feature rollout in `ios-override.json` by adding a new 25% rollout step (up from a single 10% step), keeping the same `minSupportedVersion` (`7.218.0`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 217a678d6e93787a68d8ea022d39ccc304d01e46. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->