### PR TITLE
Disable aiChat.attachMoreTabs

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -1381,7 +1381,7 @@
                     "minSupportedVersion": "0.158.0"
                 },
                 "attachMoreTabs": {
-                    "state": "internal"
+                    "state": "disabled"
                 }
             },
             "minSupportedVersion": "0.100.0",


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/inbox/1210407179200807/item/1214611507417993/story/1214789916240274

## Description
Disable aiChat.attachMoreTabs

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change that flips a single Windows feature flag from `internal` to `disabled`, reducing functionality rather than adding new behavior.
> 
> **Overview**
> Disables the Windows `aiChat.attachMoreTabs` feature flag by changing its override state from `internal` to `disabled` in `overrides/windows-override.json`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 65d0ffdccd168b397ac9caf456620ab332877dd8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->