### PR TITLE
Enable reportStackTrace for preview

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -4918,7 +4918,7 @@
                     "state": "enabled"
                 },
                 "reportStackTrace": {
-                    "state": "disabled"
+                    "state": "preview"
                 },
                 "detectInstalledAv": {
                     "state": "enabled"


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/949243614371883/task/1215034156178952?focus=true

## Description
<!-- 
  Please delete either or both process sections below.
-->

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Turning on stack trace reporting in preview increases diagnostic data volume and may include sensitive crash context; scope is limited to a single feature flag under extended crash reporting.
> 
> **Overview**
> For **Windows** remote config in `overrides/windows-override.json`, the **`reportStackTrace`** sub-feature under **`extendedCrashReporting`** is moved from **`disabled`** to **`preview`**, so Windows clients that consume this override can start collecting or sending stack traces as part of extended crash reporting on a preview rollout basis rather than keeping the capability fully off.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c4966959caec8add622fcf487c6ace74e868d698. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->