### PR TITLE
Add onboardingQuickSetup experiment to Android privacy config

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -4362,6 +4362,11 @@
                             "name": "treatment",
                             "weight": 1
                         }
+                    ],
+                    "targets": [
+                        {
+                            "isReturningUser": true
+                        }
                     ]
                 }
             }

--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -4345,6 +4345,26 @@
                     "minSupportedVersion": 52800000
                 }
             }
+        },
+        "onboardingQuickSetup": {
+            "state": "enabled",
+            "exceptions": [],
+            "features": {
+                "onboardingQuickSetupExperimentJun3": {
+                    "state": "enabled",
+                    "minSupportedVersion": 52830000,
+                    "cohorts": [
+                        {
+                            "name": "control",
+                            "weight": 1
+                        },
+                        {
+                            "name": "treatment",
+                            "weight": 1
+                        }
+                    ]
+                }
+            }
         }
     },
     "unprotectedTemporary": [],

--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -4362,11 +4362,6 @@
                             "name": "treatment",
                             "weight": 1
                         }
-                    ],
-                    "targets": [
-                        {
-                            "isReturningUser": true
-                        }
                     ]
                 }
             }


### PR DESCRIPTION
**Asana Task/Github Issue:**https://app.asana.com/1/137249556945/task/1215297245863389

## Description
Add the onboarding quick setup experiment with the cohort and treatment variant to the Android privacy config. The experiment will distributed equally between the 2 variants starting with the 5.283.0 Android version. 

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [x] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only change adding a gated experiment with standard cohort flags; no app logic or security-sensitive paths in this diff.
> 
> **Overview**
> Adds a new **`onboardingQuickSetup`** feature block to **`overrides/android-override.json`**, placed after **`optimizeTrackerAllowList`**.
> 
> The feature is **enabled** with no domain exceptions. Under it, **`onboardingQuickSetupExperimentJun3`** is enabled for Android app version **52830000** and up, with **50/50** cohort assignment between **`control`** and **`treatment`** (equal weights). This turns on remote configuration for the onboarding quick-setup A/B test on eligible Android clients.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b9cee1cf13912a9d51cd584b5a466a7eed2e81a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->