### PR TITLE
Update content-blocker extension to 2026.6.21

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -4757,7 +4757,7 @@
             "minSupportedVersion": "0.148.0",
             "exceptions": [],
             "settings": {
-                "extensionUrl": "https://staticcdn.duckduckgo.com/extensions/content-blocker/content-blocker-extension-2026.6.14.crx"
+                "extensionUrl": "https://staticcdn.duckduckgo.com/extensions/content-blocker/content-blocker-extension-2026.6.21.crx"
             },
             "features": {
                 "onboardingEnabled": {


### PR DESCRIPTION
Update content-blocker extension to 2026.6.21.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single remote-config URL bump for the ad-block extension; no logic or rollout changes in this PR.
> 
> **Overview**
> Updates the Windows remote config so **`adBlockV2Extension`** points at the new content-blocker CRX on static CDN: **`content-blocker-extension-2026.6.21.crx`** instead of **`2026.6.14`**.
> 
> No other `adBlockV2Extension` flags, rollouts, or settings change in this diff—only the **`extensionUrl`** in `windows-override.json`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b500c777dac68cb88194d9917e9fc9c535dd151. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->