### PR TITLE
Re-enable Windows recent chats at 0.157

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -1314,16 +1314,16 @@
                     "minSupportedVersion": "0.152.0"
                 },
                 "suggestions": {
-                    "state": "internal",
-                    "minSupportedVersion": "0.155.0"
+                    "state": "enabled",
+                    "minSupportedVersion": "0.157.0"
                 },
                 "suggestionsDeletion": {
                     "state": "enabled",
                     "minSupportedVersion": "0.155.0"
                 },
                 "ntpRecentChats": {
-                    "state": "internal",
-                    "minSupportedVersion": "0.155.0"
+                    "state": "enabled",
+                    "minSupportedVersion": "0.157.0"
                 },
                 "imageGeneration": {
                     "state": "enabled",


### PR DESCRIPTION
https://app.asana.com/1/137249556945/inbox/1209072953775216/item/1214692955995383/story/1214736511360352

## Description
Re-enable Windows recent chats at 0.157



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk configuration-only change that flips feature flags to enabled for Windows starting at `0.157.0`.
> 
> **Overview**
> Re-enables Windows `aiChat` UI capabilities by switching `suggestions` and `ntpRecentChats` from *internal* to **enabled**, and bumps their `minSupportedVersion` to `0.157.0` in `overrides/windows-override.json`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 83f0dbaf571b2d5193d4682f72ccd351af8c346d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->