### PR TITLE
iOS: Add nativeStoragePathMigration FF at 2% for >=7.222.0

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -244,6 +244,17 @@
                     "state": "enabled",
                     "minSupportedVersion": "7.217.0"
                 },
+                "nativeStoragePathMigration": {
+                    "state": "enabled",
+                    "minSupportedVersion": "7.222.0",
+                    "rollout": {
+                        "steps": [
+                            {
+                                "percent": 2
+                            }
+                        ]
+                    }
+                },
                 "showAIChatAddressBarChoiceScreen": {
                     "state": "enabled",
                     "minSupportedVersion": "7.220.0",


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/1201011656765697/task/1215232272887586?focus=true

## Description
Adds the duckAINativeStoragePathMigration feature flag (aiChat.nativeStoragePathMigration subfeature) to the iOS override, enabled at a 2% rollout with minimum version 7.222.0.

See https://github.com/duckduckgo/apple-browsers/pull/4906


### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Config-only change, but it gates migration of Duck.ai on-device storage paths—a small early rollout limits blast radius.
> 
> **Overview**
> Adds the **`aiChat.nativeStoragePathMigration`** subfeature to the iOS privacy-config override so Duck.ai native storage path migration can ship behind remote config.
> 
> It is **enabled** with **`minSupportedVersion` `7.222.0`** and a **2%** rollout step, placed alongside the existing `nativeStorage` / `nativeDataAccess` flags under `aiChat.features`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 649abf4c0c10f258f3b158d9baefcdbbf8821500. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->