### PR TITLE
Revert "Allow Google Tag Manager gtm.js on FIFA ticketing waiting room"

### DIFF
--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -2178,13 +2178,6 @@
                             "tvtropes.org - https://github.com/duckduckgo/privacy-configuration/pull/4006",
                             "snopes.com - https://github.com/duckduckgo/privacy-configuration/pull/4007"
                         ]
-                    },
-                    {
-                        "rule": "googletagmanager.com/gtm.js",
-                        "domains": [
-                            "access.tickets.fifa.com"
-                        ],
-                        "reason": "access.tickets.fifa.com - FIFA World Cup 2026 ticketing waiting room requires Google Tag Manager (gtm.js) for queue flow"
                     }
                 ]
             },


### PR DESCRIPTION
Reverts duckduckgo/privacy-configuration#5230

It doesn't seem that we're actually blocking this request, and so we should remove it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change that removes a single allowlist exception; impact is limited to potentially re-blocking `gtm.js` on `access.tickets.fifa.com` if it was relied on.
> 
> **Overview**
> Reverts the previously-added tracker allowlist entry that permitted `googletagmanager.com/gtm.js` on `access.tickets.fifa.com` (FIFA World Cup 2026 ticketing waiting room), removing that exception from `features/tracker-allowlist.json`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d79252cbff9915de976ae26c07d24e33f0cada6b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->