### PR TITLE
Update content-blocker extension to 2026.5.21

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -4704,7 +4704,7 @@
             "minSupportedVersion": "0.148.0",
             "exceptions": [],
             "settings": {
-                "extensionUrl": "https://staticcdn.duckduckgo.com/extensions/content-blocker/content-blocker-extension-2026.5.19.crx"
+                "extensionUrl": "https://staticcdn.duckduckgo.com/extensions/content-blocker/content-blocker-extension-2026.5.21.crx"
             },
             "features": {
                 "onboardingEnabled": {


### PR DESCRIPTION
Update content-blocker extension to 2026.5.21.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a single config change updates the CDN URL for the Windows `adBlockV2Extension` CRX; potential impact is limited to extension rollout if the URL/version is incorrect.
> 
> **Overview**
> Updates the Windows override configuration to point `adBlockV2Extension.settings.extensionUrl` at the new content-blocker CRX (`2026.5.21`) instead of `2026.5.19`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 61d18c6479372a732366fd1edb5438a3ea363d0e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->