### PR TITLE
Unset as default promo reprompt on Windows

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -4840,6 +4840,10 @@
                     "state": "enabled",
                     "minSupportedVersion": "0.127.0"
                 },
+                "repromptOnUnset": {
+                    "state": "internal",
+                    "minSupportedVersion": "0.163.0"
+                },
                 "popoverVsBannerExperiment": {
                     "state": "disabled"
                 },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1213659555956031/task/1215660553217295?focus=true

## Description
Adds a repromptOnUnset sub-feature under setAsDefaultAndAddToDock for the Windows browser, which gates re-prompting the set-as-default popover/banner when DuckDuckGo is detected as having been unset as the default browser.