### PR TITLE
PIR: iOS: Enable dbpContentBlocking on iOS

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -2757,6 +2757,9 @@
                 },
                 "freemiumPIR": {
                     "state": "disabled"
+                },
+                "dbpContentBlocking": {
+                    "state": "enabled"
                 }
             },
             "minSupportedVersion": "7.201.1"

--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -2758,7 +2758,7 @@
                 "freemiumPIR": {
                     "state": "disabled"
                 },
-                "dbpContentBlocking": {
+                "contentBlocking": {
                     "state": "enabled"
                 }
             },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1187352151074490/task/1214935778903308?focus=true

## Description
<!-- 
  Please delete either or both process sections below.
-->
Enables dbpContentBlocking on iOS, i.e. turns on tracker blocking for PIR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Turns on privacy-sensitive tracker blocking for PIR users on iOS with no staged rollout in this diff, so breakage or compatibility issues could affect a broad audience once configs ship.
> 
> **Overview**
> Enables **dbp** sub-feature **`contentBlocking`** on iOS in `overrides/ios-override.json`, turning on PIR-related tracker blocking (dbp content blocking) for clients that read `features.dbp.features.contentBlocking`.
> 
> This is a remote-config-only change: no rollout steps, version gates, or nested settings—just `"state": "enabled"` alongside existing **dbp** flags such as `freemiumPIR` (still disabled).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f50695f525e160dc0416edd64823932f9e77f703. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->