### PR TITLE
fix adblock banner on scribd-com

### DIFF
--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -2460,6 +2460,32 @@
             "html-load.com": {
                 "rules": [
                     {
+                        "rule": "stg.html-load.com/",
+                        "domains": [
+                            "scribd.com",
+                            "notebookcheck.net",
+                            "notebookcheck.com"
+                        ],
+                        "reason": [
+                            "https://github.com/duckduckgo/privacy-configuration/pull/5314",
+                            "notebookcheck.net - https://github.com/duckduckgo/privacy-configuration/pull/5090",
+                            "notebookcheck.com - https://github.com/duckduckgo/privacy-configuration/pull/5129"
+                        ]
+                    },
+                    {
+                        "rule": "html-load.com/lib.js",
+                        "domains": [
+                            "scribd.com",
+                            "notebookcheck.net",
+                            "notebookcheck.com"
+                        ],
+                        "reason": [
+                            "https://github.com/duckduckgo/privacy-configuration/pull/5314",
+                            "notebookcheck.net - https://github.com/duckduckgo/privacy-configuration/pull/5090",
+                            "notebookcheck.com - https://github.com/duckduckgo/privacy-configuration/pull/5129"
+                        ]
+                    },
+                    {
                         "rule": "html-load.com",
                         "domains": [
                             "notebookcheck.net",


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1206670747178362/task/1215443185761016?focus=true

## Description


### Site breakage mitigation process:
#### Brief explanation
- Reported URL: https://www.scribd.com/document/683147385/CAUSES-AND-CONSEQUENCES-OF-WORLD-WAR
- Problems experienced: ad block banner gets triggered by 2 trackers being blocked
- Platforms affected:
  - [ x] iOS
  - [x ] Android
  - [x ] Windows
  - [x ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked: stg.html-load.com/, html-load.com/lib.js
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Relaxes tracker blocking for Scribd only on known ad-detection endpoints; limited scope but still permits third-party requests classified as trackers.
> 
> **Overview**
> Adds **site-specific tracker allowlist** entries under `html-load.com` so DuckDuckGo stops blocking two URLs that trigger Scribd’s ad-block detection banner.
> 
> New rules allow **`stg.html-load.com/`** and **`html-load.com/lib.js`** on **`scribd.com`** (and the same domains list as existing notebookcheck mitigations). The broader **`html-load.com`** rule is unchanged and still only covers notebookcheck sites—not Scribd.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff601db2e8c77ffd5c5be69654bb7d8f502d87d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->