### PR TITLE
Harden MSP stale-exemption workflow against misleading PRs

### DIFF
--- a/.github/workflows/msp-filter-stale.yml
+++ b/.github/workflows/msp-filter-stale.yml
@@ -14,35 +14,56 @@ jobs:
                   repository: duckduckgo/privacy-configuration
                   path: privacy-configuration/
             - name: Execute Update Script
+              id: prep
               run: |
+                  set -euo pipefail
                   cd ./privacy-configuration/
-                  npm i 
+                  npm i
                   npm run build
                   DATE="$(date -u +'%Y-%m-%d')"
-                  echo "DATE=$DATE" >> $GITHUB_ENV
+                  echo "DATE=$DATE" >> "$GITHUB_ENV"
                   TEMPLATE="$(node ./scripts/filter-malicious.js)"
-                  # If TEMPLATE contains 'No updates' then exit with success
-                  if [[ $TEMPLATE == *"No updates"* ]]; then
+                  # No stale exceptions to remove: nothing to do, skip PR creation.
+                  if [[ "$TEMPLATE" == *"No updates"* ]]; then
                     echo "No updates found. Exiting with success."
+                    echo "should_create=false" >> "$GITHUB_OUTPUT"
                     exit 0
-                  fi 
-                  echo "TEMPLATE=$TEMPLATE" >> $GITHUB_ENV
+                  fi
                   PR_BODY="${TEMPLATE//\{\{date\}\}/$DATE}"
                   PR_BODY="${PR_BODY//\\n/$'\n'}" # Replace escaped newlines with actual newlines
                   PR_ID="$(echo "$PR_BODY" | grep 'PR ID: ' | cut -d' ' -f3)"
-                  echo "PR_ID=$PR_ID" >> $GITHUB_ENV
-                  echo "PR_BODY<<EOF" >> $GITHUB_ENV
-                  echo "$PR_BODY" >> $GITHUB_ENV
-                  echo "EOF" >> $GITHUB_ENV
+                  # filter-malicious.js catches its own errors and still exits 0, so a crash
+                  # surfaces as empty/invalid output rather than a non-zero status. A valid run
+                  # always emits a "PR ID:" line; a missing ID means the script failed to produce
+                  # real changes. Fail loudly instead of opening a PR with an unrelated diff.
+                  if [[ -z "$PR_ID" ]]; then
+                    echo "::error::filter-malicious.js produced no PR ID; refusing to open a PR." >&2
+                    exit 1
+                  fi
+                  echo "PR_ID=$PR_ID" >> "$GITHUB_ENV"
+                  {
+                    echo "PR_BODY<<EOF"
+                    echo "$PR_BODY"
+                    echo "EOF"
+                  } >> "$GITHUB_ENV"
                   npm run lint-fix
+                  echo "should_create=true" >> "$GITHUB_OUTPUT"
             - name: Create PR with updated configs
+              if: steps.prep.outputs.should_create == 'true'
               uses: peter-evans/create-pull-request@d8c15c739ffb916295c3e41a2e70c38504c0f6dc
               id: create-pr
               with:
                   github-token: ${{ secrets.GITHUB_TOKEN }}
                   path: privacy-configuration/
+                  # Only commit the files this workflow is meant to change. A broad path such as
+                  # "./" sweeps in unrelated working-tree churn (e.g. package-lock.json metadata
+                  # rewritten by "npm i") under a misleading title.
                   add-paths: |
-                      ./
+                      features/malicious-site-protection.json
+                      overrides/ios-override.json
+                      overrides/macos-override.json
+                      overrides/windows-override.json
+                      overrides/android-override.json
                   commit-message: Remove stale exemptions from malicious site protection
                   assignees: not-a-rootkit
                   branch: remove-stale-exemptions-${{ env.PR_ID }}

--- a/scripts/filter-malicious.js
+++ b/scripts/filter-malicious.js
@@ -32,6 +32,14 @@ function rateLimit(fn, windowMs, reqInWindow = 1) {
 
 const slowFetch = rateLimit(fetch, 1000, 30);
 
+// Domains that must always be retained regardless of the dataset. These are
+// synthetic test pages (never present in the malicious dataset) used to verify
+// that exceptions work correctly, so the staleness check would otherwise remove
+// them on every run. See PR #3964.
+const PERMANENT_EXCEPTIONS = new Set([
+    'broken.third-party.site',
+]);
+
 class ConfigProcessor {
     constructor(options = {}) {
         this.apiBaseUrl = options.apiBaseUrl || 'https://duckduckgo.com/api/protection/v2';
@@ -154,6 +162,10 @@ class ConfigProcessor {
         const updatedExceptions = [];
         const removedExceptions = [];
         for (const exception of exceptions) {
+            if (PERMANENT_EXCEPTIONS.has(exception.domain)) {
+                updatedExceptions.push(exception);
+                continue;
+            }
             const inDataset = await this.checkDomainMatch(exception.domain, platformName);
             if (inDataset) {
                 updatedExceptions.push(exception);


### PR DESCRIPTION
## Summary

The `msp-filter-stale.yml` workflow can open PRs whose diff does not match their title, and it repeatedly tries to remove a permanent test exception. This PR fixes both.

### 1. Misleading auto-generated PRs (e.g. #5325)

#5325 was titled "Remove stale exemptions..." but contained only an unrelated `package-lock.json` metadata change, versus the well-formed #3964. Two root causes:

- **Silent failures slipped past the guard.** `scripts/filter-malicious.js` catches its own errors (`main().catch(console.error)`) and still exits `0`, so a crash produces empty stdout. The old guard only bailed on the literal string `No updates`, so empty output proceeded to PR creation with an empty `PR_ID` (hence the `remove-stale-exemptions-` branch with no ID suffix on #5325). Now the job fails loudly when no `PR ID:` line is emitted, and PR creation is gated on a step output.
- **`add-paths: ./` swept in unrelated churn.** Combined with `npm i` / `npm run build` / `npm run lint-fix` mutating the working tree, any side effect (e.g. the `package-lock.json` `from` rewrite) got committed under the "Remove stale exemptions" title. `add-paths` is now scoped to the config files this workflow actually edits.

Also added `set -euo pipefail` for stricter shell error handling.

### 2. Retain the `broken.third-party.site` test exception (requested in #3964)

`broken.third-party.site` is a synthetic test page used to verify that exceptions work correctly. It is never present in the malicious dataset, so the staleness check flagged it for removal on every run (#3964). `filter-malicious.js` now treats it as a permanent exception that is always retained.

## Notes

- No active security vulnerability existed in either prior PR's diff; the workflow change is a provenance/integrity and robustness hardening so auto-generated PRs only ever contain the intended MSP config changes.
- Scoped override files (`ios`, `macos`, `windows`, `android`) plus `features/malicious-site-protection.json` match the `platforms`/`defaultConfig` written by `filter-malicious.js` (extension is intentionally not processed).

## Test plan

- [ ] No stale exceptions → job succeeds, no PR.
- [ ] Simulated script error / empty output → job fails, no PR opened.
- [ ] Real stale exceptions → PR contains only the MSP config files, with a populated `PR ID` and branch suffix.
- [ ] `broken.third-party.site` is never proposed for removal.