### PR TITLE
Enabled distributionSource in attributedMetrics

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -5053,6 +5053,9 @@
                             "paid"
                         ]
                     }
+                },
+                "distributionSource": {
+                    "state": "enabled"
                 }
             }
         },


### PR DESCRIPTION
so we get the distribution (store vs direct) on `ml.windows.app-launch`, `app_use` from atb.js, & `search` from atb.js

**Asana Task/Github Issue:**

## Description
<!-- 
  Please delete either or both process sections below.
-->

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change that toggles on an additional attributed metrics field for Windows telemetry; main risk is minor analytics schema/volume impact if downstream consumers aren’t expecting it.
> 
> **Overview**
> Enables `attributedMetrics.features.distributionSource` in `overrides/windows-override.json` for Windows.
> 
> This allows attributed telemetry to include the app’s distribution channel (e.g., store vs direct) in relevant metrics emission.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fc650c968fbcc5f7866fab9484113b30656d25ae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->