### PR TITLE
[Android] Re-enable progressBarUpgrade and update minSupportedVersion

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -4318,11 +4318,13 @@
             "minSupportedVersion": 52720000
         },
         "progressBarUpgrade": {
-            "state": "disabled",
+            "state": "enabled",
+            "minSupportedVersion": 52801000,
             "exceptions": [],
             "features": {
                 "behaviourUpdate": {
-                    "state": "disabled"
+                    "state": "enabled",
+                    "minSupportedVersion": 52801000
                 }
             }
         },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1208671518894266/task/1215194332681673

## Description
<!-- 
  Please delete either or both process sections below.
-->
Re-enables the animation according to https://app.asana.com/1/137249556945/project/1208671518894266/task/1214935059191010?focus=true.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [x] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [x] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only toggle for UI progress bar behavior on Android, scoped by minimum app version with no auth or data changes.
> 
> **Overview**
> Re-enables the Android **progress bar upgrade** remote config after it was turned off, and gates it to app builds **52801000** and newer.
> 
> The parent `progressBarUpgrade` flag and nested **`behaviourUpdate`** sub-feature are both switched from `disabled` to `enabled`, each with the same **`minSupportedVersion`**, so only clients on that version receive the updated loading/progress bar behavior (including the animation called out in the PR).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ec4f86bba66a7e7d466434f074e1462c9425172. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->