### PR TITLE
Fix homedepot add-to-cart UA

### DIFF
--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -1558,6 +1558,10 @@
                     {
                         "domain": "nationalmssociety.org",
                         "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1963"
+                    },
+                    {
+                        "domain": "homedepot.com",
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5298"
                     }
                 ]
             }


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1206670747178362/task/1215354003200208?focus=true

## Description
<!-- 
  Please delete either or both process sections below.
-->

### Site breakage mitigation process:
#### Brief explanation
- Reported URL: homedepot.com
- Problems experienced: Add to cart fails
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ x] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked: NA
- Feature being disabled/modified: customUserAgent
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-domain macOS customUserAgent exception with no auth or data-handling changes; slightly less UA hardening on one retail site.
> 
> **Overview**
> Adds **homedepot.com** to the macOS `customUserAgent` **`webViewDefault`** site list so the browser uses the WebView-style user agent on that domain instead of the default **brand** policy.
> 
> This is a **macOS-only** site-breakage mitigation for reported **add-to-cart** failures on homedepot.com (no tracker allowlist or other platform overrides in this diff).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d676c25f1c956ebd38e0e49f88b9ade9cf49db0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->