### PR TITLE
enable serp proxy for duck.co on macOS

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -532,6 +532,16 @@
                         ]
                     },
                     {
+                        "domain": "duck.co",
+                        "patchSettings": [
+                            {
+                                "op": "replace",
+                                "path": "/overlays/serpProxy/state",
+                                "value": "enabled"
+                            }
+                        ]
+                    },
+                    {
                         "domain": "m.youtube.com",
                         "patchSettings": [
                             {

--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -512,7 +512,10 @@
                 },
                 "domains": [
                     {
-                        "domain": "www.youtube.com",
+                        "domain": [
+                            "www.youtube.com", 
+                            "m.youtube.com"
+                        ],
                         "patchSettings": [
                             {
                                 "op": "replace",
@@ -522,31 +525,14 @@
                         ]
                     },
                     {
-                        "domain": "duckduckgo.com",
+                        "domain": [
+                            "duckduckgo.com", 
+                            "duck.co"
+                        ],
                         "patchSettings": [
                             {
                                 "op": "replace",
                                 "path": "/overlays/serpProxy/state",
-                                "value": "enabled"
-                            }
-                        ]
-                    },
-                    {
-                        "domain": "duck.co",
-                        "patchSettings": [
-                            {
-                                "op": "replace",
-                                "path": "/overlays/serpProxy/state",
-                                "value": "enabled"
-                            }
-                        ]
-                    },
-                    {
-                        "domain": "m.youtube.com",
-                        "patchSettings": [
-                            {
-                                "op": "replace",
-                                "path": "/overlays/youtube/state",
                                 "value": "enabled"
                             }
                         ]

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -273,11 +273,6 @@
                                 "op": "replace",
                                 "path": "/duckAiNativeStorage",
                                 "value": "enabled"
-                            },
-                            {
-                                "op": "replace",
-                                "path": "/overlays/serpProxy/state",
-                                "value": "enabled"
                             }
                         ]
                     }
@@ -655,6 +650,98 @@
                 "nativeUI": {
                     "state": "disabled"
                 }
+            },
+            "settings": {
+                "tryDuckPlayerLink": "https://www.youtube.com/watch?v=yKWIA-Pys4c",
+                "duckPlayerDisabledHelpPageLink": null,
+                "youtubePath": "watch",
+                "youtubeEmbedUrl": "youtube-nocookie.com",
+                "youTubeUrl": "youtube.com",
+                "youTubeReferrerHeaders": [
+                    "Referer"
+                ],
+                "youTubeReferrerQueryParams": [
+                    "embeds_referring_euri"
+                ],
+                "youTubeVideoIDQueryParam": "v",
+                "overlays": {
+                    "youtube": {
+                        "state": "disabled",
+                        "selectors": {
+                            "thumbLink": "a[href^='/watch']",
+                            "excludedRegions": [
+                                "#playlist",
+                                "ytd-movie-renderer",
+                                "ytd-grid-movie-renderer"
+                            ],
+                            "videoElement": "[full-bleed-player] #player-full-bleed-container video, #player video",
+                            "videoElementContainer": "[full-bleed-player] #player-full-bleed-container .html5-video-player, #player .html5-video-player",
+                            "hoverExcluded": [],
+                            "clickExcluded": [
+                                "ytd-thumbnail-overlay-toggle-button-renderer"
+                            ],
+                            "allowedEventTargets": [
+                                ".ytp-inline-preview-scrim",
+                                ".ytd-video-preview",
+                                "#thumbnail-container",
+                                "#video-title-link",
+                                "#video-title",
+                                "video.video-stream.html5-main-video"
+                            ],
+                            "drawerContainer": "body"
+                        },
+                        "thumbnailOverlays": {
+                            "state": "enabled"
+                        },
+                        "clickInterception": {
+                            "state": "enabled"
+                        },
+                        "videoOverlays": {
+                            "state": "enabled"
+                        },
+                        "videoDrawer": {
+                            "state": "disabled"
+                        }
+                    },
+                    "serpProxy": {
+                        "state": "disabled"
+                    }
+                },
+                "domains": [
+                    {
+                        "domain": "www.youtube.com",
+                        "patchSettings": [
+                            {
+                                "op": "replace",
+                                "path": "/overlays/youtube/state",
+                                "value": "enabled"
+                            }
+                        ]
+                    },
+                    {
+                        "domain": [
+                            "duckduckgo.com",
+                            "duck.co"
+                        ],
+                        "patchSettings": [
+                            {
+                                "op": "replace",
+                                "path": "/overlays/serpProxy/state",
+                                "value": "enabled"
+                            }
+                        ]
+                    },
+                    {
+                        "domain": "m.youtube.com",
+                        "patchSettings": [
+                            {
+                                "op": "replace",
+                                "path": "/overlays/youtube/state",
+                                "value": "enabled"
+                            }
+                        ]
+                    }
+                ]
             }
         },
         "newTabContinueSetUp": {

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -273,6 +273,11 @@
                                 "op": "replace",
                                 "path": "/duckAiNativeStorage",
                                 "value": "enabled"
+                            },
+                            {
+                                "op": "replace",
+                                "path": "/overlays/serpProxy/state",
+                                "value": "enabled"
                             }
                         ]
                     }


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/392891325557410/task/1214997036648061?focus=true

## Description
See title

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk configuration-only change that flips domain-scoped DuckPlayer overlay behavior; potential impact is limited to how DuckPlayer proxies/overlays are applied on DuckDuckGo SERP pages.
> 
> **Overview**
> Enables DuckPlayer’s *SERP proxy overlay* on macOS for DuckDuckGo search domains by adding `duck.co` alongside `duckduckgo.com` in the domain patch rules.
> 
> Also centralizes DuckPlayer `settings` (YouTube URL/ID parsing, overlay selectors, and per-domain overlay enablement) under the `duckPlayer` feature so the overlay state is controlled via these domain-specific patches.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4bf026814e6e320e1911400e8de0d11e515e3b79. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->