### PR TITLE
Update autoconsent to v14.89.0

### DIFF
--- a/features/autoconsent.json
+++ b/features/autoconsent.json
@@ -2345,7 +2345,9 @@
                 "#gdpr-new-container",
                 "#gdpr-new-container,#voyager-gdpr > div",
                 "#voyager-gdpr > div",
-                "#voyager-gdpr > div > div > button:nth-child(2)"
+                "#voyager-gdpr > div > div > button:nth-child(2)",
+                ".ind-cbar[data-testid=\"ind-cbar\"]",
+                ".ind-cbar[data-testid=\"ind-cbar\"] button[save-cookie][data-value=\"0\"]"
             ],
             "r": [
                 [
@@ -22629,6 +22631,39 @@
                 ],
                 [
                     1,
+                    "auto_NL_independer.nl_ind",
+                    0,
+                    "^https?://(www\\.)?independer\\.nl/",
+                    10,
+                    [
+                        1476
+                    ],
+                    [
+                        {
+                            "e": 1477
+                        }
+                    ],
+                    [
+                        {
+                            "v": 1477
+                        }
+                    ],
+                    [
+                        {
+                            "c": 1477
+                        }
+                    ],
+                    [
+                        {
+                            "check": "none",
+                            "timeout": 2000,
+                            "wv": 1476
+                        }
+                    ],
+                    {}
+                ],
+                [
+                    1,
                     "auto_NL_info.mumc.nl_8s5",
                     0,
                     "^https?://(www\\.)?info\\.mumc\\.nl/",
@@ -28756,7 +28791,7 @@
                 ],
                 "specificRuleRange": [
                     188,
-                    766
+                    767
                 ],
                 "genericStringEnd": 739,
                 "frameStringEnd": 774


### PR DESCRIPTION
Asana Task/Github Issue: https://app.asana.com/1/137249556945/project/1201844467387842/task/1215399111764411

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only ruleset sync with no runtime code changes; typical low-risk filter list update.
> 
> **Overview**
> Bumps the bundled **autoconsent** ruleset to **v14.89.0** in `features/autoconsent.json`.
> 
> The update adds **Independer** cookie-banner handling: two generic selectors (`.ind-cbar[...]` and its decline/save button) and a new Netherlands site rule `auto_NL_independer.nl_ind` for `independer.nl` (detect/click/wait flow with a 2s timeout). Metadata `specificRuleRange` end index increases by one (766 → 767) to account for the new rule.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ba5973cabdad84f05f19af20524e2e721f6c73cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->