### PR TITLE
Disable native input chat tab item plugins on Android

### DIFF
--- a/features/plugin-point-native-input-chat-tab-item-plugin.json
+++ b/features/plugin-point-native-input-chat-tab-item-plugin.json
@@ -1,0 +1,7 @@
+{
+    "_meta": {
+        "description": "Plugin Point: Native Input Chat Tab Item"
+    },
+    "state": "disabled",
+    "exceptions": []
+}

--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -3560,6 +3560,14 @@
                 }
             }
         },
+        "pluginPointNativeInputChatTabItemPlugin": {
+            "state": "disabled",
+            "features": {
+                "pluginExampleMessageCardPlugin": {
+                    "state": "disabled"
+                }
+            }
+        },
         "pluginPointNewTabPageSectionPlugin": {
             "state": "enabled",
             "features": {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1174433894299346/task/1215993064798629?focus=true

## Description

Disable `pluginPointNativeInputChatTabItemPlugin` and its sub-feature `pluginExampleMessageCardPlugin` on Android, using the same structure as `pluginPointNewTabPagePlugin` / `pluginNewTabLegacyPage`.

Adds the base feature file `plugin-point-native-input-chat-tab-item-plugin.json` (disabled by default) and an Android override with both plugin point and sub-feature set to `disabled`.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [x] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [x] This feature was covered by a tech design.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8d299aee-a82f-4195-ad0b-e6ab56abaa2f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8d299aee-a82f-4195-ad0b-e6ab56abaa2f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

