### PR TITLE
iOS: Roll out iOS unifiedToggleInput at 5% (min version 7.226.0)

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -344,9 +344,16 @@
                     "minSupportedVersion": "7.201.0"
                 },
                 "unifiedToggleInput": {
-                    "state": "internal",
+                    "state": "enabled",
                     "description": "Unified Toggle Input (UTI) for Duck.ai",
-                    "minSupportedVersion": "7.223.0"
+                    "minSupportedVersion": "7.226.0",
+                    "rollout": {
+                        "steps": [
+                            {
+                                "percent": 5
+                            }
+                        ]
+                    }
                 },
                 "aiChatAtb": {
                     "state": "enabled",


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/task/1215392695162650

## Description
Enable the unifiedToggleInput sub-feature for a public rollout: flip state from internal to enabled, bump minSupportedVersion to 7.226.0, and add a single 5% rollout step.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only change with a conservative 5% rollout and version gate; no application code in this PR.
> 
> **Overview**
> Starts a **public rollout** of the Duck.ai **Unified Toggle Input (UTI)** sub-feature on iOS by updating `overrides/ios-override.json` under `aiChat.unifiedToggleInput`.
> 
> **State** moves from `internal` to `enabled`. **Minimum app version** rises from `7.223.0` to `7.226.0`. A **rollout** block is added with a single **5%** step so only a small slice of eligible clients get the new input behavior at first.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec8e963f5bb98062a4d1e41e60cb7acd73beaa9a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->