### PR TITLE
Disable Duck.ai onboarding trackers demo experiment

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -376,30 +376,6 @@
                 "voiceShortcut": {
                     "state": "enabled",
                     "minSupportedVersion": "7.216.0"
-                },
-                "onboardingDuckAIQueryTrackersDemoExperiment": {
-                    "state": "enabled",
-                    "description": "Duck.ai onboarding trackers demo experiment cohorts",
-                    "cohorts": [
-                        {
-                            "name": "control",
-                            "weight": 1
-                        },
-                        {
-                            "name": "treatmentA",
-                            "weight": 1
-                        },
-                        {
-                            "name": "treatmentB",
-                            "weight": 1
-                        }
-                    ],
-                    "targets": [
-                        {
-                            "localeLanguage": "en",
-                            "localeCountry": "US"
-                        }
-                    ]
                 }
             },
             "settings": {


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1202406491309510/task/1213551050320249?focus=true

## Description
Remove the `onboardingDuckAIQueryTrackersDemoExperiment` from the iOS override configuration. This experiment was used to test Duck.ai onboarding query variations with trackers demo for en-US users. The experiment is now complete and no longer needed.

### Feature change process:

- [x] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL: N/A
- Problems experienced: N/A
- Platforms affected:
  - [x] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked: N/A
- Feature being disabled/modified: Duck.ai onboarding experiment
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only removal of a completed experiment; no app logic changes in this PR.
> 
> **Overview**
> Removes the **`onboardingDuckAIQueryTrackersDemoExperiment`** from **`duckAi`** feature in `overrides/ios-override.json`. This experiment tested three cohorts (control, treatmentA, treatmentB) for Duck.ai onboarding query variations with trackers demo for en-US locale users. The experiment is complete and the remote config entry is being removed for cleanup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->