### PR TITLE
Update content-blocker extension to 2026.5.19

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -4634,7 +4634,7 @@
             "minSupportedVersion": "0.148.0",
             "exceptions": [],
             "settings": {
-                "extensionUrl": "https://staticcdn.duckduckgo.com/extensions/content-blocker/content-blocker-extension-2026.5.17.crx"
+                "extensionUrl": "https://staticcdn.duckduckgo.com/extensions/content-blocker/content-blocker-extension-2026.5.19.crx"
             },
             "features": {
                 "onboardingEnabled": {


### PR DESCRIPTION
Update content-blocker extension to 2026.5.19.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a single configuration value is updated to point Windows to a newer content-blocker extension CRX; main risk is rollout issues if the CDN artifact is missing or incompatible.
> 
> **Overview**
> Updates `overrides/windows-override.json` to bump the `adBlockV2Extension` `extensionUrl` from `content-blocker-extension-2026.5.17.crx` to `content-blocker-extension-2026.5.19.crx`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c6325c728cdca3b31ddba1879ac2d23a434c3ba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->