### PR TITLE
Add sendIncidentCrashReports sub-FF

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -4979,6 +4979,12 @@
                 },
                 "detectInstalledAv": {
                     "state": "enabled"
+                },
+                "sendIncidentCrashReports": {
+                    "state": "disabled",
+                    "settings": {
+                        "ExceptionTypes": []
+                    }
                 }
             }
         },

--- a/schema/features/extendedCrashReporting.ts
+++ b/schema/features/extendedCrashReporting.ts
@@ -12,6 +12,12 @@ type SubFeatures<VersionType> = {
             OtherLogsCount?: number;
         }
     >;
+    sendIncidentCrashReports?: SubFeature<
+        VersionType,
+        {
+            ExceptionTypes?: string[];
+        }
+    >;
 };
 
 export type ExtendedCrashReporting<VersionType> = Feature<


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1210132634900450/task/1212925113896757?focus=true

## Description
Adds automatic ("incident") crash-report sending, gated by a new `sendIncidentCrashReports ` sub-feature of `ExtendedCrashReporting`.
See: https://github.com/duckduckgo/windows-browser/pull/7778

Example of the new sub-ff configuration:
```
                "sendIncidentCrashReports": {
                    "state": "enabled",
                    "settings": { 
                        "ExceptionTypes": [
                            "DuckDuckGo.CefView.BrowserProcessStartException",
                            "System.Runtime.InteropServices.COMException",
                            "FaultedException",
                            "ArgumentOutOfRangeException",
                            "SqliteException"
                        ] 
                    }
                },
```

### Feature change process:

- [x] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [x] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [x] This feature was covered by a tech design.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Schema and remote-config only; the feature is disabled by default with no exception types, so no automatic crash uploads until explicitly enabled.
> 
> **Overview**
> Introduces a new **`sendIncidentCrashReports`** sub-feature under **`extendedCrashReporting`**, intended to gate automatic (“incident”) crash report uploads from the Windows browser (paired with client work elsewhere).
> 
> The **schema** now types this sub-feature with optional **`ExceptionTypes`** (string allowlist of exception type names). **`windows-override.json`** registers the sub-feature with **`state`: `disabled`** and an empty **`ExceptionTypes`** list, so behavior stays off until remote config enables it and supplies types.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0887702b38d90f376fb7a23d2cef02ba8196f905. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->