### PR TITLE
Omit Sec-CH-UA mutations on Facebook for Windows

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -2430,6 +2430,15 @@
                     },
                     {
                         "domain": "www.smythstoys.com"
+                    },
+                    {
+                        "domain": "facebook.com"
+                    },
+                    {
+                        "domain": "www.facebook.com"
+                    },
+                    {
+                        "domain": "m.facebook.com"
                     }
                 ]
             },


### PR DESCRIPTION
Add facebook.com, www.facebook.com, and m.facebook.com to customUserAgent.omitClientHintMutations so native header mutation is skipped on Facebook, matching the existing uaChBrands exception for reCAPTCHA login breakage.

**Asana Task/Github Issue:**

## Description
<!-- 
  Please delete either or both process sections below.
-->

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, narrowly scoped configuration change that only affects `Sec-CH-UA`/client-hint mutation behavior on Facebook domains for Windows.
> 
> **Overview**
> Updates the Windows `customUserAgent` configuration to **omit client hint mutations** for `facebook.com`, `www.facebook.com`, and `m.facebook.com`, so native client-hint header modification is skipped on those sites to mitigate Facebook login/reCAPTCHA breakage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 728b4f35f37955de3b0998b16a406b209c611824. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->