### PR TITLE
Add 7-day Dependabot cooldown for npm updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,11 @@ updates:
       directory: '/'
       schedule:
           interval: 'daily'
+      # Wait at least 7 days after a release before opening an update PR,
+      # so we don't pick up freshly-published (potentially compromised)
+      # versions before the ecosystem has had time to react.
+      cooldown:
+          default-days: 7
       open-pull-requests-limit: 20
       target-branch: 'main'
       labels:


### PR DESCRIPTION
## What

Adds a 7-day `cooldown` to the npm ecosystem in `.github/dependabot.yml`:

```yaml
      cooldown:
          default-days: 7
```

## Why

We currently have **no cool-off** configured for dependency updates — no repo `.npmrc` cooldown and no `cooldown:` block in `dependabot.yml`. That means Dependabot can open an npm update PR against a version published only moments earlier, which is precisely the window in which a compromised/hijacked release is most likely to still be live on the registry before it's yanked.

A 7-day delay lets the ecosystem surface problems (advisories, yanks, broken releases) before we pick a version up. The committed lockfile already pins exact versions, so this just governs *when* new versions are proposed.

Scope note: applied to the `npm` ecosystem only (per the request re: `package.json`). Happy to extend the same cooldown to the `github-actions` ecosystem if we want consistency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Configuration-only change to dependency automation timing; no application runtime or lockfile behavior changes until merged Dependabot PRs.
> 
> **Overview**
> Adds a **7-day Dependabot cooldown** for the root **npm** ecosystem so update PRs are not opened until a release is at least a week old, reducing exposure to freshly published or compromised registry versions.
> 
> Inline comments in `.github/dependabot.yml` document the security rationale. The **github-actions** ecosystem is unchanged (still weekly, no cooldown).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 16f0102d8c1d6fee55329bcd245a0212760c8ab7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->