### PR TITLE
Modify crcldu.com rules in tracker-allowlist.json

### DIFF
--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -948,24 +948,16 @@
             "crcldu.com": {
                 "rules": [
                     {
-                        "rule": "crcldu.com/bd/sync.html",
+                        "rule": "crcldu.com",
                         "domains": [
-                            "sallybeauty.com",
-                            "walmart.com"
+                            "<all>"
                         ],
                         "reason": [
-                            "sallybeauty - https://github.com/duckduckgo/privacy-configuration/pull/5254",
-                            "walmart - https://github.com/duckduckgo/privacy-configuration/pull/5378"
+                            "https://github.com/duckduckgo/privacy-configuration/pull/5254",
+                            "https://github.com/duckduckgo/privacy-configuration/pull/5378",
+                            "Loaded as part of PerimeterX bot checks; blocking breaks the verifying mechanism"
                         ]
-                    },
-                    {
-                        "rule": "crcldu.com/bd/auditor.js",
-                        "domains": [
-                            "sallybeauty.com"
-                        ],
-                        "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5254"
                     }
-                ]
             },
             "cudasvc.com": {
                 "rules": [

--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -958,6 +958,7 @@
                             "Loaded as part of PerimeterX bot checks; blocking breaks the verifying mechanism"
                         ]
                     }
+                ]
             },
             "cudasvc.com": {
                 "rules": [


### PR DESCRIPTION
## Description

We're seeing a fair amount of crcldu requests being blocked in users reporting hard- or impossible-to-pass bot and captcha checks. PerimeterX seems to use them as a 3rd-party supplier of some verification mechanisms so blocking them means users who hit checks are often unable to pass them. Therefore, we're unblocking them everywhere.
