### PR TITLE
Add script for inline modification of JSONC files with replacement JSON data

### DIFF
--- a/scripts/set-jsonc-path.mjs
+++ b/scripts/set-jsonc-path.mjs
@@ -6,6 +6,9 @@
  * Usage:
  *   echo '"enabled"' | node scripts/set-jsonc-path.mjs features/foo.json state > features/foo.json
  *
+ * Paths use dot notation for object properties only (e.g. foo.bar, buckets.0.gte).
+ * Array indices are not supported.
+ *
  * Comments in the source file outside the modified region are preserved. The
  * result is written to stdout; the input file is not modified.
  */
@@ -24,30 +27,27 @@ const FORMATTING_OPTIONS = {
 function usage() {
     console.error(`Usage: set-jsonc-path.mjs <filename> <jsonpath>
 
-Replace the JSON value at <jsonpath> (dot notation) in <filename> with JSONC
-read from stdin. Array indices use numeric segments, e.g. exceptions.0.rules.
+Replace the JSON value at <jsonpath> in <filename> with JSONC read from stdin.
+Paths use dot notation for object properties (e.g. features.autofill.settings).
+Array indices are not supported.
 
 Examples:
   echo '"enabled"' | node scripts/set-jsonc-path.mjs features/foo.json state > features/foo.json
   cat patch.jsonc | node scripts/set-jsonc-path.mjs overrides/ios-override.json features.autofill.settings
+  echo '"18_7"' | node scripts/set-jsonc-path.mjs overrides/ios-override.json features.customUserAgent.settings.safariVersionMappings.26
 `);
 }
 
 /**
  * @param {string} dotPath
- * @returns {(string | number)[]}
+ * @returns {string[]}
  */
 export function parseDotPath(dotPath) {
     if (!dotPath) {
         return [];
     }
 
-    return dotPath.split('.').map((segment) => {
-        if (/^\d+$/.test(segment)) {
-            return Number(segment);
-        }
-        return segment;
-    });
+    return dotPath.split('.');
 }
 
 /**

--- a/scripts/set-jsonc-path.mjs
+++ b/scripts/set-jsonc-path.mjs
@@ -1,0 +1,153 @@
+#!/usr/bin/env node
+
+/**
+ * Safely replace a value at a dot-notation path in a JSONC file.
+ *
+ * Usage:
+ *   echo '"enabled"' | node scripts/set-jsonc-path.mjs features/foo.json state > features/foo.json
+ *
+ * Comments in the source file outside the modified region are preserved. The
+ * result is written to stdout; the input file is not modified.
+ */
+
+import { existsSync, readFileSync } from 'fs';
+import { modify, parse, parseTree, findNodeAtLocation, applyEdits } from 'jsonc-parser';
+import { resolve } from 'path';
+import { fileURLToPath } from 'url';
+
+const FORMATTING_OPTIONS = {
+    tabSize: 4,
+    insertSpaces: true,
+    eol: '\n',
+};
+
+function usage() {
+    console.error(`Usage: set-jsonc-path.mjs <filename> <jsonpath>
+
+Replace the JSON value at <jsonpath> (dot notation) in <filename> with JSONC
+read from stdin. Array indices use numeric segments, e.g. exceptions.0.rules.
+
+Examples:
+  echo '"enabled"' | node scripts/set-jsonc-path.mjs features/foo.json state > features/foo.json
+  cat patch.jsonc | node scripts/set-jsonc-path.mjs overrides/ios-override.json features.autofill.settings
+`);
+}
+
+/**
+ * @param {string} dotPath
+ * @returns {(string | number)[]}
+ */
+export function parseDotPath(dotPath) {
+    if (!dotPath) {
+        return [];
+    }
+
+    return dotPath.split('.').map((segment) => {
+        if (/^\d+$/.test(segment)) {
+            return Number(segment);
+        }
+        return segment;
+    });
+}
+
+/**
+ * @param {string} text
+ * @param {string} label
+ * @returns {unknown}
+ */
+export function parseJsonc(text, label) {
+    const errors = [];
+    const value = parse(text, errors, { allowTrailingComma: true });
+    if (errors.length > 0) {
+        throw new Error(`Failed to parse ${label}: ${JSON.stringify(errors)}`);
+    }
+    return value;
+}
+
+/**
+ * Replace the value at <jsonpath> in <originalText> with <replacementText>.
+ * Comments in originalText outside the replaced span are preserved.
+ *
+ * @param {string} originalText
+ * @param {string} jsonpath
+ * @param {string} replacementText
+ * @returns {string}
+ */
+export function setJsoncAtPath(originalText, jsonpath, replacementText) {
+    const trimmedReplacement = replacementText.trim();
+    if (!trimmedReplacement) {
+        throw new Error('No JSONC data provided on stdin');
+    }
+
+    const newValue = parseJsonc(trimmedReplacement, 'stdin input');
+
+    const parseErrors = [];
+    const tree = parseTree(originalText, parseErrors, { allowTrailingComma: true });
+
+    if (parseErrors.length > 0) {
+        throw new Error(`Failed to parse input file: ${JSON.stringify(parseErrors)}`);
+    }
+
+    const path = parseDotPath(jsonpath);
+    const existingNode = findNodeAtLocation(tree, path);
+
+    if (!existingNode) {
+        throw new Error(`Path not found: ${jsonpath || '<root>'}`);
+    }
+
+    const edits = modify(originalText, path, newValue, {
+        formattingOptions: FORMATTING_OPTIONS,
+    });
+    const modifiedText = applyEdits(originalText, edits);
+
+    parseJsonc(modifiedText, 'modified output');
+
+    return modifiedText;
+}
+
+/**
+ * @returns {Promise<string>}
+ */
+function readStdin() {
+    return new Promise((resolve, reject) => {
+        const chunks = [];
+        process.stdin.setEncoding('utf8');
+        process.stdin.on('data', (chunk) => chunks.push(chunk));
+        process.stdin.on('end', () => resolve(chunks.join('')));
+        process.stdin.on('error', reject);
+    });
+}
+
+async function main() {
+    const [
+        filename,
+        jsonpath,
+    ] = process.argv.slice(2);
+
+    if (!filename || jsonpath === undefined) {
+        usage();
+        process.exit(1);
+    }
+
+    const filePath = resolve(process.cwd(), filename);
+
+    if (!existsSync(filePath)) {
+        console.error(`File not found: ${filePath}`);
+        process.exit(1);
+    }
+
+    const stdinText = await readStdin();
+    const originalText = readFileSync(filePath, 'utf8');
+    const modifiedText = setJsoncAtPath(originalText, jsonpath, stdinText);
+
+    process.stdout.write(modifiedText);
+}
+
+const isMainModule = process.argv[1] === fileURLToPath(import.meta.url);
+
+if (isMainModule) {
+    main().catch((error) => {
+        console.error(error.message);
+        process.exit(1);
+    });
+}

--- a/tests/set-jsonc-path-tests.js
+++ b/tests/set-jsonc-path-tests.js
@@ -15,11 +15,11 @@ describe('set-jsonc-path', () => {
             ]);
         });
 
-        it('parses numeric segments as array indices', () => {
-            expect(parseDotPath('exceptions.0.rules')).to.deep.equal([
-                'exceptions',
-                0,
-                'rules',
+        it('keeps numeric segments as strings', () => {
+            expect(parseDotPath('buckets.0.gte')).to.deep.equal([
+                'buckets',
+                '0',
+                'gte',
             ]);
         });
     });
@@ -52,15 +52,43 @@ describe('set-jsonc-path', () => {
             expect(parseJsonc(result, 'result').settings.foo).to.equal('baz');
         });
 
-        it('replaces an array element by index', () => {
+        it('replaces a value at a numeric object key', () => {
+            const document = `{
+    "buckets": {
+        "0": { "gte": 0, "lt": 1 }
+    }
+}`;
+            const result = setJsoncAtPath(document, 'buckets.0.gte', '1');
+            expect(parseJsonc(result, 'result').buckets['0'].gte).to.equal(1);
+        });
+
+        it('replaces a value at a hyphenated object key', () => {
+            const document = `{
+    "buckets": {
+        "2-3": { "gte": 2, "lt": 4 }
+    }
+}`;
+            const result = setJsoncAtPath(document, 'buckets.2-3.gte', '3');
+            expect(parseJsonc(result, 'result').buckets['2-3'].gte).to.equal(3);
+        });
+
+        it('replaces a value in safariVersionMappings', () => {
+            const document = `{
+    "safariVersionMappings": {
+        "26": "18_6"
+    }
+}`;
+            const result = setJsoncAtPath(document, 'safariVersionMappings.26', '"18_7"');
+            expect(parseJsonc(result, 'result').safariVersionMappings['26']).to.equal('18_7');
+        });
+
+        it('does not support array indices', () => {
             const document = `{
     "exceptions": [
-        { "domain": "a.com" },
-        { "domain": "b.com" }
+        { "domain": "a.com" }
     ]
 }`;
-            const result = setJsoncAtPath(document, 'exceptions.1', '{ "domain": "c.com" }');
-            expect(parseJsonc(result, 'result').exceptions[1].domain).to.equal('c.com');
+            expect(() => setJsoncAtPath(document, 'exceptions.0.domain', '"b.com"')).to.throw('Path not found');
         });
 
         it('preserves comments in the source file outside the replaced region', () => {

--- a/tests/set-jsonc-path-tests.js
+++ b/tests/set-jsonc-path-tests.js
@@ -1,0 +1,105 @@
+import { expect } from 'chai';
+import { parseDotPath, parseJsonc, setJsoncAtPath } from '../scripts/set-jsonc-path.mjs';
+
+describe('set-jsonc-path', () => {
+    describe('parseDotPath', () => {
+        it('returns an empty path for an empty string', () => {
+            expect(parseDotPath('')).to.deep.equal([]);
+        });
+
+        it('parses property segments', () => {
+            expect(parseDotPath('features.autofill.settings')).to.deep.equal([
+                'features',
+                'autofill',
+                'settings',
+            ]);
+        });
+
+        it('parses numeric segments as array indices', () => {
+            expect(parseDotPath('exceptions.0.rules')).to.deep.equal([
+                'exceptions',
+                0,
+                'rules',
+            ]);
+        });
+    });
+
+    describe('setJsoncAtPath', () => {
+        const baseDocument = `{
+    "_meta": {
+        "description": "Explain the feature here."
+    },
+    "state": "disabled",
+    "exceptions": []
+}`;
+
+        it('replaces a scalar value at the given path', () => {
+            const result = setJsoncAtPath(baseDocument, 'state', '"enabled"');
+            expect(parseJsonc(result, 'result').state).to.equal('enabled');
+        });
+
+        it('replaces an object at a nested path', () => {
+            const document = `{
+    "settings": {
+        "foo": "bar"
+    }
+}`;
+            const replacement = `{
+    // updated config
+    "foo": "baz"
+}`;
+            const result = setJsoncAtPath(document, 'settings', replacement);
+            expect(parseJsonc(result, 'result').settings.foo).to.equal('baz');
+        });
+
+        it('replaces an array element by index', () => {
+            const document = `{
+    "exceptions": [
+        { "domain": "a.com" },
+        { "domain": "b.com" }
+    ]
+}`;
+            const result = setJsoncAtPath(document, 'exceptions.1', '{ "domain": "c.com" }');
+            expect(parseJsonc(result, 'result').exceptions[1].domain).to.equal('c.com');
+        });
+
+        it('preserves comments in the source file outside the replaced region', () => {
+            const document = `{
+    "settings": {
+        "foo": "bar",
+        // keep this source comment
+        "patchSettings": []
+    }
+}`;
+            const result = setJsoncAtPath(document, 'settings.foo', '"baz"');
+            expect(result).to.include('// keep this source comment');
+        });
+
+        it('does not preserve comments in the stdin replacement input', () => {
+            const document = `{
+    "settings": {
+        "extensionUrl": "https://example.com/old.crx"
+    }
+}`;
+            const replacement = `{
+    // updated today
+    "extensionUrl": "https://example.com/new.crx"
+}`;
+            const result = setJsoncAtPath(document, 'settings', replacement);
+            expect(result).not.to.include('// updated today');
+            expect(parseJsonc(result, 'result').settings.extensionUrl).to.equal('https://example.com/new.crx');
+        });
+
+        it('throws when the path is not found', () => {
+            expect(() => setJsoncAtPath(baseDocument, 'missing.path', '"x"')).to.throw('Path not found');
+        });
+
+        it('throws when stdin replacement is invalid JSONC', () => {
+            expect(() => setJsoncAtPath(baseDocument, 'state', 'not json')).to.throw('Failed to parse stdin input');
+        });
+
+        it('throws when stdin replacement is empty', () => {
+            expect(() => setJsoncAtPath(baseDocument, 'state', '   ')).to.throw('No JSONC data provided on stdin');
+        });
+    });
+});


### PR DESCRIPTION
**Asana Task/Github Issue:**

## Description
Add a script for doing config file modifications, ensuring the comments are preserved in the source file. This allows scripts that modify config files a safe way to do this, that conforms with the repo's file syntax and conventions. This can be used a replacement for places where we previously used `jq` or other JSON parsers to do this, and means that those projects don't have to depend on other libraries to parse the config files correctly. Examples:
- https://github.com/duckduckgo/content-blocker-extension/blob/main/.github/workflows/privacy-config-pr.yml#L40
- https://github.com/duckduckgo/autoconsent/blob/main/scripts/bundle-config-rules.ts#L18

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New tooling and unit tests only; no production runtime or config files are changed in this PR.
> 
> **Overview**
> Adds **`scripts/set-jsonc-path.mjs`**, a Node CLI that replaces a value at a dot-notation object path in a JSONC file using replacement JSONC from stdin, and writes the full file to stdout (callers redirect to update the file).
> 
> The script uses **`jsonc-parser`** to apply targeted edits so **comments outside the replaced span stay in the source file**, validates stdin and the result, and **does not support array indices** (only object property paths, including numeric or hyphenated keys as segments). Core helpers (`parseDotPath`, `parseJsonc`, `setJsoncAtPath`) are exported for reuse.
> 
> **`tests/set-jsonc-path-tests.js`** covers path parsing, nested replacements, comment behavior, error cases, and the array-index limitation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1a7817fef591771b6de6c292ff61c941c61e74d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->