### PR TITLE
Apple: experiment to nullify window.webkit.messageHandlers for site JS

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -694,6 +694,50 @@
         "ampLinks": {
             "state": "enabled"
         },
+        "apiManipulation": {
+            "state": "enabled",
+            "exceptions": [],
+            "settings": {
+                "conditionalChanges": [
+                    {
+                        "condition": [
+                            {
+                                "experiment": {
+                                    "experimentName": "appleNullifyMessageHandlersExperiment",
+                                    "cohort": "treatment"
+                                },
+                                "urlPattern": "https://*/*"
+                            },
+                            {
+                                "experiment": {
+                                    "experimentName": "appleNullifyMessageHandlersExperiment",
+                                    "cohort": "treatment"
+                                },
+                                "urlPattern": "http://*/*"
+                            }
+                        ],
+                        "patchSettings": [
+                            {
+                                "op": "add",
+                                "path": "/apiChanges",
+                                "value": {}
+                            },
+                            {
+                                "op": "add",
+                                "path": "/apiChanges/webkit.constructor.prototype.messageHandlers",
+                                "value": {
+                                    "type": "descriptor",
+                                    "getterValue": {
+                                        "type": "undefined"
+                                    },
+                                    "configurable": false
+                                }
+                            }
+                        ]
+                    }
+                ]
+            }
+        },
         "contentScopeExperiments": {
             "exceptions": [],
             "state": "enabled",
@@ -740,6 +784,27 @@
                             },
                             {
                                 "percent": 100
+                            }
+                        ]
+                    },
+                    "cohorts": [
+                        {
+                            "name": "control",
+                            "weight": 1
+                        },
+                        {
+                            "name": "treatment",
+                            "weight": 1
+                        }
+                    ]
+                },
+                "appleNullifyMessageHandlersExperiment": {
+                    "state": "enabled",
+                    "minSupportedVersion": "9999.9.9",
+                    "rollout": {
+                        "steps": [
+                            {
+                                "percent": 1
                             }
                         ]
                     },

--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -800,7 +800,7 @@
                 },
                 "appleNullifyMessageHandlersExperiment": {
                     "state": "enabled",
-                    "minSupportedVersion": "9999.9.9",
+                    "minSupportedVersion": "7.227.0",
                     "rollout": {
                         "steps": [
                             {

--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -800,7 +800,7 @@
                 },
                 "appleNullifyMessageHandlersExperiment": {
                     "state": "enabled",
-                    "minSupportedVersion": "7.227.0",
+                    "minSupportedVersion": "7.224.0",
                     "rollout": {
                         "steps": [
                             {

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -218,7 +218,7 @@
                 },
                 "appleNullifyMessageHandlersExperiment": {
                     "state": "enabled",
-                    "minSupportedVersion": "9999.9.9",
+                    "minSupportedVersion": "1.197.0",
                     "rollout": {
                         "steps": [
                             {

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -115,6 +115,50 @@
             "state": "enabled",
             "minSupportedVersion": "1.175.0"
         },
+        "apiManipulation": {
+            "state": "enabled",
+            "exceptions": [],
+            "settings": {
+                "conditionalChanges": [
+                    {
+                        "condition": [
+                            {
+                                "experiment": {
+                                    "experimentName": "appleNullifyMessageHandlersExperiment",
+                                    "cohort": "treatment"
+                                },
+                                "urlPattern": "https://*/*"
+                            },
+                            {
+                                "experiment": {
+                                    "experimentName": "appleNullifyMessageHandlersExperiment",
+                                    "cohort": "treatment"
+                                },
+                                "urlPattern": "http://*/*"
+                            }
+                        ],
+                        "patchSettings": [
+                            {
+                                "op": "add",
+                                "path": "/apiChanges",
+                                "value": {}
+                            },
+                            {
+                                "op": "add",
+                                "path": "/apiChanges/webkit.constructor.prototype.messageHandlers",
+                                "value": {
+                                    "type": "descriptor",
+                                    "getterValue": {
+                                        "type": "undefined"
+                                    },
+                                    "configurable": false
+                                }
+                            }
+                        ]
+                    }
+                ]
+            }
+        },
         "contentScopeExperiments": {
             "exceptions": [],
             "state": "enabled",
@@ -158,6 +202,27 @@
                             },
                             {
                                 "percent": 100
+                            }
+                        ]
+                    },
+                    "cohorts": [
+                        {
+                            "name": "control",
+                            "weight": 1
+                        },
+                        {
+                            "name": "treatment",
+                            "weight": 1
+                        }
+                    ]
+                },
+                "appleNullifyMessageHandlersExperiment": {
+                    "state": "enabled",
+                    "minSupportedVersion": "9999.9.9",
+                    "rollout": {
+                        "steps": [
+                            {
+                                "percent": 1
                             }
                         ]
                     },

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -218,7 +218,7 @@
                 },
                 "appleNullifyMessageHandlersExperiment": {
                     "state": "enabled",
-                    "minSupportedVersion": "1.197.0",
+                    "minSupportedVersion": "1.194.0",
                     "rollout": {
                         "steps": [
                             {


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/task/1212684734587032?focus=true

## Description

Adds a cohort-gated `apiManipulation` entry on both iOS and macOS that installs a getter returning `undefined` for the `messageHandlers` property on the `WebKitNamespace` prototype. The effect: site JS reading `window.webkit.messageHandlers` gets `undefined`, reducing `window.webkit` fingerprinting surface and addressing in-the-wild site breakage caused by visibility of the `messageHandlers` namespace.

### How it works

- **Mechanism:** `apiManipulation` with `type: "descriptor"` + `getterValue: { type: "undefined" }` against the dotted scope `webkit.constructor.prototype.messageHandlers`. The C-S-S scope walker resolves this to `Object.getPrototypeOf(window.webkit)` (the `WebKitNamespace` prototype), and installs an own-property accessor there with `configurable: false` so site JS can't override it back.
- **Cohort gating:** Standard `contentScopeExperiments` pattern — a new sub-feature `appleNullifyMessageHandlersExperiment` declares `control` / `treatment` cohorts (50/50 weight) with a 1% initial rollout step. The `conditionalChanges` entry in `apiManipulation` only applies for users in the `treatment` cohort.
- **URL scoping:** Array-of-conditions OR-composes `(treatment AND https://*/*) OR (treatment AND http://*/*)`. duck:// and other non-web schemes are skipped. Necessary because C-S-S does inject on the regular Tab `WKWebView` for duck://history, duck://release-notes, the error pages, and Duck Player on macOS — nullifying `messageHandlers` there would break `specialPages` messaging on those pages.

### Why this is safe on page-world C-S-S messaging surface

[duckduckgo/content-scope-scripts#2729](https://github.com/duckduckgo/content-scope-scripts/pull/2729) (merged) makes the transport capture handler references at construction time, so the captured ref survives the prototype-side nullify and `WebkitMessagingTransport` keeps working.


## Testing Steps

1. Force enrollment into the treatment cohort -- edit the override on your test branch so that:

- rollout.steps is [{ "percent": 100 }]
- cohort weights are control: 0, treatment: 1
- minSupportedVersion is set to a version ≤ your debug build version or deleted entirely

2. Verify experiment is active on a normal external https site:
- Open page console, run:
```
window.webkit.messageHandlers   // expect: undefined
'messageHandlers' in window.webkit  // expect: true (partial hide)
```
3. Verify page-world C-S-S messaging still works post-nullify with the new [privacy test page](https://privacy-test-pages.site/features/webkit-message-handlers)

4. Verify that experiment doesn't run on special-pages (duck://history / duck://release-notes (macOS))
5. Verify that experiment doesn't run on control group:
- Flip cohort weights to control: 1, treatment: 0

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Prototype-level WebKit API changes can break site JS and browser messaging if clients below the required C-S-S version receive treatment; rollout is limited but the change is invasive.
> 
> **Overview**
> Adds a **1% rollout** experiment on **iOS** and **macOS** that, for **treatment** users on **http/https** pages, enables **`apiManipulation`** to install a non-configurable accessor so site JS reading **`window.webkit.messageHandlers`** gets **`undefined`** (path **`webkit.constructor.prototype.messageHandlers`**).
> 
> Registers **`appleNullifyMessageHandlersExperiment`** under **`contentScopeExperiments`** (control/treatment, 50/50) and gates the patch on that cohort plus URL patterns so **duck://** and other non-web schemes are excluded. **`minSupportedVersion`** is set to **7.224.0** (iOS) and **1.194.0** (macOS) for the experiment sub-feature.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 121c3a7d7ed73df278893917cf5e43a36bcea81f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->