### PR TITLE
Enable adwall pixel

### DIFF
--- a/features/event-hub.json
+++ b/features/event-hub.json
@@ -7,7 +7,7 @@
     "settings": {
         "telemetry": {
             "webTelemetry_adwalls_day": {
-                "state": "disabled",
+                "state": "enabled",
                 "trigger": {
                     "period": {
                         "days": 1
@@ -19,10 +19,11 @@
                         "source": "adwall",
                         "buckets": {
                             "0": { "gte": 0, "lt": 1 },
-                            "1-2": { "gte": 1, "lt": 3 },
-                            "3-5": { "gte": 3, "lt": 6 },
-                            "6-10": { "gte": 6, "lt": 11 },
-                            "11-20": { "gte": 11, "lt": 21 },
+                            "1": { "gte": 1, "lt": 2 },
+                            "2-3": { "gte": 2, "lt": 4 },
+                            "4-7": { "gte": 4, "lt": 8 },
+                            "8-14": { "gte": 8, "lt": 15 },
+                            "15-20": { "gte": 15, "lt": 21 },
                             "21-39": { "gte": 21, "lt": 40 },
                             "40+": { "gte": 40 }
                         }
@@ -30,7 +31,7 @@
                 }
             },
             "webTelemetry_adwalls_week": {
-                "state": "disabled",
+                "state": "enabled",
                 "trigger": {
                     "period": {
                         "days": 7
@@ -42,10 +43,11 @@
                         "source": "adwall",
                         "buckets": {
                             "0": { "gte": 0, "lt": 1 },
-                            "1-2": { "gte": 1, "lt": 3 },
-                            "3-5": { "gte": 3, "lt": 6 },
-                            "6-10": { "gte": 6, "lt": 11 },
-                            "11-20": { "gte": 11, "lt": 21 },
+                            "1": { "gte": 1, "lt": 2 },
+                            "2-3": { "gte": 2, "lt": 4 },
+                            "4-7": { "gte": 4, "lt": 8 },
+                            "8-14": { "gte": 8, "lt": 15 },
+                            "15-20": { "gte": 15, "lt": 21 },
                             "21-39": { "gte": 21, "lt": 40 },
                             "40+": { "gte": 40 }
                         }


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/task/1214775294961602?focus=true

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it turns on additional client-side telemetry/pixel firing and changes aggregation buckets, which can impact data volume and reporting semantics.
> 
> **Overview**
> **Enables adwall telemetry/pixel firing** by switching `webTelemetry_adwalls_day` and `webTelemetry_adwalls_week` from `disabled` to `enabled` in `features/event-hub.json`.
> 
> Updates the `adwallCount` bucket ranges for both configs (e.g., splitting out `1`, shifting mid-range buckets to `2-3`, `4-7`, `8-14`, `15-20`) to change how counts are aggregated and reported.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1cb29596589fb97ef9479d296e749faa93a45612. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->