### PR TITLE
youtube 15s buffering

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -2961,7 +2961,7 @@
                     "youtubeAds": {
                         "state": "enabled",
                         "sweepIntervalMs": 2000,
-                        "slowLoadThresholdMs": 2000,
+                        "slowLoadThresholdMs": 15000,
                         "playerSelectors": [
                             "#movie_player",
                             ".html5-video-player",

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -2530,7 +2530,7 @@
                     "youtubeAds": {
                         "state": "enabled",
                         "sweepIntervalMs": 2000,
-                        "slowLoadThresholdMs": 2000,
+                        "slowLoadThresholdMs": 15000,
                         "playerSelectors": [
                             "#movie_player",
                             ".html5-video-player",

--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -5415,7 +5415,7 @@
                     "youtubeAds": {
                         "state": "enabled",
                         "sweepIntervalMs": 2000,
-                        "slowLoadThresholdMs": 2000,
+                        "slowLoadThresholdMs": 15000,
                         "playerSelectors": [
                             "#movie_player",
                             ".html5-video-player",


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/1163321984198618/task/1215138651457166

## Description
<!-- 
  Please delete either or both process sections below.
-->
Change buffering cutoff from 2sec to 15sec

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single numeric tuning in remote config for YouTube buffering detection; no auth, security, or schema changes beyond the existing optional field.
> 
> **Overview**
> Raises **`slowLoadThresholdMs`** from **2000** to **15000** on the **`youtubeAds`** detector under **`webInterferenceDetection`** in the **iOS**, **macOS**, and **Windows** platform override JSON files.
> 
> That threshold controls when a slow YouTube player load is treated as a **buffering** interference event (alongside ad and playability detection). The longer window should cut down on buffering signals during routine startup or short stalls while still allowing detection of genuinely prolonged load issues.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 82973f3175509bae5b5e7862fc242adfc1d9eb1b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->