### PR TITLE
Add wbay.com to pubads.g.doubleclick.net/ssai/event/ tracker allowlist

### DIFF
--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -1149,7 +1149,7 @@
                             "cbssports.com",
                             "rocketnews24.com",
                             "wbay.com",
-                            "wunderground.com"
+                            "wunderground.com",
                             "vidbox.dev"
                         ],
                         "reason": [

--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -1127,11 +1127,13 @@
                         "domains": [
                             "cbssports.com",
                             "rocketnews24.com",
+                            "wbay.com",
                             "wunderground.com"
                         ],
                         "reason": [
                             "cbssports.com - Live videos do not load or render.",
                             "rocketnews24.com - https://github.com/duckduckgo/privacy-configuration/issues/846",
+                            "wbay.com - Live video stream fails to load.",
                             "wunderground.com - https://github.com/duckduckgo/privacy-configuration/pull/3096"
                         ]
                     },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1206670747178362/task/1214878404544454?focus=true

## Description
The livestream video on wbay.com fails to play because the extension blocks the SSAI (Server-Side Ad Insertion) manifest request to pubads.g.doubleclick.net/ssai/event/. This endpoint serves the HLS video stream via Google DAI and is required for video playback.

Adding wbay.com to the existing allowlist rule (same pattern as cbssports.com and wunderground.com) allows the manifest request through, enabling the video player to fetch and play the stream.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it expands a tracker allowlist for a Google DoubleClick SSAI endpoint, potentially increasing third-party request exposure on `wbay.com` while being narrowly scoped to a single rule/domain.
> 
> **Overview**
> Adds `wbay.com` to the existing `doubleclick.net` tracker allowlist rule for `pubads.g.doubleclick.net/ssai/event/`, including a new breakage reason, so SSAI manifest requests are permitted and the site’s livestream video can load.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7da2bc614ee08abff4d9f29c133bf5812a4eb6de. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->