### PR TITLE
Add sub-feature to enable attaching rendering diagnostics to user feedbacks

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -4438,6 +4438,9 @@
                         "probability": 10,
                         "generation": 2
                     }
+                },
+                "attachRenderingDiagnosticsToFeedback": {
+                    "state": "disabled"
                 }
             }
         },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1210594645311934/task/1214705301166741?focus=true

## Description
Added `windowsWebviewFailures.attachRenderingDiagnosticsToFeedback` sub-feature to enable attaching rendering diagnostics to user feedbacks.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single JSON override entry defaulting to disabled; no runtime logic changes in this repo.
> 
> **Overview**
> Registers a new **`windowsWebviewFailures`** sub-feature, **`attachRenderingDiagnosticsToFeedback`**, in the Windows platform override so the browser can optionally include rendering diagnostics when users submit feedback about webview failures.
> 
> It is added alongside existing webview-failure toggles (e.g. **`nativeCrashDialogOneShot`**) with **`state": "disabled"`**, so clients get the flag in remote config but behavior stays off until it is turned on deliberately.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6fa314ed69e2c9ddc6e56487877eedb7af96a0a6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->