### PR TITLE
Enable settingsLinkInAiFeatures

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -1370,7 +1370,8 @@
                     "minSupportedVersion": "0.156.0"
                 },
                 "settingsLinkInAiFeatures": {
-                    "state": "internal"
+                    "state": "enabled",
+                    "minSupportedVersion": "0.158.0"
                 },
                 "attachMoreTabs": {
                     "state": "internal"


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/task/1214576914458989

## Description
Enable settingsLinkInAiFeatures

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk configuration-only change that enables a previously internal AI Chat subfeature for Windows starting at version `0.158.0`.
> 
> **Overview**
> Enables the Windows `aiChat` subfeature `settingsLinkInAiFeatures` by switching it from *internal* to **enabled** and gating it behind `minSupportedVersion: 0.158.0`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 395d247b9f8654c3d463d1ff3aebf20fb820c164. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->