### PR TITLE
Disable autoconsent heuristicAction on Windows and Android

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -627,7 +627,7 @@
                     }
                 },
                 "heuristicAction": {
-                    "state": "enabled"
+                    "state": "disabled"
                 }
             }
         },

--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -2091,7 +2091,7 @@
                     "state": "disabled"
                 },
                 "heuristicAction": {
-                    "state": "enabled"
+                    "state": "disabled"
                 }
             },
             "exceptions": [


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/1201844467387842/task/1215191840665591?focus=true

## Description

Disables the autoconsent `heuristicAction` subfeature in the Android and Windows platform override files.

Validation: `npm test`

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [x] Android
  - [x] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified: autoconsent `heuristicAction`
- [ ] This change is a speculative mitigation to fix reported breakage.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-13e15dac-d965-4a2c-9c5b-8ba386a4579b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-13e15dac-d965-4a2c-9c5b-8ba386a4579b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

