### PR TITLE
Bump crash reporting to 0.162.0

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -4460,7 +4460,7 @@
                 },
                 "nativeCrashDialogOneShot": {
                     "state": "enabled",
-                    "minSupportedVersion": "0.161.0",
+                    "minSupportedVersion": "0.162.0",
                     "settings": {
                         "probability": 100,
                         "generation": 4,


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1209107918776641/task/1215627548993845?focus=true

## Description
We noticed high crash rate in 0.162.x using Chromium 149.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single `minSupportedVersion` bump in `windows-override.json` with no other feature toggles or logic changes.
> 
> **Overview**
> Raises the Windows **`nativeCrashDialogOneShot`** gate under `windowsWebviewFailures` so the feature only applies on browser **0.162.0+** (was **0.161.0**). Feature flags are unchanged: still **enabled** with the same one-shot dialog settings (`probability` 100, `generation` 4, `showInSuspendedState`).
> 
> This aligns native crash UI/reporting with **0.162.x** after elevated crashes on Chromium 149, without changing other webview-failure subfeatures in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 82e6289eaac1905d735ff2b84674278034be1a21. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->