### PR TITLE
Update ad-blocking extension scriptlets for v2026.5.19

### DIFF
--- a/features/ad-blocking-extension.json
+++ b/features/ad-blocking-extension.json
@@ -4,24 +4,28 @@
     },
     "exceptions": [],
     "settings": {
-        "version": "2026.5.17",
+        "version": "2026.5.19",
         "enabledByDefault": false,
         "scriptlets": {
             "scriptlets/isolated/ublock-filters.js": {
                 "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/d58a8f8997ee8d751b41046b47d1a99ef66f423dbaa5575db3efccc02179de54.js",
-                "signature": "MEYCIQD1n5kIB8njTSntfb8C+Epyl5rN3HYv1AhaHqa1FvXgXAIhAN1ZU3N6YCOmOvJppucK/wB7mPKDnfcdhKObDUpvtvyc"
+                "signature": "MEQCIG9id0WdeZ5oHsMZp2nr0CvviaAT0CqSqspTwhTN51xpAiBVTmOYowYomYR25niZ+BH4O4VAtf19iASjPjO/KBlqyw=="
             },
             "scriptlets/main/ublock-filters.js": {
                 "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/a99944281e8860d546baa213ffa8ae499f5f02371f26669ded118003c91c8d56.js",
-                "signature": "MEUCIB7j7nOyJQaCVflY41zc/3BEvgmP1fJxtXgEfXRsN/q9AiEA/iC6ESpoPVSIDQZ152GgOwawvA6yks/uMkVwOk5Ai5s="
+                "signature": "MEQCIEnZ8yUMPxkiYV0FIiKg6GMCsXLxbaLFqp6NnI6rnmmLAiAGg/11Vw5d/cO4WU9NfnLwFJKWiM04i6dbblaCVj/xHg=="
             },
             "scriptlets/main/ublock-experimental.js": {
                 "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855.js",
-                "signature": "MEYCIQDN+Wj7xFHn+6ku07yZ2+LxgqchVswIjjmxGWFpcVwO4AIhALdvVIRtlIY2NrQNAAe0j1LRxzJ98Wwc8gjjHi0BCtSz"
+                "signature": "MEUCIGAzhHowJRWeIZSn9YqvZ/KTgryUt2izyLfbh3dCIyGsAiEA8nhz5pm3RmU/SqXPL0WfGHlJy+gnQtEvQu4OwIT8+Qo="
             },
             "scriptlets/isolated/ublock-experimental.js": {
                 "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855.js",
-                "signature": "MEUCIFC2qPZ6mcu8PQeW1mQ4+d4o67Qlbz7AuRCeBFTDaTDRAiEAxhOoh/LQ3KjCCCtUDEijCy+evULwFRX2+7qMC7gzds0="
+                "signature": "MEUCIAZIL875oXtKym076hTvKtodf0l8JlZmJwCtDCCiQRu0AiEAl6vmTE9uTG87J6gzBTGI2DzOe+0iEbvz96hlvJKC/YU="
+            },
+            "rules/youtube.json": {
+                "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/724bc80bf32c164941533b9ea3d2da44bcf51d5c861ceb748d3fd9901e4beea2.json",
+                "signature": "MEQCIGvWHm9oSFIGwIoTRZUb9lZuquWO5SKGQ4iZ5pUJ2whvAiAeIyHF6PrwWi1mtDgdzsemqAZWqW/lXdXhtI6i1S80Kg=="
             }
         }
     }


### PR DESCRIPTION
Update ad-blocking extension scriptlets for v2026.5.19.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates the shipped ad-blocking manifest to reference new signed remote scriptlet/rules assets; regressions would mainly show up as broken or changed blocking behavior on affected sites.
> 
> **Overview**
> Bumps `features/ad-blocking-extension.json` to version `2026.5.19`, updating the signatures for the existing uBlock filter/experimental scriptlet assets.
> 
> Adds a new signed `rules/youtube.json` entry (remote URL + signature) to the manifest.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 629e1c04175641a3649ed5c45a28eb7a28228a18. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->