### PR TITLE
Update content-blocker extension to 2026.6.14

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -4746,7 +4746,7 @@
             "minSupportedVersion": "0.148.0",
             "exceptions": [],
             "settings": {
-                "extensionUrl": "https://staticcdn.duckduckgo.com/extensions/content-blocker/content-blocker-extension-2026.6.7.crx"
+                "extensionUrl": "https://staticcdn.duckduckgo.com/extensions/content-blocker/content-blocker-extension-2026.6.14.crx"
             },
             "features": {
                 "onboardingEnabled": {


### PR DESCRIPTION
Update content-blocker extension to 2026.6.14.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single URL version bump in remote config; behavior depends on the new CRX being published and compatible, but no auth or data-path changes.
> 
> **Overview**
> Updates the Windows remote config so **`adBlockV2Extension`** pulls the newer content-blocker CRX from CDN: **`extensionUrl`** changes from `content-blocker-extension-2026.6.7.crx` to **`content-blocker-extension-2026.6.14.crx`**.
> 
> No other feature flags, version gates, or rollout settings under `adBlockV2Extension` are modified in this PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3d7c1650d157969dc1e762f53d7e8264ccabea7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->