### PR TITLE
Re-enable nativeRequestInterception for 0.158.2+

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -5516,15 +5516,15 @@
         },
         "nativeRequestInterception": {
             "state": "enabled",
-            "minSupportedVersion": "0.155.5",
+            "minSupportedVersion": "0.158.2",
             "exceptions": [],
             "features": {
                 "disableFirstAboutBlankNavigation": {
                     "state": "enabled"
                 },
                 "enableNativeRequestInterception": {
-                    "state": "disabled",
-                    "minSupportedVersion": "0.155.5",
+                    "state": "enabled",
+                    "minSupportedVersion": "0.158.2",
                     "rollout": {
                         "steps": [
                             {


### PR DESCRIPTION
**Asana Task/Github Issue:**

## Description

Re-enables `nativeRequestInterception` on stable after the prior rollback. Gate is narrowed to clients on `0.158.2` or later by bumping `minSupportedVersion` on both the parent and the sub-feature, and flipping the sub-feature's `state` back to `enabled`.

Diff in `overrides/windows-override.json`:

```diff
 "nativeRequestInterception": {
     "state": "enabled",
-    "minSupportedVersion": "0.155.5",
+    "minSupportedVersion": "0.158.2",
     "exceptions": [],
     "features": {
         "disableFirstAboutBlankNavigation": { "state": "enabled" },
         "enableNativeRequestInterception": {
-            "state": "disabled",
-            "minSupportedVersion": "0.155.5",
+            "state": "enabled",
+            "minSupportedVersion": "0.158.2",
             "rollout": { "steps": [ { "percent": 5 }, { "percent": 15 }, { "percent": 40 }, { "percent": 100 } ] }
         }
     }
 }
```

The existing rollout steps culminate at 100%, so eligible 0.158.2+ users get the feature 100%. `disableFirstAboutBlankNavigation` is left untouched.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Turns on network-level native request interception for eligible Windows users; prior rollback suggests breakage risk, though the higher version floor limits exposure.
> 
> **Overview**
> Re-enables **native request interception** on Windows stable in `overrides/windows-override.json` after a prior rollback. **`minSupportedVersion`** moves from `0.155.5` to **`0.158.2`** on both `nativeRequestInterception` and its `enableNativeRequestInterception` sub-feature so only newer clients qualify.
> 
> The sub-feature **`state`** goes from **`disabled`** back to **`enabled`**. Existing rollout steps (5 → 15 → 40 → 100) are unchanged; **`disableFirstAboutBlankNavigation`** is not modified.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ff9fc4ca93925a092c85cf15fb5e24fb22eb8ff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

