### PR TITLE
Add more adwall mitigations

### DIFF
--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -4388,9 +4388,15 @@
                         "rule": "merequartz.com",
                         "domains": [
                             "nbcsports.com",
-                            "pagesix.com"
+                            "pagesix.com",
+                            "weather.com",
+                            "gameskinny.com",
+                            "nj.com"
                         ],
-                        "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5114"
+                        "reason": [
+                            "nbcsports.com, pagesix.com - https://github.com/duckduckgo/privacy-configuration/pull/5114",
+                            "weather.com, gameskinny.com, nj.com - https://github.com/duckduckgo/privacy-configuration/pull/5197"
+                        ]
                     }
                 ]
             },
@@ -4446,6 +4452,171 @@
                             "deadline.com"
                         ],
                         "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5127"
+                    }
+                ]
+            },
+            "fishingtoolsbox.com": {
+                "rules": [
+                    {
+                        "rule": "fishingtoolsbox.com",
+                        "domains": [
+                            "parade.com"
+                        ],
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5197"
+                    }
+                ]
+            },
+            "cloudguppy.com": {
+                "rules": [
+                    {
+                        "rule": "cloudguppy.com",
+                        "domains": [
+                            "hollywoodreporter.com"
+                        ],
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5197"
+                    }
+                ]
+            },
+            "inventorycache.com": {
+                "rules": [
+                    {
+                        "rule": "inventorycache.com",
+                        "domains": [
+                            "gameskinny.com"
+                        ],
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5197"
+                    }
+                ]
+            },
+            "pricklydebt.com": {
+                "rules": [
+                    {
+                        "rule": "pricklydebt.com",
+                        "domains": [
+                            "sporcle.com"
+                        ],
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5197"
+                    }
+                ]
+            },
+            "knitstamp.com": {
+                "rules": [
+                    {
+                        "rule": "knitstamp.com",
+                        "domains": [
+                            "sporcle.com"
+                        ],
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5197"
+                    }
+                ]
+            },
+            "adorableattention.com": {
+                "rules": [
+                    {
+                        "rule": "adorableattention.com",
+                        "domains": [
+                            "theglobeandmail.com"
+                        ],
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5197"
+                    }
+                ]
+            },
+            "newsbotnet.com": {
+                "rules": [
+                    {
+                        "rule": "newsbotnet.com",
+                        "domains": [
+                            "palmbeachpost.com"
+                        ],
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5197"
+                    }
+                ]
+            },
+            "sheargovernor.com": {
+                "rules": [
+                    {
+                        "rule": "sheargovernor.com",
+                        "domains": [
+                            "cbssports.com"
+                        ],
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5197"
+                    }
+                ]
+            },
+            "spellknight.com": {
+                "rules": [
+                    {
+                        "rule": "spellknight.com",
+                        "domains": [
+                            "independent.co.uk"
+                        ],
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5197"
+                    }
+                ]
+            },
+            "enterdrama.com": {
+                "rules": [
+                    {
+                        "rule": "enterdrama.com",
+                        "domains": [
+                            "blu-ray.com"
+                        ],
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5197"
+                    }
+                ]
+            },
+            "glasscoyote.com": {
+                "rules": [
+                    {
+                        "rule": "glasscoyote.com",
+                        "domains": [
+                            "queerty.com"
+                        ],
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5197"
+                    }
+                ]
+            },
+            "lunchroomlock.com": {
+                "rules": [
+                    {
+                        "rule": "lunchroomlock.com",
+                        "domains": [
+                            "seattletimes.com"
+                        ],
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5197"
+                    }
+                ]
+            },
+            "carsarace.com": {
+                "rules": [
+                    {
+                        "rule": "carsarace.com",
+                        "domains": [
+                            "townhall.com"
+                        ],
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5197"
+                    }
+                ]
+            },
+            "zestyhorizon.com": {
+                "rules": [
+                    {
+                        "rule": "zestyhorizon.com",
+                        "domains": [
+                            "whattoexpect.com"
+                        ],
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5197"
+                    }
+                ]
+            },
+            "zipthelake.com": {
+                "rules": [
+                    {
+                        "rule": "zipthelake.com",
+                        "domains": [
+                            "ultimateclassicrock.com"
+                        ],
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5197"
                     }
                 ]
             }


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/72649045549333/task/1214295430255973?focus=true

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it expands tracker allowlisting across multiple high-traffic domains, which can affect blocking/privacy behavior if rules are overly broad or mis-scoped.
> 
> **Overview**
> Expands `features/tracker-allowlist.json` with additional allowlist rules intended to mitigate adwall/breakage on more publisher sites.
> 
> Updates the existing `merequartz.com` entry to cover additional domains and splits the `reason` field into per-domain provenance, and adds new allowlisted trackers (e.g., `fishingtoolsbox.com`, `cloudguppy.com`, `inventorycache.com`, etc.) scoped to specific affected domains with references to the related PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b58a55ca4a01594ecd72c62fa8f0ab5d74434197. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->