### PR TITLE
Tab label and favicon transitions back to preview for Windows

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -4910,12 +4910,12 @@
         },
         "tabLabelTransition": {
             "minSupportedVersion": "0.155.0",
-            "state": "enabled",
+            "state": "preview",
             "exceptions": []
         },
         "faviconTransitions": {
             "minSupportedVersion": "0.155.0",
-            "state": "enabled",
+            "state": "preview",
             "exceptions": []
         },
         "tabNavigationHistoryRestore": {


### PR DESCRIPTION
**Asana Task/Github Issue:**

## Description
<!-- 
  Please delete either or both process sections below.
-->

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change that reduces rollout by marking `tabLabelTransition` and `faviconTransitions` as preview on Windows; main risk is unintended UI behavior differences for users expecting them enabled.
> 
> **Overview**
> Moves the Windows feature flags `tabLabelTransition` and `faviconTransitions` from **enabled** back to **preview** in `overrides/windows-override.json`, effectively narrowing their rollout while keeping the same `minSupportedVersion`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cffb32c1ccac455590ced4efb14ec29e80eb2090. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->