### PR TITLE
Enable partial adblock v2 launch to 10% of users

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -4769,7 +4769,15 @@
                     "state": "enabled"
                 },
                 "partialLaunch": {
-                    "state": "disabled"
+                    "state": "enabled",
+                    "minSupportedVersion": "0.161.0",
+                    "rollout": {
+                        "steps": [
+                            {
+                                "percent": 10
+                            }
+                        ]
+                    }
                 }
             }
         },


### PR DESCRIPTION
**Asana Task/Github Issue:**

https://app.asana.com/1/137249556945/project/1212951208799468/task/1214809632966955?focus=true

## Description

- Enable partial adblock v2 to 10% of users who hadn't enabled/disabled it in the past

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes live remote config for core ad-blocking behavior on Windows; limited to 10% rollout and a minimum version gate reduces blast radius.
> 
> **Overview**
> Turns on **partial adblock v2 launch** for Windows by changing `adBlockV2Extension.features.partialLaunch` in `windows-override.json` from **disabled** to **enabled**.
> 
> Eligible clients on **0.161.0+** are included in a **10% rollout** (`rollout.steps` with a single 10% step), matching the intent to expose partial v2 to users who have not already toggled adblock.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 13da306808b728511a6925bcd55cba3cd8d731a9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->