### PR TITLE
avoid unsupported browser redirect by mitigating the UA

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -1585,6 +1585,10 @@
                     {
                         "domain": "xvideos.com",
                         "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5160"
+                    },
+                    {
+                        "domain": "hulu.com",
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5327"
                     }
                 ],
                 "ddgDefaultSites": [
@@ -1804,6 +1808,10 @@
                     {
                         "domain": "xvideos.com",
                         "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5160"
+                    },
+                    {
+                        "domain": "hulu.com",
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5327"
                     }
                 ],
                 "omitVersionSites": []

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -1544,6 +1544,10 @@
                     {
                         "domain": "xvideos.com",
                         "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5160"
+                    },
+                    {
+                        "domain": "hulu.com",
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5327"
                     }
                 ],
                 "webViewDefault": [


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1206670747178362/task/1215581519784519?focus=true

## Description

### Site breakage mitigation process:
#### Brief explanation
- Reported URL: hulu.com
- Problems experienced: Unsupported browser message displayed, redirecting users to an unsupported browser URL instead of loading the site
- Platforms affected:
  - [x ] iOS
  - [ ] Android
  - [ ] Windows
  - [ x] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked: NA
- Feature being disabled/modified: Custom User Agent
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-domain custom UA allowlist entries in platform override JSON; no auth, tracking, or broad behavior changes.
> 
> **Overview**
> Adds **`hulu.com`** to **custom user agent** site lists on **iOS** and **macOS** so DuckDuckGo stops sending a UA that triggers Hulu’s “unsupported browser” flow and redirect.
> 
> On **iOS**, the domain is added to **`ddgFixedSites`** and **`omitApplicationSites`** under `customUserAgent`. On **macOS**, it is added to **`defaultSites`** in the same feature. Each entry references PR **#5327** as the reason.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3d60fe6b5481d6a64ff00d744119ebdc0a756d29. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->