### PR TITLE
Enable the defaultBrowserWinBackPrompt flag on Android and sample the default browser change survey to 40% of the users

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -3750,6 +3750,10 @@
                             }
                         ]
                     }
+                },
+                "defaultBrowserWinBackPrompt": {
+                    "state": "enabled",
+                    "minSupportedVersion": 52800000
                 }
             }
         },
@@ -4240,6 +4244,9 @@
         "defaultBrowserChangedSurvey": {
             "state": "enabled",
             "minSupportedVersion": 52770000,
+            "settings": {
+                "samplingRate": 40
+            },
             "exceptions": []
         }
     },


### PR DESCRIPTION
**Asana Task/Github Issue:**https://app.asana.com/1/137249556945/project/1211724162604201/task/1214630559323873?focus=true

## Description
Enable the defaultBrowserWinBackPrompt flag starting with 5.280.0 Android version.
Also add setting for defaultBrowserChangedSurvey to show it only to 40% of the users. 

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [x] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes Android user-facing prompt/survey rollout behavior via remote configuration and could impact engagement metrics if misconfigured.
> 
> **Overview**
> Enables the `reactivateUsers.defaultBrowserWinBackPrompt` flag for Android starting at `minSupportedVersion: 52800000`.
> 
> Adds `settings.samplingRate: 40` to `defaultBrowserChangedSurvey`, limiting the survey to 40% of eligible Android users.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 985ae19353444cf199fe086a2f2902a6c45db96a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->