### PR TITLE
Update content-blocker extension to 2026.5.31

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -4723,7 +4723,7 @@
             "minSupportedVersion": "0.148.0",
             "exceptions": [],
             "settings": {
-                "extensionUrl": "https://staticcdn.duckduckgo.com/extensions/content-blocker/content-blocker-extension-2026.5.21.crx"
+                "extensionUrl": "https://staticcdn.duckduckgo.com/extensions/content-blocker/content-blocker-extension-2026.5.31.crx"
             },
             "features": {
                 "onboardingEnabled": {


### PR DESCRIPTION
Update content-blocker extension to 2026.5.31.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Ships a new bundled content-blocker CRX to Windows users via remote config; regression risk is limited to ad-blocking behavior and extension install/update, not auth or data handling.
> 
> **Overview**
> Bumps the Windows **`adBlockV2Extension`** remote-config **`extensionUrl`** so clients fetch **`content-blocker-extension-2026.5.31.crx`** instead of **`2026.5.21`**. No other feature flags or settings in this PR change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ea91590720e207949dcbfd8ecc87d75ff7d7d1fa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->