### PR TITLE
Add pageContext.aiPageContextBlocklist

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -4889,7 +4889,13 @@
                             }
                         ]
                     }
-                ]
+                ],
+                "aiChatTabAttachBlocklist": {
+                    "pdf":   { "urlExtensions": [".pdf"], "contentTypes": ["application/pdf"] },
+                    "image": { "urlExtensions": [".png", ".jpg", ".jpeg", ".gif", ".webp", ".svg", ".bmp"], "contentTypePrefixes": ["image/"] },
+                    "video": { "urlExtensions": [".mp4", ".webm", ".avi", ".mov", ".mkv"], "contentTypePrefixes": ["video/"] },
+                    "audio": { "urlExtensions": [".mp3", ".wav", ".ogg", ".flac", ".aac", ".m4a"], "contentTypePrefixes": ["audio/"] }
+                  }              
             }
         },
         "openFireWindowByDefault": {

--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -4891,11 +4891,42 @@
                     }
                 ],
                 "aiPageContextBlocklist": {
-                    "pdf":   { "urlExtensions": [".pdf"], "contentTypes": ["application/pdf"] },
-                    "image": { "urlExtensions": [".png", ".jpg", ".jpeg", ".gif", ".webp", ".svg", ".bmp"], "contentTypePrefixes": ["image/"] },
-                    "video": { "urlExtensions": [".mp4", ".webm", ".avi", ".mov", ".mkv"], "contentTypePrefixes": ["video/"] },
-                    "audio": { "urlExtensions": [".mp3", ".wav", ".ogg", ".flac", ".aac", ".m4a"], "contentTypePrefixes": ["audio/"] }
-                  }              
+                    "pdf": { "urlExtensions": [
+                            ".pdf"
+                        ], "contentTypes": [
+                            "application/pdf"
+                        ] },
+                    "image": { "urlExtensions": [
+                            ".png",
+                            ".jpg",
+                            ".jpeg",
+                            ".gif",
+                            ".webp",
+                            ".svg",
+                            ".bmp"
+                        ], "contentTypePrefixes": [
+                            "image/"
+                        ] },
+                    "video": { "urlExtensions": [
+                            ".mp4",
+                            ".webm",
+                            ".avi",
+                            ".mov",
+                            ".mkv"
+                        ], "contentTypePrefixes": [
+                            "video/"
+                        ] },
+                    "audio": { "urlExtensions": [
+                            ".mp3",
+                            ".wav",
+                            ".ogg",
+                            ".flac",
+                            ".aac",
+                            ".m4a"
+                        ], "contentTypePrefixes": [
+                            "audio/"
+                        ] }
+                }
             }
         },
         "openFireWindowByDefault": {

--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -4891,11 +4891,42 @@
                     }
                 ],
                 "aiChatTabAttachBlocklist": {
-                    "pdf":   { "urlExtensions": [".pdf"], "contentTypes": ["application/pdf"] },
-                    "image": { "urlExtensions": [".png", ".jpg", ".jpeg", ".gif", ".webp", ".svg", ".bmp"], "contentTypePrefixes": ["image/"] },
-                    "video": { "urlExtensions": [".mp4", ".webm", ".avi", ".mov", ".mkv"], "contentTypePrefixes": ["video/"] },
-                    "audio": { "urlExtensions": [".mp3", ".wav", ".ogg", ".flac", ".aac", ".m4a"], "contentTypePrefixes": ["audio/"] }
-                  }              
+                    "pdf": { "urlExtensions": [
+                            ".pdf"
+                        ], "contentTypes": [
+                            "application/pdf"
+                        ] },
+                    "image": { "urlExtensions": [
+                            ".png",
+                            ".jpg",
+                            ".jpeg",
+                            ".gif",
+                            ".webp",
+                            ".svg",
+                            ".bmp"
+                        ], "contentTypePrefixes": [
+                            "image/"
+                        ] },
+                    "video": { "urlExtensions": [
+                            ".mp4",
+                            ".webm",
+                            ".avi",
+                            ".mov",
+                            ".mkv"
+                        ], "contentTypePrefixes": [
+                            "video/"
+                        ] },
+                    "audio": { "urlExtensions": [
+                            ".mp3",
+                            ".wav",
+                            ".ogg",
+                            ".flac",
+                            ".aac",
+                            ".m4a"
+                        ], "contentTypePrefixes": [
+                            "audio/"
+                        ] }
+                }
             }
         },
         "openFireWindowByDefault": {

--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -4890,7 +4890,7 @@
                         ]
                     }
                 ],
-                "aiChatTabAttachBlocklist": {
+                "aiPageContextBlocklist": {
                     "pdf":   { "urlExtensions": [".pdf"], "contentTypes": ["application/pdf"] },
                     "image": { "urlExtensions": [".png", ".jpg", ".jpeg", ".gif", ".webp", ".svg", ".bmp"], "contentTypePrefixes": ["image/"] },
                     "video": { "urlExtensions": [".mp4", ".webm", ".avi", ".mov", ".mkv"], "contentTypePrefixes": ["video/"] },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1210407179200832/task/1214611507417993?focus=true

## Description
Add pageContext.aiPageContextBlocklist

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Remote config-only change for Windows; behavior depends on client support for the new settings key.
> 
> **Overview**
> Adds **`aiPageContextBlocklist`** under the Windows **`pageContext`** feature settings so Duck AI page-context capture can skip non-text media.
> 
> The blocklist defines four categories—**pdf**, **image**, **video**, and **audio**—each with **URL file extensions** and, where applicable, **MIME content types** or **`contentTypePrefixes`** (e.g. `image/`, `video/`, `audio/`). Clients can use these rules to avoid attaching binary or streaming content as AI page context.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e06b780125e1ca96651bc29370e6c4513ed181f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->