### PR TITLE
rollback an unnecessary mitigation

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -779,10 +779,6 @@
                     "reason": "https://github.com/duckduckgo/privacy-configuration/pull/4648"
                 },
                 {
-                    "domain": "newrepublic.com",
-                    "reason": "https://github.com/duckduckgo/privacy-configuration/pull/4652"
-                },
-                {
                     "domain": "theguardian.com",
                     "reason": "https://github.com/duckduckgo/privacy-configuration/pull/4985"
                 },

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -790,10 +790,6 @@
                     "reason": "https://github.com/duckduckgo/privacy-configuration/pull/4648"
                 },
                 {
-                    "domain": "newrepublic.com",
-                    "reason": "https://github.com/duckduckgo/privacy-configuration/pull/4652"
-                },
-                {
                     "domain": "mumsnet.com",
                     "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5119"
                 }


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1203268166580279/task/1213532518473375?focus=true

## Description
<!-- 
  Please delete either or both process sections below.
-->

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, site-specific privacy-config change that only affects autoconsent behavior on one domain for two clients.
> 
> **Overview**
> Rolls back a prior site-breakage mitigation by **removing** the `newrepublic.com` entry from the `autoconsent.exceptions` list in both `overrides/ios-override.json` and `overrides/macos-override.json`.
> 
> On iOS and macOS, **autoconsent will apply again** on that domain instead of being skipped. Other autoconsent exceptions (e.g. `postnl.nl`, `theguardian.com`, `mumsnet.com` on iOS) are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 685d8752ca2d09c18609f7522ea83e07e1a17976. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->