### PR TITLE
Update content-blocker extension to 2026.6.7

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -4737,7 +4737,7 @@
             "minSupportedVersion": "0.148.0",
             "exceptions": [],
             "settings": {
-                "extensionUrl": "https://staticcdn.duckduckgo.com/extensions/content-blocker/content-blocker-extension-2026.5.31.crx"
+                "extensionUrl": "https://staticcdn.duckduckgo.com/extensions/content-blocker/content-blocker-extension-2026.6.7.crx"
             },
             "features": {
                 "onboardingEnabled": {
@@ -4903,12 +4903,16 @@
                     }
                 ],
                 "aiPageContextBlocklist": {
-                    "pdf": { "urlExtensions": [
+                    "pdf": {
+                        "urlExtensions": [
                             ".pdf"
-                        ], "contentTypes": [
+                        ],
+                        "contentTypes": [
                             "application/pdf"
-                        ] },
-                    "image": { "urlExtensions": [
+                        ]
+                    },
+                    "image": {
+                        "urlExtensions": [
                             ".png",
                             ".jpg",
                             ".jpeg",
@@ -4916,28 +4920,36 @@
                             ".webp",
                             ".svg",
                             ".bmp"
-                        ], "contentTypePrefixes": [
+                        ],
+                        "contentTypePrefixes": [
                             "image/"
-                        ] },
-                    "video": { "urlExtensions": [
+                        ]
+                    },
+                    "video": {
+                        "urlExtensions": [
                             ".mp4",
                             ".webm",
                             ".avi",
                             ".mov",
                             ".mkv"
-                        ], "contentTypePrefixes": [
+                        ],
+                        "contentTypePrefixes": [
                             "video/"
-                        ] },
-                    "audio": { "urlExtensions": [
+                        ]
+                    },
+                    "audio": {
+                        "urlExtensions": [
                             ".mp3",
                             ".wav",
                             ".ogg",
                             ".flac",
                             ".aac",
                             ".m4a"
-                        ], "contentTypePrefixes": [
+                        ],
+                        "contentTypePrefixes": [
                             "audio/"
-                        ] }
+                        ]
+                    }
                 }
             }
         },


### PR DESCRIPTION
Update content-blocker extension to 2026.6.7.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Routine extension URL version bump plus formatting-only JSON; no new feature flags or rule changes.
> 
> **Overview**
> Updates the Windows **`adBlockV2Extension`** remote config so clients download **`content-blocker-extension-2026.6.7.crx`** instead of **2026.5.31**.
> 
> The **`pageContext.settings.aiPageContextBlocklist`** block is reformatted (multi-line JSON) with **no change** to the blocklist rules or values.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8ff768a3c9424bd241926f618077aeb16dd0422f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->