### PR TITLE
Enables semaphoreAlwaysVisible on macOS

### DIFF
--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -2254,7 +2254,7 @@
                     "minSupportedVersion": "1.183.0"
                 },
                 "semaphoreAlwaysVisible": {
-                    "state": "internal"
+                    "state": "enabled"
                 },
                 "autoplayPolicy": {
                     "state": "internal",


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/1211150618152277/task/1213834516624596

## Description
This PR enables the Feature Flag `semaphoreAlwaysVisible`.
This causes the macOS browser to always display the Semaphore (Close, Minimize, Maximize) when in fullscreen.

Reference:
https://app.asana.com/1/137249556945/project/1211150618152277/task/1213414709395588

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change that flips a macOS feature flag from internal to enabled; main impact is a UI behavior change in fullscreen mode.
> 
> **Overview**
> Enables the `semaphoreAlwaysVisible` feature for macOS by changing its override state from `internal` to `enabled` in `overrides/macos-override.json`, making the window control semaphores always visible when fullscreen.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 934b1051be37ab2d9c29dbae9369c5df1cff0e2d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->