### PR TITLE
Match client hint mitigations across headers/JS

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -2431,14 +2431,7 @@
                         "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36"
                     }
                 ],
-                "omitClientHintMutations": [
-                    {
-                        "domain": "smythstoys.com"
-                    },
-                    {
-                        "domain": "www.smythstoys.com"
-                    }
-                ]
+                "omitClientHintMutations": []
             },
             "features": {
                 "userAgentStrategies": {
@@ -4210,26 +4203,81 @@
                     {
                         "domain": "www.instagram.com",
                         "brand": "Google Chrome"
+                    },
+                    {
+                        "domain": "www.spectrum.net",
+                        "brand": "Google Chrome"
+                    },
+                    {
+                        "domain": "id.spectrum.net",
+                        "brand": "Google Chrome"
+                    },
+                    {
+                        "domain": "watch.spectrum.net",
+                        "brand": "Google Chrome"
+                    },
+                    {
+                        "domain": "www.smythstoys.com",
+                        "brand": "Google Chrome"
                     }
                 ]
             }
         },
         "uaChBrands": {
             "state": "enabled",
-            "exceptions": [
-                {
-                    "domain": "smythstoys.com",
-                    "reason": "Bot check"
-                },
-                {
-                    "domain": "facebook.com",
-                    "reason": "reCAPTCHA failing on Facebook login"
-                },
-                {
-                    "domain": "instagram.com",
-                    "reason": "reCAPTCHA failing on Instagram login"
-                }
-            ]
+            "settings": {
+                "conditionalChanges": [
+                    {
+                        "condition": {
+                            "domain": "spectrum.net"
+                        },
+                        "patchSettings": [
+                            {
+                                "op": "add",
+                                "path": "/brandName",
+                                "value": "Google Chrome"
+                            }
+                        ]
+                    },
+                    {
+                        "condition": {
+                            "domain": "facebook.com"
+                        },
+                        "patchSettings": [
+                            {
+                                "op": "add",
+                                "path": "/brandName",
+                                "value": "Google Chrome"
+                            }
+                        ]
+                    },
+                    {
+                        "condition": {
+                            "domain": "instagram.com"
+                        },
+                        "patchSettings": [
+                            {
+                                "op": "add",
+                                "path": "/brandName",
+                                "value": "Google Chrome"
+                            }
+                        ]
+                    },
+                    {
+                        "condition": {
+                            "domain": "smythstoys.com"
+                        },
+                        "patchSettings": [
+                            {
+                                "op": "add",
+                                "path": "/brandName",
+                                "value": "Google Chrome"
+                            }
+                        ]
+                    }
+                ]
+            },
+            "exceptions": []
         },
         "privacyPro": {
             "state": "enabled",

--- a/schema/features/ua-ch-brands.ts
+++ b/schema/features/ua-ch-brands.ts
@@ -2,6 +2,7 @@ import { CSSInjectFeatureSettings, Feature, FeatureState } from '../feature';
 
 type UaChBrandsSettings = CSSInjectFeatureSettings<{
     additionalCheck?: FeatureState;
+    brandName?: string;
 }>;
 
 export type UaChBrandsFeature<VersionType> = Feature<UaChBrandsSettings, VersionType>;


### PR DESCRIPTION
**Asana Task/Github Issue:**
- https://app.asana.com/1/137249556945/project/1201279386299865/task/1215808667029707?focus=true
- https://app.asana.com/1/137249556945/project/1215334559171074/task/1215859412812080?focus=true

## Description
Noticed that with PR #5363 we're now sending Google Chrome for some domains rather than just _not_ sending DuckDuckGo, so matched that to existing domains with bot issues. This required moving domains we're trying to mitigate from `omitClientHintMutations` (which leaves the baseline Chromium and GREASE values only) and moved to `clientBrandHint` overrides to match Chrome values on headers, while also matching the same to JS values in `navigator.userAgentData` with `uaChBrands`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only privacy/UA overrides for specific domains; no application logic or security paths changed beyond how client hints are presented to those sites.
> 
> **Overview**
> Aligns **Windows** broken-site mitigations so HTTP client hints and **`navigator.userAgentData`** report the same **Google Chrome** branding on problem domains.
> 
> **Smyths** is removed from **`omitClientHintMutations`** (no longer leaving only baseline Chromium/GREASE on headers). **Spectrum** (`spectrum.net` and subdomains) and **`www.smythstoys.com`** are added to **`clientBrandHint`** with **Google Chrome**.
> 
> **`uaChBrands`** stops using domain **exceptions** that disabled the feature; it now uses **`conditionalChanges`** to set **`brandName`** to **Google Chrome** for **spectrum.net**, **facebook.com**, **instagram.com**, and **smythstoys.com**. The schema adds optional **`brandName`** on **`UaChBrandsSettings`** to support that patch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f14d82c32cdc0316cc0df7c03c5fd65a92b7669c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->