### PR TITLE
Disables Hang Reporting

### DIFF
--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -2224,8 +2224,7 @@
                     "state": "enabled"
                 },
                 "hangReporting": {
-                    "state": "enabled",
-                    "minSupportedVersion": "1.189.0"
+                    "state": "disabled"
                 },
                 "unifiedURLPredictor": {
                     "state": "enabled",


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/1211150618152277/task/1214940333458278

## Description
This PR disables the `hangReporting` Feature Flag in macOS

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change that disables macOS hang reporting; main impact is reduced diagnostics/telemetry and potentially less hang data for debugging.
> 
> **Overview**
> Disables **hang reporting** for the macOS browser by setting `macOSBrowserConfig.features.hangReporting.state` to `disabled` in `overrides/macos-override.json`, and removes the associated `minSupportedVersion` gate so it is off across versions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bfa7a1bbd24ca67efac80c179d07529d52ef1bad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->