### PR TITLE
Re-enable aiChat nativeInputField on Android at 25% rollout

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -542,7 +542,7 @@
                     "minSupportedVersion": 52840000
                 },
                 "nativeInputField": {
-                    "state": "disabled",
+                    "state": "enabled",
                     "minSupportedVersion": 52840000,
                     "rollout": {
                         "steps": [


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1174433894299346/task/1215905863731635?focus=true

## Description

Re-enable the `nativeInputField` sub-feature under `aiChat` on Android. Rollout remains at 25% (existing 5% and 25% rollout steps unchanged).

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [x] This feature was covered by a tech design.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8d299aee-a82f-4195-ad0b-e6ab56abaa2f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8d299aee-a82f-4195-ad0b-e6ab56abaa2f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

