### PR TITLE
UA override for xvideos.com

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -1545,6 +1545,10 @@
                     {
                         "domain": "iheart.com",
                         "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5121"
+                    },
+                    {
+                        "domain": "xvideos.com",
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5160"
                     }
                 ],
                 "ddgDefaultSites": [
@@ -1760,6 +1764,10 @@
                     {
                         "domain": "pinterest.vn",
                         "reason": "https://github.com/duckduckgo/privacy-configuration/pull/4444"
+                    },
+                    {
+                        "domain": "xvideos.com",
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5160"
                     }
                 ],
                 "omitVersionSites": []

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -1547,6 +1547,10 @@
                     {
                         "domain": "hilton.com",
                         "reason": "https://github.com/duckduckgo/privacy-configuration/pull/4722"
+                    },
+                    {
+                        "domain": "xvideos.com",
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5160"
                     }
                 ],
                 "webViewDefault": [


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/1206670747178362/task/1214471329255271?focus=true

## Description
### Site breakage mitigation process:
#### Brief explanation
- Reported URL: xvideos.com
- Problems experienced: Autoplay on thumbnail hover/swipe is not working.
- Platforms affected:
  - [x] iOS
  - [ ] Android
  - [ ] Windows
  - [x] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked: N/A
- Feature being disabled/modified: UA string override.
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, data-free config-only change that scopes a user-agent override to a single domain; main risk is unintended site-specific behavior changes if the override causes regressions on `xvideos.com`.
> 
> **Overview**
> Adds `xvideos.com` to the `customUserAgent` override lists for **iOS** and **macOS**, ensuring the browser applies the UA-string override on that domain.
> 
> On iOS, the domain is added in both the fixed-site list and the corresponding omit/version handling list to keep behavior consistent with other UA-mitigated sites.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 54edfb62be78841b0ba181bb91b8b6ace3f0bcc7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->