### PR TITLE
Disable device enumeration for teams.live.com and teams.cloud.microsoft

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -4266,6 +4266,26 @@
                                 "value": "disabled"
                             }
                         ]
+                    },
+                    {
+                        "domain": "teams.live.com",
+                        "patchSettings": [
+                            {
+                                "op": "replace",
+                                "path": "/enumerateDevices",
+                                "value": "disabled"
+                            }
+                        ]
+                    },
+                    {
+                        "domain": "teams.cloud.microsoft",
+                        "patchSettings": [
+                            {
+                                "op": "replace",
+                                "path": "/enumerateDevices",
+                                "value": "disabled"
+                            }
+                        ]
                     }
                 ]
             }


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/949243614371883/task/1214683287286981?focus=true

## Description
Extends the `enumerateDevices` fix from #5136 to cover additional Microsoft Teams domains:

- `teams.live.com`
- `teams.cloud.microsoft`

Both domains get the same `patchSettings` as `teams.microsoft.com` — replacing `enumerateDevices` with `disabled` in the Windows `webCompat` override.

**Asana Task:** OPS-7183

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Small, targeted config change, but it alters media device enumeration behavior on Microsoft Teams domains and could impact calling/device selection if mis-scoped.
> 
> **Overview**
> Extends the Windows `webCompat` override that disables `enumerateDevices` to also apply to `teams.live.com` and `teams.cloud.microsoft`, matching the existing behavior for `teams.microsoft.com`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e2e599bc8596a055e151777bf45dfe573f48ac0d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->