### PR TITLE
Clean up browser feature flags

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -1686,33 +1686,6 @@
                     "state": "enabled",
                     "minSupportedVersion": 52590000
                 },
-                "experimentalBrowsingMenu": {
-                    "state": "enabled",
-                    "minSupportedVersion": 52660000
-                },
-                "rolloutBrowsingMenu": {
-                    "state": "enabled",
-                    "minSupportedVersion": 52742000,
-                    "rollout": {
-                        "steps": [
-                            {
-                                "percent": 5
-                            },
-                            {
-                                "percent": 25
-                            },
-                            {
-                                "percent": 50
-                            },
-                            {
-                                "percent": 75
-                            },
-                            {
-                                "percent": 100
-                            }
-                        ]
-                    }
-                },
                 "serpLogoInMenu": {
                     "state": "enabled"
                 },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1211850753229323/task/1213904242595157?focus=true

## Description
<!-- 
  Please delete either or both process sections below.
-->

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Deletes only remote feature-flag entries in JSON; no app code in this diff, though clients must tolerate missing keys if they still reference them.
> 
> **Overview**
> Removes two completed Android browser feature toggles from `androidBrowserConfig` in **`overrides/android-override.json`**: **`experimentalBrowsingMenu`** (enabled from app version 52660000) and **`rolloutBrowsingMenu`** (enabled from 52742000 with a 5→25→50→75→100% rollout). Other nearby flags such as **`newCustomTab`** and **`serpLogoInMenu`** are unchanged.
> 
> This is config-only cleanup after the browsing-menu experiment/rollout; clients that no longer read these keys should behave as if those remote flags are absent (typically falling back to shipped defaults).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8e18f51ad1bda19b70b5e81c4890bb005cec47c0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->