### PR TITLE
Enable webview crash reporting for 5% of crashes

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -4418,6 +4418,7 @@
                 },
                 "nativeCrashDialogOneShot": {
                     "state": "enabled",
+                    "minSupportedVersion": "0.158.2",
                     "settings": {
                         "probability": 5,
                         "generation": 2

--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -4417,16 +4417,10 @@
                     "state": "enabled"
                 },
                 "nativeCrashDialogOneShot": {
-                    "state": "disabled",
-                    "rollout": {
-                        "steps": [
-                            {
-                                "percent": 5.0
-                            }
-                        ]
-                    },
+                    "state": "enabled",
                     "settings": {
-                        "generation": 1
+                        "probability": 5,
+                        "generation": 2
                     }
                 }
             }

--- a/schema/features/windows-webview-failures.ts
+++ b/schema/features/windows-webview-failures.ts
@@ -13,6 +13,7 @@ type SubFeatures<VersionType> = {
         VersionType,
         {
             generation: number;
+            probability: number;
         }
     >;
 };


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1207414201589134/task/1215007615158336?focus=true

## Description
Elevated tab crashes reported here: https://app.asana.com/1/137249556945/project/1207414201589134/task/1215003880609879?focus=true

probability field was introduced in https://github.com/duckduckgo/windows-browser/pull/6733

### Feature change process:

- [x] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [x] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adjusts Windows crash-reporting feature flags to enable `nativeCrashDialogOneShot` for supported versions and changes rollout semantics, which could affect crash reporting behavior and user-facing dialogs for a subset of crashes.
> 
> **Overview**
> Enables the Windows `windowsWebviewFailures.nativeCrashDialogOneShot` subfeature and gates it to `minSupportedVersion: 0.158.2`, replacing the prior `rollout`-based toggle with a settings-based **5% sampling** via a new `probability` field.
> 
> Updates the `windows-webview-failures` schema to validate the new `probability` setting alongside `generation`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 02dd4711fa6a507daf098bbb08d7ac30d27a029e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->