### PR TITLE
Disable onboardingRebranding on macOS

### DIFF
--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -2274,6 +2274,9 @@
                             "primevideo.com"
                         ]
                     }
+                },
+                "onboardingRebranding": {
+                    "state": "disabled"
                 }
             }
         },


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/1176956903599313/task/1215138600735057?focus=true

## Description

### Feature change process:

Sets the `macOSBrowserConfig.onboardingRebranding` subfeature to `disabled` in `overrides/macos-override.json`. The macOS app's in-code default for the `onboardingRebranding` feature flag is `.enabled` (see `macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift`), so an explicit remote override is required to turn the rebranded onboarding flow off in the wild.

This change is macOS-only. The iOS rollout (`onboardingRebranding` in `overrides/ios-override.json`) is left untouched.

Validation run locally: `npm run build`, `npm run lint`, `npm run tsc` all pass. Unit tests (`npm run unit-tests`) were not run locally — a Node 26/yargs CJS-ESM incompatibility blocks mocha startup in my environment; CI will run them on Node 20 per `.nvmrc`.

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single feature-flag override in privacy configuration with no auth, data, or security surface; user-facing onboarding UX only on macOS.
> 
> **Overview**
> Adds a **macOS-only** remote config override under `macOSBrowserConfig` that sets **`onboardingRebranding`** to **`disabled`**, so production macOS clients stop using the rebranded onboarding flow despite the app’s in-code default of enabled.
> 
> **iOS** overrides are unchanged; this affects only `overrides/macos-override.json`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 40a78279b912b41f6cc1a9a0747a5e2064b869bc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->