### PR TITLE
Disable adblock until we sort the Duckplayer/SERP issue

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -4769,7 +4769,7 @@
                     "state": "enabled"
                 },
                 "partialLaunch": {
-                    "state": "enabled",
+                    "state": "disabled",
                     "minSupportedVersion": "0.161.0",
                     "rollout": {
                         "steps": [


### PR DESCRIPTION
**Asana Task/Github Issue:**

## Description
<!-- 
  Please delete either or both process sections below.
-->

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Disabling a privacy feature rollout affects all Windows clients on this config; impact is intentional mitigation but reduces ad blocking for users who would have been in partial launch.
> 
> **Overview**
> Turns off the Windows **ad block v2** partial rollout by setting `adBlockV2Extension.features.partialLaunch` from **enabled** to **disabled** in `windows-override.json`. The existing rollout metadata (`minSupportedVersion` 0.161.0, 10% step) is unchanged; only the feature flag is flipped off until Duck Player/SERP issues are resolved.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e91f23a4de0cfd4074434e9a1a6e216d1c972067. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->