### PR TITLE
Hide blank spaces on ultraboardgames.com

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -4139,6 +4139,15 @@
                 ]
             },
             {
+                "domain": "ultraboardgames.com",
+                "rules": [
+                    {
+                        "selector": ".ezoic-adpicker-ad, .ezoic-ad",
+                        "type": "hide"
+                    }
+                ]
+            },
+            {
                 "domain": "uol.com.br",
                 "rules": [
                     {


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/1200277586140538/task/1215156806949010?focus=true

## Description
### Site breakage mitigation process:
#### Brief explanation
- Reported URL: https://www.ultraboardgames.com/masterpiece/game-rules.php
- Problems experienced: Blank spaces caused by tracker blocking. Had to use `hide` because `hide-empty` and `closest-empty` didn’t work for me.
- Platforms affected:
  - [x] iOS
  - [x] Android
  - [x] Windows
  - [x] MacOS
  - [x] Extensions
- Tracker(s) being unblocked: N/A
- Feature being disabled/modified: Element hiding.
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-domain privacy config tweak with no auth, data, or shared runtime logic changes.
> 
> **Overview**
> Adds a **domain-specific** element-hiding entry for `ultraboardgames.com` so leftover Ezoic ad placeholders (`.ezoic-adpicker-ad`, `.ezoic-ad`) are removed with **`hide`** instead of the default **`hide-empty`** on `.ezoic-ad`, fixing blank gaps on pages like the game-rules URL after blocking.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eef7e67988667cc48e84bfaddab2b5db280104cf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->