### PR TITLE
Update content-blocker extension to 2026.6.23

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -4757,7 +4757,7 @@
             "minSupportedVersion": "0.148.0",
             "exceptions": [],
             "settings": {
-                "extensionUrl": "https://staticcdn.duckduckgo.com/extensions/content-blocker/content-blocker-extension-2026.6.14.crx"
+                "extensionUrl": "https://staticcdn.duckduckgo.com/extensions/content-blocker/content-blocker-extension-2026.6.23.crx"
             },
             "features": {
                 "onboardingEnabled": {


### PR DESCRIPTION
Update content-blocker extension to 2026.6.23.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single URL bump in remote config; no feature flags or logic changes, though a bad CRX URL could affect extension rollout for Windows users on adBlock V2.
> 
> **Overview**
> Updates the Windows remote config so **adBlock V2** clients download a newer bundled content-blocker CRX.
> 
> In `overrides/windows-override.json`, the `adBlockV2Extension` `settings.extensionUrl` changes from `content-blocker-extension-2026.6.14.crx` to **`content-blocker-extension
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ba948de66c951bfec4cc003f871b6b009a7539f9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->