### PR TITLE
Rollout: 1-click access to chat history

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -532,6 +532,10 @@
                 "digitalAssistantDuckAi": {
                     "state": "enabled",
                     "minSupportedVersion": 52780000
+                },
+                "historyScreen": {
+                    "state": "enabled",
+                    "minSupportedVersion": 52831000
                 }
             }
         },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1211850753229323/task/1214582224401695?focus=true

## Description

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single Android remote-config toggle with a version gate; no auth, data pipeline, or logic changes in this repo.
> 
> **Overview**
> Enables the **`historyScreen`** sub-feature under **`aiChat`** in `android-override.json`, turning on the Duck.ai chat history screen for Android builds at **`minSupportedVersion` 52831000** (full enable, no staged rollout).
> 
> This config change supports the **1-click access to chat history** rollout on Android; it sits alongside existing Duck.ai flags such as `duckAiNativeStorage` and does not alter the separate top-level **`duckAiChatHistory`** settings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee14663ae089e6fc362ec752727d91449b9c5c77. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->