### PR TITLE
Enable detectInstalledAv feature for PROFILE_IN_USE diagnosis

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -4836,6 +4836,9 @@
                 },
                 "reportStackTrace": {
                     "state": "disabled"
+                },
+                "detectInstalledAv": {
+                    "state": "enabled"
                 }
             }
         },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1208671518706472/task/1214682786524057?focus=true

## Description
<!-- 
  Please delete either or both process sections below.
-->

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Enables an additional diagnostics signal on Windows (`detectInstalledAv`), which could affect telemetry content and privacy expectations but is limited to configuration only.
> 
> **Overview**
> **Windows override config** now enables the `detectInstalledAv` subfeature under `extendedCrashReporting`, allowing the Windows app to include installed antivirus detection as part of crash/diagnostics reporting (intended to help diagnose `PROFILE_IN_USE` issues).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 115a0b28b6ddf50d65a6445d8db9c03921e246c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->