### PR TITLE
Resume adBlockingExtension featureEnabledByDefault rollout on iOS and macOS

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -3163,8 +3163,8 @@
                     "minSupportedVersion": "7.216.0"
                 },
                 "featureEnabledByDefault": {
-                    "state": "disabled",
-                    "minSupportedVersion": "7.222.0",
+                    "state": "enabled",
+                    "minSupportedVersion": "7.225.0",
                     "rollout": {
                         "steps": [
                             {

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -2713,8 +2713,8 @@
                     "minSupportedVersion": "1.186.0"
                 },
                 "featureEnabledByDefault": {
-                    "state": "disabled",
-                    "minSupportedVersion": "1.192.0",
+                    "state": "enabled",
+                    "minSupportedVersion": "1.195.0",
                     "rollout": {
                         "steps": [
                             {


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1163321984198618/task/1215650604130154?focus=true

## Description

Resumes the default-on rollout for the `adBlockingExtension` `featureEnabledByDefault` subfeature on iOS and macOS:

- Flips `state` from `disabled` to `enabled` on both platforms.
- Bumps `minSupportedVersion` to `7.225.0` (iOS) and `1.195.0` (macOS).

Rollout steps (10% → 100%) are unchanged; re-enabling lets the 10% step take effect.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Turning on default ad-blocking extension behavior for a growing user slice can affect page compatibility and breakage reports, though exposure stays gated by rollout percentages and version floors.
> 
> **Overview**
> Resumes the **default-on** rollout for `adBlockingExtension` → `featureEnabledByDefault` in the iOS and macOS privacy overrides.
> 
> On both platforms, **`state` changes from `disabled` to `enabled`**, and **`minSupportedVersion` is raised** to `7.225.0` (iOS) and `1.195.0` (macOS). The existing **10% → 100% rollout steps are unchanged**; turning the subfeature back on lets that staged exposure apply again.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 75f5454921224654a1c7dc653bab21f5e92d9430. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->