### PR TITLE
play video by displaying cookie banner on hillsdale.edu 

### DIFF
--- a/features/autoconsent.json
+++ b/features/autoconsent.json
@@ -834,6 +834,10 @@
         {
             "domain": "doublelist.com",
             "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5137"
+        },
+        {
+            "domain": "hillsdale.edu",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5140"
         }
     ],
     "settings": {


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1206670747178362/task/1214682671954764?focus=true

## Description

### Site breakage mitigation process:
#### Brief explanation
- Reported URL: https://livestream.hillsdale.edu/
- Problems experienced: all cookies are required for video to play. adding a cpm exception displays the cookie banner for the user to choose its cookies setting.
- Platforms affected:
  - [ x] iOS
  - [x ] Android
  - [x ] Windows
  - [x ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked: NA
- Feature being disabled/modified: autoconsent
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change that disables autoconsent for `hillsdale.edu`; impact is limited to this domain but could reduce automatic cookie rejection there.
> 
> **Overview**
> Adds `hillsdale.edu` to the `features/autoconsent.json` `exceptions` list, effectively disabling autoconsent on that site so the cookie banner is shown and users can choose settings (mitigating reported livestream playback breakage).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 674d021be3b630825e2df32572389376f7abfe87. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->