### PR TITLE
add showInSuspendedState setting

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -4454,7 +4454,8 @@
                     "minSupportedVersion": "0.158.6",
                     "settings": {
                         "probability": 10,
-                        "generation": 3
+                        "generation": 3,
+                        "showInSuspendedState": false
                     }
                 },
                 "attachRenderingDiagnosticsToFeedback": {

--- a/schema/features/windows-webview-failures.ts
+++ b/schema/features/windows-webview-failures.ts
@@ -14,6 +14,7 @@ type SubFeatures<VersionType> = {
         {
             generation: number;
             probability: number;
+            showInSuspendedState: boolean;
         }
     >;
 };


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/task/1215364617463249?focus=true

## Description

Adds showInSuspendedState setting to give fine grained control when to show the tab crash reporting dialog.

### Feature change process:

- [x] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [x] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Remote privacy-configuration only; no app logic in this repo. Default `false` limits behavior change until explicitly enabled.
> 
> **Overview**
> Adds a **`showInSuspendedState`** boolean to **`windowsWebviewFailures.nativeCrashDialogOneShot`** so the Windows client can control whether the one-shot native tab crash reporting dialog appears when the tab is in a suspended state.
> 
> The TypeScript schema in `windows-webview-failures.ts` is updated to require the new setting alongside existing `generation` and `probability`. The Windows override sets **`showInSuspendedState`: `false`**, so suspended tabs will not get the dialog until config is flipped remotely.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f56864c0f8a16eae9e6aa91ee7250ef0b9110d01. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->