### PR TITLE
Unblock lambda-url on foxnews.com

### DIFF
--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -3151,6 +3151,19 @@
                     }
                 ]
             },
+            "on.aws": {
+                "rules": [
+                    {
+                        "rule": "lambda-url.us-east-1.on.aws",
+                        "domains": [
+                            "foxnews.com"
+                        ],
+                        "reason": [
+                            "https://github.com/duckduckgo/privacy-configuration/pull/5194"
+                        ]
+                    }
+                ]
+            },
             "onesignal.com": {
                 "rules": [
                     {


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1206670747178362/task/1214869576895222?focus=true

## Description
<!-- 
  Please delete either or both process sections below.
-->

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:

**Reported URLs:** https://foxnation2.foxnews.com/ccas and https://foxnation2.foxnews.com/ccpc
**Problem:** Tapping \"Confirm My Refund\" does nothing. The page POSTs to an AWS Lambda Function URL on \`lambda-url.us-east-1.on.aws\`, which tracker blocking treats as the blocked tracker domain \`on.aws\`.
**Platforms affected:** Extensions (validated with Chrome dev build + local config override)
**Tracker(s) being unblocked:** \`on.aws\` (rule: \`lambda-url.us-east-1.on.aws\`)
**Mitigation:** Tracker allowlist entry for \`foxnews.com\` (covers \`foxnation2.foxnews.com\`).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new tracker allowlist entry that permits requests to `lambda-url.us-east-1.on.aws` on `foxnews.com`, which can increase allowed third-party connectivity but is narrowly scoped to a single site and subdomain pattern.
> 
> **Overview**
> Unblocks a site breakage on `foxnews.com` by adding an allowlist entry for the `on.aws` tracker.
> 
> Specifically allows `lambda-url.us-east-1.on.aws` requests when loaded by `foxnews.com` (covering `foxnation2.foxnews.com`), with the change tracked via PR reference in the rule `reason`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aaf5dd480ddff453efd63f7a432d112f98bdda8d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->