### PR TITLE
Disable progressBarUpgrade flag

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -4237,13 +4237,11 @@
             "minSupportedVersion": 52720000
         },
         "progressBarUpgrade": {
-            "state": "enabled",
-            "minSupportedVersion": 52781000,
+            "state": "disabled",
             "exceptions": [],
             "features": {
                 "behaviourUpdate": {
-                    "state": "enabled",
-                    "minSupportedVersion": 52781000
+                    "state": "disabled"
                 }
             }
         },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/414730916066338/task/1214894284386520?focus=true

## Description
Disable progressBarUpgrade flag. See https://app.asana.com/1/137249556945/project/414730916066338/task/1214732726457179?focus=true for context

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [x] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change that disables an Android feature flag; impact is limited to turning off the `progressBarUpgrade`/`behaviourUpdate` rollout and can be reverted by config update.
> 
> **Overview**
> Disables the Android `progressBarUpgrade` feature (and its nested `behaviourUpdate` toggle) in `overrides/android-override.json`, removing the previously specified `minSupportedVersion` gates so the feature remains off for all versions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 66834d3f7cef643f2c67b705f1c886045c6c4699. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->