### PR TITLE
Add sendPostIdleSessionWideEvent feature flag to Android override

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -1772,6 +1772,10 @@
                 "cachedEntityLookup": {
                     "state": "enabled",
                     "minSupportedVersion": 52810000
+                },
+                "sendPostIdleSessionWideEvent": {
+                    "state": "enabled",
+                    "minSupportedVersion": 52810000
                 }
             }
         },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1202552961248957/task/1215296585125289?focus=true

## Description
<!-- 
  Please delete either or both process sections below.
-->

Enables the sendPostIdleSessionWideEvent sub-feature under androidBrowserConfig with minSupportedVersion 52810000.


### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single JSON flag addition under existing androidBrowserConfig; affects telemetry behavior only for clients that already read this config, gated by minSupportedVersion.
> 
> **Overview**
> Turns on a new **`androidBrowserConfig`** sub-feature, **`sendPostIdleSessionWideEvent`**, in `overrides/android-override.json` so Android app builds **≥ 52810000** can emit a session-wide event after idle (alongside the existing page-load wide-event flag).
> 
> This is a **remote-config-only** change: enabled state and version gate only; no rollout steps or extra settings in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9186e8792f84a1794acf98eaf21aeb9e1d99e504. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->