### PR TITLE
Onboarding issue fixed, enable for 10%

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -4772,8 +4772,8 @@
                     "state": "enabled"
                 },
                 "partialLaunch": {
-                    "state": "disabled",
-                    "minSupportedVersion": "0.161.0",
+                    "state": "enabled",
+                    "minSupportedVersion": "0.162.2",
                     "rollout": {
                         "steps": [
                             {


### PR DESCRIPTION
**Asana Task/Github Issue:**

## Description
<!-- 
  Please delete either or both process sections below.
-->

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Remote config change affects a subset of Windows users’ ad-blocker rollout and onboarding; limited to 10% but touches a core browser feature flag.
> 
> **Overview**
> Re-enables the **adBlock V2 extension** `partialLaunch` sub-feature for Windows after an onboarding fix, targeting clients on **0.162.2+** with a **10%** rollout (unchanged from the prior rollout step).
> 
> Previously `partialLaunch` was **disabled** with `minSupportedVersion` **0.161.0**; it is now **enabled** and gated at **0.162.2** so only builds that include the fix receive the partial launch experience.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 66632eafb98b9a8fb890e0b9ff2125a91bb1e2ae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->