### PR TITLE
Roll out ad blocking featureEnabledByDefault to 100% (iOS/macOS)

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -3118,6 +3118,9 @@
                         "steps": [
                             {
                                 "percent": 10
+                            },
+                            {
+                                "percent": 100
                             }
                         ]
                     }

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -2686,6 +2686,9 @@
                         "steps": [
                             {
                                 "percent": 10
+                            },
+                            {
+                                "percent": 100
                             }
                         ]
                     }


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/task/1215328252965029

## Description

Advances the rollout of the ad blocking extension's `featureEnabledByDefault` sub-feature to 100% on iOS and macOS. A new rollout step at `percent: 100` is appended after the existing 10% step in `overrides/ios-override.json` and `overrides/macos-override.json`.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Wide config rollout changes default ad-blocking extension behavior for most users on Apple platforms; breakage risk is mitigated by prior 10% exposure but still affects core browsing.
> 
> **Overview**
> Completes the staged rollout for **ad blocking extension** `featureEnabledByDefault` on **iOS** and **macOS** by adding a second rollout step at **100%** after the existing **10%** step in `overrides/ios-override.json` and `overrides/macos-override.json`.
> 
> Eligible clients on supported versions (iOS **7.222.0+**, macOS **1.192.0+**) can now receive the default-on ad blocking extension behavior for the full rollout cohort, not just the prior 10% slice.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 798d7662ded7f2c4212a817a71b0a3b645afc562. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->