### PR TITLE
Disable apiManipulation on x.com for Windows

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -31,6 +31,12 @@
         },
         "apiManipulation": {
             "state": "enabled",
+            "exceptions": [
+                {
+                    "domain": "x.com",
+                    "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5211"
+                }
+            ],
             "settings": {
                 "apiChanges": {
                     "Navigator.prototype.deviceMemory": {


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1204912272578138/task/1214963670524532?focus=true

## Description
Fixes x.com login breakage:
 1. Open x.com in Windows Browser (CEF) (app version 0.156.2, OS 11).
 2. Start the login flow.
 3. Enter the email address.
 4. Observe that it does not progress to password entry and reloads the email entry screen.

It seems our API overrides are triggering a bot detection that prevents progress here.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change that adds a domain exception to avoid site breakage; impact is limited to `x.com` on Windows overrides.
> 
> **Overview**
> Disables `apiManipulation` on **Windows** for `x.com` by adding it to the feature’s `exceptions` list (with a reference to PR `#5211`), to mitigate reported login flow breakage potentially triggered by API overrides.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 693541a00ffed989deabf522b052b0b14eda4936. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->