### PR TITLE
Enable disableFirstAboutBlankNavigation

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -5397,7 +5397,7 @@
             "exceptions": [],
             "features": {
                 "disableFirstAboutBlankNavigation": {
-                    "state": "disabled"
+                    "state": "enabled"
                 },
                 "enableNativeRequestInterception": {
                     "state": "disabled",


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/45878998844068/task/1211665844306856?focus=true

## Description
Enables `disableFirstAboutBlankNavigation` feature for everyone with native request interception enabled.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Enables a navigation-affecting flag under `nativeRequestInterception`, which could introduce site/load regressions for Windows users using this interception path despite the small diff.
> 
> **Overview**
> Turns on `nativeRequestInterception.features.disableFirstAboutBlankNavigation` in `windows-override.json`, enabling this behavior for all Windows clients where native request interception is active (previously disabled).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ba39a367cc81586bfd187beaa7540f6c838407b2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->