### PR TITLE
Disable old Duck.ai onboarding experiment; add onboardingDuckAIQueryTrackersDemoExperiment

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -287,7 +287,7 @@
                     "minSupportedVersion": "7.197.0"
                 },
                 "onboardingDuckAIQueryExperiment": {
-                    "state": "enabled",
+                    "state": "disabled",
                     "description": "Duck.ai onboarding query experiment cohorts",
                     "cohorts": [
                         {
@@ -348,6 +348,30 @@
                 "voiceShortcut": {
                     "state": "enabled",
                     "minSupportedVersion": "7.216.0"
+                },
+                "onboardingDuckAIQueryTrackersDemoExperiment": {
+                    "state": "enabled",
+                    "description": "Duck.ai onboarding trackers demo experiment cohorts",
+                    "cohorts": [
+                        {
+                            "name": "control",
+                            "weight": 1
+                        },
+                        {
+                            "name": "treatmentA",
+                            "weight": 1
+                        },
+                        {
+                            "name": "treatmentB",
+                            "weight": 1
+                        }
+                    ],
+                    "targets": [
+                        {
+                            "localeLanguage": "en",
+                            "localeCountry": "US"
+                        }
+                    ]
                 }
             },
             "settings": {


### PR DESCRIPTION
## Summary

- Disable `onboardingDuckAIQueryExperiment` (state: disabled) to stop NA analysis from completing on the already-sampled cohort
- Add `onboardingDuckAIQueryTrackersDemoExperiment` with control + treatmentA cohorts (weight 1 each), en/US target — for the tracker-blocking demo onboarding flow

## Test plan

- [ ] Confirm old experiment shows as disabled in test config
- [ ] Confirm new experiment `onboardingDuckAIQueryTrackersDemoExperiment` appears with correct cohorts and targets

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: config-only change that toggles experiment flags and adds a new targeted cohort definition, with no code logic changes.
> 
> **Overview**
> Disables `aiChat.features.onboardingDuckAIQueryExperiment` in `overrides/ios-override.json` by switching its `state` from *enabled* to *disabled*.
> 
> Adds a new `aiChat` feature flag, `onboardingDuckAIQueryTrackersDemoExperiment`, enabled with `control`/`treatmentA`/`treatmentB` cohorts (all weight 1) and targeting `en-US` locales.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d2d4464b286787cbb83f39100411c8879ed44b1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->