### PR TITLE
Added element hiding overrides for jobnib.com

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -2411,6 +2411,19 @@
                 ]
             },
             {
+                "domain": "jobnib.com",
+                "rules": [
+                    {
+                        "selector": ".ad",
+                        "type": "override"
+                    },
+                    {
+                        "selector": ".ad-placement",
+                        "type": "override"
+                    }
+                ]
+            },
+            {
                 "domain": "joemonster.org",
                 "rules": [
                     {


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/1206670747178362/task/1215359035324497?focus=true

## Description
### Site breakage mitigation process:
#### Brief explanation
- Reported URL: https://jobnib.com/book/the-billionaires-intern-chapter-102
- Problems experienced: Anti-adblock wall.
- Platforms affected:
  - [x] iOS
  - [x] Android
  - [x] Windows
  - [x] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked: N/A
- Feature being disabled/modified: Element hiding
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-domain config change that only relaxes element hiding for two selectors; no auth, data, or broad rule changes.
> 
> **Overview**
> Adds a **jobnib.com** domain block in `element-hiding.json` with **override** rules for `.ad` and `.ad-placement`, so the global `hide-empty` rules for those selectors no longer apply on that site.
> 
> This is a site-specific breakage fix for an anti-adblock wall on book/chapter pages (reported on iOS, Android, Windows, and macOS). The site likely reuses ad-like class names for non-ad UI; stopping element hiding on those selectors lets the page render normally without changing tracker blocking.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6cddc51ef774de093759c2a53983a1b51b9b49f5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->