### PR TITLE
Unblock opta.net in tracker allowlist

### DIFF
--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -3285,6 +3285,13 @@
             "opta.net": {
                 "rules": [
                     {
+                        "rule": "opta.net/v3/v3.opta-widgets.js",
+                        "domains": [
+                            "<all>"
+                        ],
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5362"
+                    },
+                    {
                         "rule": "secure.widget.cloud.opta.net",
                         "domains": [
                             "concacaf.com"


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/1204912272578138/task/1215705585783714?focus=true

## Description
### Site breakage mitigation process:
#### Brief explanation
- Reported URL: Any using Opta widget.
- Problems experienced: Temporary mitigation for breakage caused by opta.net/v3/v3.opta-widgets.js blocklist rule
- Platforms affected:
  - [x] iOS
  - [x] Android
  - [x] Windows
  - [x] MacOS
  - [x] Extensions
- Tracker(s) being unblocked: opta.net
- Feature being disabled/modified: N/A
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Global `<all>` allowlisting of a third-party tracker script reduces blocking for opta.net everywhere, not just affected sites, which has privacy tradeoffs typical of breakage mitigations.
> 
> **Overview**
> Adds a **tracker allowlist** exception so **`opta.net/v3/v3.opta-widgets.js`** can load on **`<all>`** sites, restoring Opta sports widget content that was broken when that URL was blocked.
> 
> This sits alongside the existing **`opta.net`** rule scoped only to **`concacaf.com`** for **`secure.widget.cloud.opta.net`**; the new entry is a broader, temporary breakage fix tied to PR #5362.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c01b1c34b78d5e15d69f78ff1c7289cb596f3b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->