### PR TITLE
Remove Gizmodo from AutoConsent exceptions

### DIFF
--- a/features/autoconsent.json
+++ b/features/autoconsent.json
@@ -160,10 +160,6 @@
             "reason": "https://github.com/duckduckgo/autoconsent/issues/130"
         },
         {
-            "domain": "gizmodo.com",
-            "reason": "https://github.com/duckduckgo/privacy-configuration/pull/4426"
-        },
-        {
             "domain": "motorsport.com",
             "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1250"
         },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Asana Task/Github Issue: https://app.asana.com/1/137249556945/project/1203268166580279/task/1213966640416459?focus=true

## Description
Remove `gizmodo.com` from the AutoConsent exceptions list so AutoConsent can run on Gizmodo again.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL: gizmodo.com
- Problems experienced: AutoConsent exception should be removed
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified: AutoConsent exceptions
- [ ] This change is a speculative mitigation to fix reported breakage.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cf87c3a4-3d5c-4576-92a0-92364da783f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cf87c3a4-3d5c-4576-92a0-92364da783f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

