### PR TITLE
Disable CPM on paireyewear.com

### DIFF
--- a/features/autoconsent.json
+++ b/features/autoconsent.json
@@ -838,6 +838,10 @@
         {
             "domain": "hillsdale.edu",
             "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5140"
+        },
+        {
+            "domain": "paireyewear.com",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5147"
         }
     ],
     "settings": {


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/1200277586140538/task/1214726870817404?focus=true

## Description
### Site breakage mitigation process:
#### Brief explanation
- Reported URL: https://paireyewear.com/collections/all-frames
- Problems experienced: The product list does not load, or at least it takes a very long time. Disabling either CPM (Cookie Popup Management) or GPC (Global Privacy Control) seems to fix it.
- Platforms affected:
  - [x] iOS
  - [x] Android
  - [x] Windows
  - [x] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked: N/A
- Feature being disabled/modified: CPM (Cookie Popup Management)
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk configuration-only change that affects CPM behavior for a single domain; minimal chance of broader impact beyond that site.
> 
> **Overview**
> Disables Cookie Popup Management for `paireyewear.com` by adding it to the `features/autoconsent.json` domain exception list (with PR reference) to mitigate reported page-load breakage.
> 
> Also fixes the missing trailing newline at EOF in the JSON file.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3f1a675c80428a8cd20af6613c2827a138464346. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->