### PR TITLE
Disable Admiral experiment

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -188,7 +188,7 @@
                     ]
                 },
                 "tdsNextExperiment009": {
-                    "state": "enabled",
+                    "state": "disabled",
                     "minSupportedVersion": 52361000,
                     "rollout": {
                         "steps": [

--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -579,7 +579,7 @@
                     ]
                 },
                 "tdsNextExperiment009": {
-                    "state": "enabled",
+                    "state": "disabled",
                     "rollout": {
                         "steps": [
                             {

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -589,7 +589,7 @@
                     ]
                 },
                 "tdsNextExperiment009": {
-                    "state": "enabled",
+                    "state": "disabled",
                     "rollout": {
                         "steps": [
                             {


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/72649045549333/task/1214295430255973?focus=true

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: flips a feature/experiment flag from `enabled` to `disabled` in JSON overrides, affecting only experiment rollout behavior.
> 
> **Overview**
> **Disables the Admiral experiment** by changing `blockList.tdsNextExperiment009.state` from `enabled` to `disabled` in `android-override.json`, `ios-override.json`, and `macos-override.json`, preventing further rollout on those platforms.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9f7eebd4deb9739e26a1bc945f9b3169bac9b745. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->