### PR TITLE
Enable new address bar internally on Windows

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -5488,6 +5488,9 @@
             "features": {
                 "instantSuggestions": {
                     "state": "disabled"
+                },
+                "addressBarOverlay": {
+                    "state": "internal"
                 }
             }
         },


### PR DESCRIPTION
https://app.asana.com/1/137249556945/project/1209072953775241/task/1214384735435708?focus=true

## Description

Enable the new overlay address bar internally on Windows.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk configuration-only change that gates an address bar UI variant behind an `internal` feature flag on Windows; impact is limited to internal cohorts but could affect address bar behavior for those users.
> 
> **Overview**
> **Enables the new overlay address bar for internal Windows builds** by adding an `addressBarOverlay` subfeature (state: `internal`) under the existing `addressBar` feature in `overrides/windows-override.json`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d259372c939f6390befa3d8567d5c89e8a5db74. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->