### PR TITLE
Update autoconsent to v14.92.0

### DIFF
--- a/features/autoconsent.json
+++ b/features/autoconsent.json
@@ -1629,6 +1629,8 @@
                 "#js-consent-banner #js-cookie-reject-button",
                 "#js-consent-banner #js-cookie-dismiss-button",
                 "cookie-consent=",
+                "[data-slot=\"dialog-content\"] a[href*=\"vivenu.com/dataprivacy\"]",
+                "[data-slot=\"dialog-content\"]:has(a[href*=\"vivenu.com/dataprivacy\"]) button:nth-of-type(2)",
                 "body > div#root > div#ccpa-iframe-theme-provider[data-testid=\"ccpa-iframe-theme-provider\"] > div#ccpa-iframe[data-testid=\"ccpa-iframe\"] > div#ccpa_consent_banner[data-testid=\"ccpa_consent_banner\"] > div:not([id]) > div:nth-child(3):not([id]) > span:not([id]) > span:not([id]) > div:nth-child(2):not([id]) > span:nth-child(1):not([id]) > button#decline_cookies_button[data-testid=\"decline_cookies_button\"]",
                 "body:not([id]) > div#banner-0 > div:nth-child(1)#grouped-pageload-Banner > div:not([id]) > div:not([id]) > div:not([id]) > div:nth-child(3):not([id]) > button:nth-child(2):not([id])",
                 "body > div#iubenda-cs-banner > div:not([id]) > div:not([id]) > div:not([id]) > div:nth-child(5):not([id]) > div:nth-child(2):not([id]) > button:nth-child(1):not([id])",
@@ -1664,8 +1666,6 @@
                 "span[role=checkbox][aria-checked=true]",
                 "#save-all-pur",
                 "#reminder",
-                "div:has(> div > button[allytmln=ally-cookie-consent])",
-                "button[allytmln=ally-cookie-consent]",
                 "#footer-container ~ div",
                 "#footer-container > div",
                 "#cookiesPortletDiv",
@@ -2371,7 +2371,9 @@
                 ".consent",
                 "button.consentSettings",
                 "button#consentSubmit",
-                "#cookie-consent .cookie-consent__switch.active:not(.always_on)"
+                "#cookie-consent .cookie-consent__switch.active:not(.always_on)",
+                "div:has(> div > button[allytmln=ally-cookie-consent])",
+                "button[allytmln=ally-cookie-consent]"
             ],
             "r": [
                 [
@@ -9316,6 +9318,36 @@
                 ],
                 [
                     1,
+                    "vivenu",
+                    2,
+                    "",
+                    22,
+                    [],
+                    [
+                        {
+                            "e": 747
+                        }
+                    ],
+                    [
+                        {
+                            "v": 747
+                        }
+                    ],
+                    [
+                        {
+                            "c": 748
+                        }
+                    ],
+                    [
+                        {
+                            "check": "none",
+                            "v": 747
+                        }
+                    ],
+                    {}
+                ],
+                [
+                    1,
                     "waitrose.com",
                     2,
                     "",
@@ -9839,65 +9871,6 @@
                     [],
                     [
                         {
-                            "e": 747
-                        }
-                    ],
-                    [
-                        {
-                            "v": 747
-                        }
-                    ],
-                    [
-                        {
-                            "wait": 500
-                        },
-                        {
-                            "c": 747
-                        }
-                    ],
-                    [
-                        {
-                            "timeout": 1000,
-                            "check": "none",
-                            "wv": 747
-                        }
-                    ],
-                    {}
-                ],
-                [
-                    1,
-                    "auto_CA_coasthotels.com_f8m",
-                    0,
-                    "^https?://(www\\.)?coasthotels\\.com/",
-                    1,
-                    [],
-                    [
-                        {
-                            "e": 748
-                        }
-                    ],
-                    [
-                        {
-                            "v": 748
-                        }
-                    ],
-                    [
-                        {
-                            "c": 748
-                        }
-                    ],
-                    [],
-                    {}
-                ],
-                [
-                    1,
-                    "auto_CA_epihunter.eu_hd4",
-                    0,
-                    "^https?://(www\\.)?combell\\.com/",
-                    1,
-                    [],
-                    [
-                        {
                             "e": 749
                         }
                     ],
@@ -9925,9 +9898,9 @@
                 ],
                 [
                     1,
-                    "auto_CA_nationalarchives.gov.uk_rx0",
+                    "auto_CA_coasthotels.com_f8m",
                     0,
-                    "^https?://(www\\.)?webarchive\\.nationalarchives\\.gov\\.uk/",
+                    "^https?://(www\\.)?coasthotels\\.com/",
                     1,
                     [],
                     [
@@ -9942,26 +9915,17 @@
                     ],
                     [
                         {
-                            "wait": 500
-                        },
-                        {
                             "c": 750
                         }
                     ],
-                    [
-                        {
-                            "timeout": 1000,
-                            "check": "none",
-                            "wv": 750
-                        }
-                    ],
+                    [],
                     {}
                 ],
                 [
                     1,
-                    "auto_CA_natureconservancy.ca_3pp",
+                    "auto_CA_epihunter.eu_hd4",
                     0,
-                    "^https?://(www\\.)?natureconservancy\\.ca/",
+                    "^https?://(www\\.)?combell\\.com/",
                     1,
                     [],
                     [
@@ -9993,9 +9957,9 @@
                 ],
                 [
                     1,
-                    "auto_CA_ontariospca.ca_k32",
+                    "auto_CA_nationalarchives.gov.uk_rx0",
                     0,
-                    "^https?://(www\\.)?widget-next\\.clym-sdk\\.net/",
+                    "^https?://(www\\.)?webarchive\\.nationalarchives\\.gov\\.uk/",
                     1,
                     [],
                     [
@@ -10027,9 +9991,9 @@
                 ],
                 [
                     1,
-                    "auto_CA_phoenixnap.com_hrb",
+                    "auto_CA_natureconservancy.ca_3pp",
                     0,
-                    "^https?://(www\\.)?widget-next\\.clym-sdk\\.net/",
+                    "^https?://(www\\.)?natureconservancy\\.ca/",
                     1,
                     [],
                     [
@@ -10061,7 +10025,7 @@
                 ],
                 [
                     1,
-                    "auto_CH_phoenixnap.com_lx5",
+                    "auto_CA_ontariospca.ca_k32",
                     0,
                     "^https?://(www\\.)?widget-next\\.clym-sdk\\.net/",
                     1,
@@ -10095,9 +10059,9 @@
                 ],
                 [
                     1,
-                    "auto_CH_swisscare.com_arx",
+                    "auto_CA_phoenixnap.com_hrb",
                     0,
-                    "^https?://(www\\.)?swisscare\\.com/",
+                    "^https?://(www\\.)?widget-next\\.clym-sdk\\.net/",
                     1,
                     [],
                     [
@@ -10129,9 +10093,9 @@
                 ],
                 [
                     1,
-                    "auto_DE_alfaromeo.de_gvg_+2",
+                    "auto_CH_phoenixnap.com_lx5",
                     0,
-                    "^https?://(www\\.)?cookielaw\\.emea\\.fcagroup\\.com/|^https?://(www\\.)?cookielaw\\.emea\\.fcagroup\\.com/|^https?://(www\\.)?cookielaw\\.emea\\.fcagroup\\.com/",
+                    "^https?://(www\\.)?widget-next\\.clym-sdk\\.net/",
                     1,
                     [],
                     [
@@ -10163,9 +10127,9 @@
                 ],
                 [
                     1,
-                    "auto_DE_huss-licht-ton.de_jj0",
+                    "auto_CH_swisscare.com_arx",
                     0,
-                    "^https?://(www\\.)?huss-licht-ton\\.de/",
+                    "^https?://(www\\.)?swisscare\\.com/",
                     1,
                     [],
                     [
@@ -10197,9 +10161,9 @@
                 ],
                 [
                     1,
-                    "auto_DE_modellbau-berlinski.de_8vm",
+                    "auto_DE_alfaromeo.de_gvg_+2",
                     0,
-                    "^https?://(www\\.)?modellbau-berlinski\\.de/",
+                    "^https?://(www\\.)?cookielaw\\.emea\\.fcagroup\\.com/|^https?://(www\\.)?cookielaw\\.emea\\.fcagroup\\.com/|^https?://(www\\.)?cookielaw\\.emea\\.fcagroup\\.com/",
                     1,
                     [],
                     [
@@ -10231,9 +10195,9 @@
                 ],
                 [
                     1,
-                    "auto_DE_phoenixnap.com_xq7",
+                    "auto_DE_huss-licht-ton.de_jj0",
                     0,
-                    "^https?://(www\\.)?widget-next\\.clym-sdk\\.net/",
+                    "^https?://(www\\.)?huss-licht-ton\\.de/",
                     1,
                     [],
                     [
@@ -10265,9 +10229,9 @@
                 ],
                 [
                     1,
-                    "auto_FR_fiat.fr_3fh",
+                    "auto_DE_modellbau-berlinski.de_8vm",
                     0,
-                    "^https?://(www\\.)?cookielaw\\.emea\\.fcagroup\\.com/",
+                    "^https?://(www\\.)?modellbau-berlinski\\.de/",
                     1,
                     [],
                     [
@@ -10299,43 +10263,9 @@
                 ],
                 [
                     1,
-                    "auto_FR_stellantis.com_67q",
+                    "auto_DE_phoenixnap.com_xq7",
                     0,
-                    "^https?://(www\\.)?cookielaw\\.emea\\.fcagroup\\.com/",
-                    1,
-                    [],
-                    [
-                        {
-                            "e": 760
-                        }
-                    ],
-                    [
-                        {
-                            "v": 760
-                        }
-                    ],
-                    [
-                        {
-                            "wait": 500
-                        },
-                        {
-                            "c": 760
-                        }
-                    ],
-                    [
-                        {
-                            "timeout": 1000,
-                            "check": "none",
-                            "wv": 760
-                        }
-                    ],
-                    {}
-                ],
-                [
-                    1,
-                    "auto_GB_dropbox.com_0_+1",
-                    0,
-                    "^https?://(www\\.)?dropbox\\.com/|^https?://(www\\.)?dropbox\\.com/",
+                    "^https?://(www\\.)?widget-next\\.clym-sdk\\.net/",
                     1,
                     [],
                     [
@@ -10350,17 +10280,26 @@
                     ],
                     [
                         {
+                            "wait": 500
+                        },
+                        {
                             "c": 761
                         }
                     ],
-                    [],
+                    [
+                        {
+                            "timeout": 1000,
+                            "check": "none",
+                            "wv": 761
+                        }
+                    ],
                     {}
                 ],
                 [
                     1,
-                    "auto_GB_investing.thisismoney.co.uk_0",
+                    "auto_FR_fiat.fr_3fh",
                     0,
-                    "^https?://(www\\.)?thisismoney\\.co\\.uk/",
+                    "^https?://(www\\.)?cookielaw\\.emea\\.fcagroup\\.com/",
                     1,
                     [],
                     [
@@ -10375,17 +10314,60 @@
                     ],
                     [
                         {
+                            "wait": 500
+                        },
+                        {
                             "c": 762
                         }
                     ],
-                    [],
+                    [
+                        {
+                            "timeout": 1000,
+                            "check": "none",
+                            "wv": 762
+                        }
+                    ],
                     {}
                 ],
                 [
                     1,
-                    "auto_GB_village-hotels.co.uk_hsa",
+                    "auto_FR_stellantis.com_67q",
                     0,
-                    "^https?://(www\\.)?village-hotels\\.co\\.uk/",
+                    "^https?://(www\\.)?cookielaw\\.emea\\.fcagroup\\.com/",
+                    1,
+                    [],
+                    [
+                        {
+                            "e": 762
+                        }
+                    ],
+                    [
+                        {
+                            "v": 762
+                        }
+                    ],
+                    [
+                        {
+                            "wait": 500
+                        },
+                        {
+                            "c": 762
+                        }
+                    ],
+                    [
+                        {
+                            "timeout": 1000,
+                            "check": "none",
+                            "wv": 762
+                        }
+                    ],
+                    {}
+                ],
+                [
+                    1,
+                    "auto_GB_dropbox.com_0_+1",
+                    0,
+                    "^https?://(www\\.)?dropbox\\.com/|^https?://(www\\.)?dropbox\\.com/",
                     1,
                     [],
                     [
@@ -10400,60 +10382,17 @@
                     ],
                     [
                         {
-                            "wait": 500
-                        },
-                        {
                             "c": 763
                         }
                     ],
-                    [
-                        {
-                            "timeout": 1000,
-                            "check": "none",
-                            "wv": 763
-                        }
-                    ],
-                    {}
-                ],
-                [
-                    1,
-                    "auto_NL_fiat.nl_trv_+1",
-                    0,
-                    "^https?://(www\\.)?cookielaw\\.emea\\.fcagroup\\.com/|^https?://(www\\.)?cookielaw\\.emea\\.fcagroup\\.com/",
-                    1,
                     [],
-                    [
-                        {
-                            "e": 760
-                        }
-                    ],
-                    [
-                        {
-                            "v": 760
-                        }
-                    ],
-                    [
-                        {
-                            "wait": 500
-                        },
-                        {
-                            "c": 760
-                        }
-                    ],
-                    [
-                        {
-                            "timeout": 1000,
-                            "check": "none",
-                            "wv": 760
-                        }
-                    ],
                     {}
                 ],
                 [
                     1,
-                    "auto_NL_flitsmeister.nl_ws8",
+                    "auto_GB_investing.thisismoney.co.uk_0",
                     0,
-                    "^https?://(www\\.)?cookies\\.flitsmeister\\.com/",
+                    "^https?://(www\\.)?thisismoney\\.co\\.uk/",
                     1,
                     [],
                     [
@@ -10468,26 +10407,17 @@
                     ],
                     [
                         {
-                            "wait": 500
-                        },
-                        {
                             "c": 764
                         }
                     ],
-                    [
-                        {
-                            "timeout": 1000,
-                            "check": "none",
-                            "wv": 764
-                        }
-                    ],
+                    [],
                     {}
                 ],
                 [
                     1,
-                    "auto_NL_interpolis.nl_jk9",
+                    "auto_GB_village-hotels.co.uk_hsa",
                     0,
-                    "^https?://(www\\.)?interpolis\\.nl/",
+                    "^https?://(www\\.)?village-hotels\\.co\\.uk/",
                     1,
                     [],
                     [
@@ -10519,9 +10449,43 @@
                 ],
                 [
                     1,
-                    "auto_US_dropbox.com_0_+1",
+                    "auto_NL_fiat.nl_trv_+1",
                     0,
-                    "^https?://(www\\.)?dropbox\\.com/|^https?://(www\\.)?dropbox\\.com/",
+                    "^https?://(www\\.)?cookielaw\\.emea\\.fcagroup\\.com/|^https?://(www\\.)?cookielaw\\.emea\\.fcagroup\\.com/",
+                    1,
+                    [],
+                    [
+                        {
+                            "e": 762
+                        }
+                    ],
+                    [
+                        {
+                            "v": 762
+                        }
+                    ],
+                    [
+                        {
+                            "wait": 500
+                        },
+                        {
+                            "c": 762
+                        }
+                    ],
+                    [
+                        {
+                            "timeout": 1000,
+                            "check": "none",
+                            "wv": 762
+                        }
+                    ],
+                    {}
+                ],
+                [
+                    1,
+                    "auto_NL_flitsmeister.nl_ws8",
+                    0,
+                    "^https?://(www\\.)?cookies\\.flitsmeister\\.com/",
                     1,
                     [],
                     [
@@ -10536,8 +10500,76 @@
                     ],
                     [
                         {
-                            "text": "Decline",
+                            "wait": 500
+                        },
+                        {
                             "c": 766
+                        }
+                    ],
+                    [
+                        {
+                            "timeout": 1000,
+                            "check": "none",
+                            "wv": 766
+                        }
+                    ],
+                    {}
+                ],
+                [
+                    1,
+                    "auto_NL_interpolis.nl_jk9",
+                    0,
+                    "^https?://(www\\.)?interpolis\\.nl/",
+                    1,
+                    [],
+                    [
+                        {
+                            "e": 767
+                        }
+                    ],
+                    [
+                        {
+                            "v": 767
+                        }
+                    ],
+                    [
+                        {
+                            "wait": 500
+                        },
+                        {
+                            "c": 767
+                        }
+                    ],
+                    [
+                        {
+                            "timeout": 1000,
+                            "check": "none",
+                            "wv": 767
+                        }
+                    ],
+                    {}
+                ],
+                [
+                    1,
+                    "auto_US_dropbox.com_0_+1",
+                    0,
+                    "^https?://(www\\.)?dropbox\\.com/|^https?://(www\\.)?dropbox\\.com/",
+                    1,
+                    [],
+                    [
+                        {
+                            "e": 768
+                        }
+                    ],
+                    [
+                        {
+                            "v": 768
+                        }
+                    ],
+                    [
+                        {
+                            "text": "Decline",
+                            "c": 768
                         }
                     ],
                     [],
@@ -10552,25 +10584,25 @@
                     [],
                     [
                         {
-                            "e": 767
+                            "e": 769
                         }
                     ],
                     [
                         {
-                            "v": 767
+                            "v": 769
                         }
                     ],
                     [
                         {
-                            "k": 768
+                            "k": 770
                         },
                         {
                             "all": true,
                             "optional": true,
-                            "k": 769
+                            "k": 771
                         },
                         {
-                            "k": 770
+                            "k": 772
                         }
                     ],
                     [
@@ -10589,49 +10621,49 @@
                     "^https://cmp-consent-tool\\.privacymanager\\.io/",
                     1,
                     [
-                        771,
-                        772
+                        773,
+                        774
                     ],
                     [
                         {
-                            "e": 773
+                            "e": 775
                         }
                     ],
                     [
                         {
-                            "v": 773
+                            "v": 775
                         }
                     ],
                     [
                         {
                             "if": {
-                                "e": 774
+                                "e": 776
                             },
                             "then": [
                                 {
-                                    "k": 774
+                                    "k": 776
                                 },
                                 {
-                                    "c": 775
+                                    "c": 777
                                 }
                             ],
                             "else": [
                                 {
-                                    "c": 776
+                                    "c": 778
                                 },
                                 {
-                                    "w": 777
+                                    "w": 779
                                 },
                                 {
-                                    "w": 778
+                                    "w": 780
                                 },
                                 {
                                     "all": true,
                                     "optional": true,
-                                    "k": 779
+                                    "k": 781
                                 },
                                 {
-                                    "k": 778
+                                    "k": 780
                                 }
                             ]
                         }
@@ -10648,20 +10680,20 @@
                     [],
                     [
                         {
-                            "e": 780
+                            "e": 782
                         },
                         {
-                            "e": 781
+                            "e": 783
                         }
                     ],
                     [
                         {
-                            "v": 781
+                            "v": 783
                         }
                     ],
                     [
                         {
-                            "c": 781
+                            "c": 783
                         }
                     ],
                     [],
@@ -10863,21 +10895,21 @@
                     "^https://(www\\.)?ally\\.com/",
                     22,
                     [
-                        782
+                        1490
                     ],
                     [
                         {
-                            "e": 783
+                            "e": 1491
                         }
                     ],
                     [
                         {
-                            "v": 783
+                            "v": 1491
                         }
                     ],
                     [
                         {
-                            "h": 782
+                            "h": 1490
                         }
                     ],
                     [],
@@ -28901,18 +28933,18 @@
             "index": {
                 "genericRuleRange": [
                     0,
-                    189
+                    190
                 ],
                 "frameRuleRange": [
-                    188,
-                    214
+                    189,
+                    215
                 ],
                 "specificRuleRange": [
-                    189,
-                    769
+                    190,
+                    770
                 ],
-                "genericStringEnd": 747,
-                "frameStringEnd": 782
+                "genericStringEnd": 749,
+                "frameStringEnd": 784
             }
         }
     }


### PR DESCRIPTION
Asana Task/Github Issue: https://app.asana.com/1/137249556945/project/1201844467387842/task/1215522307764026

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Data-only consent-rule updates with no application logic changes; main risk is mis-targeted clicks on Vivenu or Ally if selectors are wrong.
> 
> **Overview**
> Bumps **autoconsent** rules in `features/autoconsent.json` to **v14.92.0**, extending automatic cookie-banner handling.
> 
> Adds **generic selectors** for Vivenu privacy dialogs (`data-slot="dialog-content"` with `vivenu.com/dataprivacy` links and the second button in that dialog). Introduces a new **site-specific rule** for **vivenu** (detect → click → verify flow using the new string indices).
> 
> **Ally** consent selectors are **relocated** within the shared string table (the `ally` rule now references different indices; `ally.com` behavior should stay the same). A large block of **index renumbering** (+2) follows insertion of the new strings, plus updated **index ranges** (`genericRuleRange`, `frameStringEnd`, etc.) so rule references stay valid.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ad80ebdfa5bbe3880b1976ecef85f56a17c289c4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->