### PR TITLE
Increase nativeCrashDialogOneShot to 100% from 0.158.6

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -4440,10 +4440,10 @@
                 },
                 "nativeCrashDialogOneShot": {
                     "state": "enabled",
-                    "minSupportedVersion": "0.158.3",
+                    "minSupportedVersion": "0.158.6",
                     "settings": {
-                        "probability": 10,
-                        "generation": 2
+                        "probability": 100,
+                        "generation": 3
                     }
                 },
                 "attachRenderingDiagnosticsToFeedback": {


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/task/1215340233310777?focus=true

## Description
Related to the incident: https://app.asana.com/1/137249556945/inbox/1209077031784539/item/1215231689389228/story/1215341437675400

Also increased the generation on the off-chance we get these VTCPMN numbers from a small subset of users who may have already submitted a crash report.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> 100% rollout changes crash-time UX and feedback collection for all eligible Windows users; scope is limited to remote config, not app logic.
> 
> **Overview**
> This PR tightens the Windows remote config for **`nativeCrashDialogOneShot`** under `windowsWebviewFailures` in response to a production incident.
> 
> **`minSupportedVersion`** is raised from **0.158.3** to **0.158.6**, so the one-shot native crash dialog only applies on newer builds. **`probability`** goes from **10** to **100**, fully enabling the dialog for eligible clients instead of a 10% sample. **`generation`** is bumped from **2** to **3** so users who already hit generation 2 can be prompted again and submit another crash report for diagnosis.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b384a1cf0d116facc31c54f8c9387ce1aefd3f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->