### PR TITLE
Enable crash reporting to 100% from 0.161.0 (in preview)

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -4460,10 +4460,10 @@
                 },
                 "nativeCrashDialogOneShot": {
                     "state": "enabled",
-                    "minSupportedVersion": "0.160.6",
+                    "minSupportedVersion": "0.161.0",
                     "settings": {
                         "probability": 100,
-                        "generation": 3,
+                        "generation": 4,
                         "showInSuspendedState": true
                     }
                 },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/949243614371883/task/1215607993379783?focus=true

## Description
<!-- 
  Please delete either or both process sections below.
-->

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single remote-config tweak under windowsWebviewFailures; affects crash UI sampling only, no auth or data-path changes.
> 
> **Overview**
> Updates the Windows **`windowsWebviewFailures`** remote config for **`nativeCrashDialogOneShot`**: **`minSupportedVersion`** moves from **0.160.6** to **0.161.0**, and **`generation`** bumps from **3** to **4** ( **`probability`** stays **100** ).
> 
> Together this ties full rollout of the one-shot native crash dialog to **0.161.0+** and resets the dialog generation so clients treat this as a new config cohort.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 908a4cb33614073bf4fe9e68af144b858c4dd6d1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->