### PR TITLE
Update autoconsent to v14.81.0

### DIFF
--- a/features/autoconsent.json
+++ b/features/autoconsent.json
@@ -2294,7 +2294,14 @@
                 "trackingconsent",
                 "aside#cookies,.overlay-cookies",
                 "body > div#cookieAreaBase > div#cookieArea > p:nth-child(1):not([id]) > a:nth-child(3):not([id])",
-                "body > div#cookieAreaBase > div#cookieArea > div:nth-child(2):not([id]) > a:nth-child(2):not([id])"
+                "body > div#cookieAreaBase > div#cookieArea > div:nth-child(2):not([id]) > a:nth-child(2):not([id])",
+                "#edp-cookies-banner",
+                "#edp-cookies-banner .edp-cookies-refuse",
+                "edp_cookie_agree=0",
+                "#cookiebanner-popup",
+                "#jg-chrome-header",
+                "#cookiebanner-popup #accept-essential-Cookies",
+                "necessary:true%2Cpreferences:false"
             ],
             "r": [
                 [
@@ -25872,6 +25879,37 @@
                 ],
                 [
                     1,
+                    "edpb-edps",
+                    2,
+                    "^https://(www\\.)?(edpb|edps)\\.europa\\.eu/",
+                    22,
+                    [
+                        1433
+                    ],
+                    [
+                        {
+                            "e": 1434
+                        }
+                    ],
+                    [
+                        {
+                            "v": 1433
+                        }
+                    ],
+                    [
+                        {
+                            "c": 1434
+                        }
+                    ],
+                    [
+                        {
+                            "cc": 1435
+                        }
+                    ],
+                    {}
+                ],
+                [
+                    1,
                     "ef-ccpa",
                     0,
                     "^https://(www\\.)?eforms\\.com",
@@ -26347,6 +26385,50 @@
                         }
                     ],
                     [],
+                    {}
+                ],
+                [
+                    1,
+                    "justgiving.com",
+                    2,
+                    "^https://(?:[a-z0-9-]+\\.)?justgiving\\.com/",
+                    22,
+                    [
+                        1436
+                    ],
+                    [
+                        {
+                            "any": [
+                                {
+                                    "e": 1436
+                                },
+                                {
+                                    "e": 1437
+                                }
+                            ]
+                        }
+                    ],
+                    [
+                        {
+                            "v": 1436
+                        },
+                        {
+                            "e": 1438
+                        }
+                    ],
+                    [
+                        {
+                            "c": 1438
+                        }
+                    ],
+                    [
+                        {
+                            "wait": 500
+                        },
+                        {
+                            "cc": 1439
+                        }
+                    ],
                     {}
                 ],
                 [
@@ -28314,7 +28396,7 @@
                 ],
                 "specificRuleRange": [
                     185,
-                    756
+                    758
                 ],
                 "genericStringEnd": 722,
                 "frameStringEnd": 757


### PR DESCRIPTION
Asana Task/Github Issue: https://app.asana.com/1/137249556945/project/1201844467387842/task/1214793735797314

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily updates the `autoconsent.json` rule dataset; risk is limited to potential regressions in cookie-consent handling for the newly added/modified site patterns.
> 
> **Overview**
> Updates `features/autoconsent.json` to the v14.81.0 autoconsent ruleset.
> 
> Adds new consent-handling entries for `edpb/edps.europa.eu` and `justgiving.com`, plus additional banner selectors/cookie strings and associated rule-range metadata adjustments.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b079adb3b819493546212c88da837ff243bab86c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->