### PR TITLE
Add Admiral experiment at 25%

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -186,6 +186,31 @@
                             "weight": 1
                         }
                     ]
+                },
+                "tdsNextExperiment009": {
+                    "state": "enabled",
+                    "minSupportedVersion": 52361000,
+                    "rollout": {
+                        "steps": [
+                            {
+                                "percent": 25
+                            }
+                        ]
+                    },
+                    "settings": {
+                        "controlUrl": "v5/experiments/202605adm01-android-tds-control.json",
+                        "treatmentUrl": "v5/experiments/202605adm01-android-tds-treatment.json"
+                    },
+                    "cohorts": [
+                        {
+                            "name": "control",
+                            "weight": 1
+                        },
+                        {
+                            "name": "treatment",
+                            "weight": 1
+                        }
+                    ]
                 }
             }
         },

--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -577,6 +577,30 @@
                             "weight": 1
                         }
                     ]
+                },
+                "tdsNextExperiment009": {
+                    "state": "enabled",
+                    "rollout": {
+                        "steps": [
+                            {
+                                "percent": 25
+                            }
+                        ]
+                    },
+                    "settings": {
+                        "controlUrl": "v5/experiments/202605adm01-ios-tds-control.json",
+                        "treatmentUrl": "v5/experiments/202605adm01-ios-tds-treatment.json"
+                    },
+                    "cohorts": [
+                        {
+                            "name": "control",
+                            "weight": 1
+                        },
+                        {
+                            "name": "treatment",
+                            "weight": 1
+                        }
+                    ]
                 }
             }
         },

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -587,6 +587,30 @@
                             "weight": 1
                         }
                     ]
+                },
+                "tdsNextExperiment009": {
+                    "state": "enabled",
+                    "rollout": {
+                        "steps": [
+                            {
+                                "percent": 25
+                            }
+                        ]
+                    },
+                    "settings": {
+                        "controlUrl": "v6/experiments/202605adm01-macos-tds-control.json",
+                        "treatmentUrl": "v6/experiments/202605adm01-macos-tds-treatment.json"
+                    },
+                    "cohorts": [
+                        {
+                            "name": "control",
+                            "weight": 1
+                        },
+                        {
+                            "name": "treatment",
+                            "weight": 1
+                        }
+                    ]
                 }
             }
         },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/72649045549333/task/1214295430255973?focus=true

## Description

Releases Admiral experiment at 25%

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes privacy configuration to enable a new `tdsNextExperiment009` rollout, which can alter tracker/blocklist behavior for a subset of users across platforms.
> 
> **Overview**
> **Enables a new Admiral blocklist experiment** by adding `tdsNextExperiment009` under `blockList` in the Android, iOS, and macOS override configs.
> 
> The experiment is **turned on with a 25% rollout** and points control/treatment cohorts to new `202605adm01` experiment URLs (with Android also gating on `minSupportedVersion: 52361000`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 14a35a2475a2bb4fb5dd3d3c8284f80eebd561b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->