### PR TITLE
Enable scopedAccessCredentials and canUseV2ConnectFlow for Windows sync

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -3945,10 +3945,12 @@
                     "minSupportedVersion": "0.147.5"
                 },
                 "scopedAccessCredentials": {
-                    "state": "internal"
+                    "state": "enabled",
+                    "minSupportedVersion": "0.162.0"
                 },
                 "canUseV2ConnectFlow": {
-                    "state": "internal"
+                    "state": "enabled",
+                    "minSupportedVersion": "0.162.0"
                 },
                 "canShowV2ConnectCode": {
                     "state": "internal"


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/72649045549333/task/1214701355776046?focus=true

## Description
Enables the following two Sync flags starting from Windows Browser v0.162.0:
- `scopedAccessCredentials`
- `canUseV2ConnectFlow`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Exposes sync credential scoping and the V2 device-connect flow to production Windows clients at a fixed minimum version; misconfiguration could affect sync setup before related UI (canShowV2ConnectCode) is enabled.
> 
> **Overview**
> Turns on two **Sync** sub-features for the Windows browser in `windows-override.json`, both gated to **v0.162.0+**.
> 
> **`scopedAccessCredentials`** and **`canUseV2ConnectFlow`** change from **`internal`** to **`enabled`** with **`minSupportedVersion`: `0.162.0`**. **`canShowV2ConnectCode`** is unchanged and remains **`internal`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 34d89a556e76f01b1ee02647914ef6cdae28b886. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->