### PR TITLE
Roll out adBlockingExtension enabled-by-default to 10% (iOS & macOS)

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -3098,6 +3098,17 @@
                 "featureEnabled": {
                     "state": "enabled",
                     "minSupportedVersion": "7.216.0"
+                },
+                "featureEnabledByDefault": {
+                    "state": "enabled",
+                    "minSupportedVersion": "7.222.0",
+                    "rollout": {
+                        "steps": [
+                            {
+                                "percent": 10
+                            }
+                        ]
+                    }
                 }
             }
         },

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -2682,6 +2682,17 @@
                 "featureEnabled": {
                     "state": "enabled",
                     "minSupportedVersion": "1.186.0"
+                },
+                "featureEnabledByDefault": {
+                    "state": "enabled",
+                    "minSupportedVersion": "1.192.0",
+                    "rollout": {
+                        "steps": [
+                            {
+                                "percent": 10
+                            }
+                        ]
+                    }
                 }
             }
         },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/task/1215100640464193

## Description

Enables the `featureEnabledByDefault` subfeature of `adBlockingExtension` at a **10% rollout** on iOS and macOS.

- **iOS** (`overrides/ios-override.json`): subfeature `enabled`, `minSupportedVersion` `7.222.0`, rollout `10%`.
- **macOS** (`overrides/macos-override.json`): subfeature `enabled`, `minSupportedVersion` `1.192.0`, rollout `10%`.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

> Opened as a **draft** — not yet ready to merge. Tech design: N/A.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Default-on ad blocking for 10% of eligible clients can change browsing behavior and site compatibility; impact is bounded by rollout percentage and minimum app versions.
> 
> **Overview**
> Adds a new **`featureEnabledByDefault`** subfeature under **`adBlockingExtension`** in the iOS and macOS privacy config overrides so the ad-blocking extension can be **on by default** for a staged audience.
> 
> On **iOS** (`overrides/ios-override.json`), the subfeature is enabled with **`minSupportedVersion` `7.222.0`** and a **10%** rollout step. On **macOS** (`overrides/macos-override.json`), it uses **`minSupportedVersion` `1.192.0`** with the same **10%** rollout. Existing **`featureEnabled`** behavior is unchanged; this only introduces the default-on path behind version and rollout gates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 19b246516fb2aa37bdc19865689dd7206040ea6f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->