### PR TITLE
Reduce crash reporting rate to 10%

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -4452,7 +4452,7 @@
                     "state": "enabled",
                     "minSupportedVersion": "0.158.6",
                     "settings": {
-                        "probability": 100,
+                        "probability": 10,
                         "generation": 3
                     }
                 },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1209077031784564/task/1215342382948306?focus=true

## Description
Overnight 100% didn't provide us with much data for the [incident](https://app.asana.com/1/137249556945/project/1209077031784564/task/1215231689389228). Reducing back to 10%.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single numeric remote-config change with no code or schema updates; only affects how often the native crash dialog is shown on Windows.
> 
> **Overview**
> Lowers the Windows remote-config **sampling rate** for **`nativeCrashDialogOneShot`** under **`windowsWebviewFailures`**: **`settings.probability`** goes from **100** to **10**, while the feature stays **enabled** with **`generation`: 3** and the same **`minSupportedVersion`**.
> 
> This scales back a temporary **100%** rollout after it did not yield useful incident data, returning to a **10%** chance that eligible clients show the one-shot native crash dialog.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f3caa6ee7c0e40daa9eab7576fdb36dadf4c129f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->