### PR TITLE
disable reportStackTrace

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -4915,7 +4915,7 @@
                     "state": "enabled"
                 },
                 "reportStackTrace": {
-                    "state": "enabled"
+                    "state": "disabled"
                 },
                 "detectInstalledAv": {
                     "state": "enabled"


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1210132634900450/task/1215060874119340?focus=true

## Description
<!-- 
  Please delete either or both process sections below.
-->

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change that stops sending stack traces in Windows `extendedCrashReporting`, which may reduce diagnostic detail but shouldn’t affect runtime behavior.
> 
> **Overview**
> Disables `extendedCrashReporting.features.reportStackTrace` in `windows-override.json`, turning off stack trace reporting for Windows extended crash reports.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit edd02640ebc06cf91b8af412c9f05d3cadd4127a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->