### PR TITLE
Update autoconsent to v14.79.0

### DIFF
--- a/features/autoconsent.json
+++ b/features/autoconsent.json
@@ -1802,7 +1802,7 @@
                 "div.b-cookies-informer",
                 "div.b-cookies-informer__nav > button:nth-child(1)",
                 "body > div#cookieChoiceInfo > div:nth-child(2)#cookieButtonBar > a:nth-child(2)#cookieChoiceRefuse",
-                "[status=open]:has([aria-label=\"Privacy Disclosure\"])",
+                "div[role=\"dialog\"][aria-label^=\"Privacy Disclosure\"]",
                 "div.b-cookies-informer__switchers",
                 "div.b-cookies-informer__switchers input:not([disabled])",
                 "div.b-cookies-informer__nav > button",
@@ -2275,7 +2275,9 @@
                 "body > div#cookieNotice > span:not([id])",
                 "#react-consent-modal",
                 "#react-consent-modal .flex.flex-column",
-                "#react-consent-modal .flex.flex-row.justify-between button:first-child"
+                "#react-consent-modal .flex.flex-row.justify-between button:first-child",
+                "cookie-banner#cookie-banner-host",
+                "groups=C1%3A1%2CC3%3A0"
             ],
             "r": [
                 [
@@ -26055,6 +26057,39 @@
                 ],
                 [
                     1,
+                    "hearst-us",
+                    1,
+                    "^https://(www\\.)?(menshealth|womenshealthmag|cosmopolitan|esquire|elle|elledecor|harpersbazaar|goodhousekeeping|popularmechanics|caranddriver|delish|veranda|roadandtrack|bestproducts|countryliving|housebeautiful|bicycling|biography|pitchfork|prevention|runnersworld|thepioneerwoman|townandcountrymag)\\.com/",
+                    10,
+                    [
+                        952
+                    ],
+                    [
+                        {
+                            "e": 952
+                        }
+                    ],
+                    [
+                        {
+                            "check": "any",
+                            "v": 952
+                        }
+                    ],
+                    [
+                        {
+                            "h": 952
+                        }
+                    ],
+                    [
+                        {
+                            "check": "none",
+                            "v": 952
+                        }
+                    ],
+                    {}
+                ],
+                [
+                    1,
                     "hetzner.com",
                     2,
                     "^https://www\\.hetzner\\.com/",
@@ -27877,6 +27912,57 @@
                 ],
                 [
                     1,
+                    "volvocars-com",
+                    2,
+                    "^https://([a-z0-9-]+\\.)?volvocars\\.com/",
+                    10,
+                    [
+                        1426
+                    ],
+                    [
+                        {
+                            "exists": [
+                                "cookie-banner#cookie-banner-host",
+                                "#dialog_cookie_consent"
+                            ]
+                        }
+                    ],
+                    [
+                        {
+                            "visible": [
+                                "cookie-banner#cookie-banner-host",
+                                "#dialog_cookie_consent"
+                            ]
+                        }
+                    ],
+                    [
+                        {
+                            "wait": 500
+                        },
+                        {
+                            "waitForThenClick": [
+                                "cookie-banner#cookie-banner-host",
+                                "#onetrust-reject-all-handler"
+                            ]
+                        },
+                        {
+                            "waitForVisible": [
+                                "cookie-banner#cookie-banner-host",
+                                "#dialog_cookie_consent"
+                            ],
+                            "check": "none",
+                            "timeout": 5000
+                        }
+                    ],
+                    [
+                        {
+                            "cc": 1427
+                        }
+                    ],
+                    {}
+                ],
+                [
+                    1,
                     "wikiwand",
                     1,
                     "^https://(www\\.)?wikiwand\\.com/",
@@ -27897,33 +27983,6 @@
                     [
                         {
                             "h": 947
-                        }
-                    ],
-                    [],
-                    {}
-                ],
-                [
-                    1,
-                    "womenshealthmag-us",
-                    1,
-                    "^https://(www\\.)?womenshealthmag\\.com/",
-                    10,
-                    [
-                        952
-                    ],
-                    [
-                        {
-                            "e": 952
-                        }
-                    ],
-                    [
-                        {
-                            "v": 952
-                        }
-                    ],
-                    [
-                        {
-                            "h": 952
                         }
                     ],
                     [],
@@ -28143,7 +28202,7 @@
                 ],
                 "specificRuleRange": [
                     185,
-                    755
+                    756
                 ],
                 "genericStringEnd": 717,
                 "frameStringEnd": 752


### PR DESCRIPTION
Asana Task/Github Issue: https://app.asana.com/1/137249556945/project/1201844467387842/task/1214725200679035

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Config-only changes, but they modify site-specific autoconsent matching/click behavior; incorrect selectors or rules could break consent handling on affected domains.
> 
> **Overview**
> Updates `features/autoconsent.json` rule set (v14.79.0) by tweaking generic matchers/selectors (notably replacing the `Privacy Disclosure` selector) and adding new generic signals like `cookie-banner#cookie-banner-host` and a `groups=...` cookie value.
> 
> Adds/adjusts site-specific autoconsent rules, including a consolidated `hearst-us` rule for multiple Hearst domains and a new `volvocars-com` flow that waits for/targets an OneTrust “reject all” action, and bumps the `specificRuleRange` index to account for the new entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dafcf4ccd72127c35f1a4516904a0a3de0acd665. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->