### PR TITLE
Windows: Enable sync / canShowV2ConnectCode

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -3956,7 +3956,8 @@
                     "minSupportedVersion": "0.162.0"
                 },
                 "canShowV2ConnectCode": {
-                    "state": "internal"
+                    "state": "enabled",
+                    "minSupportedVersion": "0.162.0"
                 }
             }
         },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/72649045549333/task/1214701355776046?focus=true

## Description
Enables the `canShowV2ConnectCode` sync flag starting from Windows Browser v0.162.0.
Should be merged only after cross-platform agreement.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single remote-config toggle with a min version; no app code changes in this PR.
> 
> **Overview**
> **Windows sync remote config:** `canShowV2ConnectCode` under `sync.features` in `windows-override.json` is promoted from **`internal`** to **`enabled`**, with **`minSupportedVersion`: `0.162.0`**.
> 
> That aligns the flag with the other v0.162.0 sync V2 pieces already enabled on Windows (`canUseV2ConnectFlow`, `scopedAccessCredentials`). Clients on **0.162.0+** can show the V2 connect code in sync setup; older builds stay off via the version gate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 962756b32ce1b8c6602fe97e8d813efee066f744. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->