### PR TITLE
Roll out Admiral experiment to 100%

### DIFF
--- a/.cursor/BUGBOT.md
+++ b/.cursor/BUGBOT.md
@@ -16,6 +16,9 @@ When a feature transitions from `internal` to `enabled` (or from `enabled` to `i
 ### Parent and Subfeature Independence
 Parent features and their subfeatures are **not** co-dependent — a subfeature's state is evaluated independently of its parent. Because of this, they often require the exact same gating (e.g. matching `state`, `minSupportedVersion`, rollout targets). When transitioning a subfeature, ensure its gating is explicitly set rather than assuming it inherits from the parent.
 
+### Rollout Step Edits
+When a rollout percentage changes, the diff must **append** a new entry to `rollout.steps[]` rather than mutate an existing entry. Each step is a discrete event clients persist; modifying an existing `percent` is silently ignored for already-enrolled users. Flag any PR that edits or removes an existing step object instead of appending a new one. See [`.cursor/rules/rollout-steps.mdc`](../.cursor/rules/rollout-steps.mdc) and [`docs/incremental-rollout-implementation-guide.md`](../docs/incremental-rollout-implementation-guide.md).
+
 ## Element Hiding Feature Validation
 
 ### Schema & Implementation References

--- a/.cursor/rules/rollout-steps.mdc
+++ b/.cursor/rules/rollout-steps.mdc
@@ -1,0 +1,85 @@
+---
+description: Rules for editing rollout `steps[]` arrays in privacy-remote-configuration features and overrides. Use when bumping, lowering, or otherwise changing a feature's rollout percentage in `features/*.json` or `overrides/*-override.json`.
+globs: features/**/*.json,overrides/**/*.json
+alwaysApply: false
+---
+
+# Rollout Step Edits
+
+## Rule: append a new step, never modify an existing one
+
+When changing a rollout percentage, **append a new entry to `rollout.steps[]`**.
+Never edit the `percent` of an existing entry, and never delete prior entries.
+
+Each step is a discrete rollout event that clients persist. Mutating an existing
+step is silent: clients that have already processed that step skip re-evaluation,
+so the bump does not reach already-seen users. Appending a new step is the only
+way to enroll additional users (or roll back, on Android).
+
+This applies to every rollout block in this repo:
+
+- Top-level feature `rollout`
+- Sub-feature `rollout` (the common case)
+- `contentScopeExperiments` features
+- TDS experiments (`tdsNextExperimentNNN`) and similar A/B-cohort experiments
+
+## Examples
+
+### Bumping 25% → 100% (correct)
+
+```json
+"rollout": {
+    "steps": [
+        { "percent": 25 },
+        { "percent": 100 }
+    ]
+}
+```
+
+### Bumping 25% → 100% (incorrect — mutates existing step)
+
+```json
+"rollout": {
+    "steps": [
+        { "percent": 100 }
+    ]
+}
+```
+
+### Multi-step ramp (correct)
+
+```json
+"rollout": {
+    "steps": [
+        { "percent": 1 },
+        { "percent": 10 },
+        { "percent": 25 },
+        { "percent": 50 },
+        { "percent": 100 }
+    ]
+}
+```
+
+## Halting or rolling back a rollout
+
+- **Halt entirely**: set the sub-feature's `state` to `disabled`. This disables
+  the feature for everyone, including already-enrolled users. Do not touch the
+  `steps[]` array.
+- **Lower the percentage** (Android-only, where rollbacks are supported): append
+  a new step with the lower `percent`. Still do not edit prior steps.
+
+## Reviewer checklist
+
+When reviewing a PR that changes a `rollout.steps[]` array:
+
+1. Confirm the diff is purely additive — only `+` lines for new step objects.
+2. If a step object is being modified or deleted, flag it: this is almost
+   always wrong and should be a new appended step instead.
+3. Confirm step `percent` values are monotonic for ramp-ups, or explicitly
+   documented as a rollback for ramp-downs.
+
+## Reference
+
+- Canonical doc: [docs/incremental-rollout-implementation-guide.md](../../docs/incremental-rollout-implementation-guide.md)
+- Examples in git history: PRs #5111, #5104, #5093, #5053 (each appends one
+  new step per rollout bump).

--- a/docs/incremental-rollout-implementation-guide.md
+++ b/docs/incremental-rollout-implementation-guide.md
@@ -43,6 +43,44 @@ The remote config supports incremental rollouts for sub-features. Follow these s
 - No additional support beyond supporting your sub-feature is needed on the client side to handle a rollout.
 - Setting a sub-feature's state to `disabled` will effectively halt a rollout and will disable the feature for anyone who was enrolled.
 
+## Bumping a Rollout Percentage
+
+> **Rule: append a new step, never modify an existing one.**
+
+When increasing (or decreasing) a rollout percentage, **append a new entry to the
+`steps` array**. Do **not** edit the `percent` value of an existing step.
+
+Each step represents a discrete rollout event that clients track to decide who
+to enroll next. Mutating an existing step is a silent change — clients that have
+already processed that step will not re-evaluate it, and the bump will be
+ignored for already-seen users.
+
+### Example: bumping 25% → 100%
+
+Correct (append):
+
+```json
+"rollout": {
+    "steps": [
+        { "percent": 25 },
+        { "percent": 100 }
+    ]
+}
+```
+
+Incorrect (mutate in place):
+
+```json
+"rollout": {
+    "steps": [
+        { "percent": 100 }
+    ]
+}
+```
+
+This applies to every kind of rollout block — top-level features, sub-features,
+content scope experiments, and TDS experiments alike.
+
 For technical details about how rollouts work, see [this Asana task](https://app.asana.com/0/1198194956794324/1204934761241565/f).
 
 ## See Also

--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -194,6 +194,9 @@
                         "steps": [
                             {
                                 "percent": 25
+                            },
+                            {
+                                "percent": 100
                             }
                         ]
                     },

--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -584,6 +584,9 @@
                         "steps": [
                             {
                                 "percent": 25
+                            },
+                            {
+                                "percent": 100
                             }
                         ]
                     },

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -594,6 +594,9 @@
                         "steps": [
                             {
                                 "percent": 25
+                            },
+                            {
+                                "percent": 100
                             }
                         ]
                     },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/72649045549333/task/1214295430255973?focus=true

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Expands the rollout for an enabled TDS experiment to 100% across multiple platform overrides, which can impact all clients in those channels. The rest is documentation/rule guidance, but incorrect rollout edits could affect enrollment behavior.
> 
> **Overview**
> Ramps `tdsNextExperiment009` rollout from 25% to **100%** by *appending* a new `{ "percent": 100 }` step in `overrides/android-override.json`, `overrides/ios-override.json`, and `overrides/macos-override.json`.
> 
> Adds explicit reviewer/author guidance that rollout percentage changes must append new entries to `rollout.steps[]` (new `.cursor/rules/rollout-steps.mdc`, linked from `.cursor/BUGBOT.md`, and documented in `docs/incremental-rollout-implementation-guide.md`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 89596948bd966eeddd40576a96edbfa14aee4e1b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->