### PR TITLE
Update ad-blocking extension scriptlets for v2026.6.21

### DIFF
--- a/features/ad-blocking-extension.json
+++ b/features/ad-blocking-extension.json
@@ -4,28 +4,28 @@
     },
     "exceptions": [],
     "settings": {
-        "version": "2026.6.14",
+        "version": "2026.6.21",
         "enabledByDefault": false,
         "scriptlets": {
             "scriptlets/isolated/ublock-filters.js": {
                 "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/68c82cf4f44f1b7cd13ba3bcede72f4fac56039f4681abd9339327176f3fb255.js",
-                "signature": "MEUCIHSQMtOCek2hbib5/9FUg2Thr3rZcFmE8BJ2OTf8JVB7AiEAvMTX0nNg7l6jJyV90Q4Qwzjxzm8xl7RIFGrCqgW6Ab4="
+                "signature": "MEUCIQC3721Nx0HPFNRhpEK6udRYQhpRnVzV6kRX2ldRPRP/dQIgTeoaD8HkznNIYZ94RU3m+kowLk5tu5582tRHrmHbV44="
             },
             "scriptlets/main/ublock-filters.js": {
-                "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/38aaf2e3d6e85e4aa3714b0e7a4fb5fb02ae890ad75e815f0fc0d6d10b909ce0.js",
-                "signature": "MEQCIDWAb8eCwLOyGvAwtIYkFQ/nXYtUgFEy+rzzIeXq4xmrAiAT/22ufqPNpIyuEjwxQseZeTW45OKZa+zZVJfsE/JjSA=="
+                "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/1fa4a776a3d5c1b5fdb89bbeeb5a4b9da709220e1e90cee66cf4d1375a5efed1.js",
+                "signature": "MEYCIQCjpMRNWOULSHS6bJtC65tbzLYnfoIS0/kDoP1Y9sXi7QIhAN5PtxiI5R1kNijnNSkNGyukiTCwy3/4CA6P1QRGtifY"
             },
             "scriptlets/main/ublock-experimental.js": {
                 "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855.js",
-                "signature": "MEYCIQDxR5To5A6rLRXu/mjjZcXB84bioT3J61TXMmh0hz4AWQIhANefImqBkZBuWfUgw7RiEcZci7xZh8Hjvsekcxq8bl/W"
+                "signature": "MEUCIHjNNDyK5E5yOVc4ZQLYqJCj0GioiNQnGB7IjYt0F/g8AiEAjFRZIOi/BJln2tnWBA8lsVX9FmTghGm9Oqhkrd418EM="
             },
             "scriptlets/isolated/ublock-experimental.js": {
                 "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855.js",
-                "signature": "MEQCIGKKEx5xESD7Pt3uwbiRdFSjtUL/plIwOnsSAKiumn85AiBskiue7fy/krisEhkN6EPnwOBl4vtvATKuI/K1pq5BMA=="
+                "signature": "MEYCIQCsIPZrN5hptzhVVI24iNuMc0xMIFqiA79QQ5xs2U8L1AIhAMSVwJNDt7jO1/8Am9pr6+GQCVk30MNLVKBbg6XTIGt7"
             },
             "rules/youtube.json": {
                 "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/2337db6aa7466667595226f780b6590779db3007ac0a65ef3833f89610c92824.json",
-                "signature": "MEYCIQCNcw7ASqRdvxgVWDPRTXAhuqFMZfiWSgKx64oZFxEyRwIhANddeIW4xsHVqoZc3x//Zo1UIv56NAjjafdtH8jDnaFA"
+                "signature": "MEUCIC9i79Zbhhgt2YyDtwiPR/4HmUFyp1DLxMCV6I1iXvHPAiEAowW6qEV0COAanci3+vGdnCpTJlhX8MJ4v52SZ7l4dWo="
             }
         }
     }


### PR DESCRIPTION
Update ad-blocking extension scriptlets for v2026.6.21.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single JSON manifest update with versioned CDN URLs and signatures; no application logic changes in this diff.
> 
> **Overview**
> Bumps the macOS/iOS ad blocking extension config from **2026.6.14** to **2026.6.21**.
> 
> All listed scriptlet and rule entries get refreshed **signatures**; **`scriptlets/main/ublock-filters.js`** also points at a new CDN script URL. URLs for the experimental scriptlets and **`rules/youtube.json`** are unchanged aside from signature updates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b9851c8a1f6904a4dbcdd383383d596c6d767f5d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->