### PR TITLE
Update ad-blocking extension scriptlets for v2026.6.23

### DIFF
--- a/features/ad-blocking-extension.json
+++ b/features/ad-blocking-extension.json
@@ -4,28 +4,28 @@
     },
     "exceptions": [],
     "settings": {
-        "version": "2026.6.21",
+        "version": "2026.6.23",
         "enabledByDefault": false,
         "scriptlets": {
             "scriptlets/isolated/ublock-filters.js": {
-                "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/68c82cf4f44f1b7cd13ba3bcede72f4fac56039f4681abd9339327176f3fb255.js",
-                "signature": "MEUCIQC3721Nx0HPFNRhpEK6udRYQhpRnVzV6kRX2ldRPRP/dQIgTeoaD8HkznNIYZ94RU3m+kowLk5tu5582tRHrmHbV44="
+                "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/dd60a3329b8dacaf619a7ff6b15fbf22c65333c9f73f9fd3083d234daa644898.js",
+                "signature": "MEQCIEyb1e0BQzIkqrexlzXF4RZWm0mRyEmDw1YSrDZU0I6dAiAlnxa4UMzGiKqY7++KupBkG/hQJz4w4BJEcj2BfMaGkA=="
             },
             "scriptlets/main/ublock-filters.js": {
-                "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/1fa4a776a3d5c1b5fdb89bbeeb5a4b9da709220e1e90cee66cf4d1375a5efed1.js",
-                "signature": "MEYCIQCjpMRNWOULSHS6bJtC65tbzLYnfoIS0/kDoP1Y9sXi7QIhAN5PtxiI5R1kNijnNSkNGyukiTCwy3/4CA6P1QRGtifY"
+                "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/202dc5c3cef849bb0613ca02efe78ac45bf6a886d4b1df6c13684336d134b320.js",
+                "signature": "MEUCIQDNvjOu9AzTlZAgy8Gb6hRezLu0KtRX5WjKJsXwiV7jWgIgZlNbmBdylMB2QVcK5Rsm6tDO6LUsWZY2Sf4txmo6VOQ="
             },
             "scriptlets/main/ublock-experimental.js": {
                 "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855.js",
-                "signature": "MEUCIHjNNDyK5E5yOVc4ZQLYqJCj0GioiNQnGB7IjYt0F/g8AiEAjFRZIOi/BJln2tnWBA8lsVX9FmTghGm9Oqhkrd418EM="
+                "signature": "MEUCIA7mNbZKETLQBvybfipWAY6Feat1Zw+yRtBacN39OjztAiEA7ACVxagN8FY7iYXxAE7cIh+qZuQtSK7xgGxjheWoxaA="
             },
             "scriptlets/isolated/ublock-experimental.js": {
                 "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855.js",
-                "signature": "MEYCIQCsIPZrN5hptzhVVI24iNuMc0xMIFqiA79QQ5xs2U8L1AIhAMSVwJNDt7jO1/8Am9pr6+GQCVk30MNLVKBbg6XTIGt7"
+                "signature": "MEYCIQDE7wWUwTS90egBzLzxB7baNcUYdYwgvwoXtd2oUNa+eQIhALigPi5usQ+t6xgitCG1qJeHXR4+hxmxWGFtqfEyXuBo"
             },
             "rules/youtube.json": {
                 "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/2337db6aa7466667595226f780b6590779db3007ac0a65ef3833f89610c92824.json",
-                "signature": "MEUCIC9i79Zbhhgt2YyDtwiPR/4HmUFyp1DLxMCV6I1iXvHPAiEAowW6qEV0COAanci3+vGdnCpTJlhX8MJ4v52SZ7l4dWo="
+                "signature": "MEUCIBaJ33YqDMP3mYOuvtzMRKXediIDCs+p7atFMPGdXyd8AiEAmj7Tiy9X50teLttyYYig90CKs0MZ3G8+RBOZ5JGYQNU="
             }
         }
     }


### PR DESCRIPTION
Update ad-blocking extension scriptlets for v2026.6.23.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes signed remote scriptlet payloads used by content blocking on macOS/iOS; incorrect URLs or signatures could break ad blocking or cause clients to reject updates.
> 
> **Overview**
> Bumps the macOS/iOS ad-blocking extension config from **2026.6.21** to **2026.6.23** in `features/ad-blocking-extension.json`.
> 
> **Isolated and main uBlock filter scriptlets** get new CDN URLs and ECDSA signatures. **Experimental scriptlets** keep the same empty-scriptlet URL but have refreshed signatures. **YouTube rules** (`rules/youtube.json`) keep the same URL with an updated signature only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 48c51e25e02caa5dd6fafac282755d34e0d0bf11. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->