### PR TITLE
Update autoconsent to v15.0.0

### DIFF
--- a/features/autoconsent.json
+++ b/features/autoconsent.json
@@ -28513,7 +28513,7 @@
                     1,
                     "twitch.tv",
                     2,
-                    "^https?://(www\\.)?twitch\\.tv",
+                    "^https?://([\\w-]+\\.)?twitch\\.tv",
                     22,
                     [
                         889


### PR DESCRIPTION
Asana Task/Github Issue: https://app.asana.com/1/137249556945/project/1201844467387842/task/1215893801658992

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only autoconsent rule update with a narrow URL-regex change for Twitch; no auth, data, or app logic changes.
> 
> **Overview**
> Updates the bundled **autoconsent** ruleset to **v15.0.0** (regenerated `features/autoconsent.json`).
> 
> The only visible rule change in this diff widens the **twitch.tv** URL match from optional `www` only to **any subdomain** (`^https?://([\w-]+\.)?twitch\.tv`), so autoconsent can run on Twitch hostnames beyond `www.twitch.tv`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a1d3fb6d6bd9ed1ebe184840276a258180ff1092. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->