### PR TITLE
Enable autofillPasskeys

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -1621,9 +1621,6 @@
                 "totp": {
                     "state": "internal"
                 },
-                "autofillPasskeys": {
-                    "state": "internal"
-                },
                 "siteSpecificFixes": {
                     "state": "enabled",
                     "settings": {
@@ -2067,6 +2064,11 @@
                     }
                 }
             }
+        },
+        "autofillPasskeys": {
+            "state": "enabled",
+            "minSupportedVersion": "0.161.0",
+            "exceptions": []
         },
         "bookmarks": {
             "state": "enabled",


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1142021229838617/task/1213877733607029?focus=true

## Description
Enable autofillPasskeys

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Enables authentication-related passkey autofill for Windows users on supported builds; scope is limited to config rollout but affects login flows.
> 
> **Overview**
> Turns on **passkey autofill** for the Windows browser via `windows-override.json` by promoting `autofillPasskeys` from an **internal** sub-feature under `autofill` to a **top-level** feature with **`state`: `enabled`**.
> 
> The new entry adds **`minSupportedVersion`: `0.161.0`** and an empty **`exceptions`** list so only clients at or above that version receive the flag.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9176d1ad496763ce589e6d55f8e3bc0afa427836. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->