### PR TITLE
disable canShowNativeCrashReportingDialog for now

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -5014,7 +5014,7 @@
             "exceptions": [],
             "features": {
                 "canShowNativeCrashReportingDialog": {
-                    "state": "enabled",
+                    "state": "disabled",
                     "rollout": {
                         "steps": [
                             {


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1200953757949605/task/1215448555905647?focus=true

## Description
Conclude experiment. Follow up on https://github.com/duckduckgo/privacy-configuration/pull/5311

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single remote-config toggle with no auth or data-path changes; effect is stopping an optional crash-reporting dialog for Windows clients.
> 
> **Overview**
> Concludes the Windows **native crash reporting dialog** experiment by setting `canShowNativeCrashReportingDialog` to **disabled** in `windows-override.json` (follow-up to privacy-configuration #5311).
> 
> The parent `nativeCrashReporting` feature stays **enabled**; only the sub-feature that gates showing the dialog is turned off. The existing 5% rollout block is unchanged but no longer activates the UI while `state` is `disabled`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c9fcb1ddaaee09c89894cc6a6c67fad9e1ddc90d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->