### PR TITLE
Allow Google Tag Manager gtm.js on FIFA ticketing waiting room

### DIFF
--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -2093,6 +2093,13 @@
                             "tvtropes.org - https://github.com/duckduckgo/privacy-configuration/pull/4006",
                             "snopes.com - https://github.com/duckduckgo/privacy-configuration/pull/4007"
                         ]
+                    },
+                    {
+                        "rule": "googletagmanager.com/gtm.js",
+                        "domains": [
+                            "access.tickets.fifa.com"
+                        ],
+                        "reason": "access.tickets.fifa.com - FIFA World Cup 2026 ticketing waiting room requires Google Tag Manager (gtm.js) for queue flow"
                     }
                 ]
             },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1206777341262243/task/1214192147872053?focus=true

## Description

Add tracker allowlist rule for googletagmanager.com/gtm.js on access.tickets.fifa.com so the FIFA World Cup 2026 queue page can load GTM without tracker blocking.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new tracker allowlist exception for `googletagmanager.com/gtm.js`, which expands third-party tracking script execution on a specific domain and could have privacy/regression implications if scoped incorrectly.
> 
> **Overview**
> Allows `googletagmanager.com/gtm.js` to load on `access.tickets.fifa.com` by adding a new entry to `features/tracker-allowlist.json`, intended to prevent the FIFA World Cup 2026 ticketing waiting-room queue flow from breaking when trackers are blocked.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6eef048d4e575d52bf79667ab087a9aa640ab988. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->