### PR TITLE
Update ad-blocking extension scriptlets for v2026.6.14

### DIFF
--- a/features/ad-blocking-extension.json
+++ b/features/ad-blocking-extension.json
@@ -4,28 +4,28 @@
     },
     "exceptions": [],
     "settings": {
-        "version": "2026.6.7",
+        "version": "2026.6.14",
         "enabledByDefault": false,
         "scriptlets": {
             "scriptlets/isolated/ublock-filters.js": {
-                "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/19f3d232fcc31384ff21a01a45d8a5158f12fcab2a169a13e6393ea8f93be689.js",
-                "signature": "MEUCIQCISDU5LDZ8lQPHa1Odvl+BCtGCxoacojzLLAepGLsmngIgB8MH3CJFk5pupCdthWq19/+uf22wyLAx+j3OXQZvCN0="
+                "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/68c82cf4f44f1b7cd13ba3bcede72f4fac56039f4681abd9339327176f3fb255.js",
+                "signature": "MEUCIHSQMtOCek2hbib5/9FUg2Thr3rZcFmE8BJ2OTf8JVB7AiEAvMTX0nNg7l6jJyV90Q4Qwzjxzm8xl7RIFGrCqgW6Ab4="
             },
             "scriptlets/main/ublock-filters.js": {
-                "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/2eb4650b80efae2c8ac6760e2bc9edf6319017da98da8195d1e9801553bef416.js",
-                "signature": "MEUCIEZpjV78Cr1vB1SWFdOuLe2BC4MOLyoebt5y3TetsfCCAiEAu3BRv96c3+psJETgetybQtD9V9/7ef6OWybqgKhFs4Y="
+                "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/38aaf2e3d6e85e4aa3714b0e7a4fb5fb02ae890ad75e815f0fc0d6d10b909ce0.js",
+                "signature": "MEQCIDWAb8eCwLOyGvAwtIYkFQ/nXYtUgFEy+rzzIeXq4xmrAiAT/22ufqPNpIyuEjwxQseZeTW45OKZa+zZVJfsE/JjSA=="
             },
             "scriptlets/main/ublock-experimental.js": {
                 "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855.js",
-                "signature": "MEUCIE4RmldRUoQHIEieYbQVIzDYHo3n7uVPWeQCffGK8sjFAiEAkpaC0Q+YbyGZ7fCaUassNp1KnfXw96n69YzQrG60w/g="
+                "signature": "MEYCIQDxR5To5A6rLRXu/mjjZcXB84bioT3J61TXMmh0hz4AWQIhANefImqBkZBuWfUgw7RiEcZci7xZh8Hjvsekcxq8bl/W"
             },
             "scriptlets/isolated/ublock-experimental.js": {
                 "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855.js",
-                "signature": "MEQCIAgux1wCSQ0+6ZW+sN/Oldd/ef+IsmufvwLzoHwKgCHWAiBECd2m/mh5GkaT5qHS6Jt1LrpVHDtE4u1XztuJ5SI0NQ=="
+                "signature": "MEQCIGKKEx5xESD7Pt3uwbiRdFSjtUL/plIwOnsSAKiumn85AiBskiue7fy/krisEhkN6EPnwOBl4vtvATKuI/K1pq5BMA=="
             },
             "rules/youtube.json": {
                 "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/2337db6aa7466667595226f780b6590779db3007ac0a65ef3833f89610c92824.json",
-                "signature": "MEUCIQCxRM6qG0HY8s6RyWb5LZTVxGEGRKCbDX7rdiSspKHQ0QIgb4kbB+vb+LlJ0c1+rHWHY+WcvueS30HuCqDCLMOfDfc="
+                "signature": "MEYCIQCNcw7ASqRdvxgVWDPRTXAhuqFMZfiWSgKx64oZFxEyRwIhANddeIW4xsHVqoZc3x//Zo1UIv56NAjjafdtH8jDnaFA"
             }
         }
     }


### PR DESCRIPTION
Update ad-blocking extension scriptlets for v2026.6.14.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes signed remote scriptlet payloads used by content blocking; bad URLs or signatures could break ad blocking or block loading until fixed.
> 
> **Overview**
> Bumps the macOS/iOS ad-blocking extension config from **2026.6.7** to **2026.6.14** in `features/ad-blocking-extension.json`.
> 
> **Isolated and main uBlock filter scriptlets** get new CDN URLs and ECDSA signatures. **Experimental uBlock scriptlets** (URLs unchanged, empty-hash placeholders) and **YouTube rules** only have updated signatures. No changes to exceptions, `enabledByDefault`, or other settings structure.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 96382a508a5cde58ab70f29b14912a0b8e6a26bf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->