### PR TITLE
Add crashLoopThresholdSeconds=20

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -4456,7 +4456,8 @@
                     "settings": {
                         "autoRecoveryBrowserEngine": true,
                         "autoRecoveryTab": true,
-                        "autoRecoveryTabOutOfMemory": false
+                        "autoRecoveryTabOutOfMemory": false,
+                        "crashLoopThresholdSeconds": 20
                     }
                 },
                 "nativeCrashDialog": {

--- a/schema/features/windows-webview-failures.ts
+++ b/schema/features/windows-webview-failures.ts
@@ -7,6 +7,7 @@ type SubFeatures<VersionType> = {
             autoRecoveryBrowserEngine: boolean;
             autoRecoveryTab: boolean;
             autoRecoveryTabOutOfMemory: boolean;
+            crashLoopThresholdSeconds: number;
         }
     >;
     nativeCrashDialogOneShot?: SubFeature<


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1209077031784564/task/1215828469467571?focus=true

## Description
This is now a hard-coded 5 second in the code. Turning this into a setting and increasing it as we're dealing with some users experiencing a ~12-13 second/iteration crash loop in https://app.asana.com/1/137249556945/project/1209077031784564/task/1215654630017988

### Feature change process:

- [x] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [x] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small Windows-only privacy-config change that only tunes crash-loop detection timing for auto-recovery; no auth or data-handling impact in this repo.
> 
> **Overview**
> Introduces a remote-config knob **`crashLoopThresholdSeconds`** on the Windows **`windowsWebviewFailures` → `crashAutoRecovery`** subfeature, replacing a client hard-coded **5s** crash-loop window with a schema-validated setting set to **20** in **`windows-override.json`**.
> 
> The TypeScript schema in **`windows-webview-failures.ts`** is updated so **`crashAutoRecovery`** settings include the new numeric field alongside the existing auto-recovery booleans.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b0f26301014b2dc5a02dd64d0f258874319a8eb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->