### PR TITLE
Enable crash dialog for 100% of crashes for >=0.162.1

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -4460,16 +4460,17 @@
                     }
                 },
                 "nativeCrashDialog": {
-                    "state": "preview"
+                    "state": "internal"
                 },
                 "ignoreInvalidCastExceptionOnDisposal": {
                     "state": "enabled"
                 },
                 "nativeCrashDialogOneShot": {
-                    "state": "disabled",
+                    "state": "enabled",
+                    "minSupportedVersion": "0.162.1",
                     "settings": {
-                        "probability": 10,
-                        "generation": 4,
+                        "probability": 100,
+                        "generation": 5,
                         "showInSuspendedState": true
                     }
                 },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1209077031784564/task/1215827775167235

## Description
Related to https://app.asana.com/1/137249556945/project/1209077031784564/task/1215654630017988?focus=true

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> User-facing crash recovery UX changes for all Windows users on ≥0.162.1; gated by version but affects every eligible crash event.
> 
> **Overview**
> Updates **Windows** remote config under `windowsWebviewFailures` to roll out the native crash dialog more broadly after a limited experiment.
> 
> **`nativeCrashDialogOneShot`** is turned **on** for clients **≥ 0.162.1**, with **`probability`** raised from **10** to **100** and **`generation`** bumped from **4** to **5** (so eligible crashes should consistently get the one-shot dialog). **`nativeCrashDialog`** is moved from **`preview`** to **`internal`**, tightening who sees the base flag relative to the one-shot path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4cda923f79b8d51db3e86e88c9ff2cf7bf316d04. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->