### PR TITLE
Windows: new Sync feature flags for v2 exchange mechanism

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -3951,6 +3951,12 @@
                 },
                 "scopedAccessCredentials": {
                     "state": "internal"
+                },
+                "v2_scanning_enabled": {
+                    "state": "internal"
+                },
+                "v2_code_enabled": {
+                    "state": "internal"
                 }
             }
         },

--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -3952,10 +3952,10 @@
                 "scopedAccessCredentials": {
                     "state": "internal"
                 },
-                "v2ScanningEnabled": {
+                "canUseV2ConnectFlow": {
                     "state": "internal"
                 },
-                "v2CodeEnabled": {
+                "canShowV2ConnectCode": {
                     "state": "internal"
                 }
             }

--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -3952,10 +3952,10 @@
                 "scopedAccessCredentials": {
                     "state": "internal"
                 },
-                "v2_scanning_enabled": {
+                "v2ScanningEnabled": {
                     "state": "internal"
                 },
-                "v2_code_enabled": {
+                "v2CodeEnabled": {
                     "state": "internal"
                 }
             }


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/72649045549333/task/1214965501713836?focus=true

## Description
Adds two new feature flags for the Sync feature, currently set to "internal".

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only internal feature flags; no rollout to enabled users in this change.
> 
> **Overview**
> Adds two **internal** Sync sub-feature flags on the Windows privacy override: **`canUseV2ConnectFlow`** and **`canShowV2ConnectCode`**, alongside existing flags like **`scopedAccessCredentials`**. They gate the v2 device connect / exchange UX without enabling it for general users yet.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0703f0e0b0381b51333ec274578040032cf13723. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->