### PR TITLE
Disable nativeCrashDialogOneShot

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -4432,8 +4432,7 @@
                     "state": "enabled"
                 },
                 "nativeCrashDialogOneShot": {
-                    "state": "enabled",
-                    "minSupportedVersion": "0.157.4",
+                    "state": "disabled",
                     "settings": {
                         "probability": 10,
                         "generation": 2


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1207414201589134/task/1215007607799529?focus=true

## Description
Disabling crash dialog for external users after being enabled for a week.

### Feature change process:

- [x] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single remote-config toggle with no application code changes; only stops showing the experimental native crash dialog to users.
> 
> **Overview**
> Turns off the **`nativeCrashDialogOneShot`** sub-feature under **`windowsWebviewFailures`** in `overrides/windows-override.json` for Windows clients.
> 
> The flag moves from **`enabled`** (with **`minSupportedVersion`** `0.157.4`) to **`disabled`**, so the sampled native crash dialog (`probability` / `generation` settings are unchanged but inactive) no longer ships to external users after the prior week-long enable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c9c19fa1aa1ae4c40cb29e8e6ceb7957751d4f98. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->