### PR TITLE
Update ad-blocking extension scriptlets for v2026.5.21

### DIFF
--- a/features/ad-blocking-extension.json
+++ b/features/ad-blocking-extension.json
@@ -4,24 +4,28 @@
     },
     "exceptions": [],
     "settings": {
-        "version": "2026.5.17",
+        "version": "2026.5.21",
         "enabledByDefault": false,
         "scriptlets": {
             "scriptlets/isolated/ublock-filters.js": {
                 "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/d58a8f8997ee8d751b41046b47d1a99ef66f423dbaa5575db3efccc02179de54.js",
-                "signature": "MEYCIQD1n5kIB8njTSntfb8C+Epyl5rN3HYv1AhaHqa1FvXgXAIhAN1ZU3N6YCOmOvJppucK/wB7mPKDnfcdhKObDUpvtvyc"
+                "signature": "MEUCIQCOnLvvZ8stUQMNYnwbZnRDEfe5fclOyGJwUXsM2BXujAIgegfE90yKZ7WlqQh24kcLsGxXSm5inVvNQT/rCw8mC0E="
             },
             "scriptlets/main/ublock-filters.js": {
                 "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/a99944281e8860d546baa213ffa8ae499f5f02371f26669ded118003c91c8d56.js",
-                "signature": "MEUCIB7j7nOyJQaCVflY41zc/3BEvgmP1fJxtXgEfXRsN/q9AiEA/iC6ESpoPVSIDQZ152GgOwawvA6yks/uMkVwOk5Ai5s="
+                "signature": "MEUCIQCbb8oGK6k+qHr3iIeYedCQrOLEs4ktKnM3m4AaXldqKwIgAlUrmaWYU/2S+Kf/qj3Tz904jvNISyyF5VOm8oMTUKA="
             },
             "scriptlets/main/ublock-experimental.js": {
                 "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855.js",
-                "signature": "MEYCIQDN+Wj7xFHn+6ku07yZ2+LxgqchVswIjjmxGWFpcVwO4AIhALdvVIRtlIY2NrQNAAe0j1LRxzJ98Wwc8gjjHi0BCtSz"
+                "signature": "MEYCIQD3ofJiKKWDiRR0CNfY5VO/ntX2YCLk5WiQldDkzJPyCAIhANDJEWEVcQjdBkBjkoXnymY5IGqwd4tbFpsxgabO+Iyb"
             },
             "scriptlets/isolated/ublock-experimental.js": {
                 "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855.js",
-                "signature": "MEUCIFC2qPZ6mcu8PQeW1mQ4+d4o67Qlbz7AuRCeBFTDaTDRAiEAxhOoh/LQ3KjCCCtUDEijCy+evULwFRX2+7qMC7gzds0="
+                "signature": "MEQCIBx3Tdrk2x4XrpimRQVpQZmaxckfIda7kL9LXajdTjpSAiAohuG+3GxrnXWNUnKAWPOdQR1Mvy3sWo6tl2ItuLEfkA=="
+            },
+            "rules/youtube.json": {
+                "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/2337db6aa7466667595226f780b6590779db3007ac0a65ef3833f89610c92824.json",
+                "signature": "MEUCIFOB5ug5E6bG5RwdpNObWDSVGmTVwps7xLuU2CAVW4GgAiEA9G0rcUalc2YfyWQ3nAdqeUKe28yRaerwDYYglLjp6Tg="
             }
         }
     }


### PR DESCRIPTION
Update ad-blocking extension scriptlets for v2026.5.21.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change; main risk is runtime breakage if updated signatures/URLs don’t match the hosted assets.
> 
> **Overview**
> Updates `features/ad-blocking-extension.json` to **version `2026.5.21`**.
> 
> Rotates signatures for the existing uBlock filter/experimental scriptlets and adds a new `rules/youtube.json` remote ruleset entry (URL + signature).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ad521cfc3b9a8a2b3ecc53b83052d0b9f38e9e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->