### PR TITLE
Unblock on.aws

### DIFF
--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -3154,12 +3154,13 @@
             "on.aws": {
                 "rules": [
                     {
-                        "rule": "lambda-url.us-east-1.on.aws",
+                        "rule": "on.aws",
                         "domains": [
-                            "foxnews.com"
+                            "<all>"
                         ],
                         "reason": [
-                            "https://github.com/duckduckgo/privacy-configuration/pull/5194"
+                            "https://github.com/duckduckgo/privacy-configuration/pull/5194",
+                            "https://github.com/duckduckgo/privacy-configuration/pull/5195"
                         ]
                     }
                 ]


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1200342317600122/task/1214895337218881?focus=true

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Expands the `on.aws` allowlist from a specific Lambda URL pattern and single domain to a catch-all rule for all domains, which could reduce tracker blocking coverage if overly broad.
> 
> **Overview**
> Updates `features/tracker-allowlist.json` to **unblock `on.aws` more broadly** by replacing the specific `lambda-url.us-east-1.on.aws` rule scoped to `foxnews.com` with a generic `on.aws` rule that applies to `<all>` domains, and records an additional PR link in the rule’s `reason` metadata.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2291663efb11969f83cdb16661f26afbd9976792. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->