### PR TITLE
Update autoconsent to v14.82.0

### DIFF
--- a/features/autoconsent.json
+++ b/features/autoconsent.json
@@ -2301,7 +2301,9 @@
                 "#cookiebanner-popup",
                 "#jg-chrome-header",
                 "#cookiebanner-popup #accept-essential-Cookies",
-                "necessary:true%2Cpreferences:false"
+                "necessary:true%2Cpreferences:false",
+                "[data-testid=\"cookie-policy-manage-dialog\"]",
+                "[data-testid=\"cookie-policy-manage-dialog-decline-button\"]"
             ],
             "r": [
                 [
@@ -25994,7 +25996,7 @@
                     1,
                     "facebook",
                     2,
-                    "^https://([a-z0-9-]+\\.)?facebook\\.com/",
+                    "^https://(www\\.)?facebook\\.com/",
                     22,
                     [],
                     [
@@ -26014,6 +26016,37 @@
                         {
                             "check": "none",
                             "wv": 976
+                        }
+                    ],
+                    [],
+                    {}
+                ],
+                [
+                    1,
+                    "facebook-mobile",
+                    2,
+                    "^https://(m|mbasic)\\.facebook\\.com/",
+                    22,
+                    [
+                        1440
+                    ],
+                    [
+                        {
+                            "e": 1440
+                        }
+                    ],
+                    [
+                        {
+                            "v": 1440
+                        }
+                    ],
+                    [
+                        {
+                            "c": 1441
+                        },
+                        {
+                            "check": "none",
+                            "wv": 1440
                         }
                     ],
                     [],
@@ -28396,7 +28429,7 @@
                 ],
                 "specificRuleRange": [
                     185,
-                    758
+                    759
                 ],
                 "genericStringEnd": 722,
                 "frameStringEnd": 757


### PR DESCRIPTION
Asana Task/Github Issue: https://app.asana.com/1/137249556945/project/1201844467387842/task/1214823184645609

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates cookie-consent automation rules, including Facebook URL matching and new selectors; mistakes here could break consent handling or cause unexpected interactions on affected sites.
> 
> **Overview**
> Updates `features/autoconsent.json` rule data.
> 
> Adds new cookie banner selectors (including `data-testid`-based ones) and adjusts Facebook coverage by tightening the main domain regex to `www.facebook.com` while introducing a separate `facebook-mobile` rule for `m`/`mbasic` subdomains, which also shifts the recorded rule range metadata accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8df7cd59f79bb5f4b372c0875cafc6611d2f73c1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->