### PR TITLE
Disable showNewAddressBarPickerScreen for nativeInputField rollout on Android

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -556,7 +556,7 @@
                     }
                 },
                 "showNewAddressBarPickerScreen": {
-                    "state": "enabled",
+                    "state": "disabled",
                     "minSupportedVersion": 52840000
                 }
             }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**Asana Task/Github Issue:**

## Description

Rebased on latest `main` and disabled `showNewAddressBarPickerScreen` under `aiChat` on Android to avoid conflicting with the `nativeInputField` rollout (still enabled at 25%).

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [x] This feature was covered by a tech design.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8d299aee-a82f-4195-ad0b-e6ab56abaa2f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8d299aee-a82f-4195-ad0b-e6ab56abaa2f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

