### PR TITLE
Parse tracker-allowlist source as JSONC in tests

### DIFF
--- a/tests/tracker-allowlist-tests.js
+++ b/tests/tracker-allowlist-tests.js
@@ -764,8 +764,7 @@ describe('tracker-allowlist-validator', () => {
 
     describe('validate real tracker-allowlist.json', () => {
         it('has no violations in features/tracker-allowlist.json', () => {
-            const raw = fs.readFileSync('./features/tracker-allowlist.json', 'utf-8');
-            const config = JSON.parse(raw);
+            const config = readJsoncFile('./features/tracker-allowlist.json');
             const allowlistedTrackers = config.settings.allowlistedTrackers;
             const errors = validateAllowlist(allowlistedTrackers);
             if (errors.length > 0) {
@@ -777,7 +776,7 @@ describe('tracker-allowlist-validator', () => {
 
     describe('validate generated platform configs', () => {
         const platformOutput = platforms.map((item) => item.replace('browsers/', 'extension-'));
-        const baseConfig = JSON.parse(fs.readFileSync('./features/tracker-allowlist.json', 'utf-8'));
+        const baseConfig = readJsoncFile('./features/tracker-allowlist.json');
         const baseTrackers = baseConfig.settings.allowlistedTrackers;
         const baseErrors = validateAllowlist(baseTrackers);
         const baseErrorKeys = new Set(baseErrors.map((e) => `${e.type}|${e.tracker}|${e.message}`));


### PR DESCRIPTION
The tracker-allowlist tests still read features/tracker-allowlist.json with JSON.parse, which #4221 missed. Switch both reads to readJsoncFile so the test suite keeps passing once comments are added to the source file. Generated-config reads stay on JSON.parse.

**Asana Task/Github Issue:**

## Description
<!-- 
  Please delete either or both process sections below.
-->

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change to config loading; no runtime or allowlist behavior is modified.
> 
> **Overview**
> Tracker allowlist validation tests now load **`features/tracker-allowlist.json`** through **`readJsoncFile`** instead of **`JSON.parse`**, in both the “validate real tracker-allowlist.json” case and the platform-config suite’s base-config setup.
> 
> That matches how the build reads feature lists and keeps the suite green when the source file includes JSONC comments (a gap left after earlier JSONC work). Reads of **generated** `*-config.json` outputs are unchanged and still use strict JSON parsing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 01b578acde53f8adcf5001932568ec4e8af68ec7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->