### PR TITLE
Add preserve-header-order config

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -4205,6 +4205,23 @@
         "clientBrandHint": {
             "state": "enabled"
         },
+        "preserveHeaderOrder": {
+            "state": "internal",
+            "exceptions": [],
+            "settings": {
+                "placements": [
+                    {
+                        "header": "Sec-GPC",
+                        "position": "before",
+                        "anchor": "^sec-fetch-site$"
+                    },
+                    {
+                        "header": "Cookie",
+                        "position": "last"
+                    }
+                ]
+            }
+        },
         "uaChBrands": {
             "state": "enabled",
             "exceptions": [

--- a/schema/config.ts
+++ b/schema/config.ts
@@ -21,6 +21,7 @@ import { WindowsWebViewFailures } from './features/windows-webview-failures';
 import { CustomUserAgentFeature } from './features/custom-user-agent';
 import { BurnFeature } from './features/burn';
 import { ClientBrandHintFeature } from './features/client-brand-hint';
+import { PreserveHeaderOrderFeature } from './features/preserve-header-order';
 import { Taskbar } from './features/taskbar';
 import { AppHealth } from './features/appHealth';
 import { ElementHidingFeature } from './features/element-hiding';
@@ -69,6 +70,7 @@ export type ConfigV5<VersionType> = {
         autofill?: AutofillFeature<VersionType>;
         burn?: BurnFeature<VersionType>;
         clientBrandHint?: ClientBrandHintFeature<VersionType>;
+        preserveHeaderOrder?: PreserveHeaderOrderFeature<VersionType>;
         taskbar?: Taskbar<VersionType>;
         import?: ImportFeature<VersionType>;
         cookie?: CookieFeature<VersionType>;

--- a/schema/features/preserve-header-order.ts
+++ b/schema/features/preserve-header-order.ts
@@ -1,9 +1,9 @@
 import { Feature } from '../feature';
 
 // A placement rule for one header. The shape enforces the fields each position
-// needs: 'index' requires `index`; 'before'/'after' require `anchor` (a regex
-// matched against header NAMES — the native layer splits position/anchor on the
-// first ':', so a ':' inside the regex, e.g. a non-capturing group, is preserved).
+// needs: 'index' requires `index`; 'before'/'after' require `anchor`, matched
+// against header NAMES (case-insensitive): `^name$` = exact, `^name` = prefix,
+// otherwise substring. This is NOT a regex engine.
 type HeaderPlacement =
     | { header: string; position: 'first' | 'last' }
     | { header: string; position: 'index'; index: number }

--- a/schema/features/preserve-header-order.ts
+++ b/schema/features/preserve-header-order.ts
@@ -4,9 +4,7 @@ import { Feature } from '../feature';
 // needs: 'before'/'after' require `anchor`, matched against header NAMES
 // (case-insensitive): `^name$` = exact, `^name` = prefix, otherwise substring.
 // This is NOT a regex engine.
-type HeaderPlacement =
-    | { header: string; position: 'first' | 'last' }
-    | { header: string; position: 'before' | 'after'; anchor: string };
+type HeaderPlacement = { header: string; position: 'first' | 'last' } | { header: string; position: 'before' | 'after'; anchor: string };
 
 // Placements are applied in declaration order (each repositions one header).
 type PreserveHeaderOrderSettings = {

--- a/schema/features/preserve-header-order.ts
+++ b/schema/features/preserve-header-order.ts
@@ -1,12 +1,11 @@
 import { Feature } from '../feature';
 
 // A placement rule for one header. The shape enforces the fields each position
-// needs: 'index' requires `index`; 'before'/'after' require `anchor`, matched
-// against header NAMES (case-insensitive): `^name$` = exact, `^name` = prefix,
-// otherwise substring. This is NOT a regex engine.
+// needs: 'before'/'after' require `anchor`, matched against header NAMES
+// (case-insensitive): `^name$` = exact, `^name` = prefix, otherwise substring.
+// This is NOT a regex engine.
 type HeaderPlacement =
     | { header: string; position: 'first' | 'last' }
-    | { header: string; position: 'index'; index: number }
     | { header: string; position: 'before' | 'after'; anchor: string };
 
 // Placements are applied in declaration order (each repositions one header).

--- a/schema/features/preserve-header-order.ts
+++ b/schema/features/preserve-header-order.ts
@@ -1,0 +1,17 @@
+import { Feature } from '../feature';
+
+// A placement rule for one header. The shape enforces the fields each position
+// needs: 'index' requires `index`; 'before'/'after' require `anchor` (a regex
+// matched against header NAMES — the native layer splits position/anchor on the
+// first ':', so a ':' inside the regex, e.g. a non-capturing group, is preserved).
+type HeaderPlacement =
+    | { header: string; position: 'first' | 'last' }
+    | { header: string; position: 'index'; index: number }
+    | { header: string; position: 'before' | 'after'; anchor: string };
+
+// Placements are applied in declaration order (each repositions one header).
+type PreserveHeaderOrderSettings = {
+    placements?: HeaderPlacement[];
+};
+
+export type PreserveHeaderOrderFeature<VersionType> = Feature<PreserveHeaderOrderSettings, VersionType>;

--- a/schema/features/preserve-header-order.ts
+++ b/schema/features/preserve-header-order.ts
@@ -6,9 +6,17 @@ import { Feature } from '../feature';
 // This is NOT a regex engine.
 type HeaderPlacement = { header: string; position: 'first' | 'last' } | { header: string; position: 'before' | 'after'; anchor: string };
 
-// Placements are applied in declaration order (each repositions one header).
+// A per-site override keyed by eTLD+1 (e.g. "example.com"). An empty `placements`
+// array means "no reordering for this domain" (natural order) — distinct from
+// omitting the domain, which falls back to the default `placements`.
+type DomainOverride = { domain: string; placements: HeaderPlacement[] };
+
+// `placements` is the default rule set, applied in declaration order (each
+// repositions one header). `domainOverrides` lets specific eTLD+1s use a different
+// rule set (or opt out of reordering via an empty list).
 type PreserveHeaderOrderSettings = {
     placements?: HeaderPlacement[];
+    domainOverrides?: DomainOverride[];
 };
 
 export type PreserveHeaderOrderFeature<VersionType> = Feature<PreserveHeaderOrderSettings, VersionType>;


### PR DESCRIPTION
**Asana Task/Github Issue: https://app.asana.com/1/137249556945/project/1211781871643034/task/1215416677198079?focus=true**

## Description
A remote-config feature preserveHeaderOrder gates a native change to the header-ordering step: when enabled, the natural order is preserved and only the configured headers are repositioned; when disabled, the original ordering runs unchanged.

Tech design: https://app.asana.com/1/137249556945/project/1211781871643034/task/1215425692493110?focus=true

### Feature change process:

- [X] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [X] This code for the config change is ready to merge.
- [X] This feature was covered by a tech design.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how outbound request headers are ordered for Windows when enabled, which can affect site compatibility; rollout is internal-only and config-only in this repo.
> 
> **Overview**
> Adds remote-config feature **`preserveHeaderOrder`** so clients can gate native HTTP header reordering: when on, only configured headers move while the rest stay in natural order; when off, existing ordering is unchanged.
> 
> Introduces schema types in `preserve-header-order.ts` for **`placements`** (first/last/before/after with anchor matching on header names) and optional **`domainOverrides`** per eTLD+1, including empty placement lists to skip reordering on specific sites. Registers the feature on the main config schema and enables it on **Windows** at **`internal`** with default rules placing **`Sec-GPC`** before **`sec-fetch-site`** and **`Cookie`** last.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2646751a15b33294ee00c1db12200600da8d858e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->