### PR TITLE
Enable eventHub and adwall events on Windows

### DIFF
--- a/features/web-detection.json
+++ b/features/web-detection.json
@@ -217,6 +217,112 @@
                         "value": { "fireEvent": { "state": "enabled", "type": "admiralAdwall" } }
                     }
                 ]
+            },
+            {
+                "condition": {
+                    "injectName": "windows",
+                    "minSupportedVersion": "0.162.0"
+                },
+                "patchSettings": [
+                    {
+                        "op": "add",
+                        "path": "/detectors/adwalls/generic_en/triggers",
+                        "value": { "auto": { "state": "enabled", "when": { "intervalMs": [
+                                        500,
+                                        1000,
+                                        5000
+                                    ] } } }
+                    },
+                    {
+                        "op": "add",
+                        "path": "/detectors/adwalls/generic_en/actions",
+                        "value": { "fireEvent": { "state": "enabled", "type": "adwall" } }
+                    },
+                    {
+                        "op": "add",
+                        "path": "/detectors/adwalls/generic_de/triggers",
+                        "value": { "auto": { "state": "enabled", "when": { "intervalMs": [
+                                        500,
+                                        1000,
+                                        5000
+                                    ] } } }
+                    },
+                    {
+                        "op": "add",
+                        "path": "/detectors/adwalls/generic_de/actions",
+                        "value": { "fireEvent": { "state": "enabled", "type": "adwall" } }
+                    },
+                    {
+                        "op": "add",
+                        "path": "/detectors/adwalls/generic_es/triggers",
+                        "value": { "auto": { "state": "enabled", "when": { "intervalMs": [
+                                        500,
+                                        1000,
+                                        5000
+                                    ] } } }
+                    },
+                    {
+                        "op": "add",
+                        "path": "/detectors/adwalls/generic_es/actions",
+                        "value": { "fireEvent": { "state": "enabled", "type": "adwall" } }
+                    },
+                    {
+                        "op": "add",
+                        "path": "/detectors/adwalls/generic_it/triggers",
+                        "value": { "auto": { "state": "enabled", "when": { "intervalMs": [
+                                        500,
+                                        1000,
+                                        5000
+                                    ] } } }
+                    },
+                    {
+                        "op": "add",
+                        "path": "/detectors/adwalls/generic_it/actions",
+                        "value": { "fireEvent": { "state": "enabled", "type": "adwall" } }
+                    },
+                    {
+                        "op": "add",
+                        "path": "/detectors/adwalls/generic_nl/triggers",
+                        "value": { "auto": { "state": "enabled", "when": { "intervalMs": [
+                                        500,
+                                        1000,
+                                        5000
+                                    ] } } }
+                    },
+                    {
+                        "op": "add",
+                        "path": "/detectors/adwalls/generic_nl/actions",
+                        "value": { "fireEvent": { "state": "enabled", "type": "adwall" } }
+                    },
+                    {
+                        "op": "add",
+                        "path": "/detectors/adwalls/generic_se/triggers",
+                        "value": { "auto": { "state": "enabled", "when": { "intervalMs": [
+                                        500,
+                                        1000,
+                                        5000
+                                    ] } } }
+                    },
+                    {
+                        "op": "add",
+                        "path": "/detectors/adwalls/generic_se/actions",
+                        "value": { "fireEvent": { "state": "enabled", "type": "adwall" } }
+                    },
+                    {
+                        "op": "add",
+                        "path": "/detectors/adwalls/admiral/triggers",
+                        "value": { "auto": { "state": "enabled", "when": { "intervalMs": [
+                                        500,
+                                        1000,
+                                        5000
+                                    ] } } }
+                    },
+                    {
+                        "op": "add",
+                        "path": "/detectors/adwalls/admiral/actions",
+                        "value": { "fireEvent": { "state": "enabled", "type": "admiralAdwall" } }
+                    }
+                ]
             }
         ]
     }

--- a/features/web-detection.json
+++ b/features/web-detection.json
@@ -113,116 +113,16 @@
         },
         "conditionalChanges": [
             {
-                "condition": {
-                    "injectName": "android",
-                    "minSupportedVersion": 52720000
-                },
-                "patchSettings": [
+                "condition": [
                     {
-                        "op": "add",
-                        "path": "/detectors/adwalls/generic_en/triggers",
-                        "value": { "auto": { "state": "enabled", "when": { "intervalMs": [
-                                        500,
-                                        1000,
-                                        5000
-                                    ] } } }
+                        "injectName": "android",
+                        "minSupportedVersion": 52720000
                     },
                     {
-                        "op": "add",
-                        "path": "/detectors/adwalls/generic_en/actions",
-                        "value": { "fireEvent": { "state": "enabled", "type": "adwall" } }
-                    },
-                    {
-                        "op": "add",
-                        "path": "/detectors/adwalls/generic_de/triggers",
-                        "value": { "auto": { "state": "enabled", "when": { "intervalMs": [
-                                        500,
-                                        1000,
-                                        5000
-                                    ] } } }
-                    },
-                    {
-                        "op": "add",
-                        "path": "/detectors/adwalls/generic_de/actions",
-                        "value": { "fireEvent": { "state": "enabled", "type": "adwall" } }
-                    },
-                    {
-                        "op": "add",
-                        "path": "/detectors/adwalls/generic_es/triggers",
-                        "value": { "auto": { "state": "enabled", "when": { "intervalMs": [
-                                        500,
-                                        1000,
-                                        5000
-                                    ] } } }
-                    },
-                    {
-                        "op": "add",
-                        "path": "/detectors/adwalls/generic_es/actions",
-                        "value": { "fireEvent": { "state": "enabled", "type": "adwall" } }
-                    },
-                    {
-                        "op": "add",
-                        "path": "/detectors/adwalls/generic_it/triggers",
-                        "value": { "auto": { "state": "enabled", "when": { "intervalMs": [
-                                        500,
-                                        1000,
-                                        5000
-                                    ] } } }
-                    },
-                    {
-                        "op": "add",
-                        "path": "/detectors/adwalls/generic_it/actions",
-                        "value": { "fireEvent": { "state": "enabled", "type": "adwall" } }
-                    },
-                    {
-                        "op": "add",
-                        "path": "/detectors/adwalls/generic_nl/triggers",
-                        "value": { "auto": { "state": "enabled", "when": { "intervalMs": [
-                                        500,
-                                        1000,
-                                        5000
-                                    ] } } }
-                    },
-                    {
-                        "op": "add",
-                        "path": "/detectors/adwalls/generic_nl/actions",
-                        "value": { "fireEvent": { "state": "enabled", "type": "adwall" } }
-                    },
-                    {
-                        "op": "add",
-                        "path": "/detectors/adwalls/generic_se/triggers",
-                        "value": { "auto": { "state": "enabled", "when": { "intervalMs": [
-                                        500,
-                                        1000,
-                                        5000
-                                    ] } } }
-                    },
-                    {
-                        "op": "add",
-                        "path": "/detectors/adwalls/generic_se/actions",
-                        "value": { "fireEvent": { "state": "enabled", "type": "adwall" } }
-                    },
-                    {
-                        "op": "add",
-                        "path": "/detectors/adwalls/admiral/triggers",
-                        "value": { "auto": { "state": "enabled", "when": { "intervalMs": [
-                                        500,
-                                        1000,
-                                        5000
-                                    ] } } }
-                    },
-                    {
-                        "op": "add",
-                        "path": "/detectors/adwalls/admiral/actions",
-                        "value": { "fireEvent": { "state": "enabled", "type": "admiralAdwall" } }
+                        "injectName": "windows",
+                        "minSupportedVersion": "0.162.0"
                     }
-                ]
-            },
-            {
-                "condition": {
-                    "injectName": "windows",
-                    "minSupportedVersion": "0.162.0"
-                },
+                ],
                 "patchSettings": [
                     {
                         "op": "add",

--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -5330,6 +5330,10 @@
                 }
             }
         },
+        "eventHub": {
+            "state": "internal",
+            "minSupportedVersion": "0.162.0"
+        },
         "webDetection": {
             "state": "enabled",
             "minSupportedVersion": "0.147.0"


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/481882893211075/task/1212993781157340?focus=true

## Description

Enables the `eventHub` client-side telemetry framework on Windows and wires up the adwall detection events that feed it. Companion to the Windows EventHub implementation work.

- **`overrides/windows-override.json`** — adds an `eventHub` override (`state: internal`, `minSupportedVersion: 0.162.0`).
- **`features/web-detection.json`** — adds a `conditionalChanges` entry for `injectName: "windows"` (`minSupportedVersion: 0.162.0`) mirroring the existing Android block: enables the adwall `auto` triggers and `fireEvent` actions (`type: "adwall"` for the generic detectors, `"admiralAdwall"` for admiral). This makes content-scope-scripts emit `webEvent`s that `eventHub` aggregates into bucketed pixels.

No new schema or shared feature definition is introduced — the `eventHub` feature and `adwall` detectors already exist cross-platform.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [x] This feature was covered by a tech design.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces internal client telemetry aggregation and page-level adwall event emission on Windows for builds ≥0.162.0; gated as internal but increases in-the-wild detection and event traffic.
> 
> **Overview**
> Turns on **Windows** support for the `eventHub` telemetry path and the adwall **web-detection** `fireEvent` pipeline that feeds it.
> 
> **`overrides/windows-override.json`** adds an `eventHub` feature override (`state: internal`, `minSupportedVersion: 0.162.0`), alongside existing `webDetection` / `webEvents` entries.
> 
> **`features/web-detection.json`** extends the adwall `conditionalChanges` block so it applies to both Android and Windows: `condition` becomes an array that keeps the Android gate and adds `injectName: "windows"` at `0.162.0`, reusing the same patches that enable auto triggers and `fireEvent` actions (`adwall` / `admiralAdwall`) for the generic adwall detectors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a6d56ec2fd46f50abb9557aca7112f2568d7dfd7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->