### PR TITLE
Get incident crash reports for OOM in Preview

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -5073,9 +5073,11 @@
                     "state": "enabled"
                 },
                 "sendIncidentCrashReports": {
-                    "state": "disabled",
+                    "state": "preview",
                     "settings": {
-                        "ExceptionTypes": []
+                        "ExceptionTypes": [
+                            "System.OutOfMemoryException"
+                        ]
                     }
                 }
             }


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1213202687018001/task/1215492556220356?focus=true

## Description
Privacy Triage : https://app.asana.com/1/137249556945/project/69071770703008/task/1215994819927186?focus=true


### Feature change process:

- [x] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [x] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [x] This feature was covered by a tech design.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Turns on client crash/incident telemetry for OOM in preview; scope is narrow but still involves sending diagnostic data after privacy triage.
> 
> **Overview**
> For **Windows**, the `extendedCrashReporting` sub-feature **`sendIncidentCrashReports`** is turned from **disabled** to **preview**, so incident crash reporting can run for a limited audience before full rollout.
> 
> The **`ExceptionTypes`** allowlist is updated from empty to **`System.OutOfMemoryException`**, so only out-of-memory incidents are eligible for those reports—not all crash types.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4862d998cfdac7b694632b411cb4a5987255974d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->