### PR TITLE
fix scrolling on pbs-org add cpm exception

### DIFF
--- a/features/autoconsent.json
+++ b/features/autoconsent.json
@@ -858,6 +858,10 @@
         {
             "domain": "rhebs.com",
             "reason": "https://app.asana.com/1/137249556945/project/1202630464207380/task/1215205439937637?focus=true"
+        },
+        {
+            "domain": "pbs.org",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5297"
         }
     ],
     "settings": {


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1206670747178362/task/1215288453952516?focus=true

## Description
<!-- 
  Please delete either or both process sections below.
-->

### Site breakage mitigation process:
#### Brief explanation
- Reported URL: pbs.org
- Problems experienced: landing to the site leads to a grey overlay and the inability to scroll up/down the page
- Platforms affected:
  - [x ] iOS
  - [x ] Android
  - [ x] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked: NA
- Feature being disabled/modified: autoconsent
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-domain config exception with no logic changes; tradeoff is autoconsent not running on pbs.org.
> 
> **Overview**
> Adds **`pbs.org`** to the autoconsent **`exceptions`** list so automatic cookie-consent handling is skipped on that site.
> 
> This targets reported breakage (grey overlay and no scrolling on iOS, Android, and Windows) linked to autoconsent/CMP interaction on PBS.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit be1fac95ec0bc4ab2726118559bee8e56ed53ca6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->