### PR TITLE
Update content-blocker extension to 2026.5.12

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -4620,7 +4620,7 @@
             "minSupportedVersion": "0.148.0",
             "exceptions": [],
             "settings": {
-                "extensionUrl": "https://staticcdn.duckduckgo.com/extensions/content-blocker/content-blocker-extension-2026.5.8.crx"
+                "extensionUrl": "https://staticcdn.duckduckgo.com/extensions/content-blocker/content-blocker-extension-2026.5.12.crx"
             },
             "features": {
                 "onboardingEnabled": {


### PR DESCRIPTION
Update content-blocker extension to 2026.5.12.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a single config change updating the CRX download URL; the main risk is rollout breakage if the new CDN artifact is missing or incompatible.
> 
> **Overview**
> Updates the Windows override config to point `adBlockV2Extension.settings.extensionUrl` at the `content-blocker-extension-2026.5.12.crx` artifact (from `2026.5.8`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec5d229ecfdfdee172aa2a45bcdbc8d31141fbe7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->