### PR TITLE
Enable AdBlockV2 -> partialLaunch subfeature flag with 10% step

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -4739,7 +4739,14 @@
                     "state": "enabled"
                 },
                 "partialLaunch": {
-                    "state": "disabled"
+                    "state": "enabled",
+                    "rollout": {
+                        "steps": [
+                            {
+                                "percent": 10
+                            }
+                        ]
+                    }
                 }
             }
         },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1205889582400204/task/1214809632966955?focus=true

## Description
Enable AdBlockV2 -> partialLaunch subfeature flag with 10% step


### Feature change process:

- [x] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [x] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [x] This feature was covered by a tech design.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Partial Ad Block V2 rollout affects browsing for ~10% of Windows users; config-only but touches core content-blocking behavior.
> 
> **Overview**
> Turns on the **AdBlock V2** `partialLaunch` subfeature for **Windows** clients in `windows-override.json`, changing it from **disabled** to **enabled** with a **10%** rollout step.
> 
> This is a staged config-only change: no application code moves, only who gets the partial Ad Block V2 launch path on Windows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ddc29b571b8230f1ede98ea1606d7a72f5f0610e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->