### PR TITLE
add tracker exception to unfreeze login page

### DIFF
--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -1341,7 +1341,8 @@
                             "supermarketperimeter.com",
                             "speedweek.com",
                             "timesofmalta.com",
-                            "vidbox.dev"
+                            "vidbox.dev",
+                            "olx.ba"
                         ],
                         "reason": [
                             "ah.nl - 'Bonus offer' elements do not render and are not clickable.",
@@ -1369,7 +1370,8 @@
                             "timesofmalta.com - https://github.com/duckduckgo/privacy-configuration/pull/4646",
                             "hawaiiathletics.com - https://github.com/duckduckgo/privacy-configuration/pull/5071",
                             "vidbox.dev - domain propagation from doubleclick.net catch-all",
-                            "parade.com - https://github.com/duckduckgo/privacy-configuration/pull/5117"
+                            "parade.com - https://github.com/duckduckgo/privacy-configuration/pull/5117",
+                            "olx.ba - https://github.com/duckduckgo/privacy-configuration/pull/5185"
                         ]
                     },
                     {


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1204912272578138/task/1214829964224191?focus=true

## Description

### Site breakage mitigation process:
#### Brief explanation
- Reported URL: olx.ba/login
- Problems experienced:
- Platforms affected:
  - [ x] iOS
  - [x ] Android
  - [ ] Windows
  - [x ] MacOS
  - [ x] Extensions
- Tracker(s) being unblocked: securepubads.g.doubleclick.net/tag/js/gpt.js
- Feature being disabled/modified: NA
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Expands a `doubleclick.net` allowlist exception to an additional domain, which can increase tracking exposure on that site and should be verified to only address the reported breakage.
> 
> **Overview**
> Adds `olx.ba` to the allowlist for `securepubads.g.doubleclick.net/tag/js/gpt.js` in `features/tracker-allowlist.json`, with a linked rationale, to mitigate reported login-page breakage (page freeze) on `olx.ba/login`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 533e2ac30655428daad3c3c5dc8d80691616d85c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->