### PR TITLE
Add requestBlocklist rule for youtube.com/youtubei/v1/player/ad_break

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -2502,7 +2502,22 @@
         },
         "requestBlocklist": {
             "state": "enabled",
-            "minSupportedVersion": 52730000
+            "minSupportedVersion": 52730000,
+            "settings": {
+                "blockedRequests": {
+                    "youtube.com": {
+                        "rules": [
+                            {
+                                "rule": "youtube.com/youtubei/v1/player/ad_break",
+                                "domains": [
+                                    "youtube.com"
+                                ],
+                                "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5389"
+                            }
+                        ]
+                    }
+                }
+            }
         },
         "requestFilterer": {
             "state": "enabled",

--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -2505,6 +2505,28 @@
             "minSupportedVersion": 52730000,
             "settings": {
                 "blockedRequests": {
+                    "privacy-test-pages.site": {
+                        "rules": [
+                            {
+                                "rule": "privacy-test-pages.site/privacy-protections/request-blocklist/*?block=true",
+                                "domains": [
+                                    "privacy-test-pages.site"
+                                ],
+                                "reason": "Testing rule for the privacy test page, see https://privacy-test-pages.site/privacy-protections/request-blocklist/"
+                            }
+                        ]
+                    },
+                    "third-party.site": {
+                        "rules": [
+                            {
+                                "rule": "third-party.site/privacy-protections/request-blocklist/*?block=true",
+                                "domains": [
+                                    "privacy-test-pages.site"
+                                ],
+                                "reason": "Testing rule for the privacy test page, see https://privacy-test-pages.site/privacy-protections/request-blocklist/"
+                            }
+                        ]
+                    },
                     "youtube.com": {
                         "rules": [
                             {


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1213896455081060/task/1215862253457340?focus=true

## Description
Equivalent to https://github.com/duckduckgo/content-blocker-extension/blob/main/src/rules/youtube.json , only on Android

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [x] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Blocking a YouTube player API on a major site can affect playback or ad behavior; impact is limited to Android clients on supported app versions.
> 
> **Overview**
> Adds **`requestBlocklist.settings.blockedRequests`** to the Android privacy override so the client can block specific network requests (not tracker lists).
> 
> The notable new rule blocks **`youtube.com/youtubei/v1/player/ad_break`** on **`youtube.com`**, matching the extension content-blocker YouTube rule and targeting Android only. The same override block also wires in the existing privacy-test-pages request-blocklist test rules for **`privacy-test-pages.site`** and **`third-party.site`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a3bb3858f081962472378fcd023cac0e7ca17bc5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->