### PR TITLE
Expand crcldu mitigation to Walmart

### DIFF
--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -953,8 +953,10 @@
                             "sallybeauty.com",
                             "walmart.com"
                         ],
-                        "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5254",
-                        "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5378"
+                        "reason": [
+                            "sallybeauty - https://github.com/duckduckgo/privacy-configuration/pull/5254",
+                            "walmart - https://github.com/duckduckgo/privacy-configuration/pull/5378"
+                        ]
                     }
                 ]
             },

--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -948,7 +948,7 @@
             "crcldu.com": {
                 "rules": [
                     {
-                        "rule": "crcldu.com",
+                        "rule": "crcldu.com/bd/sync.html",
                         "domains": [
                             "sallybeauty.com",
                             "walmart.com"

--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -948,11 +948,13 @@
             "crcldu.com": {
                 "rules": [
                     {
-                        "rule": "crcldu.com/bd/sync.html",
+                        "rule": "crcldu.com",
                         "domains": [
-                            "sallybeauty.com"
+                            "sallybeauty.com",
+                            "walmart.com"
                         ],
-                        "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5254"
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5254",
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5378"
                     }
                 ]
             },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1200277586140538/task/1215824035124323?focus=true

### Site breakage mitigation process:
#### Brief explanation
- Reported URL: walmart.com
- Problems experienced: when bot check triggered, users can't pass with this tracker blocked -- seems to happen more on Windows, but we have reports across all browsers
- Platforms affected:
  - [?] iOS
  - [x] Android
  - [x] Windows
  - [?] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked: `crcldu.com/bd/sync.html`
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.
