### PR TITLE
Increase probability for nativeCrashDialogOneShot to 10

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -4423,7 +4423,7 @@
                     "state": "enabled",
                     "minSupportedVersion": "0.157.4",
                     "settings": {
-                        "probability": 5,
+                        "probability": 10,
                         "generation": 2
                     }
                 }


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/task/1215066279824386?focus=true

## Description
To help resolve [Elevated visible tab crashes on 158.2](https://app.asana.com/1/137249556945/project/1207414201589134/task/1215003880609879?focus=true)

### Feature change process:

- [x] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [x] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk configuration tweak that only increases the rollout probability of `nativeCrashDialogOneShot` on Windows; no code or schema changes.
> 
> **Overview**
> In `overrides/windows-override.json`, increases the `windowsWebviewFailures.nativeCrashDialogOneShot` `probability` setting from **5** to **10** (keeping `generation` and `minSupportedVersion` unchanged) to expand how often the one-shot native crash dialog is shown on Windows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c00d7c60bd05ad0e898071e84a22c1d403835957. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->