### PR TITLE
Disable autoconsent on express.co.uk (Pay or OK)

### DIFF
--- a/features/autoconsent.json
+++ b/features/autoconsent.json
@@ -850,6 +850,10 @@
         {
             "domain": "polizei.nrw",
             "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5154"
+        },
+        {
+            "domain": "express.co.uk",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5220"
         }
     ],
     "settings": {


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1206670747178362/task/1214960087001349?focus=true

## Description
Disabled autoconsent on express.co.uk due to a pay or ok wall - opting out of the consent popup forces the user to a paywall.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change that adds a single site exception; impact is limited to autoconsent behavior on `express.co.uk`.
> 
> **Overview**
> Disables autoconsent on `express.co.uk` by adding it to the `features/autoconsent.json` exceptions list (to avoid triggering a pay-or-OK wall when rejecting cookies).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ccf6ef213ebc2c8c1f4027a50dce0669734e403f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->