### PR TITLE
add serp proxy to duck.co domains

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -532,6 +532,16 @@
                         ]
                     },
                     {
+                        "domain": "duck.co",
+                        "patchSettings": [
+                            {
+                                "op": "replace",
+                                "path": "/overlays/serpProxy/state",
+                                "value": "enabled"
+                            }
+                        ]
+                    },
+                    {
                         "domain": "m.youtube.com",
                         "patchSettings": [
                             {

--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -513,7 +513,7 @@
                 "domains": [
                     {
                         "domain": [
-                            "www.youtube.com", 
+                            "www.youtube.com",
                             "m.youtube.com"
                         ],
                         "patchSettings": [
@@ -526,7 +526,7 @@
                     },
                     {
                         "domain": [
-                            "duckduckgo.com", 
+                            "duckduckgo.com",
                             "duck.co"
                         ],
                         "patchSettings": [

--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -512,7 +512,10 @@
                 },
                 "domains": [
                     {
-                        "domain": "www.youtube.com",
+                        "domain": [
+                            "www.youtube.com", 
+                            "m.youtube.com"
+                        ],
                         "patchSettings": [
                             {
                                 "op": "replace",
@@ -522,31 +525,14 @@
                         ]
                     },
                     {
-                        "domain": "duckduckgo.com",
+                        "domain": [
+                            "duckduckgo.com", 
+                            "duck.co"
+                        ],
                         "patchSettings": [
                             {
                                 "op": "replace",
                                 "path": "/overlays/serpProxy/state",
-                                "value": "enabled"
-                            }
-                        ]
-                    },
-                    {
-                        "domain": "duck.co",
-                        "patchSettings": [
-                            {
-                                "op": "replace",
-                                "path": "/overlays/serpProxy/state",
-                                "value": "enabled"
-                            }
-                        ]
-                    },
-                    {
-                        "domain": "m.youtube.com",
-                        "patchSettings": [
-                            {
-                                "op": "replace",
-                                "path": "/overlays/youtube/state",
                                 "value": "enabled"
                             }
                         ]


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/392891325557410/task/1214935180910575?focus=true

## Description
Enables serpProxy for duck.co (dev instances).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change that expands domain matching for existing Duck Player overlay toggles; main risk is unintended enablement of overlays on additional hostnames.
> 
> **Overview**
> Updates `overrides/ios-override.json` Duck Player domain rules to **enable the `serpProxy` overlay on `duck.co`** (in addition to `duckduckgo.com`).
> 
> Also consolidates domain matching by allowing a single rule to target multiple hostnames (e.g., `www.youtube.com` + `m.youtube.com`) and removes the now-redundant standalone `m.youtube.com` entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1a95dd98bf883e54896260ef13fe9019e9c505e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->