### PR TITLE
Internal rollout for webview pixels

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -4617,7 +4617,8 @@
                     }
                 },
                 "pixelReporting": {
-                    "state": "disabled"
+                    "state": "internal",
+                    "minSupportedVersion": "0.163.0"
                 },
                 "useSingleWebViewEnvironment": {
                     "state": "enabled",

--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -4616,6 +4616,9 @@
                         "useStartupTimeoutInstead": "disabled"
                     }
                 },
+                "pixelReporting": {
+                    "state": "disabled"
+                },
                 "useSingleWebViewEnvironment": {
                     "state": "enabled",
                     "minSupportedVersion": "0.155.0"


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/1212608041264997/task/1216017028679537?focus=true

## Description
Adding `webview.pixelReporting` sub-feature to enable rolling out WebView health monitoring.
Starting with internal release only.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only addition gated to internal users and a minimum app version; no production user-facing behavior change yet.
> 
> **Overview**
> Adds a new **`webview.pixelReporting`** sub-feature on the Windows privacy configuration so the browser can roll out **WebView health monitoring pixels** via remote config.
> 
> The flag is set to **`internal`** with **`minSupportedVersion` `0.163.0`**, limiting it to internal builds until a broader rollout is configured.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4765e6493fd16dd3ccd507373177a83fd513b78a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->