### PR TITLE
Enabling sendIncidentCrashReports for testing purposes

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -5002,9 +5002,13 @@
                     "state": "enabled"
                 },
                 "sendIncidentCrashReports": {
-                    "state": "disabled",
+                    "state": "preview",
                     "settings": {
-                        "ExceptionTypes": []
+                        "ExceptionTypes": [
+                            "System.NullReferenceException",
+                            "OutOfMemoryException",
+                            "System.Runtime.InteropServices.COMException"
+                        ]
                     }
                 }
             }


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/45878998844068/task/1212890803347615?focus=true

## Description
Enabling `sendIncidentCrashReports` in Preview just as a test to make sure it works as it should before we need it in real incidents.

More info: [Automatic Sentry Crash Reports Documentation](https://app.asana.com/1/137249556945/project/1210132634900450/task/1215492556220356?focus=true)

### Feature change process:

- [x] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [x] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [x] This feature was covered by a tech design.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Preview-only remote config that can cause selected Windows crashes to be sent to Sentry; scope is limited to three exception types but still affects crash telemetry and privacy-sensitive diagnostics.
> 
> **Overview**
> For **Windows** only, **`sendIncidentCrashReports`** under **`extendedCrashReporting`** is turned on in **preview** (was **disabled**) so automatic Sentry incident crash reporting can be validated before production use.
> 
> **`ExceptionTypes`** is no longer empty: it now lists **`System.NullReferenceException`**, **`OutOfMemoryException`**, and **`System.Runtime.InteropServices.COMException`** as the exception types that trigger those reports.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 35bacac961fd4866dc7e4bd46560861b2c8e21f8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->