### PR TITLE
Removed GPC exception for claude.com

### DIFF
--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -721,13 +721,7 @@
             ]
         },
         "gpc": {
-            "state": "enabled",
-            "exceptions": [
-                {
-                    "domain": "claude.com",
-                    "reason": "https://github.com/duckduckgo/privacy-configuration/pull/4970"
-                }
-            ]
+            "state": "enabled"
         },
         "webCompat": {
             "state": "enabled",


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/1206670747178362/task/1214073058901602?focus=true

## Description
### Site breakage mitigation process:
#### Brief explanation
- Reported URL: https://claude.com/product/cowork
- Problems experienced: Was a blank page on first load on macOS, now fixed on their end so we can remove the mitigation (i.e. reverts #4970 )
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [x] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked: N/A
- Feature being disabled/modified: Global Privacy Control (GPC)
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change that re-enables Global Privacy Control on `claude.com` for macOS; potential risk is reintroducing site breakage if the underlying issue recurs.
> 
> **Overview**
> Removes the macOS-specific `gpc` exception for `claude.com`, so GPC is now applied normally without a domain carve-out.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4020ad5052b252f2eae8334a62c572721eb43ad0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->