### PR TITLE
Split aiChat.attachMoreTabs for sidebar and omnibar

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -1380,7 +1380,10 @@
                     "state": "enabled",
                     "minSupportedVersion": "0.158.0"
                 },
-                "attachMoreTabs": {
+                "sidebarAttachMoreTabs": {
+                    "state": "disabled"
+                },
+                "omnibarAttachMoreTabs": {
                     "state": "disabled"
                 }
             },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/72649045549333/task/1214611507417993?focus=true

## Description
Split aiChat.attachMoreTabs for sidebar and omnibar

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it renames/splits a feature flag key, which can silently disable the feature if consumers still read `attachMoreTabs` or don’t handle the new keys.
> 
> **Overview**
> Updates the Windows `aiChat` feature configuration to **replace** the single `attachMoreTabs` flag with two independently controlled flags: `sidebarAttachMoreTabs` and `omnibarAttachMoreTabs` (both currently `disabled`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a3d8c6d04276aa33f104a394841bc0bd997d725c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->