### PR TITLE
Disable Claude enumerateDevices API

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -71,6 +71,22 @@
                     {
                         "condition": [
                             {
+                                "domain": "claude.ai"
+                            }
+                        ],
+                        "patchSettings": [
+                            {
+                                "op": "add",
+                                "path": "/apiChanges/MediaDevices.prototype.enumerateDevices",
+                                "value": {
+                                    "type": "remove"
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "condition": [
+                            {
                                 "domain": "1cs.jp"
                             },
                             {


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/task/1214895337872099?focus=true

## Description
<!-- 
  Please delete either or both process sections below.
-->

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Windows `apiManipulation` behavior for `claude.ai` by removing `MediaDevices.prototype.enumerateDevices`, which may impact device-selection or voice features on that site if relied upon.
> 
> **Overview**
> **Windows override config** adds a new `apiManipulation` conditional rule for `claude.ai` that removes `MediaDevices.prototype.enumerateDevices` via `/apiChanges/MediaDevices.prototype.enumerateDevices`.
> 
> This effectively disables that API on `claude.ai` while leaving other per-domain API patches unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 416f99f01280db40bd10f13845b955f9e4b7a074. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->