### PR TITLE
Disable CPM on moonpalace.com and lucrin.com

### DIFF
--- a/features/autoconsent.json
+++ b/features/autoconsent.json
@@ -857,11 +857,19 @@
         },
         {
             "domain": "rhebs.com",
-            "reason": "https://app.asana.com/1/137249556945/project/1202630464207380/task/1215205439937637?focus=true"
+            "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5259"
         },
         {
             "domain": "pbs.org",
             "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5297"
+        },
+        {
+            "domain": "moonpalace.com",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5301"
+        },
+        {
+            "domain": "lucrin.com",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5301"
         }
     ],
     "settings": {


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/1200277586140538/task/1215441876337165?focus=true
https://app.asana.com/1/137249556945/project/1200277586140538/task/1215441876337171?focus=true

## Description
### Site breakage mitigation process:
#### Brief explanation
- Reported URLs: https://www.moonpalace.com/ & https://www.lucrin.com/
- Problems experienced: Dark overlay, preventing interaction with page.
- Platforms affected:
  - [x] iOS
  - [x] Android
  - [x] Windows
  - [x] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked: N/A
- Feature being disabled/modified: Cookie Popup Management (CPM)
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only additions to the autoconsent exceptions list with no logic or security changes.
> 
> **Overview**
> Adds **autoconsent exceptions** for `moonpalace.com` and `lucrin.com` so Cookie Popup Management (CPM) is not applied there, addressing reported dark-overlay breakage that blocked page interaction on iOS, Android, Windows, and macOS.
> 
> Also updates the `rhebs.com` exception **reason** to point at privacy-configuration PR #5259 instead of the Asana task, and adds a trailing newline at the end of `autoconsent.json`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ab96f981ccf15a28699e473d1097589e2f540626. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->