### PR TITLE
Revert "Disabling performanceMetrics for macOS and iOS"

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -2161,6 +2161,7 @@
         },
         "performanceMetrics": {
             "state": "enabled",
+            "minSupportedVersion": "7.224.0",
             "settings": {
                 "firstContentfulPaint": "disabled",
                 "expandedPerformanceMetricsOnLoad": "enabled"

--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -2160,7 +2160,11 @@
             ]
         },
         "performanceMetrics": {
-            "state": "disabled"
+            "state": "enabled",
+            "settings": {
+                "firstContentfulPaint": "disabled",
+                "expandedPerformanceMetricsOnLoad": "disabled"
+            }
         },
         "breakageReporting": {
             "state": "enabled"

--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -2163,7 +2163,7 @@
             "state": "enabled",
             "settings": {
                 "firstContentfulPaint": "disabled",
-                "expandedPerformanceMetricsOnLoad": "disabled"
+                "expandedPerformanceMetricsOnLoad": "enabled"
             }
         },
         "breakageReporting": {

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -1312,7 +1312,7 @@
             "state": "enabled",
             "settings": {
                 "firstContentfulPaint": "disabled",
-                "expandedPerformanceMetricsOnLoad": "disabled"
+                "expandedPerformanceMetricsOnLoad": "enabled"
             }
         },
         "breakageReporting": {

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -1309,7 +1309,11 @@
             "minSupportedVersion": "0.22.3"
         },
         "performanceMetrics": {
-            "state": "disabled"
+            "state": "enabled",
+            "settings": {
+                "firstContentfulPaint": "disabled",
+                "expandedPerformanceMetricsOnLoad": "disabled"
+            }
         },
         "breakageReporting": {
             "state": "enabled"

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -1310,6 +1310,7 @@
         },
         "performanceMetrics": {
             "state": "enabled",
+            "minSupportedVersion": "1.194.0",
             "settings": {
                 "firstContentfulPaint": "disabled",
                 "expandedPerformanceMetricsOnLoad": "enabled"


### PR DESCRIPTION
Asana task: https://app.asana.com/1/137249556945/project/1214769851840802/task/1215251004351243?focus=true

Reverts duckduckgo/privacy-configuration#4490

This feature was disabled accidentally on the native side.
Native PR to restore: https://github.com/duckduckgo/apple-browsers/pull/5230

See https://app.asana.com/1/137249556945/project/1214769851840802/task/1215201969942744?focus=true for details

Do not merge until the native side is merged, at which point we should set this to target the appropriate minimum app versions


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only toggle with minSupportedVersion guards; main risk is shipping before the native fix lands, not security or data-handling changes.
> 
> **Overview**
> Re-enables the **`performanceMetrics`** remote feature on **iOS** and **macOS** after it was turned off in privacy-configuration #4490 (described as an accidental disable on the native side).
> 
> For both platforms, **`state`** goes from **`disabled`** to **`enabled`**, with **`minSupportedVersion`** gates (**`7.224.0`** on iOS, **`1.194.0`** on macOS) and shared **`settings`**: **`firstContentfulPaint`** stays **`disabled`**, **`expandedPerformanceMetricsOnLoad`** is **`enabled`**.
> 
> Merge is intended to follow the matching native restore in apple-browsers so clients at those minimum versions actually support the feature.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 32074e76cf9bbe586454c955c0c3deab840107bf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->