### PR TITLE
Enable tab crash reporting for >=0.158.3

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -4432,7 +4432,8 @@
                     "state": "enabled"
                 },
                 "nativeCrashDialogOneShot": {
-                    "state": "disabled",
+                    "state": "enabled",
+                    "minSupportedVersion": "0.158.3",
                     "settings": {
                         "probability": 10,
                         "generation": 2


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/task/1215231456245269?focus=true

## Description
Related to a minor incident: https://app.asana.com/1/137249556945/inbox/1209077031784539/item/1215231456245269/story/1215231511857076

### Feature change process:

- [x] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes crash-recovery UX via remote config with version gating and 10% sampling; limited scope but user-visible on tab/native crashes.
> 
> **Overview**
> Turns on the **`nativeCrashDialogOneShot`** sub-feature under **`windowsWebviewFailures`** for the Windows browser override, gated to **`minSupportedVersion` `0.158.3`**. Existing rollout settings stay the same (**`probability` 10**, **`generation` 2**).
> 
> This is a remote-config-only change (no app code); it enables sampled one-shot native crash dialog behavior on supported builds, aligned with enabling tab crash reporting from 0.158.3 onward.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce5ce1dacebfab8029f32ff3b2ad8e93592793b1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->