### PR TITLE
Windows: Re-enable chat deletion from 0.160 onwards

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -1381,8 +1381,11 @@
                     "minSupportedVersion": "0.157.0"
                 },
                 "suggestionsDeletion": {
-                    "state": "internal",
-                    "minSupportedVersion": "0.155.0"
+                    "state": "enabled",
+                    "minSupportedVersion": "0.160.0"
+                },
+                "hiddenWebViewSoftwareRendering": {
+                    "state": "enabled"
                 },
                 "ntpRecentChats": {
                     "state": "enabled",


### PR DESCRIPTION
https://app.asana.com/1/137249556945/project/949243614371883/task/1215034156178952?focus=true

## Description

Windows: Re-enable chat deletion from 0.160 onwards - First version with simplified hidden webview handling.

Also enable the `hiddenWebViewSoftwareRendering` experiment (potential COMException mitigation)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Remote feature-flag rollout only in windows-override.json; no application code changes, with version gating limiting exposure to 0.160+.
> 
> **Overview**
> Updates the **Windows** remote config under `aiChat` so Duck AI **suggestions deletion** is turned back on for users on **0.160+**, after it had been held at **internal** with a **0.155** floor.
> 
> The change sets `suggestionsDeletion` to **enabled** and raises `minSupportedVersion` to **0.160.0**, matching the first Windows build with simplified hidden webview handling. It also adds a new **`hiddenWebViewSoftwareRendering`** subfeature flag set to **enabled**, alongside the existing suggestions-related flags.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a51461401abe94f49b28e16a3ee65e338275fd0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->