### PR TITLE
Enable multiDownloadPermission from 0.158.0

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -5433,7 +5433,8 @@
             "state": "enabled"
         },
         "multiDownloadPermission": {
-            "state": "internal",
+            "state": "enabled",
+            "minSupportedVersion": "0.158.0",
             "exceptions": []
         }
     },


### PR DESCRIPTION
**Asana Task/Github Issue:**

## Description
Enable multiDownloadPermission from 0.158.0

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [X] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Enables a previously internal-gated permission feature for Windows, which could change download prompting/handling behavior for users on eligible versions. Risk is limited to configuration but impacts a permissions-related control surface.
> 
> **Overview**
> **Enables `multiDownloadPermission` in the Windows override config** by switching it from `internal` to `enabled` and adding `minSupportedVersion: 0.158.0`, so the feature applies only to Windows clients on `>= 0.158.0`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e128d1692bf729499c75c113b4c219f1b51595cc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->