### PR TITLE
iOS: enable defaultExistingIPhoneUsersToNewTabAfterIdle at 2% from 7.…

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -2642,6 +2642,17 @@
                         "idleThresholdSeconds": 1800
                     }
                 },
+                "defaultExistingIPhoneUsersToNewTabAfterIdle": {
+                    "state": "enabled",
+                    "minSupportedVersion": "7.220.0",
+                    "rollout": {
+                        "steps": [
+                            {
+                                "percent": 2
+                            }
+                        ]
+                    }
+                },
                 "onboardingRebranding": {
                     "state": "enabled",
                     "minSupportedVersion": "7.214.0"


### PR DESCRIPTION
…220.0

**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/1204186595873227/task/1214934880112562?focus=true

## Description
Default Opt in 2% of old users to NTP after idle

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Enables a behavior-changing iOS feature flag for existing users (defaulting to a new tab after idle) starting at v7.220.0, initially at 2% rollout. Risk is limited to UX/behavior regressions for that cohort if the flag is mis-scoped or the rollout needs quick rollback.
> 
> **Overview**
> **Adds a new iOS remote-config feature flag** `defaultExistingIPhoneUsersToNewTabAfterIdle` under `iOSBrowserConfig`.
> 
> The flag is **enabled from iOS version `7.220.0`** and introduced with a **2% rollout step**, defaulting a small cohort of existing iPhone users to the “new tab after idle” behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c8f9557053b2b03d86ec895385bb2865625f056b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->