### PR TITLE
Update ad-blocking extension scriptlets for v2026.5.31

### DIFF
--- a/features/ad-blocking-extension.json
+++ b/features/ad-blocking-extension.json
@@ -4,28 +4,28 @@
     },
     "exceptions": [],
     "settings": {
-        "version": "2026.5.21",
+        "version": "2026.5.31",
         "enabledByDefault": false,
         "scriptlets": {
             "scriptlets/isolated/ublock-filters.js": {
-                "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/d58a8f8997ee8d751b41046b47d1a99ef66f423dbaa5575db3efccc02179de54.js",
-                "signature": "MEUCIQCOnLvvZ8stUQMNYnwbZnRDEfe5fclOyGJwUXsM2BXujAIgegfE90yKZ7WlqQh24kcLsGxXSm5inVvNQT/rCw8mC0E="
+                "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/8cf8f2d0df9ccee318f297a3d9c627c73e4912c6282293e3fee3ab55cfcd530d.js",
+                "signature": "MEQCIHtrF/ukj0GgSLxjXOg2x1eRnXz1VMrwiBx2G3q4wN2kAiB/flvLO1ICpss0TOctG4i00rl1WxOsKm1ex0+sj5bKLw=="
             },
             "scriptlets/main/ublock-filters.js": {
-                "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/a99944281e8860d546baa213ffa8ae499f5f02371f26669ded118003c91c8d56.js",
-                "signature": "MEUCIQCbb8oGK6k+qHr3iIeYedCQrOLEs4ktKnM3m4AaXldqKwIgAlUrmaWYU/2S+Kf/qj3Tz904jvNISyyF5VOm8oMTUKA="
+                "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/999e38e3f90ee06a1b9a3c6b3e11d065eaf6b44d00404ac584659a565fa79b10.js",
+                "signature": "MEYCIQD2+ky24ckipg5p3hLL3PJ5riGEKSJFgvZAN9jqmkahIwIhAKCy+wfHJAfRG8NddqwplrlMxn7oJaYJs2du+qvdCE6W"
             },
             "scriptlets/main/ublock-experimental.js": {
                 "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855.js",
-                "signature": "MEYCIQD3ofJiKKWDiRR0CNfY5VO/ntX2YCLk5WiQldDkzJPyCAIhANDJEWEVcQjdBkBjkoXnymY5IGqwd4tbFpsxgabO+Iyb"
+                "signature": "MEUCIH1zFrtsmHW1HplJ2LLFipJTqjo0MzC9oy89zxpYoGv9AiEA5/1HtmjPxD0aHs0Hmod7QnWhlEJmKC37gFiXxnltLSg="
             },
             "scriptlets/isolated/ublock-experimental.js": {
                 "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855.js",
-                "signature": "MEQCIBx3Tdrk2x4XrpimRQVpQZmaxckfIda7kL9LXajdTjpSAiAohuG+3GxrnXWNUnKAWPOdQR1Mvy3sWo6tl2ItuLEfkA=="
+                "signature": "MEUCIQDjtlc8lY/UfPXnTuFMc4VL3+TKzUaaj5RTvgEHXSQxoAIgSLYG0nNxPFqvpkrKnk+T1ajth6QHBsYB9wv6wEPw2EU="
             },
             "rules/youtube.json": {
                 "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/2337db6aa7466667595226f780b6590779db3007ac0a65ef3833f89610c92824.json",
-                "signature": "MEUCIFOB5ug5E6bG5RwdpNObWDSVGmTVwps7xLuU2CAVW4GgAiEA9G0rcUalc2YfyWQ3nAdqeUKe28yRaerwDYYglLjp6Tg="
+                "signature": "MEQCIDks6S5lBtQ/lhRpUThJvsPtjR9K97lXNCV/mqJ0O8asAiB8K6i10fMLU3DJ9K9YA24c8DK7YBqibHxFZONcXmimDA=="
             }
         }
     }


### PR DESCRIPTION
Update ad-blocking extension scriptlets for v2026.5.31.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only CDN URL and signature rotation for content-blocker scriptlets; no application logic or schema changes.
> 
> **Overview**
> Bumps the ad blocking extension payload from **2026.5.21** to **2026.5.31** in `features/ad-blocking-extension.json`.
> 
> Clients will fetch new **ublock-filters** scriptlet bundles (isolated and main) via updated CDN URLs and ECDSA signatures. Signatures are also refreshed for **ublock-experimental** scriptlets (URLs unchanged) and for **rules/youtube.json** (URL unchanged).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4341b03a1a8161cddd8c88269c2544669f1c74e8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->