### PR TITLE
Add element-hiding rule for findagrave.com to collapse empty ad slot

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -1732,6 +1732,15 @@
                 ]
             },
             {
+                "domain": "findagrave.com",
+                "rules": [
+                    {
+                        "selector": ".ad__slot--wrapper",
+                        "type": "hide-empty"
+                    }
+                ]
+            },
+            {
                 "domain": "flickr.com",
                 "rules": [
                     {


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1206670747178362/task/1214960086182123?focus=true

## Description
The DuckDuckGo extension blocks ad content on findagrave.com, but the empty .ad__slot--wrapper container remains at 342px height, creating a large blank space in the middle of the memorial list on mobile viewports.

Add a hide-empty rule for .ad__slot--wrapper on findagrave.com to collapse the container when its contents are empty.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a single domain-scoped `hide-empty` selector rule; impact is limited to `findagrave.com` layout if the selector matches unintended elements.
> 
> **Overview**
> Adds a new domain-specific element-hiding entry for `findagrave.com` to apply a `hide-empty` rule on `.ad__slot--wrapper`, collapsing leftover whitespace when ad content is blocked.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 100f0b6b7c0d06e89f87126740549233a734645a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->