### PR TITLE
Update ad-blocking extension scriptlets for v2026.6.7

### DIFF
--- a/features/ad-blocking-extension.json
+++ b/features/ad-blocking-extension.json
@@ -4,28 +4,28 @@
     },
     "exceptions": [],
     "settings": {
-        "version": "2026.5.31",
+        "version": "2026.6.7",
         "enabledByDefault": false,
         "scriptlets": {
             "scriptlets/isolated/ublock-filters.js": {
-                "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/8cf8f2d0df9ccee318f297a3d9c627c73e4912c6282293e3fee3ab55cfcd530d.js",
-                "signature": "MEQCIHtrF/ukj0GgSLxjXOg2x1eRnXz1VMrwiBx2G3q4wN2kAiB/flvLO1ICpss0TOctG4i00rl1WxOsKm1ex0+sj5bKLw=="
+                "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/19f3d232fcc31384ff21a01a45d8a5158f12fcab2a169a13e6393ea8f93be689.js",
+                "signature": "MEUCIQCISDU5LDZ8lQPHa1Odvl+BCtGCxoacojzLLAepGLsmngIgB8MH3CJFk5pupCdthWq19/+uf22wyLAx+j3OXQZvCN0="
             },
             "scriptlets/main/ublock-filters.js": {
-                "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/999e38e3f90ee06a1b9a3c6b3e11d065eaf6b44d00404ac584659a565fa79b10.js",
-                "signature": "MEYCIQD2+ky24ckipg5p3hLL3PJ5riGEKSJFgvZAN9jqmkahIwIhAKCy+wfHJAfRG8NddqwplrlMxn7oJaYJs2du+qvdCE6W"
+                "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/2eb4650b80efae2c8ac6760e2bc9edf6319017da98da8195d1e9801553bef416.js",
+                "signature": "MEUCIEZpjV78Cr1vB1SWFdOuLe2BC4MOLyoebt5y3TetsfCCAiEAu3BRv96c3+psJETgetybQtD9V9/7ef6OWybqgKhFs4Y="
             },
             "scriptlets/main/ublock-experimental.js": {
                 "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855.js",
-                "signature": "MEUCIH1zFrtsmHW1HplJ2LLFipJTqjo0MzC9oy89zxpYoGv9AiEA5/1HtmjPxD0aHs0Hmod7QnWhlEJmKC37gFiXxnltLSg="
+                "signature": "MEUCIE4RmldRUoQHIEieYbQVIzDYHo3n7uVPWeQCffGK8sjFAiEAkpaC0Q+YbyGZ7fCaUassNp1KnfXw96n69YzQrG60w/g="
             },
             "scriptlets/isolated/ublock-experimental.js": {
                 "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855.js",
-                "signature": "MEUCIQDjtlc8lY/UfPXnTuFMc4VL3+TKzUaaj5RTvgEHXSQxoAIgSLYG0nNxPFqvpkrKnk+T1ajth6QHBsYB9wv6wEPw2EU="
+                "signature": "MEQCIAgux1wCSQ0+6ZW+sN/Oldd/ef+IsmufvwLzoHwKgCHWAiBECd2m/mh5GkaT5qHS6Jt1LrpVHDtE4u1XztuJ5SI0NQ=="
             },
             "rules/youtube.json": {
                 "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/2337db6aa7466667595226f780b6590779db3007ac0a65ef3833f89610c92824.json",
-                "signature": "MEQCIDks6S5lBtQ/lhRpUThJvsPtjR9K97lXNCV/mqJ0O8asAiB8K6i10fMLU3DJ9K9YA24c8DK7YBqibHxFZONcXmimDA=="
+                "signature": "MEUCIQCxRM6qG0HY8s6RyWb5LZTVxGEGRKCbDX7rdiSspKHQ0QIgb4kbB+vb+LlJ0c1+rHWHY+WcvueS30HuCqDCLMOfDfc="
             }
         }
     }


### PR DESCRIPTION
Update ad-blocking extension scriptlets for v2026.6.7.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Clients verify signed scriptlet payloads before injection; incorrect URLs or signatures would break ad-blocking on macOS/iOS until the next config fix.
> 
> **Overview**
> Bumps the macOS/iOS ad-blocking extension config to **v2026.6.7** in `features/ad-blocking-extension.json`.
> 
> **uBlock filter scriptlets** (`scriptlets/isolated/ublock-filters.js` and `scriptlets/main/ublock-filters.js`) now point at new CDN URLs with updated integrity **signatures**. **Experimental** scriptlet entries keep the same URLs but get new signatures. **`rules/youtube.json`** is unchanged on URL but gets a new signature.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f7de7df70a0c54dfea0bae972eae290e7c0c579e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->