### PR TITLE
enable product surface telemetry on ios

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -2610,7 +2610,7 @@
                     }
                 },
                 "productTelemetrySurfaceUsage": {
-                    "state": "disabled",
+                    "state": "enabled",
                     "minSupportedVersion": "7.199.0",
                     "description": "Temporarily gather telemetry around product surfaces being used."
                 },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/task/1215831363616879?focus=true

## Description
Enable product surface telemetry for iOS.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single feature-flag flip in remote config with an existing version gate; increases telemetry collection but does not change app logic in this repo.
> 
> **Overview**
> Turns on the **`productTelemetrySurfaceUsage`** flag under **`iOSBrowserConfig`** in `ios-override.json` by changing its **`state`** from **`disabled`** to **`enabled`**.
> 
> Eligible iOS builds (**`minSupportedVersion`** **`7.199.0`**) can now emit the temporary telemetry described in the flag (**product surfaces in use**). No rollout steps or other fields were changed in this PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5cc8b0520f5fbe9c8fd02f58d5c814a49caa2579. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->