### PR TITLE
Add StartupBoostSilentUpdateRelaunch sub-feature flag (off by default)

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -1562,6 +1562,9 @@
             "features": {
                 "startInForeground": {
                     "state": "enabled"
+                },
+                "silentUpdateRelaunch": {
+                    "state": "disabled"
                 }
             }
         },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1213659555956031/task/1211565797837298?focus=true

## Description
Adds a new Windows-only sub-feature _silentUpdateRelaunch_ under the existing _windowsStartupBoost_ feature, shipped **disabled**.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [X] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only change with the new behavior off by default; no runtime logic in this repo.
> 
> **Overview**
> Adds a Windows-only privacy-config sub-feature **`silentUpdateRelaunch`** under **`windowsStartupBoost`** in `windows-override.json`, alongside the existing **`startInForeground`** flag.
> 
> The new flag is shipped with **`state: "disabled"`**, so remote config can gate silent relaunch behavior after updates without changing **`windowsStartupBoost`**’s overall enabled state.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 759c8efee9804b828a7ccd335270bb9e452e98d8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->