### PR TITLE
Hide blank interstitial page on walkerplus.com

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -4463,6 +4463,15 @@
                 ]
             },
             {
+                "domain": "walkerplus.com",
+                "rules": [
+                    {
+                        "selector": "[id='pfx_interstitial']",
+                        "type": "hide"
+                    }
+                ]
+            },
+            {
                 "domain": "washingtontimes.com",
                 "rules": [
                     {


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/1200277586140538/task/1214736238677597?focus=true

## Description
### Site breakage mitigation process:
#### Brief explanation
- Reported URL: https://www.walkerplus.com/event/ar0314e592195/
- Problems experienced: A blank black page is shown when clicking same-site links. It’s actually a full-page interstitial ad, blocked by tracker blocking, that you have to close to continue (although that’s not obvious).
- Platforms affected:
  - [x] iOS
  - [x] Android
  - [x] Windows
  - [x] MacOS
  - [x] Extensions
- Tracker(s) being unblocked: N/A
- Feature being disabled/modified: Element hiding
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a single domain-scoped element-hiding rule; potential risk is limited to unintended hiding on `walkerplus.com` if the selector matches legitimate content.
> 
> **Overview**
> Adds a new `element-hiding.json` domain override for `walkerplus.com` to **hide** the `#pfx_interstitial` element, mitigating a full-page interstitial/blank-screen issue when navigating the site.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e10b930066723a1899005598f6b1f40fab5845c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->