### PR TITLE
Disable recent chat deletion on Windows

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -1381,7 +1381,7 @@
                     "minSupportedVersion": "0.157.0"
                 },
                 "suggestionsDeletion": {
-                    "state": "enabled",
+                    "state": "internal",
                     "minSupportedVersion": "0.155.0"
                 },
                 "ntpRecentChats": {


### PR DESCRIPTION
## Description
Disable recent chat deletion on Windows.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a single Windows-only feature flag is tightened from `enabled` to `internal`, limiting exposure without affecting data handling or core logic.
> 
> **Overview**
> Updates `overrides/windows-override.json` to change the `aiChat` subfeature `suggestionsDeletion` from **`enabled`** to **`internal`** on Windows, effectively disabling public access to recent chat deletion behind an internal gate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 70e5ca79859c136dc6f20ba7312baca70a784c63. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->