### PR TITLE
Update ad-blocking extension scriptlets for v2026.5.12

### DIFF
--- a/features/ad-blocking-extension.json
+++ b/features/ad-blocking-extension.json
@@ -4,24 +4,24 @@
     },
     "exceptions": [],
     "settings": {
-        "version": "2026.5.8",
+        "version": "2026.5.12",
         "enabledByDefault": false,
         "scriptlets": {
             "scriptlets/isolated/ublock-filters.js": {
                 "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/9ef2ee259997607f891e91448fcbf717e3b9366141b17ee3739bd41bcd7122bc.js",
-                "signature": "MEUCIF29f3XY7GA8VgB9UbCzUG++LxwCsHdFbjaJAsywdvHEAiEAxvB54M+38SoexE9Udj/ba+zTTg/Q8mSg3fYn0DIzuMQ="
+                "signature": "MEUCIBbzhr9mr0anXlWaeqWF4SuTXYpyBaQgMQ+eOViLuKKTAiEAjerUxcXMhFo8QO6Yx4V0RjiwvhAfKBzTAJTNs3RtVVw="
             },
             "scriptlets/main/ublock-filters.js": {
-                "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/75d3e03a27ebf119537fcdc94735d98355f495d5cb1cf1a76d7f26fe16874df6.js",
-                "signature": "MEYCIQDfnpczIJJtjrTXBUgo18PeIG6UFmWF/O1KfpdbbRyq8gIhAOYASdN/jSGA5d/UxALzicWks2omLK8fd22Vv4CeHMwi"
+                "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/1cf5597a879e30f4e0939569f1f5138b3478756b0e19ecbeeed38acdb3aa4b9c.js",
+                "signature": "MEUCIE5T33IVMKSwGb//9TtarJ6WnPJ3BjQoJ6a7cDnt4iNCAiEA3crKN8h914WmH4eES/GpTPP5RRgNbqvSrJFdiIQ3Vys="
             },
             "scriptlets/main/ublock-experimental.js": {
                 "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855.js",
-                "signature": "MEYCIQCDwOT4aNfrOfbVdJxMZrjyRRpm9WRb2gf9xE4le7UhUwIhAPFkBT/lPa6Tx915NpcGELtwXUaK4HgT7l/qOtIqBP2x"
+                "signature": "MEUCIQDGKIIG4uNgDaaU0isFdUgd0L7v1CKYCuZsWnIGQwK6DAIgDM+EguxbzswGk3kLAUht4k3ibjzqGOcB0XNV76XMYzM="
             },
             "scriptlets/isolated/ublock-experimental.js": {
                 "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855.js",
-                "signature": "MEUCIQDx68lVUgkK/u5ZuDzmffVccmfjhatnXKkPOghpKWyCBAIgbFo/UqyjJf3bi+ymJuxzErsT1TyuYxLlSe1WQh0XFY8="
+                "signature": "MEQCIFOxE4mh+vfbtah0LPvMY6CRh1HJNLfitYiD1lR20MP2AiBiyZaJLJL9Zqav5GhhMv7BQ1HrDZ9BkNBMa+AgGSHM5Q=="
             }
         }
     }


### PR DESCRIPTION
Update ad-blocking extension scriptlets for v2026.5.12.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates remote scriptlet URLs and cryptographic signatures, which can change runtime blocking behavior and depends on correct artifact/signature pairing.
> 
> **Overview**
> Updates `features/ad-blocking-extension.json` to **version `2026.5.12`** and refreshes the scriptlet metadata.
> 
> This swaps the `scriptlets/main/ublock-filters.js` CDN URL and updates signatures for all listed scriptlets so clients fetch/verify the new artifacts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9267aea949e3fa1a7ae1c0dea696d9034fcfbe0a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->