### PR TITLE
Enables Watchdog in 1.189

### DIFF
--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -2224,7 +2224,8 @@
                     "state": "enabled"
                 },
                 "hangReporting": {
-                    "state": "disabled"
+                    "state": "enabled",
+                    "minSupportedVersion": "1.189.0"
                 },
                 "unifiedURLPredictor": {
                     "state": "enabled",


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/1211150618152277/task/1214940333458276

## Description
This PR enables the hangReporting Feature Flag in macOS, +1.189.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Enables a new macOS browser feature flag, which could affect stability/performance and increase diagnostic reporting for users on newer versions.
> 
> **Overview**
> **Enables macOS hang reporting (watchdog)** by flipping `macOSBrowserConfig.features.hangReporting` from disabled to enabled.
> 
> The flag is gated with `minSupportedVersion: 1.189.0`, so it only applies to macOS app versions `>= 1.189.0`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a25d942a568b411ea2d84027c725d9c397618ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->