### PR TITLE
Roll out Android UTI at 5%

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -527,6 +527,17 @@
                 "digitalAssistantDuckAi": {
                     "state": "enabled",
                     "minSupportedVersion": 52780000
+                },
+                "nativeInputField": {
+                    "state": "enabled",
+                    "minSupportedVersion": 52840000,
+                    "rollout": {
+                        "steps": [
+                            {
+                                "percent": 5
+                            }
+                        ]
+                    }
                 }
             }
         },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1157893581871903/task/1215641620311437?focus=true
## Description
Start incremental rollout of the `nativeInputField` sub-feature under `aiChat` on Android at 5%, gated to app version `52840000` and above.
### Feature change process:
- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [x] This feature was covered by a tech design.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single JSON override with a small percentage rollout and version gate; no auth or data-path changes.
> 
> **Overview**
> Enables the **`nativeInputField`** sub-feature under **`aiChat`** on Android via `overrides/android-override.json`, starting a **5% incremental rollout** for app builds **52840000+**.
> 
> The flag is **`enabled`** with a single rollout step at **5%**; other `aiChat` sub-features in the same block are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b532d9354db3b50f2601d79e7beccc918f8c66af. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->