### PR TITLE
Update autoconsent to v14.91.0

### DIFF
--- a/features/autoconsent.json
+++ b/features/autoconsent.json
@@ -1847,7 +1847,7 @@
                 "[class*=ConsentBanner] .frDWEu",
                 "[class*=ConsentBanner] .hXIpFU",
                 "xeConsentState={%22performance%22:false%2C%22marketing%22:false%2C%22compliance%22:false}",
-                "#cookie-consent .cookie-consent__switch:not(.always_on)",
+                "#cookie-consent[style*=\"max-height\"] #cookie-status-reject",
                 "#cookie-consent .cookie-selection__btn",
                 "[class*=modal]",
                 "[class*=modal] a[href*='/cookie-policy']",
@@ -2370,7 +2370,8 @@
                 ".consent__wrapper",
                 ".consent",
                 "button.consentSettings",
-                "button#consentSubmit"
+                "button#consentSubmit",
+                "#cookie-consent .cookie-consent__switch.active:not(.always_on)"
             ],
             "r": [
                 [
@@ -25671,6 +25672,33 @@
                 ],
                 [
                     1,
+                    "aytm",
+                    2,
+                    "^https?://(www\\.|)?aytm\\.com/",
+                    22,
+                    [
+                        959
+                    ],
+                    [
+                        {
+                            "e": 965
+                        }
+                    ],
+                    [
+                        {
+                            "v": 965
+                        }
+                    ],
+                    [
+                        {
+                            "c": 965
+                        }
+                    ],
+                    [],
+                    {}
+                ],
+                [
+                    1,
                     "bahn-de",
                     0,
                     "^https://(www\\.)?bahn\\.de/",
@@ -27335,7 +27363,9 @@
                     [
                         {
                             "all": true,
-                            "c": 965
+                            "timeout": 500,
+                            "optional": true,
+                            "c": 1489
                         },
                         {
                             "c": 966
@@ -28879,7 +28909,7 @@
                 ],
                 "specificRuleRange": [
                     189,
-                    768
+                    769
                 ],
                 "genericStringEnd": 747,
                 "frameStringEnd": 782


### PR DESCRIPTION
Asana Task/Github Issue: https://app.asana.com/1/137249556945/project/1201844467387842/task/1215466051639128

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Auto-generated cookie-banner automation rules only; no app logic changes, with localized selector and flow tweaks typical of a routine ruleset release.
> 
> **Overview**
> Bumps the generated **`features/autoconsent.json`** ruleset to **autoconsent v14.91.0**, adjusting shared selectors and two site-specific flows.
> 
> **Generic selectors:** One shared click target now prefers **`#cookie-status-reject`** when the banner is visible (`#cookie-consent[style*="max-height"]`) instead of toggling **`.cookie-consent__switch:not(.always_on)`**. Another list gains **`#cookie-consent .cookie-consent__switch.active:not(.always_on)`** (plus a trailing-comma fix on **`button#consentSubmit`**).
> 
> **Site rules:** Adds coverage for **aytm.com** (`^https?://(www\\.|)?aytm\\.com/`). **opera.com**’s consent sequence replaces a mandatory **`c: 965`** step with an **optional 500ms** click (**`c: 1489`**) before the existing **`c: 966`** step.
> 
> Packaging metadata updates **`specificRuleRange`** end index **768 → 769** for the new rule.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 99eb32789adf4617554e01cd2b7617de6a59fce5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->