### PR TITLE
update element-hiding-mdc rules file with unsupported browser policy

### DIFF
--- a/.cursor/rules/element-hiding.mdc
+++ b/.cursor/rules/element-hiding.mdc
@@ -3,6 +3,7 @@ globs: features/element-hiding.json,overrides/**/*.json
 alwaysApply: false
 description: Element hiding mitigation decision guide and rule type reference for privacy-configuration. Use this when working with element-hiding rules and mitigations.
 ---
+
 # Element Hiding Mitigation Rules
 
 ## Schema & Configuration References
@@ -15,34 +16,34 @@ description: Element hiding mitigation decision guide and rule type reference fo
 ```typescript
 // Hide rules (no values field allowed)
 type ElementHidingRuleHide = {
-  selector: string;
-  type: 'hide-empty' | 'hide' | 'closest-empty' | 'override';
-  // No values field allowed for hide rules
-}
+    selector: string;
+    type: 'hide-empty' | 'hide' | 'closest-empty' | 'override';
+    // No values field allowed for hide rules
+};
 
 // Modify rules (values field required)
 type ElementHidingRuleModify = {
-  selector: string;
-  type: 'modify-style' | 'modify-attr';
-  values: ElementHidingValue[];  // Required for modify rules
-}
+    selector: string;
+    type: 'modify-style' | 'modify-attr';
+    values: ElementHidingValue[]; // Required for modify rules
+};
 
 // Disable rules (no selector field allowed)
 type ElementHidingRuleDisable = {
-  type: 'disable-default';
-}
+    type: 'disable-default';
+};
 
 type ElementHidingRule = ElementHidingRuleHide | ElementHidingRuleModify | ElementHidingRuleDisable;
 
 type ElementHidingValue = {
-  property: string;
-  value: string;
-}
+    property: string;
+    value: string;
+};
 
 type ElementHidingDomain = {
-  domain: string | string[];
-  rules: ElementHidingRule[];
-}
+    domain: string | string[];
+    rules: ElementHidingRule[];
+};
 ```
 
 ## Element Hiding Mitigation Decision Tree (Strategy-Prioritized):
@@ -61,22 +62,30 @@ Adblock detection? → disable-default + add working rules
 Layout/visual issues? → modify-style
 ↓
 Attribute issues? → modify-attr
+↓
+Unsupported browser warning? → See Unsupported Browser Policy
 ```
 
 ## Rule Type Reference
 
-| Rule Type | Use Case | Values Field | Notes |
-|-----------|----------|--------------|-------|
-| `hide-empty` | Empty ad containers or blank placeholders | ❌ **Forbidden** | ✅ Default rule. Hides only if empty. |
-| `closest-empty` | Empty parent container remains | ❌ **Forbidden** | Crawls up DOM tree to hide the empty parent. |
-| `hide` | Always hide, even if visible content | ❌ **Forbidden** | ⚠️ Use sparingly — can cause detection. |
-| `override` | Cancel specific global rules | ❌ **Forbidden** | Domain-specific only. Fixes global breakage. |
-| `disable-default` | Defuse adblock detection | ❌ **Forbidden** | Domain-specific only. Never alone; rebuild safe rules. |
-| `modify-style` | Layout or visibility tweaks | ✅ **Required** | Replace CSS values (e.g., height → 0px). |
-| `modify-attr` | Attribute corrections | ✅ **Required** | Replace element attributes (e.g., src/class). |
+| Rule Type         | Use Case                                  | Values Field     | Notes                                                  |
+| ----------------- | ----------------------------------------- | ---------------- | ------------------------------------------------------ |
+| `hide-empty`      | Empty ad containers or blank placeholders | ❌ **Forbidden** | ✅ Default rule. Hides only if empty.                  |
+| `closest-empty`   | Empty parent container remains            | ❌ **Forbidden** | Crawls up DOM tree to hide the empty parent.           |
+| `hide`            | Always hide, even if visible content      | ❌ **Forbidden** | ⚠️ Use sparingly — can cause detection.                |
+| `override`        | Cancel specific global rules              | ❌ **Forbidden** | Domain-specific only. Fixes global breakage.           |
+| `disable-default` | Defuse adblock detection                  | ❌ **Forbidden** | Domain-specific only. Never alone; rebuild safe rules. |
+| `modify-style`    | Layout or visibility tweaks               | ✅ **Required**  | Replace CSS values (e.g., height → 0px).               |
+| `modify-attr`     | Attribute corrections                     | ✅ **Required**  | Replace element attributes (e.g., src/class).          |
+
+## Unsupported Browser Policy
+
+- Top 1000 sites: cosmetic treatment first, UA exception if that fails
+- Non-top sites: UA exception first
 
 ### Configuration Structure
-- **Rule Placement**: 
+
+- **Rule Placement**:
 - **Domain-specific rules**: Go in `domains[]` array
 - **Global rules**: Go in top-level `rules[]` array
 - **Global settings**: `useStrictHideStyleTag`, `hideTimeouts`, `unhideTimeouts`


### PR DESCRIPTION
**Asana Task/Github Issue:**

## Description
<!-- 
  Please delete either or both process sections below.
-->

### Feature change process:

Updated the element-hiding cursor's rules file with the unsupported browser policy


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to Cursor rules; no product code, schema, or element-hiding JSON configuration is modified.
> 
> **Overview**
> Updates the **element-hiding** Cursor rules doc (`.cursor/rules/element-hiding.mdc`) to guide mitigations when sites show **unsupported browser** warnings.
> 
> The mitigation decision tree gains a final step pointing to a new **Unsupported Browser Policy** section: **top 1000** sites should try cosmetic treatment first, then a UA exception; **non-top** sites should prefer a UA exception first. The change set also reformats the embedded TypeScript examples (semicolons/indentation), aligns the rule-type reference table, and fixes minor markdown (EOF newline, configuration bullets).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ffec72d7f502d483b23ad839de864bf4dcbaf48. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->