### PR TITLE
Add Target PublicKeyCredential Android shim

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -3747,7 +3747,7 @@
                             },
                             {
                                 "op": "add",
-                                "path": "/apiChanges/PublicKeyCredential.isExternalCtap2SecurityKeySupported",
+                                "path": "/apiChanges/PublicKeyCredential.isExternalCTAP2SecurityKeySupported",
                                 "value": {
                                     "type": "descriptor",
                                     "getterValue": {

--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -3693,6 +3693,75 @@
                                 }
                             }
                         ]
+                    },
+                    {
+                        "condition": [
+                            {
+                                "domain": "target.com"
+                            }
+                        ],
+                        "patchSettings": [
+                            {
+                                "op": "add",
+                                "path": "/apiChanges/PublicKeyCredential",
+                                "value": {
+                                    "type": "descriptor",
+                                    "getterValue": {
+                                        "type": "object",
+                                        "value": {}
+                                    },
+                                    "define": true
+                                }
+                            },
+                            {
+                                "op": "add",
+                                "path": "/apiChanges/PublicKeyCredential.isUserVerifyingPlatformAuthenticatorAvailable",
+                                "value": {
+                                    "type": "descriptor",
+                                    "getterValue": {
+                                        "type": "function",
+                                        "functionValue": {
+                                            "type": "boolean",
+                                            "value": false,
+                                            "async": true
+                                        }
+                                    },
+                                    "define": true
+                                }
+                            },
+                            {
+                                "op": "add",
+                                "path": "/apiChanges/PublicKeyCredential.isConditionalMediationAvailable",
+                                "value": {
+                                    "type": "descriptor",
+                                    "getterValue": {
+                                        "type": "function",
+                                        "functionValue": {
+                                            "type": "boolean",
+                                            "value": false,
+                                            "async": true
+                                        }
+                                    },
+                                    "define": true
+                                }
+                            },
+                            {
+                                "op": "add",
+                                "path": "/apiChanges/PublicKeyCredential.isExternalCtap2SecurityKeySupported",
+                                "value": {
+                                    "type": "descriptor",
+                                    "getterValue": {
+                                        "type": "function",
+                                        "functionValue": {
+                                            "type": "boolean",
+                                            "value": false,
+                                            "async": true
+                                        }
+                                    },
+                                    "define": true
+                                }
+                            }
+                        ]
                     }
                 ]
             }

--- a/schema/feature.ts
+++ b/schema/feature.ts
@@ -95,7 +95,9 @@ export type CSSConfigSetting = CSSConfigSettingSingle | CSSConfigSettingSingle[]
 type CSSConfigSettingSingle = {
     type: 'undefined' | 'number' | 'string' | 'function' | 'boolean' | 'null' | 'array' | 'object';
     functionName?: string;
+    functionValue?: CSSConfigSetting;
     value?: JSONValidValueType;
+    async?: boolean;
     criteria?: {
         arch: string;
     };


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1206777341262243/task/1214565595655097?focus=true

## Description
Target expects to be able to access `PublicKeyCredential`, which we don't support. Giving it something that doesn't throw an undefined error allows users to log in again.

### Feature change process:

- [x] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [x] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL: target.com
- Problems experienced: login won't progress past username/email entry
- Platforms affected:
  - [x] Android
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped domain-specific API stubs and schema-only typing; no real WebAuthn is enabled—capability probes return false.
> 
> **Overview**
> Adds an **Android-only** `apiManipulation` site fix for **target.com** so login can proceed when the site probes WebAuthn APIs that are missing in the WebView.
> 
> On `target.com`, content scope scripts now define a stub **`PublicKeyCredential`** object and three static capability checks—**`isUserVerifyingPlatformAuthenticatorAvailable`**, **`isConditionalMediationAvailable`**, and **`isExternalCTAP2SecurityKeySupported`**—each exposed as async functions that resolve to **`false`**, avoiding undefined-reference errors without enabling real passkey flows.
> 
> **`schema/feature.ts`** extends **`CSSConfigSetting`** with optional **`functionValue`** (nested return config for injected functions) and **`async`** so this shim shape is valid for Content Scope Scripts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e270be906caf4350cfc57a584a7510a34370280d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->