### PR TITLE
Enable UI responsiveness instrumentation for external Windows users

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -4743,10 +4743,12 @@
             "minSupportedVersion": "0.158.0",
             "features": {
                 "keypressToCharacterRender": {
-                    "state": "enabled"
+                    "state": "enabled",
+                    "minSupportedVersion": "0.158.0"
                 },
                 "keypressToSuggestionRender": {
-                    "state": "enabled"
+                    "state": "enabled",
+                    "minSupportedVersion": "0.158.0"
                 }
             }
         },

--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -4739,13 +4739,14 @@
             }
         },
         "uiResponsiveness": {
-            "state": "internal",
+            "state": "enabled",
+            "minSupportedVersion": "0.158.0",
             "features": {
                 "keypressToCharacterRender": {
-                    "state": "internal"
+                    "state": "enabled"
                 },
                 "keypressToSuggestionRender": {
-                    "state": "internal"
+                    "state": "enabled"
                 }
             }
         },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1212377141129925/task/1213904343638504

## Description
Enable UI responsiveness instrumentation for external Windows users

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change that enables additional UI responsiveness instrumentation for Windows clients; main impact is increased telemetry/measurement starting at `0.158.0`.
> 
> **Overview**
> Enables the `uiResponsiveness` feature flag for Windows (previously `internal`), making UI responsiveness instrumentation available to external users.
> 
> Also enables the `keypressToCharacterRender` and `keypressToSuggestionRender` sub-features and gates them (and the parent flag) behind `minSupportedVersion: 0.158.0`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ce2974c7531ca88fd755cfd36a02efecd2c5407. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->