### PR TITLE
Enable attachRenderingDiagnosticsToFeedback from v0.161.0

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -4447,7 +4447,8 @@
                     }
                 },
                 "attachRenderingDiagnosticsToFeedback": {
-                    "state": "disabled"
+                    "state": "enabled",
+                    "minSupportedVersion": "0.161.0"
                 }
             }
         },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/task/1215333245125234

## Description
Enable attachRenderingDiagnosticsToFeedback from v0.161.0

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single privacy-configuration toggle with a version floor; no application code changes, though feedback may carry additional diagnostic data on supported builds.
> 
> **Overview**
> Turns on the **`attachRenderingDiagnosticsToFeedback`** sub-feature under **`windowsWebviewFailures`** in `windows-override.json`, gated with **`minSupportedVersion`: `0.161.0`**.
> 
> Eligible Windows browser builds will include rendering diagnostics when users submit feedback, which should help debug WebView/rendering issues alongside existing crash and webview failure tooling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 319d990a74d7bffe69a0f90c50ae2b22fe7aca56. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->