### PR TITLE
enable canShowNativeCrashReportingDialog for 5% of users

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -5005,7 +5005,7 @@
             "exceptions": [],
             "features": {
                 "canShowNativeCrashReportingDialog": {
-                    "state": "disabled",
+                    "state": "enabled",
                     "rollout": {
                         "steps": [
                             {

--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -5005,7 +5005,14 @@
             "exceptions": [],
             "features": {
                 "canShowNativeCrashReportingDialog": {
-                    "state": "disabled"
+                    "state": "disabled",
+                    "rollout": {
+                        "steps": [
+                            {
+                                "percent": 5
+                            }
+                        ]
+                    }
                 }
             }
         },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1200953757949605/task/1215448555905647?focus=true

## Description

Enable canShowNativeCrashReportingDialog for 5% of users temporarily to be able to collect native only crash dumps.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Limited Windows rollout of crash-reporting UI and native dump collection; config-only but affects post-crash user experience and diagnostic data for the enrolled cohort.
> 
> **Overview**
> Turns on the Windows **`canShowNativeCrashReportingDialog`** sub-feature under **`nativeCrashReporting`**, which was previously fully off. It is now **`enabled`** with a **5%** rollout so a small slice of Windows users can see the native crash reporting dialog and submit **native-only** crash dumps for debugging.
> 
> This is a **Windows override** change only (`overrides/windows-override.json`); parent **`nativeCrashReporting`** stays enabled with no other edits in the diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 426516e377ba45086f487440f46cd41f2e79f738. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->