### PR TITLE
Android: Enable useQueryPurchases 

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -3407,6 +3407,10 @@
                             "localeLanguage": "en"
                         }
                     ]
+                },
+                "useQueryPurchases": {
+                    "state": "enabled",
+                    "minSupportedVersion": 52840000
                 }
             }
         },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/task/1215658562572637?focus=true

## Description
Release useQueryPurchases to 5.284.0

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [x] This feature was covered by a tech design.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Privacy Pro purchase verification behavior on Android; misconfiguration could affect subscription state for users on supported builds.
> 
> **Overview**
> Turns on the **`useQueryPurchases`** flag under **`privacyPro`** in `android-override.json`, gated by **`minSupportedVersion`: 52840000**.
> 
> This config change lets supported Android builds use the Play Billing **`queryPurchases`** path for subscription/purchase checks instead of whatever legacy flow applied when the flag was off. The diff only adds the feature entry (enabled, version floor); it does **not** add a **`rollout`** block with **`percent`: 10** like other gradual Privacy Pro releases—so reviewers should confirm whether 10% exposure is enforced elsewhere or still needs to be added here.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a27845fcce7449161979df916405ca284f02988b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->