### PR TITLE
broken videos on ign.com

### DIFF
--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -1386,7 +1386,7 @@
                             "vidbox.dev - domain propagation from doubleclick.net catch-all",
                             "parade.com - https://github.com/duckduckgo/privacy-configuration/pull/5117",
                             "olx.ba - https://github.com/duckduckgo/privacy-configuration/pull/5185",
-                            "ign.com - pre-roll video playback stalls; player requires GPT (gpt.js / pubads_impl) to load."
+                            "ign.com - https://github.com/duckduckgo/privacy-configuration/pull/5330"
                         ]
                     },
                     {
@@ -1403,7 +1403,7 @@
                             "wunderground.com - Video element does not display.",
                             "rocketnews24.com - https://github.com/duckduckgo/privacy-configuration/issues/846",
                             "vidbox.dev - domain propagation from doubleclick.net catch-all",
-                            "ign.com - pre-roll video playback stalls; player requires GPT (gpt.js / pubads_impl) to load."
+                            "ign.com - https://github.com/duckduckgo/privacy-configuration/pull/5330"
                         ]
                     },
                     {

--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -1355,7 +1355,8 @@
                             "speedweek.com",
                             "timesofmalta.com",
                             "vidbox.dev",
-                            "olx.ba"
+                            "olx.ba",
+                            "ign.com"
                         ],
                         "reason": [
                             "ah.nl - 'Bonus offer' elements do not render and are not clickable.",
@@ -1384,7 +1385,8 @@
                             "hawaiiathletics.com - https://github.com/duckduckgo/privacy-configuration/pull/5071",
                             "vidbox.dev - domain propagation from doubleclick.net catch-all",
                             "parade.com - https://github.com/duckduckgo/privacy-configuration/pull/5117",
-                            "olx.ba - https://github.com/duckduckgo/privacy-configuration/pull/5185"
+                            "olx.ba - https://github.com/duckduckgo/privacy-configuration/pull/5185",
+                            "ign.com - pre-roll video playback stalls; player requires GPT (gpt.js / pubads_impl) to load."
                         ]
                     },
                     {
@@ -1393,13 +1395,15 @@
                             "ah.nl",
                             "wunderground.com",
                             "rocketnews24.com",
-                            "vidbox.dev"
+                            "vidbox.dev",
+                            "ign.com"
                         ],
                         "reason": [
                             "ah.nl - 'Bonus offer' elements do not render and are not clickable.",
                             "wunderground.com - Video element does not display.",
                             "rocketnews24.com - https://github.com/duckduckgo/privacy-configuration/issues/846",
-                            "vidbox.dev - domain propagation from doubleclick.net catch-all"
+                            "vidbox.dev - domain propagation from doubleclick.net catch-all",
+                            "ign.com - pre-roll video playback stalls; player requires GPT (gpt.js / pubads_impl) to load."
                         ]
                     },
                     {


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/1204912272578138/task/1215466323963503

## Description
<!-- 
  Please delete either or both process sections below.
-->
 Fixes broken videos on ign.com

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow, domain-scoped exceptions for ad/video infrastructure on ign.com only; same mitigation pattern as other publisher sites.
> 
> **Overview**
> Adds **ign.com** to the tracker allowlist for two **doubleclick.net** URL patterns used by Google Publisher Tag: `securepubads.g.doubleclick.net/tag/js/gpt.js` and `securepubads.g.doubleclick.net/gpt/pubads_impl_`, with reasons pointing to PR #5330.
> 
> This is a **site-breakage** change so blocked GPT/pubads scripts can load on IGN and **videos can play** again. IGN already had separate allowlist entries (e.g. Amazon `publisher.js`, IMA SDK); this extends coverage to the DoubleClick GPT stack.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8833775c186ac68ed08bf022fd5c0d39e4f20101. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->