### PR TITLE
Add StubHub autofill site-specific rule

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -1079,6 +1079,21 @@
                                         }
                                     }
                                 ]
+                            },
+                            {
+                                "condition": {
+                                    "urlPattern": "https://my.stubhub.com/secure/login*"
+                                },
+                                "patchSettings": [
+                                    {
+                                        "path": "/formTypeSettings/-",
+                                        "op": "add",
+                                        "value": {
+                                            "selector": "form",
+                                            "type": "login"
+                                        }
+                                    }
+                                ]
                             }
                         ]
                     }

--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -1235,6 +1235,21 @@
                                         }
                                     }
                                 ]
+                            },
+                            {
+                                "condition": {
+                                    "urlPattern": "https://my.stubhub.com/secure/login*"
+                                },
+                                "patchSettings": [
+                                    {
+                                        "path": "/formTypeSettings/-",
+                                        "op": "add",
+                                        "value": {
+                                            "selector": "form",
+                                            "type": "login"
+                                        }
+                                    }
+                                ]
                             }
                         ]
                     }

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -1239,6 +1239,21 @@
                                         }
                                     }
                                 ]
+                            },
+                            {
+                                "condition": {
+                                    "urlPattern": "https://my.stubhub.com/secure/login*"
+                                },
+                                "patchSettings": [
+                                    {
+                                        "path": "/formTypeSettings/-",
+                                        "op": "add",
+                                        "value": {
+                                            "selector": "form",
+                                            "type": "login"
+                                        }
+                                    }
+                                ]
                             }
                         ]
                     }

--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -2059,6 +2059,21 @@
                                         }
                                     }
                                 ]
+                            },
+                            {
+                                "condition": {
+                                    "urlPattern": "https://my.stubhub.com/secure/login*"
+                                },
+                                "patchSettings": [
+                                    {
+                                        "path": "/formTypeSettings/-",
+                                        "op": "add",
+                                        "value": {
+                                            "selector": "form",
+                                            "type": "login"
+                                        }
+                                    }
+                                ]
                             }
                         ]
                     }


### PR DESCRIPTION
**Asana Task/Github Issue:** Fallback privacy-config fix for https://github.com/duckduckgo/duckduckgo-autofill/pull/935

## Description
<!-- 
  Please delete either or both process sections below.
-->

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow, URL-scoped autofill classification only; no auth, tracking, or broad feature toggles changed.
> 
> **Overview**
> Adds a **site-specific autofill fix** for StubHub’s secure login page on **Android, iOS, macOS, and Windows**.
> 
> Under `autofill` → `siteSpecificFixes` → `conditionalChanges`, each platform override gains a new entry keyed by `urlPattern` `https://my.stubhub.com/secure/login*`. When that URL matches, config patches append a `formTypeSettings` rule that treats the page’s `form` element as type **login**, so autofill can classify and offer credentials on that flow (same pattern as other URL-scoped login fixes in these files).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 54a6e7e32f8ed082f0a7deb6dc934878c85bc80d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->