### PR TITLE
Add bookmarkAllOpenTabs subfeature for Windows

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -2008,6 +2008,9 @@
                 },
                 "sort": {
                     "state": "enabled"
+                },
+                "bookmarkAllOpenTabs": {
+                    "state": "internal"
                 }
             }
         },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/72649045549333/task/1207131845494224?focus=true

## Description
Disabled by default, enabled for internal users. The Windows browser gates its new "Bookmark All Tabs" menu items, keyboard shortcut, and dialog plumbing on this subfeature so we can roll the feature out incrementally.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change that adds a new feature flag entry without altering runtime code paths in this repo. The main risk is misconfiguration (incorrect state/placement) affecting rollout gating in the Windows client.
> 
> **Overview**
> Adds a new `bookmarks.bookmarkAllOpenTabs` subfeature to `overrides/windows-override.json`, set to `internal` to gate the Windows “Bookmark All Tabs” functionality for incremental rollout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 320bf01834ba2b33127cdd83adc87a8212d20d26. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->