### PR TITLE
Add base flags definition

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -35,6 +35,10 @@
                 }
             }
         },
+        "adBlockingExtension": {
+            "exceptions": [],
+            "state": "disabled"
+        },
         "additionalCampaignPixelParams": {
             "state": "enabled",
             "exceptions": [],

--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -37,7 +37,8 @@
         },
         "adBlockingExtension": {
             "exceptions": [],
-            "state": "disabled"
+            "state": "internal",
+            "minSupportedVersion": 52831006
         },
         "additionalCampaignPixelParams": {
             "state": "enabled",


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/task/1214799321117705?focus=true

## Description
Add `adBlockingExtension` to android override

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [x] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only addition with internal state and a version floor; no broad user rollout until state or client logic changes.
> 
> **Overview**
> Adds the **`adBlockingExtension`** feature block to the Android privacy override so the Android app can read remote flags for ad-blocking extension work.
> 
> The new entry uses **`state: "internal"`** (not broadly enabled), an empty **`exceptions`** list, and **`minSupportedVersion`: 52831006**, gating it to newer Android builds. This mirrors the feature key used on other platforms but is a minimal Android-specific stub rather than the fuller enabled/sub-feature shape seen elsewhere.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c56cf5f6e8d149d736ae0fc4e8b38c6080adc901. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->