### PR TITLE
Disable Claude media APIs for investigation

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -71,6 +71,29 @@
                     {
                         "condition": [
                             {
+                                "domain": "claude.ai"
+                            }
+                        ],
+                        "patchSettings": [
+                            {
+                                "op": "add",
+                                "path": "/apiChanges/MediaDevices.prototype.enumerateDevices",
+                                "value": {
+                                    "type": "remove"
+                                }
+                            },
+                            {
+                                "op": "add",
+                                "path": "/apiChanges/MediaDevices.prototype.getUserMedia",
+                                "value": {
+                                    "type": "remove"
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "condition": [
+                            {
                                 "domain": "1cs.jp"
                             },
                             {


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/task/1214895337872099?focus=true

## Description

This is to investigate a camera prompt that is occurring for Windows users only on Cloud. Do not move this, as it's only part of an investigation.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes web API surface on `claude.ai` for Windows, which could break camera/mic features or site behavior while mitigating unwanted permission prompts.
> 
> **Overview**
> Adds a Windows-only `apiManipulation` exception for `claude.ai` that **removes** `MediaDevices.prototype.enumerateDevices` and `MediaDevices.prototype.getUserMedia` via conditional `patchSettings`, to prevent/diagnose unexpected camera prompts on that domain.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f518895c8661150b64ef4fc187d563759589af0f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->