### PR TITLE
Update minSupportedVersion for adBlockingExtension

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -38,7 +38,7 @@
         "adBlockingExtension": {
             "exceptions": [],
             "state": "internal",
-            "minSupportedVersion": 52831006
+            "minSupportedVersion": 52831000
         },
         "additionalCampaignPixelParams": {
             "state": "enabled",


### PR DESCRIPTION
Set 5.283.1 as the minSupportedVersion

**Asana Task/Github Issue:**

## Description
<!-- 
  Please delete either or both process sections below.
-->

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single numeric threshold tweak for an internal Android feature flag with no logic or state changes.
> 
> **Overview**
> Lowers the Android **`adBlockingExtension`** version gate in `overrides/android-override.json` by changing **`minSupportedVersion`** from `52831006` to `52831000` (aligned with app **5.283.1** per the PR). The feature stays **`internal`**; only which Android builds are considered supported for this flag changes—slightly **earlier** builds in that release line can now receive the config.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 231a6048ff606052f5880003ad003888d3dcea1d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->