### PR TITLE
Autoconsent (CPM) exception to hide overlay on elpais.com

### DIFF
--- a/features/autoconsent.json
+++ b/features/autoconsent.json
@@ -854,6 +854,10 @@
         {
             "domain": "express.co.uk",
             "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5220"
+        },
+        {
+            "domain": "elpais.com",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5245"
         }
     ],
     "settings": {


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/1200277586140538/task/1215086248098052?focus=true

## Description
### Site breakage mitigation process:
#### Brief explanation
- Reported URL: https://english.elpais.com/
- Problems experienced: Dark overlay covering the page and blocking interaction. Works if you disable CPM (Cookie Popup Management).
- Platforms affected:
  - [x] iOS
  - [x] Android
  - [x] Windows
  - [x] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked: N/A
- Feature being disabled/modified: CPM (Cookie Popup Management)
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-domain configuration exception with no logic or security impact; same approach as existing site-specific CPM mitigations.
> 
> **Overview**
> Adds **`elpais.com`** to the autoconsent **`exceptions`** list in `features/autoconsent.json`, so Cookie Popup Management is not applied on that site. This follows the same pattern as other breakage mitigations (e.g. `express.co.uk`) and addresses a dark overlay that blocked interaction on sites such as `english.elpais.com` when CPM was enabled.
> 
> Also fixes the file ending with a proper closing brace and newline (no functional change to rules).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6899da0f295767470edf08a5dad2e3dc960106b0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->