### PR TITLE
Reduce crash reporting probability back to 10% for the weekend

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -4441,7 +4441,7 @@
                     "state": "enabled",
                     "minSupportedVersion": "0.158.3",
                     "settings": {
-                        "probability": 100,
+                        "probability": 10,
                         "generation": 2
                     }
                 },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/task/1215237961877302?focus=true

## Description
Related to the incident https://app.asana.com/1/137249556945/project/949243614371883/task/1215231689389228?focus=true

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single numeric remote-config change for crash UI sampling; no app logic changes in this diff.
> 
> **Overview**
> Lowers how often the Windows **native crash dialog (one-shot, generation 2)** is shown by changing `nativeCrashDialogOneShot` **probability** from **100** to **10** in `overrides/windows-override.json`, under `windowsWebviewFailures`. The feature stays **enabled** with `minSupportedVersion` **0.158.3** unchanged. This is a temporary rollout dial-back tied to a recent incident.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d1b33a753bf158cc3aa03f284a57ed3fad6b0cb2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->