### PR TITLE
Add Android YouTube interference detection and daily pixel

### DIFF
--- a/features/event-hub.json
+++ b/features/event-hub.json
@@ -101,6 +101,51 @@
                         }
                     }
                 }
+            },
+            "webTelemetry_youtubeInterference_day": {
+                "state": "enabled",
+                "trigger": {
+                    "period": {
+                        "days": 1
+                    }
+                },
+                "parameters": {
+                    "videoAd": {
+                        "template": "counter",
+                        "source": "youtube_videoAd",
+                        "buckets": {
+                            "true": { "gte": 1 }
+                        }
+                    },
+                    "staticAd": {
+                        "template": "counter",
+                        "source": "youtube_staticAd",
+                        "buckets": {
+                            "true": { "gte": 1 }
+                        }
+                    },
+                    "playabilityError": {
+                        "template": "counter",
+                        "source": "youtube_playabilityError",
+                        "buckets": {
+                            "true": { "gte": 1 }
+                        }
+                    },
+                    "adBlocker": {
+                        "template": "counter",
+                        "source": "youtube_adBlocker",
+                        "buckets": {
+                            "true": { "gte": 1 }
+                        }
+                    },
+                    "buffering": {
+                        "template": "counter",
+                        "source": "youtube_buffering",
+                        "buckets": {
+                            "true": { "gte": 1 }
+                        }
+                    }
+                }
             }
         }
     }

--- a/features/event-hub.json
+++ b/features/event-hub.json
@@ -101,51 +101,6 @@
                         }
                     }
                 }
-            },
-            "webTelemetry_youtubeInterference_day": {
-                "state": "enabled",
-                "trigger": {
-                    "period": {
-                        "days": 1
-                    }
-                },
-                "parameters": {
-                    "videoAd": {
-                        "template": "counter",
-                        "source": "youtube_videoAd",
-                        "buckets": {
-                            "true": { "gte": 1 }
-                        }
-                    },
-                    "staticAd": {
-                        "template": "counter",
-                        "source": "youtube_staticAd",
-                        "buckets": {
-                            "true": { "gte": 1 }
-                        }
-                    },
-                    "playabilityError": {
-                        "template": "counter",
-                        "source": "youtube_playabilityError",
-                        "buckets": {
-                            "true": { "gte": 1 }
-                        }
-                    },
-                    "adBlocker": {
-                        "template": "counter",
-                        "source": "youtube_adBlocker",
-                        "buckets": {
-                            "true": { "gte": 1 }
-                        }
-                    },
-                    "buffering": {
-                        "template": "counter",
-                        "source": "youtube_buffering",
-                        "buckets": {
-                            "true": { "gte": 1 }
-                        }
-                    }
-                }
             }
         }
     }

--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ import {
     inlineReasonArrays,
     mergeAllowlistedTrackers,
     mergeEventHubTelemetry,
+    mergeInterferenceTypes,
     addHashToFeatures,
     stripReasons,
     getBaseFeatureConfigs,
@@ -291,6 +292,22 @@ async function buildPlatforms() {
                             ...baseSettings,
                             ...overrideSettings,
                             telemetry: mergeEventHubTelemetry(baseSettings.telemetry || {}, overrideSettings.telemetry || {}),
+                        };
+                    } else if (key === 'webInterferenceDetection' && platformKey === 'settings') {
+                        // Merge interferenceTypes per key so platforms inherit base types and
+                        // only declare the ones they override or add. This keeps platform configs
+                        // from drifting as base types change, and picks up new types
+                        // automatically. Other webInterferenceDetection settings keys still
+                        // override wholesale.
+                        const baseSettings = platformConfig.features[key].settings || {};
+                        const overrideSettings = platformOverride.features[key][platformKey];
+                        platformConfig.features[key][platformKey] = {
+                            ...baseSettings,
+                            ...overrideSettings,
+                            interferenceTypes: mergeInterferenceTypes(
+                                baseSettings.interferenceTypes || {},
+                                overrideSettings.interferenceTypes || {},
+                            ),
                         };
                     } else if ((key === 'clickToLoad' || key === 'clickToPlay') && platformKey === 'settings') {
                         // Handle Click to Load settings override later, so that individual entities

--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -38,7 +38,8 @@
         "adBlockingExtension": {
             "exceptions": [],
             "state": "internal",
-            "minSupportedVersion": 52831006
+"state": "enabled",
+"minSupportedVersion": 52840000
         },
         "additionalCampaignPixelParams": {
             "state": "enabled",

--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -37,9 +37,8 @@
         },
         "adBlockingExtension": {
             "exceptions": [],
-            "state": "internal",
-"state": "enabled",
-"minSupportedVersion": 52840000
+            "state": "enabled",
+            "minSupportedVersion": 52840000
         },
         "additionalCampaignPixelParams": {
             "state": "enabled",

--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -4396,7 +4396,7 @@
                     "youtubeAds": {
                         "state": "enabled",
                         "sweepIntervalMs": 2000,
-                        "slowLoadThresholdMs": 15000,
+                        "slowLoadThresholdMs": 2000,
                         "playerSelectors": [
                             "#movie_player",
                             ".html5-video-player",

--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -751,7 +751,8 @@
                         "conditionalChanges": [
                             {
                                 "condition": [
-                                    { "domain": "ring.com" }],
+                                    { "domain": "ring.com" }
+                                ],
                                 "patchSettings": [
                                     {
                                         "path": "/formTypeSettings/-",
@@ -765,7 +766,8 @@
                             },
                             {
                                 "condition": [
-                                    { "domain": "www.joinblvd.com" }],
+                                    { "domain": "www.joinblvd.com" }
+                                ],
                                 "patchSettings": [
                                     {
                                         "path": "/formTypeSettings/-",
@@ -779,7 +781,8 @@
                             },
                             {
                                 "condition": [
-                                    { "domain": "alibris.com" }],
+                                    { "domain": "alibris.com" }
+                                ],
                                 "patchSettings": [
                                     {
                                         "path": "/formTypeSettings/-",
@@ -801,7 +804,8 @@
                             },
                             {
                                 "condition": [
-                                    { "domain": "accounts.google.com" }],
+                                    { "domain": "accounts.google.com" }
+                                ],
                                 "patchSettings": [
                                     {
                                         "path": "/formBoundarySelector",
@@ -820,7 +824,8 @@
                             },
                             {
                                 "condition": [
-                                    { "domain": "coolors.co" }],
+                                    { "domain": "coolors.co" }
+                                ],
                                 "patchSettings": [
                                     {
                                         "path": "/failsafeSettings/maxInputsPerPage",
@@ -831,7 +836,8 @@
                             },
                             {
                                 "condition": [
-                                    { "domain": "areaclientes.orange.es" }],
+                                    { "domain": "areaclientes.orange.es" }
+                                ],
                                 "patchSettings": [
                                     {
                                         "path": "/formTypeSettings/-",
@@ -846,7 +852,8 @@
                             {
                                 "condition": [
                                     { "domain": "estore.archives.gov" },
-                                    { "domain": "localhost" }],
+                                    { "domain": "localhost" }
+                                ],
                                 "patchSettings": [
                                     {
                                         "path": "/formTypeSettings/-",
@@ -861,7 +868,8 @@
                             {
                                 "condition": [
                                     { "domain": "zendesk.com" },
-                                    { "domain": "localhost" }],
+                                    { "domain": "localhost" }
+                                ],
                                 "patchSettings": [
                                     {
                                         "path": "/inputTypeSettings/-",
@@ -875,7 +883,8 @@
                             },
                             {
                                 "condition": [
-                                    { "domain": "cvs.com" }],
+                                    { "domain": "cvs.com" }
+                                ],
                                 "patchSettings": [
                                     {
                                         "path": "/inputTypeSettings/-",
@@ -889,7 +898,8 @@
                             },
                             {
                                 "condition": [
-                                    { "domain": "att.com" }],
+                                    { "domain": "att.com" }
+                                ],
                                 "patchSettings": [
                                     {
                                         "path": "/inputTypeSettings/-",
@@ -903,7 +913,8 @@
                             },
                             {
                                 "condition": [
-                                    { "domain": "gamestop.com" }],
+                                    { "domain": "gamestop.com" }
+                                ],
                                 "patchSettings": [
                                     {
                                         "path": "/inputTypeSettings/-",
@@ -937,7 +948,8 @@
                             },
                             {
                                 "condition": [
-                                    { "domain": "asana.com" }],
+                                    { "domain": "asana.com" }
+                                ],
                                 "patchSettings": [
                                     {
                                         "path": "/inputTypeSettings/-",
@@ -951,7 +963,8 @@
                             },
                             {
                                 "condition": [
-                                    { "domain": "portal.vectorsecurity.com" }],
+                                    { "domain": "portal.vectorsecurity.com" }
+                                ],
                                 "patchSettings": [
                                     {
                                         "path": "/formTypeSettings/-",
@@ -965,7 +978,8 @@
                             },
                             {
                                 "condition": [
-                                    { "domain": "reddit.com" }],
+                                    { "domain": "reddit.com" }
+                                ],
                                 "patchSettings": [
                                     {
                                         "path": "/formTypeSettings/-",
@@ -979,7 +993,8 @@
                             },
                             {
                                 "condition": [
-                                    { "domain": "netflix.com" }],
+                                    { "domain": "netflix.com" }
+                                ],
                                 "patchSettings": [
                                     {
                                         "path": "/formTypeSettings/-",
@@ -998,7 +1013,8 @@
                             },
                             {
                                 "condition": [
-                                    { "domain": "aa.com" }],
+                                    { "domain": "aa.com" }
+                                ],
                                 "patchSettings": [
                                     {
                                         "path": "/formBoundarySelector",
@@ -1010,7 +1026,8 @@
                             {
                                 "condition": [
                                     { "domain": "bet365.bet.br" },
-                                    { "domain": "bet365.com" }],
+                                    { "domain": "bet365.com" }
+                                ],
                                 "patchSettings": [
                                     {
                                         "path": "/formBoundarySelector",
@@ -1021,7 +1038,8 @@
                             },
                             {
                                 "condition": [
-                                    { "domain": "order.yodobashi.com" }],
+                                    { "domain": "order.yodobashi.com" }
+                                ],
                                 "patchSettings": [
                                     {
                                         "path": "/formTypeSettings/-",
@@ -1040,7 +1058,8 @@
                             },
                             {
                                 "condition": [
-                                    { "domain": "challenge.spotify.com" }],
+                                    { "domain": "challenge.spotify.com" }
+                                ],
                                 "patchSettings": [
                                     {
                                         "path": "/inputTypeSettings/-",
@@ -1054,7 +1073,8 @@
                             },
                             {
                                 "condition": [
-                                    { "domain": "login.coinbase.com" }],
+                                    { "domain": "login.coinbase.com" }
+                                ],
                                 "patchSettings": [
                                     {
                                         "path": "/inputTypeSettings/-",
@@ -1076,7 +1096,8 @@
                             },
                             {
                                 "condition": [
-                                    { "domain": "signin.autodesk.com" }],
+                                    { "domain": "signin.autodesk.com" }
+                                ],
                                 "patchSettings": [
                                     {
                                         "path": "/inputTypeSettings/-",

--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -751,8 +751,7 @@
                         "conditionalChanges": [
                             {
                                 "condition": [
-                                    { "domain": "ring.com" }
-                                ],
+                                    { "domain": "ring.com" }],
                                 "patchSettings": [
                                     {
                                         "path": "/formTypeSettings/-",
@@ -766,8 +765,7 @@
                             },
                             {
                                 "condition": [
-                                    { "domain": "www.joinblvd.com" }
-                                ],
+                                    { "domain": "www.joinblvd.com" }],
                                 "patchSettings": [
                                     {
                                         "path": "/formTypeSettings/-",
@@ -781,8 +779,7 @@
                             },
                             {
                                 "condition": [
-                                    { "domain": "alibris.com" }
-                                ],
+                                    { "domain": "alibris.com" }],
                                 "patchSettings": [
                                     {
                                         "path": "/formTypeSettings/-",
@@ -804,8 +801,7 @@
                             },
                             {
                                 "condition": [
-                                    { "domain": "accounts.google.com" }
-                                ],
+                                    { "domain": "accounts.google.com" }],
                                 "patchSettings": [
                                     {
                                         "path": "/formBoundarySelector",
@@ -824,8 +820,7 @@
                             },
                             {
                                 "condition": [
-                                    { "domain": "coolors.co" }
-                                ],
+                                    { "domain": "coolors.co" }],
                                 "patchSettings": [
                                     {
                                         "path": "/failsafeSettings/maxInputsPerPage",
@@ -836,8 +831,7 @@
                             },
                             {
                                 "condition": [
-                                    { "domain": "areaclientes.orange.es" }
-                                ],
+                                    { "domain": "areaclientes.orange.es" }],
                                 "patchSettings": [
                                     {
                                         "path": "/formTypeSettings/-",
@@ -852,8 +846,7 @@
                             {
                                 "condition": [
                                     { "domain": "estore.archives.gov" },
-                                    { "domain": "localhost" }
-                                ],
+                                    { "domain": "localhost" }],
                                 "patchSettings": [
                                     {
                                         "path": "/formTypeSettings/-",
@@ -868,8 +861,7 @@
                             {
                                 "condition": [
                                     { "domain": "zendesk.com" },
-                                    { "domain": "localhost" }
-                                ],
+                                    { "domain": "localhost" }],
                                 "patchSettings": [
                                     {
                                         "path": "/inputTypeSettings/-",
@@ -883,8 +875,7 @@
                             },
                             {
                                 "condition": [
-                                    { "domain": "cvs.com" }
-                                ],
+                                    { "domain": "cvs.com" }],
                                 "patchSettings": [
                                     {
                                         "path": "/inputTypeSettings/-",
@@ -898,8 +889,7 @@
                             },
                             {
                                 "condition": [
-                                    { "domain": "att.com" }
-                                ],
+                                    { "domain": "att.com" }],
                                 "patchSettings": [
                                     {
                                         "path": "/inputTypeSettings/-",
@@ -913,8 +903,7 @@
                             },
                             {
                                 "condition": [
-                                    { "domain": "gamestop.com" }
-                                ],
+                                    { "domain": "gamestop.com" }],
                                 "patchSettings": [
                                     {
                                         "path": "/inputTypeSettings/-",
@@ -948,8 +937,7 @@
                             },
                             {
                                 "condition": [
-                                    { "domain": "asana.com" }
-                                ],
+                                    { "domain": "asana.com" }],
                                 "patchSettings": [
                                     {
                                         "path": "/inputTypeSettings/-",
@@ -963,8 +951,7 @@
                             },
                             {
                                 "condition": [
-                                    { "domain": "portal.vectorsecurity.com" }
-                                ],
+                                    { "domain": "portal.vectorsecurity.com" }],
                                 "patchSettings": [
                                     {
                                         "path": "/formTypeSettings/-",
@@ -978,8 +965,7 @@
                             },
                             {
                                 "condition": [
-                                    { "domain": "reddit.com" }
-                                ],
+                                    { "domain": "reddit.com" }],
                                 "patchSettings": [
                                     {
                                         "path": "/formTypeSettings/-",
@@ -993,8 +979,7 @@
                             },
                             {
                                 "condition": [
-                                    { "domain": "netflix.com" }
-                                ],
+                                    { "domain": "netflix.com" }],
                                 "patchSettings": [
                                     {
                                         "path": "/formTypeSettings/-",
@@ -1013,8 +998,7 @@
                             },
                             {
                                 "condition": [
-                                    { "domain": "aa.com" }
-                                ],
+                                    { "domain": "aa.com" }],
                                 "patchSettings": [
                                     {
                                         "path": "/formBoundarySelector",
@@ -1026,8 +1010,7 @@
                             {
                                 "condition": [
                                     { "domain": "bet365.bet.br" },
-                                    { "domain": "bet365.com" }
-                                ],
+                                    { "domain": "bet365.com" }],
                                 "patchSettings": [
                                     {
                                         "path": "/formBoundarySelector",
@@ -1038,8 +1021,7 @@
                             },
                             {
                                 "condition": [
-                                    { "domain": "order.yodobashi.com" }
-                                ],
+                                    { "domain": "order.yodobashi.com" }],
                                 "patchSettings": [
                                     {
                                         "path": "/formTypeSettings/-",
@@ -1058,8 +1040,7 @@
                             },
                             {
                                 "condition": [
-                                    { "domain": "challenge.spotify.com" }
-                                ],
+                                    { "domain": "challenge.spotify.com" }],
                                 "patchSettings": [
                                     {
                                         "path": "/inputTypeSettings/-",
@@ -1073,8 +1054,7 @@
                             },
                             {
                                 "condition": [
-                                    { "domain": "login.coinbase.com" }
-                                ],
+                                    { "domain": "login.coinbase.com" }],
                                 "patchSettings": [
                                     {
                                         "path": "/inputTypeSettings/-",
@@ -1096,8 +1076,7 @@
                             },
                             {
                                 "condition": [
-                                    { "domain": "signin.autodesk.com" }
-                                ],
+                                    { "domain": "signin.autodesk.com" }],
                                 "patchSettings": [
                                     {
                                         "path": "/inputTypeSettings/-",
@@ -4385,7 +4364,56 @@
         },
         "eventHub": {
             "state": "enabled",
-            "minSupportedVersion": 52720000
+            "minSupportedVersion": 52720000,
+            "settings": {
+                "telemetry": {
+                    "webTelemetry_youtubeInterference_day": {
+                        "state": "enabled",
+                        "trigger": {
+                            "period": {
+                                "days": 1
+                            }
+                        },
+                        "parameters": {
+                            "videoAd": {
+                                "template": "counter",
+                                "source": "youtube_videoAd",
+                                "buckets": {
+                                    "true": { "gte": 1 }
+                                }
+                            },
+                            "staticAd": {
+                                "template": "counter",
+                                "source": "youtube_staticAd",
+                                "buckets": {
+                                    "true": { "gte": 1 }
+                                }
+                            },
+                            "playabilityError": {
+                                "template": "counter",
+                                "source": "youtube_playabilityError",
+                                "buckets": {
+                                    "true": { "gte": 1 }
+                                }
+                            },
+                            "adBlocker": {
+                                "template": "counter",
+                                "source": "youtube_adBlocker",
+                                "buckets": {
+                                    "true": { "gte": 1 }
+                                }
+                            },
+                            "buffering": {
+                                "template": "counter",
+                                "source": "youtube_buffering",
+                                "buckets": {
+                                    "true": { "gte": 1 }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
         },
         "webInterferenceDetection": {
             "state": "enabled",

--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -4387,6 +4387,99 @@
             "state": "enabled",
             "minSupportedVersion": 52720000
         },
+        "webInterferenceDetection": {
+            "state": "enabled",
+            "minSupportedVersion": 52720000,
+            "settings": {
+                "autoRunDelayMs": 100,
+                "interferenceTypes": {
+                    "youtubeAds": {
+                        "state": "enabled",
+                        "sweepIntervalMs": 2000,
+                        "slowLoadThresholdMs": 15000,
+                        "playerSelectors": [
+                            "#movie_player",
+                            ".html5-video-player",
+                            "#player"
+                        ],
+                        "adClasses": [
+                            "ytp-ad-text",
+                            "ytp-ad-skip-button",
+                            "ytp-ad-skip-button-container",
+                            "ytp-ad-message-container",
+                            "ytp-ad-player-overlay",
+                            "ytp-ad-image-overlay",
+                            "video-ads",
+                            "ad-showing",
+                            "ad-interrupting"
+                        ],
+                        "adTextPatterns": [
+                            "\\badvertisement\\b",
+                            "\\bskip ad\\b",
+                            "\\bskip ads\\b",
+                            "^ad\\s*[•:·]"
+                        ],
+                        "staticAdSelectors": {
+                            "background": ".player-container-background",
+                            "thumbnail": ".player-container-background-image, .player-container-background ytd-thumbnail",
+                            "image": ".player-container-background yt-image"
+                        },
+                        "playabilityErrorSelectors": [
+                            "ytm-player-error-message-renderer",
+                            "yt-player-error-message-renderer",
+                            ".ytp-error",
+                            ".playability-status-message",
+                            ".playability-reason"
+                        ],
+                        "playabilityErrorPatterns": [
+                            "content isn't available",
+                            "video (is )?unavailable",
+                            "playback (is )?disabled",
+                            "confirm you're not a (ro)?bot",
+                            "sign in to confirm",
+                            "unusual traffic",
+                            "try again later"
+                        ],
+                        "adBlockerDetectionSelectors": [
+                            "ytd-enforcement-message-view-model",
+                            "ytd-popup-container tp-yt-paper-dialog",
+                            "tp-yt-paper-dialog",
+                            ".ytd-enforcement-message-view-model",
+                            "#dialog",
+                            "[role=\"dialog\"]"
+                        ],
+                        "adBlockerDetectionPatterns": [
+                            "ad\\s*blockers?\\s*(are)?\\s*not allowed",
+                            "using an ad\\s*blocker",
+                            "allow youtube ads",
+                            "disable.*ad\\s*blocker",
+                            "turn off.*ad\\s*blocker",
+                            "ad\\s*blocker.*detected",
+                            "ad\\s*blocking",
+                            "will be blocked after \\d+ videos?",
+                            "playback will be blocked",
+                            "playback is blocked",
+                            "youtube is allowlisted",
+                            "video player will be blocked",
+                            "ad\\s*blockers?\\s*violate",
+                            "violate.*terms of service"
+                        ],
+                        "loginStateSelectors": {
+                            "signInButton": "a[href*=\"accounts.google.com/ServiceLogin\"]",
+                            "avatarButton": "#avatar-btn",
+                            "premiumLogo": "ytd-topbar-logo-renderer a[title*=\"Premium\"]"
+                        },
+                        "fireDetectionEvents": {
+                            "adBlocker": true,
+                            "playabilityError": true,
+                            "videoAd": true,
+                            "staticAd": true,
+                            "buffering": true
+                        }
+                    }
+                }
+            }
+        },
         "progressBarUpgrade": {
             "state": "enabled",
             "minSupportedVersion": 52801000,

--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -4438,12 +4438,11 @@
         },
         "webInterferenceDetection": {
             "state": "enabled",
-            "minSupportedVersion": 52840000,
             "settings": {
                 "autoRunDelayMs": 100,
                 "interferenceTypes": {
                     "youtubeAds": {
-                        "state": "enabled",
+                        "state": "disabled",
                         "sweepIntervalMs": 2000,
                         "slowLoadThresholdMs": 15000,
                         "playerSelectors": [
@@ -4526,7 +4525,21 @@
                             "buffering": true
                         }
                     }
-                }
+                },
+                "conditionalChanges": [
+                    {
+                        "condition": {
+                            "minSupportedVersion": 52840000
+                        },
+                        "patchSettings": [
+                            {
+                                "op": "replace",
+                                "path": "/interferenceTypes/youtubeAds/state",
+                                "value": "enabled"
+                            }
+                        ]
+                    }
+                ]
             }
         },
         "progressBarUpgrade": {

--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -4396,7 +4396,7 @@
                     "youtubeAds": {
                         "state": "enabled",
                         "sweepIntervalMs": 2000,
-                        "slowLoadThresholdMs": 2000,
+                        "slowLoadThresholdMs": 15000,
                         "playerSelectors": [
                             "#movie_player",
                             ".html5-video-player",

--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -4389,7 +4389,7 @@
         },
         "webInterferenceDetection": {
             "state": "enabled",
-            "minSupportedVersion": 52720000,
+            "minSupportedVersion": 52840000,
             "settings": {
                 "autoRunDelayMs": 100,
                 "interferenceTypes": {

--- a/tests/build-tests.js
+++ b/tests/build-tests.js
@@ -5,6 +5,7 @@ import {
     inlineReasonArrays,
     mergeAllowlistedTrackers,
     mergeEventHubTelemetry,
+    mergeInterferenceTypes,
     addHashToFeatures,
 } from '../util.js';
 
@@ -267,6 +268,62 @@ describe('mergeEventHubTelemetry', () => {
     it('returns base entries unchanged when the override is empty', () => {
         const base = { base_pixel_day: baseEntry('base') };
         expect(mergeEventHubTelemetry(base, {})).to.deep.equal(base);
+    });
+});
+
+describe('mergeInterferenceTypes', () => {
+    const baseType = (interval) => ({
+        state: 'enabled',
+        sweepIntervalMs: interval,
+        playerSelectors: [
+            '#player',
+        ],
+    });
+
+    it('inherits base types not present in the override', () => {
+        const base = { adwallDetection: baseType(1000) };
+        const override = { youtubeAds: baseType(2000) };
+        expect(mergeInterferenceTypes(base, override)).to.deep.equal({
+            adwallDetection: baseType(1000),
+            youtubeAds: baseType(2000),
+        });
+    });
+
+    it('lets the override replace a base type with the same key', () => {
+        const base = { adwallDetection: baseType(1000) };
+        const override = { adwallDetection: baseType(2000) };
+        expect(mergeInterferenceTypes(base, override)).to.deep.equal({
+            adwallDetection: baseType(2000),
+        });
+    });
+
+    it('replaces matching keys wholesale rather than deep-merging them', () => {
+        const base = {
+            adwallDetection: {
+                state: 'enabled',
+                sweepIntervalMs: 1000,
+                playerSelectors: [
+                    '#player',
+                    '#movie_player',
+                ],
+            },
+        };
+        const override = {
+            adwallDetection: {
+                state: 'enabled',
+                sweepIntervalMs: 2000,
+                playerSelectors: [
+                    '#player',
+                ],
+            },
+        };
+        // The override type wins entirely — the extra base selector is not carried over.
+        expect(mergeInterferenceTypes(base, override)).to.deep.equal(override);
+    });
+
+    it('returns base types unchanged when the override is empty', () => {
+        const base = { adwallDetection: baseType(1000) };
+        expect(mergeInterferenceTypes(base, {})).to.deep.equal(base);
     });
 });
 

--- a/tests/config-tests.js
+++ b/tests/config-tests.js
@@ -554,6 +554,26 @@ describe('EventHub telemetry override merge', () => {
     });
 });
 
+describe('webInterferenceDetection interferenceTypes override merge', () => {
+    // Android declares only its platform-specific interference types in its override; the build
+    // must merge in the base types so the platform does not drift as base types change.
+    const androidConfig = latestConfigs.find((c) => c.name === 'v5/android-config.json');
+    const interferenceTypes = androidConfig?.body?.features?.webInterferenceDetection?.settings?.interferenceTypes || {};
+    const baseInterferenceTypes = readJsoncFile('./features/web-interference-detection.json').settings.interferenceTypes;
+
+    it('inherits base interference types not declared in the android override', () => {
+        for (const baseName of Object.keys(baseInterferenceTypes)) {
+            expect(interferenceTypes, `Android webInterferenceDetection is missing inherited base type '${baseName}'`).to.have.property(
+                baseName,
+            );
+        }
+    });
+
+    it('keeps android-specific interference types', () => {
+        expect(interferenceTypes).to.have.property('youtubeAds');
+    });
+});
+
 describe('EventHub schema source rules', () => {
     const validate = createValidator('EventHubSettings');
 

--- a/util.js
+++ b/util.js
@@ -137,6 +137,22 @@ export function mergeEventHubTelemetry(base, override) {
 }
 
 /**
+ * Merge a platform's webInterferenceDetection interferenceTypes overrides onto the base.
+ *
+ * Interference types are merged per key: a platform override only needs to declare the
+ * types it changes or adds, and inherits every other type from the base config. This keeps
+ * platforms from drifting out of date as base types change, and ensures they pick up
+ * newly-added types automatically. A type present in both is replaced wholesale by the
+ * override (no deep merge within a type).
+ *
+ * @param {object} base - base interferenceTypes record (type name -> type)
+ * @param {object} override - platform override interferenceTypes record
+ */
+export function mergeInterferenceTypes(base, override) {
+    return { ...base, ...override };
+}
+
+/**
  * Traverse the input (JSON data) and ensure any "reason" fields are strings in the output.
  *
  * This allows specifying reasons as an array of strings, and converts these to


### PR DESCRIPTION


**Asana Task/Github Issue:**

## Description
<!-- 
  Please delete either or both process sections below.
-->
Enable webInterferenceDetection youtubeAds for Android 

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [x] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [x] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Ships user-visible YouTube monitoring and changes ad-blocking extension rollout on Android; mitigated by version-gated enablement and config-only changes with new merge tests.
> 
> **Overview**
> Adds **Android** rollout for YouTube **web interference detection** and related **EventHub** telemetry, plus build support so platform overrides can extend base `interferenceTypes` without replacing the whole feature.
> 
> The config pipeline now **merges** `webInterferenceDetection.settings.interferenceTypes` per key (same pattern as EventHub telemetry): Android can declare only `youtubeAds` while still inheriting base types like `adwallDetection`. Unit and config tests lock in that behavior.
> 
> **Android override** turns on `webInterferenceDetection` with a full `youtubeAds` detector (selectors, ad-blocker/playability patterns, detection events). `youtubeAds` starts **disabled** and flips to **enabled** at `minSupportedVersion` **52840000** via `conditionalChanges`. **EventHub** gains daily `webTelemetry_youtubeInterference_day` counters for video/static ads, playability errors, ad-blocker UI, and buffering.
> 
> **`adBlockingExtension`** moves from **internal** to **enabled** with minimum version **52840000** (was 52831006).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a8c0982325c0731ab70bd31fc3ca737085531eda. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->