### PR TITLE
Add domain entry for privacy-test-pages.site

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -87,6 +87,9 @@
                             },
                             {
                                 "domain": "claude.com"
+                            },
+                            {
+                                "domain": "privacy-test-pages.site"
                             }
                         ],
                         "patchSettings": [


### PR DESCRIPTION
**Asana Task/Github Issue:**

## Description
<!-- 
  Please delete either or both process sections below.
-->

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change that extends an existing domain allow/exception list; potential impact is limited to `privacy-test-pages.site` behavior on Windows.
> 
> **Overview**
> Adds `privacy-test-pages.site` to the `apiManipulation` conditional domain list in `windows-override.json`, so it receives the same `MediaDevices` event-listener no-op patches already applied to `youtube.com`, `linkedin.com`, and `claude.*`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a2137ea9be06e5bbd50c90a1d50d4ad9012bdf8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->