### PR TITLE
Add protechts block on linkedin

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -5142,7 +5142,44 @@
             }
         },
         "requestBlocklist": {
-            "state": "enabled"
+            "state": "enabled",
+            "settings": {
+                "blockedRequests": {
+                    "privacy-test-pages.site": {
+                        "rules": [
+                            {
+                                "rule": "privacy-test-pages.site/privacy-protections/request-blocklist/*?block=true",
+                                "domains": [
+                                    "privacy-test-pages.site"
+                                ],
+                                "reason": "Testing rule for the privacy test page, see https://privacy-test-pages.site/privacy-protections/request-blocklist/"
+                            }
+                        ]
+                    },
+                    "third-party.site": {
+                        "rules": [
+                            {
+                                "rule": "third-party.site/privacy-protections/request-blocklist/*?block=true",
+                                "domains": [
+                                    "privacy-test-pages.site"
+                                ],
+                                "reason": "Testing rule for the privacy test page, see https://privacy-test-pages.site/privacy-protections/request-blocklist/"
+                            }
+                        ]
+                    },
+                    "protechts.net": {
+                        "rules": [
+                            {
+                                "rule": "protechts.net",
+                                "domains": [
+                                    "linkedin.com"
+                                ],
+                                "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5218"
+                            }
+                        ]
+                    }
+                }
+            }
         },
         "passwordManagerExtensions": {
             "state": "internal",


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/task/1214933948986277?focus=true

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes network request blocking behavior; an overly broad block could cause site breakage (especially on `linkedin.com`).
> 
> **Overview**
> Adds `requestBlocklist` configuration to `windows-override.json`, introducing explicit `blockedRequests` rules.
> 
> This includes a new block for `protechts.net` when browsing `linkedin.com`, plus test-only rules for `privacy-test-pages.site` and `third-party.site` used by the privacy test page.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a3826f997644c0947d7f19357942c5398621fa35. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->