### PR TITLE
Enable PIR goToMarket on iOS for 7.227.0

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -2754,7 +2754,7 @@
                 },
                 "goToMarket": {
                     "state": "enabled",
-                    "minSupportedVersion": "7.228.0",
+                    "minSupportedVersion": "7.227.0",
                     "rollout": {
                         "steps": [
                             {

--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -2754,7 +2754,7 @@
                 },
                 "goToMarket": {
                     "state": "enabled",
-                    "minSupportedVersion": "7.224.0",
+                    "minSupportedVersion": "7.228.0",
                     "rollout": {
                         "steps": [
                             {

--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -2754,7 +2754,14 @@
                 },
                 "goToMarket": {
                     "state": "enabled",
-                    "minSupportedVersion": "7.224.0"
+                    "minSupportedVersion": "7.224.0",
+                    "rollout": {
+                        "steps": [
+                            {
+                                "percent": 50
+                            }
+                        ]
+                    }
                 },
                 "freemiumPIR": {
                     "state": "disabled"

--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -2753,7 +2753,8 @@
                     "minSupportedVersion": "7.201.1"
                 },
                 "goToMarket": {
-                    "state": "disabled"
+                    "state": "enabled",
+                    "minSupportedVersion": "7.224.0"
                 },
                 "freemiumPIR": {
                     "state": "disabled"


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1203581873609357/task/1213763847118555?focus=true

## Description

Re-enables the goToMarket DBP subfeature (Settings NEW badge + provisional first-scan notification), disabled in #4778 during the March GTM pause. minSupportedVersion 7.227.0 is required (release-window check) and sets the 3-minor relaunch window.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> User-facing GTM surfaces (badges/notifications) ship via remote config with rollout, but behavior changes for a large product area without code changes in this repo.
> 
> **Overview**
> Re-enables the **`dbp.goToMarket`** subfeature on iOS in `ios-override.json`, reversing the prior **disabled** state from the March GTM pause. Eligible clients must be on **`minSupportedVersion` `7.227.0`** or newer, and exposure is limited to a **50%** rollout step.
> 
> This turns back on the PIR go-to-market UX called out in the PR (e.g. Settings **NEW** badge and provisional first-scan notification) for users in the rollout cohort on supported app versions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b36b29bd675d10a7410020a904598b13854cee1f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->