### PR TITLE
Disable attribution metrics FF to mitigate incident

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -5146,7 +5146,7 @@
             "exceptions": []
         },
         "attributedMetrics": {
-            "state": "enabled",
+            "state": "false",
             "minSupportedVersion": "0.150.0",
             "exceptions": [],
             "features": {


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1207414201589134/task/1215420104526043?focus=true

## Description
Mitigate incident

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Remote kill-switch for attribution/metrics emission on Windows only; unusual `state` value `"false"` (not the usual `disabled`) may affect how clients interpret the flag.
> 
> **Overview**
> Turns off the **attributed metrics** feature flag for DuckDuckGo **Windows** clients only by changing `attributedMetrics.state` from `enabled` to `false` in `windows-override.json`, as an incident mitigation. Nested sub-feature flags under `attributedMetrics` are unchanged; only the top-level gate is flipped.
> 
> This is a remote-config-only change (no app code). iOS, macOS, and Android overrides still leave `attributedMetrics` enabled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a116790f93dcdf1b1dc531de13e1d7a30839929b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->