### PR TITLE
Added click-to-load exception for bandsintown.com

### DIFF
--- a/overrides/extension-override.json
+++ b/overrides/extension-override.json
@@ -52,7 +52,13 @@
                 "Youtube": {
                     "state": "disabled"
                 }
-            }
+            },
+            "exceptions": [
+                {
+                    "domain": "bandsintown.com",
+                    "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5149"
+                }
+            ]
         },
         "clickToPlay": {
             "state": "enabled",

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -838,6 +838,10 @@
                 {
                     "domain": "zoosk.com",
                     "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2646"
+                },
+                {
+                    "domain": "bandsintown.com",
+                    "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5149"
                 }
             ]
         },


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/1206670747178362/task/1214687897317768?focus=true

## Description
### Site breakage mitigation process:
#### Brief explanation
- Reported URL: https://www.bandsintown.com/t/108170508
- Problems experienced: Ticket page fails to load and does not redirect to Ticketmaster checkout (stays blank/stuck) when protections are enabled.
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [x] MacOS
  - [x] Extensions
- Tracker(s) being unblocked: N/A
- Feature being disabled/modified: Click-to-load (Facebook)
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it relaxes a privacy protection (`clickToLoad`) on a specific domain, which could increase third-party content loading there. Scope is limited to a single-site exception in JSON overrides.
> 
> **Overview**
> Adds a new `clickToLoad` **exception** for `bandsintown.com` in both `overrides/extension-override.json` and `overrides/macos-override.json`.
> 
> This is a targeted breakage mitigation that allows click-to-load behavior to be bypassed on that domain (with a linked PR as the documented reason).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 492b26d32fd761e95d69d0477b8019e328f5ae7e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->