### PR TITLE
Enable nativeCrashDialog for preview

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -4454,16 +4454,15 @@
                     }
                 },
                 "nativeCrashDialog": {
-                    "state": "internal"
+                    "state": "preview"
                 },
                 "ignoreInvalidCastExceptionOnDisposal": {
                     "state": "enabled"
                 },
                 "nativeCrashDialogOneShot": {
-                    "state": "enabled",
-                    "minSupportedVersion": "0.162.0",
+                    "state": "disabled",
                     "settings": {
-                        "probability": 100,
+                        "probability": 10,
                         "generation": 4,
                         "showInSuspendedState": true
                     }


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1209077031784564/task/1215716331570199?focus=true

## Description
<!-- 
  Please delete either or both process sections below.
-->

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes crash-time UX for preview Windows users; misconfiguration could affect recovery flows or experiment sampling, but scope is limited to remote feature flags.
> 
> **Overview**
> Updates **Windows** remote config under `windowsWebviewFailures` to roll out the native crash dialog to **preview** users and dial back the one-shot experiment.
> 
> **`nativeCrashDialog`** moves from `internal` to **`preview`**, so preview-channel builds can show the native crash UI instead of keeping it staff-only.
> 
> **`nativeCrashDialogOneShot`** is turned **`disabled`** (was `enabled` with `minSupportedVersion` `0.162.0`). Its settings stay but **`probability` drops from 100 to 10**, limiting exposure if the flag is re-enabled later.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ecd372d6758857c49538858013f1d53981a2467c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->