### PR TITLE
Disable GPC (Global Privacy Control) on filson.com

### DIFF
--- a/features/gpc.json
+++ b/features/gpc.json
@@ -95,6 +95,10 @@
         {
             "domain": "petsplace.nl",
             "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5128"
+        },
+        {
+            "domain": "filson.com",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5159"
         }
     ],
     "settings": {


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/1206670747178362/task/1214682858241510?focus=true

## Description
### Site breakage mitigation process:
#### Brief explanation
- Reported URL: https://www.filson.com/collections/outlet-mens?
- Problems experienced: Products are not shown. Instead, there’s a loading spinner below the top nav bar that never stops loading.
- Platforms affected:
  - [x] iOS
  - [x] Android
  - [x] Windows
  - [x] MacOS
  - [x] Extensions
- Tracker(s) being unblocked: N/A
- Feature being disabled/modified: GPC (Global Privacy Control)
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change, limited to a single domain; primary impact is reduced privacy signaling on `filson.com` to mitigate site breakage.
> 
> **Overview**
> Disables Global Privacy Control on `filson.com` by adding it to `features/gpc.json`'s `exceptions` list (with a tracking PR reference), as a targeted mitigation for reported site breakage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit be345eee20c9973366450a2c2eda507a2ddb77a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->