### PR TITLE
Set enumerateDevices messaging timeout to 5 minutes on Windows

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -4316,7 +4316,10 @@
                     "state": "enabled",
                     "changes": []
                 },
-                "enumerateDevices": "enabled",
+                "enumerateDevices": {
+                    "state": "enabled",
+                    "timeoutMs": 300000
+                },
                 "domains": [
                     {
                         "domain": "asana.com",

--- a/schema/features/webcompat.ts
+++ b/schema/features/webcompat.ts
@@ -55,7 +55,13 @@ type FullWebCompatOptions = CSSInjectFeatureSettings<{
             domain?: string;
         }[];
     };
-    enumerateDevices: FeatureState;
+    enumerateDevices:
+        | FeatureState
+        | {
+              state: FeatureState;
+              timeoutMs?: number;
+              timeoutEnabled?: boolean;
+          };
     webNotifications:
         | FeatureState
         | {


### PR DESCRIPTION


**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1209253361096901/task/1215062150508380?focus=true
 
## Description
Configure webCompat.enumerateDevices.timeoutMs to 300000 in the Windows override so the native device-enumeration handshake can wait longer before falling back to the original enumerateDevices API.

Extend the webcompat schema to document timeoutMs and timeoutEnabled.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a small configuration/schema extension that only affects Windows `webCompat.enumerateDevices` behavior and doesn’t touch security-sensitive logic.
> 
> **Overview**
> Updates the Windows override to configure `webCompat.enumerateDevices` as an object with a **5-minute** `timeoutMs` (300000) instead of a bare enabled/disabled flag.
> 
> Extends the `webcompat` schema so `enumerateDevices` can be either a `FeatureState` or an object that includes optional `timeoutMs` and `timeoutEnabled` fields, documenting/validating the new config shape.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a317259e40ba3a8580882b587d705226955bf04d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->