### PR TITLE
Android: Enable Duck.ai voice chat service

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -536,6 +536,10 @@
                 "historyScreen": {
                     "state": "enabled",
                     "minSupportedVersion": 52831000
+                },
+                "duckAiVoiceChatService": {
+                    "state": "enabled",
+                    "minSupportedVersion": 52840000
                 }
             }
         },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/task/1214609692567208?focus=true

## Description
Enable duckAiVoiceChatService to all users from Android 5.284.0 and up

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single remote-config toggle with a version gate; no app code or rollout logic in this PR.
> 
> **Overview**
> Turns on the **`duckAiVoiceChatService`** sub-feature under **`aiChat`** in **`android-override.json`**, alongside existing Duck.ai voice-related flags (`duckAiVoiceEntryPoint`, `digitalAssistantDuckAi`).
> 
> The flag is **`enabled`** with **`minSupportedVersion`: `52840000`** (Android **5.284.0**), so eligible app versions can use the Duck.ai voice chat service with no rollout steps or cohorts in this change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dfe3002431b4e48c822124ee35425cb8a4f2964e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->