### PR TITLE
Add Force Dark Mode exception for duck.ai

### DIFF
--- a/features/force-dark-mode-on-websites.json
+++ b/features/force-dark-mode-on-websites.json
@@ -6,6 +6,10 @@
             "reason": "Prevents any modification of dark mode colors on our websites"
         },
         {
+            "domain": "duck.ai",
+            "reason": "Prevents any modification of dark mode colors on our websites"
+        },
+        {
             "domain": "sky.com",
             "reason": "Site natively supports dark mode, forcing it causes visual issues"
         }


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/task/1215279543223425

## Description
Adds `duck.ai` to the Force Dark Mode on Websites (`forceDarkModeOnWebsites`) exceptions list, so forced dark mode is not applied there. Duck.ai ships its own dark mode; forcing Dark Reader on top may break it.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL: duck.ai
- Problems experienced: Black pages with elements missing.
- Platforms affected:
  - [x] iOS
  - [ ] Android
  - [ ] Windows
  - [x] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked: N/A
- Feature being disabled/modified: Force Dark Mode on Websites (forceDarkModeOnWebsites)
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-domain exception in a feature config list; no logic or security changes.
> 
> **Overview**
> Adds **`duck.ai`** to the **Force Dark Mode on Websites** feature exceptions in `force-dark-mode-on-websites.json`, matching the existing **`duckduckgo.com`** entry so forced dark mode (e.g. Dark Reader) is not applied on that domain.
> 
> This addresses reported breakage on iOS and macOS (black pages / missing UI) where duck.ai’s native dark mode conflicts with forced dark mode.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 60d6cd63ea831231b24823339e9aeea9ae0f38ff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->