### PR TITLE
Enable crash dialog for 0.160.0 with showInSuspendedState=true

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -4451,11 +4451,11 @@
                 },
                 "nativeCrashDialogOneShot": {
                     "state": "enabled",
-                    "minSupportedVersion": "0.158.6",
+                    "minSupportedVersion": "0.160.6",
                     "settings": {
-                        "probability": 10,
+                        "probability": 100,
                         "generation": 3,
-                        "showInSuspendedState": false
+                        "showInSuspendedState": true
                     }
                 },
                 "attachRenderingDiagnosticsToFeedback": {


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1209077031784564/task/1215412060191066?focus=true

## Description
Related to https://app.asana.com/1/137249556945/project/1209077031784564/task/1215231689389228

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Config-only change, but it affects crash UX for all eligible Windows users on 0.160.6+ and may increase visible dialogs during suspended-tab crashes.
> 
> **Overview**
> Updates **Windows** remote config for `windowsWebViewFailures.nativeCrashDialogOneShot` to broaden the native crash dialog experiment on **0.160.x+** clients.
> 
> **`minSupportedVersion`** moves from **0.158.6** to **0.160.6**, so the one-shot dialog applies only on builds that include the suspended-state behavior. **`probability`** goes from **10** to **100**, so eligible users always get the one-shot path instead of a small sample. **`showInSuspendedState`** flips from **false** to **true**, enabling the dialog when the tab/window is in a suspended state (generation **3** is unchanged).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ba89cc9dc550f2fc865c7c379cd62219e35dcadb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->