### PR TITLE
Add Windows per-provider captcha web-detection and telemetry

### DIFF
--- a/features/web-detection.json
+++ b/features/web-detection.json
@@ -290,7 +290,8 @@
             {
                 "condition": [
                     {
-                        "injectName": "windows"
+                        "injectName": "windows",
+                        "minSupportedVersion": "0.165.0"
                     }
                 ],
                 "patchSettings": [

--- a/features/web-detection.json
+++ b/features/web-detection.json
@@ -290,8 +290,7 @@
             {
                 "condition": [
                     {
-                        "injectName": "windows",
-                        "minSupportedVersion": "0.164.0"
+                        "injectName": "windows"
                     }
                 ],
                 "patchSettings": [

--- a/features/web-detection.json
+++ b/features/web-detection.json
@@ -88,6 +88,43 @@
                     }
                 }
             },
+            "captcha": {
+                "recaptcha": {
+                    "match": {
+                        "element": {
+                            "selector": [
+                                ".g-recaptcha",
+                                "iframe[src*='recaptcha']",
+                                "iframe[title*='recaptcha' i]"
+                            ],
+                            "visibility": "visible"
+                        }
+                    }
+                },
+                "hcaptcha": {
+                    "match": {
+                        "element": {
+                            "selector": [
+                                ".h-captcha",
+                                "iframe[src*='hcaptcha.com']",
+                                "iframe[title*='hcaptcha' i]"
+                            ],
+                            "visibility": "visible"
+                        }
+                    }
+                },
+                "turnstile": {
+                    "match": {
+                        "element": {
+                            "selector": [
+                                ".cf-turnstile",
+                                "iframe[src*='challenges.cloudflare.com']"
+                            ],
+                            "visibility": "visible"
+                        }
+                    }
+                }
+            },
             "commentsDisabled": {
                 "generic": {
                     "match": {
@@ -221,6 +258,61 @@
                         "op": "add",
                         "path": "/detectors/adwalls/admiral/actions",
                         "value": { "fireEvent": { "state": "enabled", "type": "admiralAdwall" } }
+                    }
+                ]
+            },
+            {
+                "condition": [
+                    {
+                        "injectName": "windows",
+                        "minSupportedVersion": "0.164.0"
+                    }
+                ],
+                "patchSettings": [
+                    {
+                        "op": "add",
+                        "path": "/detectors/captcha/recaptcha/triggers",
+                        "value": { "auto": { "state": "enabled", "when": { "intervalMs": [
+                                        500,
+                                        1000,
+                                        3000,
+                                        5000
+                                    ] } } }
+                    },
+                    {
+                        "op": "add",
+                        "path": "/detectors/captcha/recaptcha/actions",
+                        "value": { "fireEvent": { "state": "enabled", "type": "captcha_recaptcha" } }
+                    },
+                    {
+                        "op": "add",
+                        "path": "/detectors/captcha/hcaptcha/triggers",
+                        "value": { "auto": { "state": "enabled", "when": { "intervalMs": [
+                                        500,
+                                        1000,
+                                        3000,
+                                        5000
+                                    ] } } }
+                    },
+                    {
+                        "op": "add",
+                        "path": "/detectors/captcha/hcaptcha/actions",
+                        "value": { "fireEvent": { "state": "enabled", "type": "captcha_hcaptcha" } }
+                    },
+                    {
+                        "op": "add",
+                        "path": "/detectors/captcha/turnstile/triggers",
+                        "value": { "auto": { "state": "enabled", "when": { "intervalMs": [
+                                        500,
+                                        1000,
+                                        3000,
+                                        5000
+                                    ] } } }
+                    },
+                    {
+                        "op": "add",
+                        "path": "/detectors/captcha/turnstile/actions",
+                        "value": { "fireEvent": { "state": "enabled", "type": "captcha_turnstile" } }
                     }
                 ]
             }

--- a/features/web-detection.json
+++ b/features/web-detection.json
@@ -117,10 +117,36 @@
                     "match": {
                         "element": {
                             "selector": [
-                                ".cf-turnstile",
-                                "iframe[src*='challenges.cloudflare.com']"
+                                ".cf-turnstile:not(#turnstile-wrapper)",
+                                ".cf-turnstile:not(#turnstile-wrapper) iframe"
                             ],
                             "visibility": "visible"
+                        }
+                    }
+                },
+                "cloudflare": {
+                    "match": {
+                        "element": {
+                            "selector": [
+                                "#challenge-form",
+                                "#cf-wrapper",
+                                ".cf-browser-verification",
+                                "#challenge-running",
+                                "#cf-challenge-running",
+                                "#challenge-stage"
+                            ],
+                            "visibility": "visible"
+                        }
+                    }
+                },
+                "other": {
+                    "match": {
+                        "text": {
+                            "pattern": [
+                                "press (and|&) hold to (confirm|verify)",
+                                "slide( right)? to (verify|complete)",
+                                "complete the security check to (access|continue)"
+                            ]
                         }
                     }
                 }
@@ -313,6 +339,36 @@
                         "op": "add",
                         "path": "/detectors/captcha/turnstile/actions",
                         "value": { "fireEvent": { "state": "enabled", "type": "captcha_turnstile" } }
+                    },
+                    {
+                        "op": "add",
+                        "path": "/detectors/captcha/cloudflare/triggers",
+                        "value": { "auto": { "state": "enabled", "when": { "intervalMs": [
+                                        500,
+                                        1000,
+                                        3000,
+                                        5000
+                                    ] } } }
+                    },
+                    {
+                        "op": "add",
+                        "path": "/detectors/captcha/cloudflare/actions",
+                        "value": { "fireEvent": { "state": "enabled", "type": "captcha_cloudflare" } }
+                    },
+                    {
+                        "op": "add",
+                        "path": "/detectors/captcha/other/triggers",
+                        "value": { "auto": { "state": "enabled", "when": { "intervalMs": [
+                                        500,
+                                        1000,
+                                        3000,
+                                        5000
+                                    ] } } }
+                    },
+                    {
+                        "op": "add",
+                        "path": "/detectors/captcha/other/actions",
+                        "value": { "fireEvent": { "state": "enabled", "type": "captcha_other" } }
                     }
                 ]
             }

--- a/features/web-detection.json
+++ b/features/web-detection.json
@@ -291,7 +291,7 @@
                 "condition": [
                     {
                         "injectName": "windows",
-                        "minSupportedVersion": "0.165.0"
+                        "minSupportedVersion": "0.164.0"
                     }
                 ],
                 "patchSettings": [

--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -5548,6 +5548,22 @@
                             "source": "captcha_turnstile"
                         },
                         "parameters": {}
+                    },
+                    "webTelemetry_captcha_cloudflare": {
+                        "state": "enabled",
+                        "trigger": {
+                            "type": "immediate",
+                            "source": "captcha_cloudflare"
+                        },
+                        "parameters": {}
+                    },
+                    "webTelemetry_captcha_other": {
+                        "state": "enabled",
+                        "trigger": {
+                            "type": "immediate",
+                            "source": "captcha_other"
+                        },
+                        "parameters": {}
                     }
                 }
             }

--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -5524,6 +5524,30 @@
                                 "dataKey": "loginState"
                             }
                         }
+                    },
+                    "webTelemetry_captcha_recaptcha": {
+                        "state": "enabled",
+                        "trigger": {
+                            "type": "immediate",
+                            "source": "captcha_recaptcha"
+                        },
+                        "parameters": {}
+                    },
+                    "webTelemetry_captcha_hcaptcha": {
+                        "state": "enabled",
+                        "trigger": {
+                            "type": "immediate",
+                            "source": "captcha_hcaptcha"
+                        },
+                        "parameters": {}
+                    },
+                    "webTelemetry_captcha_turnstile": {
+                        "state": "enabled",
+                        "trigger": {
+                            "type": "immediate",
+                            "source": "captcha_turnstile"
+                        },
+                        "parameters": {}
                     }
                 }
             }

--- a/tests/config-tests.js
+++ b/tests/config-tests.js
@@ -284,7 +284,7 @@ describe('EventHub validation tests', () => {
                 }
             });
 
-            it('each telemetry entry declares a parameters object, and period entries have at least one', () => {
+            it('each telemetry entry declares a parameters object, and non-immediate entries have at least one', () => {
                 for (const [
                     name,
                     entry,
@@ -292,12 +292,13 @@ describe('EventHub validation tests', () => {
                     const params = entry.parameters;
                     expect(params).to.be.an('object', `Telemetry '${name}' is missing parameters`);
                     // Immediate pixels fire once per event and may legitimately carry no parameters (e.g. a
-                    // per-provider captcha pixel, where the provider is the pixel itself). Only period
-                    // (aggregating) pixels are meaningless without at least one parameter to report.
-                    if ((entry.trigger.type ?? 'period') === 'period') {
+                    // per-provider captcha pixel, where the provider is the pixel itself). Skip the check only
+                    // for immediate triggers rather than matching on 'period', so any future trigger type is
+                    // still required to carry at least one parameter until it's explicitly exempted here.
+                    if ((entry.trigger.type ?? 'period') !== 'immediate') {
                         expect(Object.keys(params).length).to.be.greaterThan(
                             0,
-                            `Period telemetry '${name}' must have at least one parameter`,
+                            `Non-immediate telemetry '${name}' must have at least one parameter`,
                         );
                     }
                 }

--- a/tests/config-tests.js
+++ b/tests/config-tests.js
@@ -295,7 +295,10 @@ describe('EventHub validation tests', () => {
                     // per-provider captcha pixel, where the provider is the pixel itself). Only period
                     // (aggregating) pixels are meaningless without at least one parameter to report.
                     if ((entry.trigger.type ?? 'period') === 'period') {
-                        expect(Object.keys(params).length).to.be.greaterThan(0, `Period telemetry '${name}' must have at least one parameter`);
+                        expect(Object.keys(params).length).to.be.greaterThan(
+                            0,
+                            `Period telemetry '${name}' must have at least one parameter`,
+                        );
                     }
                 }
             });
@@ -568,7 +571,13 @@ describe('Windows captcha telemetry', () => {
             .flatMap((block) => block.patchSettings.map((patch) => ({ condition: block.condition, patch })))
             .filter(({ patch }) => patch.path.startsWith('/detectors/captcha/') && patch.path.endsWith('/actions'));
 
-    const providers = ['recaptcha', 'hcaptcha', 'turnstile', 'cloudflare', 'other'];
+    const providers = [
+        'recaptcha',
+        'hcaptcha',
+        'turnstile',
+        'cloudflare',
+        'other',
+    ];
 
     it('declares a separate immediate telemetry entry per captcha provider', () => {
         const telemetry = windowsConfig?.body?.features?.eventHub?.settings?.telemetry ?? {};
@@ -592,7 +601,11 @@ describe('Windows captcha telemetry', () => {
             ).to.equal(true);
             firedTypes.add(fireEvent.type);
         }
-        expect([...firedTypes].sort()).to.deep.equal([
+        expect(
+            [
+                ...firedTypes,
+            ].sort(),
+        ).to.deep.equal([
             'captcha_cloudflare',
             'captcha_hcaptcha',
             'captcha_other',

--- a/tests/config-tests.js
+++ b/tests/config-tests.js
@@ -562,66 +562,6 @@ describe('EventHub telemetry override merge', () => {
     });
 });
 
-describe('Windows captcha telemetry', () => {
-    const windowsConfig = latestConfigs.find((c) => c.name === 'v5/windows-config.json');
-    const androidConfig = latestConfigs.find((c) => c.name === 'v5/android-config.json');
-
-    const captchaActionPatches = (config) =>
-        (config?.body?.features?.webDetection?.settings?.conditionalChanges ?? [])
-            .flatMap((block) => block.patchSettings.map((patch) => ({ condition: block.condition, patch })))
-            .filter(({ patch }) => patch.path.startsWith('/detectors/captcha/') && patch.path.endsWith('/actions'));
-
-    const providers = [
-        'recaptcha',
-        'hcaptcha',
-        'turnstile',
-        'cloudflare',
-        'other',
-    ];
-
-    it('declares a separate immediate telemetry entry per captcha provider', () => {
-        const telemetry = windowsConfig?.body?.features?.eventHub?.settings?.telemetry ?? {};
-        for (const provider of providers) {
-            const entry = telemetry[`webTelemetry_captcha_${provider}`];
-            expect(entry, `windows eventHub should declare webTelemetry_captcha_${provider}`).to.not.equal(undefined);
-            expect(entry.trigger).to.deep.equal({ type: 'immediate', source: `captcha_${provider}` });
-            // Per-provider pixels carry no parameters: the provider is identified by the pixel, not a data value.
-            expect(entry.parameters).to.deep.equal({});
-        }
-    });
-
-    it('fires a distinct per-provider captcha event for each detector, gated to windows only', () => {
-        const firedTypes = new Set();
-        for (const { condition, patch } of captchaActionPatches(windowsConfig)) {
-            const fireEvent = patch.value.fireEvent;
-            expect(fireEvent.data, `${patch.path} must not carry a data payload (per-provider pixels)`).to.equal(undefined);
-            expect(
-                condition.every((c) => c.injectName === 'windows'),
-                `${patch.path} must be gated to windows so other platforms never fire it`,
-            ).to.equal(true);
-            firedTypes.add(fireEvent.type);
-        }
-        expect(
-            [
-                ...firedTypes,
-            ].sort(),
-        ).to.deep.equal([
-            'captcha_cloudflare',
-            'captcha_hcaptcha',
-            'captcha_other',
-            'captcha_recaptcha',
-            'captcha_turnstile',
-        ]);
-    });
-
-    it('does not declare captcha telemetry consumers on other platforms', () => {
-        const androidTelemetry = androidConfig?.body?.features?.eventHub?.settings?.telemetry ?? {};
-        for (const provider of providers) {
-            expect(androidTelemetry[`webTelemetry_captcha_${provider}`]).to.equal(undefined);
-        }
-    });
-});
-
 describe('EventHub schema source rules', () => {
     const validate = createValidator('EventHubSettings');
 

--- a/tests/config-tests.js
+++ b/tests/config-tests.js
@@ -284,14 +284,19 @@ describe('EventHub validation tests', () => {
                 }
             });
 
-            it('each telemetry entry must have at least one parameter', () => {
+            it('each telemetry entry declares a parameters object, and period entries have at least one', () => {
                 for (const [
                     name,
                     entry,
                 ] of Object.entries(telemetry)) {
                     const params = entry.parameters;
                     expect(params).to.be.an('object', `Telemetry '${name}' is missing parameters`);
-                    expect(Object.keys(params).length).to.be.greaterThan(0, `Telemetry '${name}' must have at least one parameter`);
+                    // Immediate pixels fire once per event and may legitimately carry no parameters (e.g. a
+                    // per-provider captcha pixel, where the provider is the pixel itself). Only period
+                    // (aggregating) pixels are meaningless without at least one parameter to report.
+                    if ((entry.trigger.type ?? 'period') === 'period') {
+                        expect(Object.keys(params).length).to.be.greaterThan(0, `Period telemetry '${name}' must have at least one parameter`);
+                    }
                 }
             });
 
@@ -551,6 +556,50 @@ describe('EventHub telemetry override merge', () => {
 
     it('keeps windows-specific telemetry entries', () => {
         expect(telemetry).to.have.property('webTelemetry_youtube_videoAd_day');
+    });
+});
+
+describe('Windows captcha telemetry', () => {
+    const windowsConfig = latestConfigs.find((c) => c.name === 'v5/windows-config.json');
+    const androidConfig = latestConfigs.find((c) => c.name === 'v5/android-config.json');
+
+    const captchaActionPatches = (config) =>
+        (config?.body?.features?.webDetection?.settings?.conditionalChanges ?? [])
+            .flatMap((block) => block.patchSettings.map((patch) => ({ condition: block.condition, patch })))
+            .filter(({ patch }) => patch.path.startsWith('/detectors/captcha/') && patch.path.endsWith('/actions'));
+
+    const providers = ['recaptcha', 'hcaptcha', 'turnstile'];
+
+    it('declares a separate immediate telemetry entry per captcha provider', () => {
+        const telemetry = windowsConfig?.body?.features?.eventHub?.settings?.telemetry ?? {};
+        for (const provider of providers) {
+            const entry = telemetry[`webTelemetry_captcha_${provider}`];
+            expect(entry, `windows eventHub should declare webTelemetry_captcha_${provider}`).to.not.equal(undefined);
+            expect(entry.trigger).to.deep.equal({ type: 'immediate', source: `captcha_${provider}` });
+            // Per-provider pixels carry no parameters: the provider is identified by the pixel, not a data value.
+            expect(entry.parameters).to.deep.equal({});
+        }
+    });
+
+    it('fires a distinct per-provider captcha event for each detector, gated to windows only', () => {
+        const firedTypes = new Set();
+        for (const { condition, patch } of captchaActionPatches(windowsConfig)) {
+            const fireEvent = patch.value.fireEvent;
+            expect(fireEvent.data, `${patch.path} must not carry a data payload (per-provider pixels)`).to.equal(undefined);
+            expect(
+                condition.every((c) => c.injectName === 'windows'),
+                `${patch.path} must be gated to windows so other platforms never fire it`,
+            ).to.equal(true);
+            firedTypes.add(fireEvent.type);
+        }
+        expect([...firedTypes].sort()).to.deep.equal(['captcha_hcaptcha', 'captcha_recaptcha', 'captcha_turnstile']);
+    });
+
+    it('does not declare captcha telemetry consumers on other platforms', () => {
+        const androidTelemetry = androidConfig?.body?.features?.eventHub?.settings?.telemetry ?? {};
+        for (const provider of providers) {
+            expect(androidTelemetry[`webTelemetry_captcha_${provider}`]).to.equal(undefined);
+        }
     });
 });
 

--- a/tests/config-tests.js
+++ b/tests/config-tests.js
@@ -568,7 +568,7 @@ describe('Windows captcha telemetry', () => {
             .flatMap((block) => block.patchSettings.map((patch) => ({ condition: block.condition, patch })))
             .filter(({ patch }) => patch.path.startsWith('/detectors/captcha/') && patch.path.endsWith('/actions'));
 
-    const providers = ['recaptcha', 'hcaptcha', 'turnstile'];
+    const providers = ['recaptcha', 'hcaptcha', 'turnstile', 'cloudflare', 'other'];
 
     it('declares a separate immediate telemetry entry per captcha provider', () => {
         const telemetry = windowsConfig?.body?.features?.eventHub?.settings?.telemetry ?? {};
@@ -592,7 +592,13 @@ describe('Windows captcha telemetry', () => {
             ).to.equal(true);
             firedTypes.add(fireEvent.type);
         }
-        expect([...firedTypes].sort()).to.deep.equal(['captcha_hcaptcha', 'captcha_recaptcha', 'captcha_turnstile']);
+        expect([...firedTypes].sort()).to.deep.equal([
+            'captcha_cloudflare',
+            'captcha_hcaptcha',
+            'captcha_other',
+            'captcha_recaptcha',
+            'captcha_turnstile',
+        ]);
     });
 
     it('does not declare captcha telemetry consumers on other platforms', () => {


### PR DESCRIPTION
## What

Adds the numerator for the **visible captchas per million navigations** metric (Windows): per-provider captcha detection in the `webDetection` feature plus matching **immediate** `eventHub` pixels.

Five providers, one immediate pixel each (no bucketing — required for an accurate per-navigation ratio):

| Detector | Fires | Pixel |
|---|---|---|
| `recaptcha` | `captcha_recaptcha` | `webTelemetry_captcha_recaptcha_windows` |
| `hcaptcha` | `captcha_hcaptcha` | `webTelemetry_captcha_hcaptcha_windows` |
| `turnstile` (widget) | `captcha_turnstile` | `webTelemetry_captcha_turnstile_windows` |
| `cloudflare` (interstitial) | `captcha_cloudflare` | `webTelemetry_captcha_cloudflare_windows` |
| `other` (generic) | `captcha_other` | `webTelemetry_captcha_other_windows` |

## Notes

- **Detection is element + visibility only** — we count *visible* challenges. Window-property signals (`window.grecaptcha` etc.) are deliberately not used: a loaded captcha library is not a visible challenge and would inflate the ratio.
- **Turnstile vs Cloudflare interstitial:** the current interstitial embeds Turnstile via `<div id="turnstile-wrapper" class="cf-turnstile">`, so the turnstile detector excludes `#turnstile-wrapper` to keep the two surfaces separable (a widget regression vs an Under-Attack-Mode change).
- Windows-only for now (gated via `conditionalChanges`, ≥ 0.164.0); EventHub currently exists on Android + Windows, Android can follow.
- Kill-switch is the feature/detector `state`.

## Validation

`npm run build`, `npm run unit-tests` (876 passing, incl. the per-provider captcha telemetry test extended to all 5 providers), and `npm run tsc` all green.

Test coverage for the detection itself lives in the paired content-scope-scripts PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config and telemetry-only changes gated to Windows ≥ 0.164.0; no auth, data handling, or runtime logic in this repo.
> 
> **Overview**
> Adds **five captcha provider detectors** under `webDetection` (`recaptcha`, `hcaptcha`, `turnstile`, `cloudflare`, `other`) using visible DOM/text matching, plus a Windows-only conditional patch (≥ 0.164.0) that wires auto polling and `fireEvent` actions for each provider.
> 
> Registers matching **immediate** EventHub pixels in `windows-override.json` (`webTelemetry_captcha_*`) so each detection fires a dedicated telemetry event with empty parameters.
> 
> Relaxes config validation in `config-tests.js` so **immediate** telemetry entries may have zero parameters; non-immediate entries still require at least one.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2bf1948ce4feb422b9d4d3b29120f3f1d1b0c6e9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->