### PR TITLE
enable webevents so youtube ad detection events are fired

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -5112,6 +5112,10 @@
             "state": "enabled",
             "minSupportedVersion": "0.147.0"
         },
+        "webEvents": {
+            "state": "enabled",
+            "minSupportedVersion": "0.157.0"
+        },
         "webInterferenceDetection": {
             "state": "enabled",
             "minSupportedVersion": "0.146.0",


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/task/1214097468178147?focus=true

## Description
Enable web events so youtube ad detection events are sent to the native handler. 

### Feature change process:

- [x] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [x] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [x] This feature was covered by a tech design.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change that flips on `webEvents` for Windows clients >= `0.157.0`; main risk is unintended telemetry/event volume changes for that platform/version gate.
> 
> **Overview**
> Enables the `webEvents` feature flag in `windows-override.json`, gated behind `minSupportedVersion: 0.157.0`, so Windows builds can emit web event signals (e.g., for YouTube ad detection).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 875c6c1807c49566b81d55a7b6ced8ea53e24ef6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->