### PR TITLE
enable aiChat.nativeStorage and roll out to 25%

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -1350,8 +1350,15 @@
                     "minSupportedVersion": "0.156.0"
                 },
                 "nativeStorage": {
-                    "state": "preview",
-                    "minSupportedVersion": "0.157.0"
+                    "state": "enabled",
+                    "minSupportedVersion": "0.157.0",
+                    "rollout": {
+                        "steps": [
+                            {
+                                "percent": 25.0
+                            }
+                        ]
+                    }
                 },
                 "omnibarReasoningEffort": {
                     "state": "enabled",


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1210407179200832/task/1213984294426946?focus=true

## Description
Enable aiChat.nativeStorage and roll out to 25%
Reasoning: https://app.asana.com/1/137249556945/project/1210407179200832/task/1214488302021218?focus=true

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Enables `aiChat.nativeStorage` for Windows clients, which changes how chat data may be persisted and could surface storage/migration issues for a subset of users. Limited initial rollout (25%) mitigates blast radius but still touches data persistence behavior.
> 
> **Overview**
> **Windows feature config change:** switches `aiChat.nativeStorage` from *preview* to **enabled** (min version `0.157.0`).
> 
> Adds a **25% rollout** step for this flag in `windows-override.json`, moving the feature into a controlled partial release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 368d7db4aee161f404bbb2e147de7d29bd918112. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->