### PR TITLE
Disable AI recent chats on Windows to mitigate COMException

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -1314,7 +1314,7 @@
                     "minSupportedVersion": "0.152.0"
                 },
                 "suggestions": {
-                    "state": "enabled",
+                    "state": "internal",
                     "minSupportedVersion": "0.155.0"
                 },
                 "suggestionsDeletion": {
@@ -1322,7 +1322,7 @@
                     "minSupportedVersion": "0.155.0"
                 },
                 "ntpRecentChats": {
-                    "state": "enabled",
+                    "state": "internal",
                     "minSupportedVersion": "0.155.0"
                 },
                 "imageGeneration": {


### PR DESCRIPTION
https://app.asana.com/0/949243614371883/1214692955995383

## Description

Disable AI recent chats on Windows to mitigate COMException



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change that gates AI Chat UI features on Windows; main impact is reduced functionality if these entry points were expected to be enabled.
> 
> **Overview**
> Updates `overrides/windows-override.json` to **gate Windows AI Chat entry points** by changing the `aiChat` sub-features `suggestions` and `ntpRecentChats` from `enabled` to `internal` (min versions unchanged), effectively disabling those surfaces for normal Windows releases to mitigate the reported COMException.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0de0c8e5304a0887dcfc07520fc273c12e5ce869. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->