### PR TITLE
Debug Claude getUserMedia API

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -71,6 +71,27 @@
                     {
                         "condition": [
                             {
+                                "domain": "claude.ai"
+                            }
+                        ],
+                        "patchSettings": [
+                            {
+                                "op": "add",
+                                "path": "/apiChanges/MediaDevices.prototype.getUserMedia",
+                                "value": {
+                                    "type": "descriptor",
+                                    "define": true,
+                                    "getterValue": {
+                                        "type": "function",
+                                        "functionName": "debug"
+                                    }
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "condition": [
+                            {
                                 "domain": "1cs.jp"
                             },
                             {


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/task/1214895337872099?focus=true

## Description
<!-- 
  Please delete either or both process sections below.
-->

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a domain-scoped override that redefines `MediaDevices.prototype.getUserMedia` on `claude.ai`, which could impact camera/mic access behavior on that site if misconfigured.
> 
> **Overview**
> Adds a new Windows `apiManipulation` conditional override for **`claude.ai`** that `define`s `MediaDevices.prototype.getUserMedia` as a function descriptor pointing to `debug`.
> 
> No other override rules are changed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9becfd291a5f16b8cdd6db3a880673f2e199f25d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->