### PR TITLE
Add bookmarks_action_day Windows eventHub telemetry

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -5524,6 +5524,52 @@
                                 "dataKey": "loginState"
                             }
                         }
+                    },
+                    "bookmarks_action_day": {
+                        "state": "enabled",
+                        "trigger": {
+                            "period": {
+                                "days": 1
+                            }
+                        },
+                        "parameters": {
+                            "create": {
+                                "template": "counter",
+                                "source": "bookmarkCreate",
+                                "buckets": {
+                                    "0": { "gte": 0, "lt": 1 },
+                                    "1-2": { "gte": 1, "lt": 3 },
+                                    "3+": { "gte": 3 }
+                                }
+                            },
+                            "edit": {
+                                "template": "counter",
+                                "source": "bookmarkEdit",
+                                "buckets": {
+                                    "0": { "gte": 0, "lt": 1 },
+                                    "1-2": { "gte": 1, "lt": 3 },
+                                    "3+": { "gte": 3 }
+                                }
+                            },
+                            "delete": {
+                                "template": "counter",
+                                "source": "bookmarkDelete",
+                                "buckets": {
+                                    "0": { "gte": 0, "lt": 1 },
+                                    "1-2": { "gte": 1, "lt": 3 },
+                                    "3+": { "gte": 3 }
+                                }
+                            },
+                            "manageOpen": {
+                                "template": "counter",
+                                "source": "bookmarkManageOpen",
+                                "buckets": {
+                                    "0": { "gte": 0, "lt": 1 },
+                                    "1-2": { "gte": 1, "lt": 3 },
+                                    "3+": { "gte": 3 }
+                                }
+                            }
+                        }
                     }
                 }
             }


### PR DESCRIPTION
**Asana Task/Github Issue:**

## Description

Adds the `bookmarks_action_day` EventHub telemetry entry to the Windows override (`overrides/windows-override.json`, under `eventHub.settings.telemetry`). It's a daily period pixel reporting privacy-safe bucketed counts of bookmark actions — `create`, `edit`, `delete`, `manageOpen` — sourced from the Windows client's EventHub bookmark wiring (sources `bookmarkCreate` / `bookmarkEdit` / `bookmarkDelete` / `bookmarkManageOpen`). Buckets are `0` / `1-2` / `3+` (matching the `bookmarks_action_day_windows` pixel definition); `state: enabled`, `period: 1 day`. The `0` bucket is included so the pixel also fires on zero-activity days (DAU denominator).

Pairs with the Windows client wiring in duckduckgo/windows-browser#8054. Reuses the existing eventHub `counter` template — no new schema needed.

**Validation:**
- `node index.js` (build) succeeds; the entry generates into `generated/v3,v4,v5/windows-config.json` (period `days: 1` → `seconds: 86400` per the standard Windows period collapse).
- `npm run unit-tests` (mocha): **1089 passing / 0 failing**, including the eventHub check that fireEvent sources have a corresponding parameter source on `windows-config.json`.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change. <!-- reuses the existing eventHub counter template/schema; no new schema -->
- [ ] I have tested this change locally in all supported browsers. <!-- Windows-only entry; validated via build + unit tests above -->
- [ ] This code for the config change is ready to merge. <!-- draft: pending client rollout + pixel/privacy sign-off -->
- [ ] This feature was covered by a tech design.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only telemetry addition with bucketed counts; no auth, data handling, or runtime logic changes in this repo.
> 
> **Overview**
> Adds **`bookmarks_action_day`** under Windows **`eventHub.settings.telemetry`**, enabled with a **1-day** period trigger.
> 
> The pixel reports privacy-safe **counter** buckets (`0`, `1-2`, `3+`) for **`create`**, **`edit`**, **`delete`**, and **`manageOpen`**, wired to EventHub sources `bookmarkCreate`, `bookmarkEdit`, `bookmarkDelete`, and `bookmarkManageOpen`. The **`0`** bucket ensures the pixel fires on zero-activity days for DAU-style denominators. Uses the existing eventHub **`counter`** template only—no schema changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2332cf42f996093b80fa58b86fbf837a386876ee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->