### PR TITLE
Enable onboardingRebranding for macOS >=1.192.0

### DIFF
--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -2276,7 +2276,8 @@
                     }
                 },
                 "onboardingRebranding": {
-                    "state": "disabled"
+                    "state": "enabled",
+                    "minSupportedVersion": "1.192.0"
                 }
             }
         },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1176956903599313/task/1215138600735057?focus=true

## Description

Switch the macOS `onboardingRebranding` override from `disabled` to `enabled` with `minSupportedVersion` `1.192.0`, so the feature ships only on macOS app versions 1.192.0 and above.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single remote-config toggle with a version floor; no application logic or security-sensitive code changes in this PR.
> 
> **Overview**
> Turns on **onboarding rebranding** for the macOS browser via the `macOSBrowserConfig` feature override in `overrides/macos-override.json`.
> 
> `onboardingRebranding` changes from `disabled` to **`enabled`**, with **`minSupportedVersion`: `1.192.0`** so only macOS app builds at or above that version receive the updated onboarding experience.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f4df01595f305ade0650e481f1f1e64d17dfe74. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->