### PR TITLE
enable browseruilock 52791000

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -2258,8 +2258,8 @@
             }
         },
         "browserUiLock": {
-            "state": "disabled",
-            "minSupportedVersion": 52700000,
+            "state": "enabled",
+            "minSupportedVersion": 52791000,
             "exceptions": [],
             "settings": {
                 "overflowTypes": [


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1202552961248957/task/1214187547786011?focus=true

## Description
<!-- 
  Please delete either or both process sections below.
-->

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [x] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [x] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it flips a feature flag that changes runtime browser UI behavior for eligible Android versions, potentially impacting rendering/scrolling on some sites.
> 
> **Overview**
> Enables **`browserUiLock`** in `overrides/android-override.json`, raising the `minSupportedVersion` threshold from `52700000` to `52791000` so the feature only activates on newer Android app builds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 60bf18d56eb9289953d727f856bdba32eee50c02. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->