### PR TITLE
Disable nativeInputField (Android)

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -542,7 +542,7 @@
                     "minSupportedVersion": 52840000
                 },
                 "nativeInputField": {
-                    "state": "enabled",
+                    "state": "disabled",
                     "minSupportedVersion": 52840000,
                     "rollout": {
                         "steps": [


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/488551667048375/task/1215862725570121?focus=true

## Description
Disables the native input on Android due an issue when sending the first prompt.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [x] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single remote feature-flag flip in Android privacy config; no app code changes, with intended UX fallback away from the broken native input path.
> 
> **Overview**
> Turns off the **`nativeInputField`** sub-feature under **`aiChat`** in **`android-override.json`** by changing its **`state`** from **`enabled`** to **`disabled`**, as a remote-config kill switch for Android Duck.ai.
> 
> This stops clients from using the native Duck.ai input path (including any staged rollout at 5%/25%) so users fall back to the previous input behavior while a **first-prompt send** issue is addressed. **`minSupportedVersion`** and rollout steps are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f1767d064aaad6626c9b06f37c40b0e68805aa35. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->