### PR TITLE
Windows: Revert Sync v2 feature flags to internal

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -3945,12 +3945,10 @@
                     "minSupportedVersion": "0.147.5"
                 },
                 "scopedAccessCredentials": {
-                    "state": "enabled",
-                    "minSupportedVersion": "0.162.0"
+                    "state": "internal"
                 },
                 "canUseV2ConnectFlow": {
-                    "state": "enabled",
-                    "minSupportedVersion": "0.162.0"
+                    "state": "internal"
                 },
                 "canShowV2ConnectCode": {
                     "state": "internal"


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/72649045549333/task/1214701355776046?focus=true

## Description
Reverts `scopedAccessCredentials` and `canUseV2ConnectFlow` back to `state: internal`

Merge only when the v2 flows must be turned off.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Disabling sync v2 connect and scoped credential features for all non-internal Windows clients can break or hide sync setup paths users may already rely on, but the change is limited to remote flags and is reversible.
> 
> **Overview**
> **Windows-only remote config change** under `sync.features` in `windows-override.json`.
> 
> `scopedAccessCredentials` and `canUseV2ConnectFlow` are rolled back from **`enabled`** (with `minSupportedVersion` **0.162.0**) to **`internal`**, removing the version gate for those entries. That turns off Sync v2 connect flows and scoped access credentials for general Windows users while keeping them available for internal builds. **`canShowV2ConnectCode`** is unchanged and remains **`internal`**.
> 
> Intended as an emergency revert if v2 flows need to be disabled in production.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 960df7515d0a4d221374f30f2e462081115f2a18. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->