### PR TITLE
Enable VPN feature flags on iOS and macOS

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -128,16 +128,20 @@
                     "state": "enabled"
                 },
                 "excludeCGNAT": {
-                    "state": "enabled"
+                    "state": "enabled",
+                    "minSupportedVersion": "7.230.0"
                 },
                 "strictRoutingToggle": {
-                    "state": "enabled"
+                    "state": "enabled",
+                    "minSupportedVersion": "7.230.0"
                 },
                 "showCopyDiagnosticsButton": {
-                    "state": "enabled"
+                    "state": "enabled",
+                    "minSupportedVersion": "7.230.0"
                 },
                 "strictRoutingReminder": {
-                    "state": "enabled"
+                    "state": "enabled",
+                    "minSupportedVersion": "7.230.0"
                 }
             }
         },

--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -126,6 +126,18 @@
                 },
                 "riskyDomainsProtection": {
                     "state": "enabled"
+                },
+                "excludeCGNAT": {
+                    "state": "enabled"
+                },
+                "strictRoutingToggle": {
+                    "state": "enabled"
+                },
+                "showCopyDiagnosticsButton": {
+                    "state": "enabled"
+                },
+                "strictRoutingReminder": {
+                    "state": "enabled"
                 }
             }
         },

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -230,16 +230,20 @@
                     "state": "enabled"
                 },
                 "excludeCGNAT": {
-                    "state": "enabled"
+                    "state": "enabled",
+                    "minSupportedVersion": "1.200.0"
                 },
                 "strictRoutingToggle": {
-                    "state": "enabled"
+                    "state": "enabled",
+                    "minSupportedVersion": "1.200.0"
                 },
                 "showCopyDiagnosticsButton": {
-                    "state": "enabled"
+                    "state": "enabled",
+                    "minSupportedVersion": "1.200.0"
                 },
                 "strictRoutingReminder": {
-                    "state": "enabled"
+                    "state": "enabled",
+                    "minSupportedVersion": "1.200.0"
                 },
                 "appStoreSystemExtension": {
                     "state": "enabled"

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -229,6 +229,18 @@
                 "riskyDomainsProtection": {
                     "state": "enabled"
                 },
+                "excludeCGNAT": {
+                    "state": "enabled"
+                },
+                "strictRoutingToggle": {
+                    "state": "enabled"
+                },
+                "showCopyDiagnosticsButton": {
+                    "state": "enabled"
+                },
+                "strictRoutingReminder": {
+                    "state": "enabled"
+                },
                 "appStoreSystemExtension": {
                     "state": "enabled"
                 },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1206580121312550/task/1215879520240902?focus=true

## Description

Graduate four `networkProtection` subfeatures from internal-only to public on iOS and macOS, so their corresponding VPN settings and tips ship to all users.

Each subfeature gates user-facing VPN behaviour landed in apple-browsers: `excludeCGNAT` (#4960), `strictRoutingToggle` (#5166), `showCopyDiagnosticsButton` (#5400), and `strictRoutingReminder` (#5487). This config change is what flips them on remotely.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Remote enablement of VPN routing and diagnostics UI can affect connectivity behavior for users on supported builds; impact is bounded by minSupportedVersion gates.
> 
> **Overview**
> This PR turns on four **`networkProtection`** subfeatures in the iOS and macOS privacy overrides so eligible app versions can expose VPN settings and tips that already exist behind remote config.
> 
> On **iOS** (`minSupportedVersion` **7.230.0**), it enables **`excludeCGNAT`**, **`strictRoutingToggle`**, **`showCopyDiagnosticsButton`**, and **`strictRoutingReminder`**. On **macOS** (**1.200.0**), the same four flags are added under **`networkProtection`**.
> 
> There is no app code in this diff—only remote config—so merging flips these capabilities on for users at or above those version floors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 409cac3d7d6e5367d0721b6729efd38b6202a394. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->