### PR TITLE
Api manipulation mediadevices noop and schema changes

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -89,7 +89,6 @@
                                 "path": "/apiChanges/MediaDevices.prototype.addEventListener",
                                 "value": {
                                     "type": "descriptor",
-                                    "define": true,
                                     "value": {
                                         "type": "function",
                                         "functionName": "noop"
@@ -101,7 +100,6 @@
                                 "path": "/apiChanges/MediaDevices.prototype.removeEventListener",
                                 "value": {
                                     "type": "descriptor",
-                                    "define": true,
                                     "value": {
                                         "type": "function",
                                         "functionName": "noop"

--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -71,6 +71,62 @@
                     {
                         "condition": [
                             {
+                                "domain": "youtube.com"
+                            },
+                            {
+                                "domain": "linkedin.com"
+                            },
+                            {
+                                "domain": "claude.ai"
+                            },
+                            {
+                                "domain": "claude.com"
+                            }
+                        ],
+                        "patchSettings": [
+                            {
+                                "op": "add",
+                                "path": "/apiChanges/MediaDevices.prototype.addEventListener",
+                                "value": {
+                                    "type": "descriptor",
+                                    "define": true,
+                                    "value": {
+                                        "type": "function",
+                                        "functionName": "noop"
+                                    }
+                                }
+                            },
+                            {
+                                "op": "add",
+                                "path": "/apiChanges/MediaDevices.prototype.removeEventListener",
+                                "value": {
+                                    "type": "descriptor",
+                                    "define": true,
+                                    "value": {
+                                        "type": "function",
+                                        "functionName": "noop"
+                                    }
+                                }
+                            },
+                            {
+                                "op": "add",
+                                "path": "/apiChanges/MediaDevices.prototype.ondevicechange",
+                                "value": {
+                                    "type": "descriptor",
+                                    "getterValue": {
+                                        "type": "undefined"
+                                    },
+                                    "setterValue": {
+                                        "type": "function",
+                                        "functionName": "noop"
+                                    }
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "condition": [
+                            {
                                 "domain": "1cs.jp"
                             },
                             {

--- a/schema/features/api-manipulation.ts
+++ b/schema/features/api-manipulation.ts
@@ -8,13 +8,6 @@ type DescriptorAPIChange = {
     type: 'descriptor';
     enumerable?: boolean;
     configurable?: boolean;
-    // If true and the property is not already an own property of the target, defines a new own
-    // property (shadowing any inherited one from the prototype chain - e.g. set this when
-    // targeting `MediaDevices.prototype.addEventListener` which is inherited from
-    // `EventTarget.prototype`). When false or omitted, the change is merged with any existing
-    // own descriptor; changes whose target property exists only via the prototype chain are
-    // silently skipped.
-    define?: boolean;
     // Accessor-style overrides: supply `getterValue` to override the property's getter, and/or
     // `setterValue` to override its setter (each invoked on access/assignment respectively).
     // Either or both may be supplied; mutually exclusive with `value`.
@@ -26,6 +19,7 @@ type DescriptorAPIChange = {
     // Mutually exclusive with `getterValue`/`setterValue`. At least one of `getterValue`,
     // `setterValue`, or `value` must be supplied; this is enforced at runtime.
     value?: CSSConfigSetting;
+    define?: boolean; // If this is true, it permits defining new properties on the object. Otherwise, it only permits modifying existing properties.
 };
 
 type FullAPIManipulationOptions = CSSInjectFeatureSettings<{

--- a/schema/features/api-manipulation.ts
+++ b/schema/features/api-manipulation.ts
@@ -8,8 +8,24 @@ type DescriptorAPIChange = {
     type: 'descriptor';
     enumerable?: boolean;
     configurable?: boolean;
-    getterValue: CSSConfigSetting;
-    define?: boolean; // If this is true, it permits defining new properties on the object. Otherwise, it only permits modifying existing properties.
+    // If true and the property is not already an own property of the target, defines a new own
+    // property (shadowing any inherited one from the prototype chain - e.g. set this when
+    // targeting `MediaDevices.prototype.addEventListener` which is inherited from
+    // `EventTarget.prototype`). When false or omitted, the change is merged with any existing
+    // own descriptor; changes whose target property exists only via the prototype chain are
+    // silently skipped.
+    define?: boolean;
+    // Accessor-style overrides: supply `getterValue` to override the property's getter, and/or
+    // `setterValue` to override its setter (each invoked on access/assignment respectively).
+    // Either or both may be supplied; mutually exclusive with `value`.
+    getterValue?: CSSConfigSetting;
+    setterValue?: CSSConfigSetting;
+    // Value-style overrides: supply `value` to replace the property with a data descriptor
+    // (also used to replace methods, including DOM methods - the runtime masks the replacement
+    // so `toString()`, `name`, and `length` continue to resemble the original).
+    // Mutually exclusive with `getterValue`/`setterValue`. At least one of `getterValue`,
+    // `setterValue`, or `value` must be supplied; this is enforced at runtime.
+    value?: CSSConfigSetting;
 };
 
 type FullAPIManipulationOptions = CSSInjectFeatureSettings<{


### PR DESCRIPTION
**Asana Task/Github Issue:**  https://app.asana.com/1/137249556945/inbox/1199237043596759/item/1214898456412755/story/1214881007727955?focus=true

## Description

This adds support for setter and value type definitions that are going to be added in the following ContentScopeScripts patch: https://github.com/duckduckgo/content-scope-scripts/pull/2703/changes

It also fixes the known issue with these APIs by preventing the enumeration prompts on these known websites; the patch is scoped narrowly because this may cause breakage in.

Because the feature currently doesn't support value and set a value, this will be backwards compatible, but won't be supported until there's a hot fix.

Once applied, these patch settings should result in the following:
```json
      "settings": {
        "apiChanges": {
          "MediaDevices.prototype.addEventListener": {
            "type": "descriptor",
            "value": {
              "type": "function",
              "functionName": "noop"
            }
          },
          "MediaDevices.prototype.ondevicechange": {
            "type": "descriptor",
            "getterValue": {
              "type": "undefined"
            },
            "setterValue": {
              "type": "function",
              "functionName": "noop"
            }
          },
          "MediaDevices.prototype.removeEventListener": {
            "type": "descriptor",
            "value": {
              "type": "function",
              "functionName": "noop"
            }
          }
        }
```


### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it expands the `apiManipulation` schema and introduces domain-scoped overrides that can alter `MediaDevices` behavior on major sites, which may cause site-specific breakage if the runtime doesn’t fully support the new descriptor shapes yet.
> 
> **Overview**
> Updates the `apiManipulation` schema to allow descriptor overrides to specify optional `setterValue` and/or `value` (in addition to `getterValue`), enabling both accessor-style and data-descriptor-style API replacements.
> 
> Adds a Windows-only, domain-scoped `apiManipulation` override for `youtube.com`, `linkedin.com`, `claude.ai`, and `claude.com` that no-ops `MediaDevices.prototype.addEventListener`/`removeEventListener` and forces `MediaDevices.prototype.ondevicechange` to have an `undefined` getter with a no-op setter to prevent device enumeration prompts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d1c97247d33824bac9700e2fb6f8f9abb8aca279. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->