### PR TITLE
Remove handleAboutBlank feature flag from Android privacy config

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -1639,26 +1639,6 @@
                         ]
                     }
                 },
-                "handleAboutBlank": {
-                    "state": "enabled",
-                    "minSupportedVersion": 52603000,
-                    "rollout": {
-                        "steps": [
-                            {
-                                "percent": 5
-                            },
-                            {
-                                "percent": 20
-                            },
-                            {
-                                "percent": 50
-                            },
-                            {
-                                "percent": 100
-                            }
-                        ]
-                    }
-                },
                 "reduceBrowserTabBundleSize": {
                     "state": "enabled",
                     "minSupportedVersion": 52690000,


### PR DESCRIPTION
**Asana Task/Github Issue:**https://app.asana.com/1/137249556945/project/1211724162604201/task/1212015085457818?focus=true

## Description
Remove the handleAboutBlank feature flag from the privacy configuration, which was used to roll out the fix for handling the about:blank urls. 
The fix is rolled out to 100% of the users and the flag was implemented permanently in the app. The flag was kept in the privacy config for backwards compatibility but now the adoption of the versions with the permanent implementation is high enough to remove the flag.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [x] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only removal of a fully rolled-out flag; no app logic changes in this PR.
> 
> **Overview**
> Removes the **`handleAboutBlank`** feature from **`androidBrowserConfig`** in `overrides/android-override.json`. That entry had been an enabled rollout (`minSupportedVersion` 52603000, 5→20→50→100%) for the about:blank handling fix; the behavior is now always on in supported app builds, so the remote flag is dropped for config cleanup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1cb49431d995cdf60f7dfd9eab788b151d49b490. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->