### PR TITLE
Increase crash reporting probability to 100%

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -4435,7 +4435,7 @@
                     "state": "enabled",
                     "minSupportedVersion": "0.158.3",
                     "settings": {
-                        "probability": 10,
+                        "probability": 100,
                         "generation": 2
                     }
                 },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/task/1215237208054720?focus=true

## Description
Related to a minor incident: https://app.asana.com/1/137249556945/project/949243614371883/task/1215231689389228?focus=true

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single numeric remote-config change with no auth or data-path changes; main effect is more users seeing the native crash dialog.
> 
> **Overview**
> Raises the Windows remote-config **sampling rate** for `nativeCrashDialogOneShot` (under `windowsWebviewFailures`) from **10% to 100%**, so every eligible client on **≥ 0.158.3** should get the one-shot native crash dialog instead of a small rollout cohort. **`generation`** stays at **2**; only `settings.probability` changes in `overrides/windows-override.json`.
> 
> This is a **privacy-configuration** knob tied to post-incident crash visibility (per PR context), not application code.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2562863864ec043882959600b0823afedfdd0156. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->