### PR TITLE
Windows facebook default ua ch

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -2319,6 +2319,12 @@
                     },
                     {
                         "domain": "www.smythstoys.com"
+                    },
+                    {
+                        "domain": "facebook.com"
+                    },
+                    {
+                        "domain": "www.facebook.com"
                     }
                 ]
             },
@@ -4067,6 +4073,10 @@
                 {
                     "domain": "smythstoys.com",
                     "reason": "Bot check"
+                },
+                {
+                    "domain": "facebook.com",
+                    "reason": "reCAPTCHA failing on Facebook login"
                 }
             ]
         },

--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -4069,7 +4069,7 @@
                     "reason": "Bot check"
                 },
                 {
-                    "domain": "www.facebook.com",
+                    "domain": "facebook.com",
                     "reason": "reCAPTCHA failing on Facebook login"
                 }
             ]

--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -2319,12 +2319,6 @@
                     },
                     {
                         "domain": "www.smythstoys.com"
-                    },
-                    {
-                        "domain": "facebook.com"
-                    },
-                    {
-                        "domain": "www.facebook.com"
                     }
                 ]
             },
@@ -4075,7 +4069,7 @@
                     "reason": "Bot check"
                 },
                 {
-                    "domain": "facebook.com",
+                    "domain": "www.facebook.com",
                     "reason": "reCAPTCHA failing on Facebook login"
                 }
             ]


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/949243614371883/task/1214964767697548?focus=true

## Description
<!-- 
  Please delete either or both process sections below.
-->

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change that adds a single domain exception to `uaChBrands`; impact is limited to UA client-hints behavior on `www.facebook.com` and could slightly reduce fingerprinting protections there.
> 
> **Overview**
> Adds `www.facebook.com` to the Windows override `uaChBrands.exceptions`, disabling UA-CH brand hints for Facebook to mitigate a login reCAPTCHA failure.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c9aa1ae5c6267abcd7f57dd428a41132b2012a6f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->