### PR TITLE
Update ad-blocking extension scriptlets for v2026.5.17

### DIFF
--- a/features/ad-blocking-extension.json
+++ b/features/ad-blocking-extension.json
@@ -4,24 +4,24 @@
     },
     "exceptions": [],
     "settings": {
-        "version": "2026.5.12",
+        "version": "2026.5.17",
         "enabledByDefault": false,
         "scriptlets": {
             "scriptlets/isolated/ublock-filters.js": {
-                "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/9ef2ee259997607f891e91448fcbf717e3b9366141b17ee3739bd41bcd7122bc.js",
-                "signature": "MEUCIBbzhr9mr0anXlWaeqWF4SuTXYpyBaQgMQ+eOViLuKKTAiEAjerUxcXMhFo8QO6Yx4V0RjiwvhAfKBzTAJTNs3RtVVw="
+                "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/d58a8f8997ee8d751b41046b47d1a99ef66f423dbaa5575db3efccc02179de54.js",
+                "signature": "MEYCIQD1n5kIB8njTSntfb8C+Epyl5rN3HYv1AhaHqa1FvXgXAIhAN1ZU3N6YCOmOvJppucK/wB7mPKDnfcdhKObDUpvtvyc"
             },
             "scriptlets/main/ublock-filters.js": {
-                "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/1cf5597a879e30f4e0939569f1f5138b3478756b0e19ecbeeed38acdb3aa4b9c.js",
-                "signature": "MEUCIE5T33IVMKSwGb//9TtarJ6WnPJ3BjQoJ6a7cDnt4iNCAiEA3crKN8h914WmH4eES/GpTPP5RRgNbqvSrJFdiIQ3Vys="
+                "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/a99944281e8860d546baa213ffa8ae499f5f02371f26669ded118003c91c8d56.js",
+                "signature": "MEUCIB7j7nOyJQaCVflY41zc/3BEvgmP1fJxtXgEfXRsN/q9AiEA/iC6ESpoPVSIDQZ152GgOwawvA6yks/uMkVwOk5Ai5s="
             },
             "scriptlets/main/ublock-experimental.js": {
                 "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855.js",
-                "signature": "MEUCIQDGKIIG4uNgDaaU0isFdUgd0L7v1CKYCuZsWnIGQwK6DAIgDM+EguxbzswGk3kLAUht4k3ibjzqGOcB0XNV76XMYzM="
+                "signature": "MEYCIQDN+Wj7xFHn+6ku07yZ2+LxgqchVswIjjmxGWFpcVwO4AIhALdvVIRtlIY2NrQNAAe0j1LRxzJ98Wwc8gjjHi0BCtSz"
             },
             "scriptlets/isolated/ublock-experimental.js": {
                 "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855.js",
-                "signature": "MEQCIFOxE4mh+vfbtah0LPvMY6CRh1HJNLfitYiD1lR20MP2AiBiyZaJLJL9Zqav5GhhMv7BQ1HrDZ9BkNBMa+AgGSHM5Q=="
+                "signature": "MEUCIFC2qPZ6mcu8PQeW1mQ4+d4o67Qlbz7AuRCeBFTDaTDRAiEAxhOoh/LQ3KjCCCtUDEijCy+evULwFRX2+7qMC7gzds0="
             }
         }
     }


### PR DESCRIPTION
Update ad-blocking extension scriptlets for v2026.5.17.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates a JSON manifest to point at new scriptlet CDN URLs and signatures, with no code or logic changes. Main risk is operational (bad URL/signature causing scriptlets to fail to load/verify).
> 
> **Overview**
> Updates the ad-blocking extension manifest (`features/ad-blocking-extension.json`) to **version `2026.5.17`**.
> 
> Repoints the `ublock-filters` scriptlets (main + isolated) to new CDN artifact URLs and updates signatures, and refreshes signatures for both `ublock-experimental` scriptlets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 16b0a587077532c276f1f434b9431b6fd3c264f7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->