### PR TITLE
add and enable aichat.onboardingToggleAffectsNtpAndDdg

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -1439,6 +1439,10 @@
                 },
                 "omnibarAttachMoreTabs": {
                     "state": "disabled"
+                },
+                "onboardingToggleAffectsNtpAndDdg": {
+                    "state": "enabled",
+                    "minSupportedVersion": "0.162.0"
                 }
             },
             "minSupportedVersion": "0.100.0",


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1210407179200832/task/1215385527516386?focus=true

## Description
add and enable aichat.onboardingToggleAffectsNtpAndDdg

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single privacy-configuration override flipping a version-gated AI chat feature flag; no runtime code changes in this PR.
> 
> **Overview**
> Enables the **`aiChat.onboardingToggleAffectsNtpAndDdg`** sub-feature for the Windows browser in `windows-override.json`, so clients on **0.162.0+** will apply AI chat onboarding toggle behavior on the **new tab page** and **duckduckgo.com** (not just other entry points).
> 
> This is a remote feature-flag change only; no application code in this PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8282d32c2df93580ac934eaaf77bc7ce23acad46. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->