### PR TITLE
Disable flags reportStackTrace and sendIncidentCrashReports

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -4996,19 +4996,15 @@
                     "state": "enabled"
                 },
                 "reportStackTrace": {
-                    "state": "preview"
+                    "state": "disabled"
                 },
                 "detectInstalledAv": {
                     "state": "enabled"
                 },
                 "sendIncidentCrashReports": {
-                    "state": "preview",
+                    "state": "disabled",
                     "settings": {
-                        "ExceptionTypes": [
-                            "System.NullReferenceException",
-                            "OutOfMemoryException",
-                            "System.Runtime.InteropServices.COMException"
-                        ]
+                        "ExceptionTypes": []
                     }
                 }
             }


### PR DESCRIPTION
**Asana Task/Github Issue:** 

## Description
Disable flags:
-  `reportStackTrace` because we are not in incident mode anymore 
- `sendIncidentCrashReports` because test has been completed

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only toggle in Windows overrides; reduces crash/stack telemetry with no auth or data-handling logic changes.
> 
> **Overview**
> Turns off two **extended crash reporting** sub-features in the Windows privacy config (`overrides/windows-override.json`).
> 
> **`reportStackTrace`** moves from `preview` to **`disabled`**, so stack traces are no longer collected for extended crash reporting on Windows.
> 
> **`sendIncidentCrashReports`** also moves from `preview` to **`disabled`**, and its **`ExceptionTypes`** list is cleared (previously targeted specific exceptions such as `NullReferenceException`, OOM, and COM exceptions). Incident-mode crash uploads are therefore shut down after the completed test.
> 
> Other `extendedCrashReporting` features (e.g. `processStatusTracking`, `detectInstalledAv`) are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c9ba82d4605ef837f480eb1bdc622323d282d818. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->