### PR TITLE
blind mitigate loading issues on uhc-com by adding tracker exception

### DIFF
--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -999,12 +999,14 @@
                         "domains": [
                             "shapermint.com",
                             "indeed.com",
-                            "hrblock.com"
+                            "hrblock.com",
+                            "uhc.com"
                         ],
                         "reason": [
                             "https://github.com/duckduckgo/privacy-configuration/issues/1571",
                             "indeed.com - https://github.com/duckduckgo/privacy-configuration/issues/2163",
-                            "hrblock.com - https://github.com/duckduckgo/privacy-configuration/pull/4394"
+                            "hrblock.com - https://github.com/duckduckgo/privacy-configuration/pull/4394",
+                            "uhc.com - https://github.com/duckduckgo/privacy-configuration/pull/5148"
                         ]
                     },
                     {

--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -1011,11 +1011,13 @@
                         "rule": "datadoghq-browser-agent.com",
                         "domains": [
                             "indeed.com",
-                            "hrblock.com"
+                            "hrblock.com",
+                            "uhc.com"
                         ],
                         "reason": [
                             "indeed.com - https://github.com/duckduckgo/privacy-configuration/issues/2163",
-                            "hrblock.com - https://github.com/duckduckgo/privacy-configuration/pull/4394"
+                            "hrblock.com - https://github.com/duckduckgo/privacy-configuration/pull/4394",
+                            "uhc.com - https://github.com/duckduckgo/privacy-configuration/pull/5148"
                         ]
                     }
                 ]


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1200277586140538/task/1213225453818103?focus=true

## Description

### Site breakage mitigation process:
#### Brief explanation
- Reported URL: https://member.uhc.com/onboarding/welcome
- Problems experienced: Blank/white screen after successful login. 
- Platforms affected:
  - [ x] iOS
  - [ ] Android
  - [ x] Windows
  - [ x] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked: datadoghq-browser-agent.com
- Feature being disabled/modified:
- [x ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new tracker allowlist exception for `uhc.com`, which can impact tracking protections on that site if the rule is too broad or abused.
> 
> **Overview**
> Adds `uhc.com` to the allowlist for `datadoghq-browser-agent.com` (including the `datadog-logs-v4.js` path) in `features/tracker-allowlist.json`, with a linked justification to mitigate a reported blank-screen login/onboarding breakage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 105458ca9f48b9911795d1418071d5a08d0743a9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->