### PR TITLE
Apple: Enable scopedAccessCredentials and canUseV2ConnectFlow for Sync V2

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -1883,6 +1883,18 @@
                             "weight": 1
                         }
                     ]
+                },
+                "scopedAccessCredentials": {
+                    "state": "enabled",
+                    "minSupportedVersion": "7.225.0"
+                },
+                "canUseV2ConnectFlow": {
+                    "state": "enabled",
+                    "minSupportedVersion": "7.225.0"
+                },
+                "canShowV2ConnectCode": {
+                    "state": "disabled",
+                    "minSupportedVersion": "7.225.0"
                 }
             }
         },

--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -1896,7 +1896,7 @@
                     "minSupportedVersion": "7.225.0"
                 },
                 "canShowV2ConnectCode": {
-                    "state": "disabled",
+                    "state": "internal",
                     "minSupportedVersion": "7.225.0"
                 }
             }

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -1645,6 +1645,18 @@
                 "aiChatSync": {
                     "state": "enabled",
                     "minSupportedVersion": "1.178.3"
+                },
+                "scopedAccessCredentials": {
+                    "state": "enabled",
+                    "minSupportedVersion": "1.195.0"
+                },
+                "canUseV2ConnectFlow": {
+                    "state": "enabled",
+                    "minSupportedVersion": "1.195.0"
+                },
+                "canShowV2ConnectCode": {
+                    "state": "disabled",
+                    "minSupportedVersion": "1.195.0"
                 }
             }
         },

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -1658,7 +1658,7 @@
                     "minSupportedVersion": "1.195.0"
                 },
                 "canShowV2ConnectCode": {
-                    "state": "disabled",
+                    "state": "internal",
                     "minSupportedVersion": "1.195.0"
                 }
             }


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/72649045549333/task/1214719720396797?focus=true

## Description
Enables the following two Sync flags starting from iOS release 7.225.0, macOS release 1.195.0:

- `scopedAccessCredentials`
- `canUseV2ConnectFlow`

Also updates `canShowV2ConnectCode` to `internal` (to be enabled in unison with all platforms later this week)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches sync setup and credential-related remote flags; misconfiguration could affect device pairing before apps are ready, though connect-code UI remains disabled.
> 
> **Overview**
> Adds three **Sync V2** sub-features under `sync.features` in the iOS and macOS privacy overrides, aligning Apple platforms with the flags already present on Windows.
> 
> **`scopedAccessCredentials`** and **`canUseV2ConnectFlow`** are set to **enabled** with platform minimum versions (iOS **7.225.0**, macOS **1.195.0**). **`canShowV2ConnectCode`** is **disabled** on both, so the V2 connect-code UI stays off while the underlying flow and credential behavior can ship behind version gates.
> 
> No other platforms or sync settings are changed in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce211eb55c069a5d08e46b8b7af21a570f77008e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->