### PR TITLE
Disable Claude getUserMedia API

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -71,6 +71,22 @@
                     {
                         "condition": [
                             {
+                                "domain": "claude.ai"
+                            }
+                        ],
+                        "patchSettings": [
+                            {
+                                "op": "add",
+                                "path": "/apiChanges/MediaDevices.prototype.getUserMedia",
+                                "value": {
+                                    "type": "remove"
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "condition": [
+                            {
                                 "domain": "1cs.jp"
                             },
                             {


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/task/1214895337872099?focus=true

## Description
<!-- 
  Please delete either or both process sections below.
-->

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes a core web API for `claude.ai`, which could break voice/camera features or other site flows on Windows. Scope is limited to a single domain and the `windows-override.json` configuration.
> 
> **Overview**
> **Windows config change:** adds a `conditionalChanges` rule in `windows-override.json` for `claude.ai` that removes `MediaDevices.prototype.getUserMedia` via `apiManipulation`.
> 
> This effectively disables `getUserMedia` (camera/mic access API) only on that domain for Windows builds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0e9d3e29a3ad5473e50987018e76df924e154524. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->