### PR TITLE
Disable ad blocking extension default flag for iOS and macOS

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -3148,7 +3148,7 @@
                     "minSupportedVersion": "7.216.0"
                 },
                 "featureEnabledByDefault": {
-                    "state": "enabled",
+                    "state": "disabled",
                     "minSupportedVersion": "7.222.0",
                     "rollout": {
                         "steps": [

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -2705,7 +2705,7 @@
                     "minSupportedVersion": "1.186.0"
                 },
                 "featureEnabledByDefault": {
-                    "state": "enabled",
+                    "state": "disabled",
                     "minSupportedVersion": "1.192.0",
                     "rollout": {
                         "steps": [


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1163321984198618/task/1215630427803216?focus=true

## Description
<!-- 
  Please delete either or both process sections below.
-->

Disables the ad blocking extension default flag.

### Feature change process:

- [x] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [x] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [x] This feature was covered by a tech design.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default browsing/privacy behavior for eligible app versions via remote config; scope is limited to one sub-feature with rollout still defined.
> 
> **Overview**
> Turns off **default-on** behavior for the ad blocking extension on **iOS** and **macOS** by setting `adBlockingExtension.features.featureEnabledByDefault` from `enabled` to `disabled` in `ios-override.json` and `macos-override.json`.
> 
> The parent `adBlockingExtension` feature and `featureEnabled` stay **enabled**, so the capability remains available; only the opt-in-by-default path is removed. Existing **10% → 100%** rollout steps on `featureEnabledByDefault` are unchanged for when default-on is turned back on remotely.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d9071f2ede31d750a315f14f1e5a0f0fc6b23917. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->