### PR TITLE
Enable crash reporting for 0.157.4

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -4418,7 +4418,7 @@
                 },
                 "nativeCrashDialogOneShot": {
                     "state": "enabled",
-                    "minSupportedVersion": "0.158.2",
+                    "minSupportedVersion": "0.157.4",
                     "settings": {
                         "probability": 5,
                         "generation": 2


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/task/1215007607799535?focus=true

## Description
Related PR: https://github.com/duckduckgo/privacy-configuration/pull/5223
Due to an ongoing elevated VTC numbers: https://app.asana.com/1/137249556945/project/1207414201589134/task/1215003880609879?focus=true

### Feature change process:

- [x] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [x] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change that broadens exposure of a Windows crash-reporting dialog to older app versions; main risk is unintended rollout on versions not validated for the feature.
> 
> **Overview**
> Updates the Windows override config to **enable the `nativeCrashDialogOneShot` crash-reporting rollout starting at `0.157.4`** by lowering its `minSupportedVersion` (from `0.158.2` to `0.157.4`), keeping the existing rollout settings (5% probability, generation 2) unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b3c8226ac973b5bb2ee4de24786eb6952d01263f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->