### PR TITLE
Update element hiding rule for "experiencing interruptions" toast on YT

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -4527,7 +4527,7 @@
                         "type": "hide"
                     },
                     {
-                        "selector": "#toast[role='region']:has(.yt-notification-action-renderer > yt-formatted-string)",
+                        "selector": "#toast:has(> #text-container > yt-formatted-string#text.yt-notification-action-renderer)",
                         "type": "hide"
                     }
                 ]

--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -4527,7 +4527,7 @@
                         "type": "hide"
                     },
                     {
-                        "selector": "#toast[role='region']:has(yt-button-shape > a[href='https://support.google.com/youtube/answer/3037019#check_ad_blockers&zippy=%2Ccheck-your-extensions-including-ad-blockers'])",
+                        "selector": "ytd-popup-container:has(tp-yt-paper-toast > .yt-notification-action-renderer)",
                         "type": "hide"
                     }
                 ]

--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -4527,7 +4527,7 @@
                         "type": "hide"
                     },
                     {
-                        "selector": "ytd-popup-container:has(tp-yt-paper-toast > .yt-notification-action-renderer)",
+                        "selector": "#toast[role='region']:has(.yt-notification-action-renderer > yt-formatted-string)",
                         "type": "hide"
                     }
                 ]


### PR DESCRIPTION
**Asana Task/Github Issue:** Follow up to https://github.com/duckduckgo/privacy-configuration/pull/5004

## Description
Seems the selector has changed, so updating rule to match.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change that narrows/updates a `youtube.com` element-hiding selector; the main risk is over/under-matching the toast if YouTube DOM changes again.
> 
> **Overview**
> Updates the `youtube.com` element-hiding rule for the “experiencing interruptions” toast by replacing the previous support-link-based selector with a new `#toast:has(> #text-container > yt-formatted-string#text.yt-notification-action-renderer)` match so the toast continues to be hidden after YouTube’s markup change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 53860d31518ac78095e2805a9022e94d78411579. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->