### PR TITLE
Windows: Add VPN toolbar promo feature flag

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -4316,6 +4316,9 @@
                 "allowProTierPurchase": {
                     "state": "enabled",
                     "minSupportedVersion": "0.147.5"
+                },
+                "vpnToolbarUpsell": {
+                    "state": "disabled"
                 }
             },
             "settings": {


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/1205044477659400/task/1215153536996602?focus=true

## Description
Adds the `vpnToolbarUpsell `subfeature under `privacyPro `in the Windows override config.
This gates the new VPN subscription promo on the toolbar and is currently disabled.


### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single Windows config entry defaulting to disabled; no runtime behavior change until the flag is enabled elsewhere.
> 
> **Overview**
> Adds a new **`privacyPro`** subfeature **`vpnToolbarUpsell`** to the Windows override only, placed alongside existing subscription flags such as **`allowProTierPurchase`**.
> 
> The flag is set to **`disabled`**, so remote config can gate a VPN subscription promo in the toolbar without turning it on until a follow-up change enables it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd61f43e13cabf21a716fb1590c2d5d9072a0171. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->