### PR TITLE
iOS+macOS: Enable sync `canShowV2ConnectCode`

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -1872,7 +1872,7 @@
                     "minSupportedVersion": "7.225.0"
                 },
                 "canShowV2ConnectCode": {
-                    "state": "internal",
+                    "state": "enabled",
                     "minSupportedVersion": "7.225.0"
                 }
             }

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -1658,7 +1658,7 @@
                     "minSupportedVersion": "1.195.0"
                 },
                 "canShowV2ConnectCode": {
-                    "state": "internal",
+                    "state": "enabled",
                     "minSupportedVersion": "1.195.0"
                 }
             }


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/72649045549333/task/1214719720396797?focus=true

## Description
Enables the canShowV2ConnectCode sync flag starting from iOS 7.225.0 / macOS 1.195.0. To be merged in tandem with all platforms


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Turns on user-visible sync V2 connect-code UI for production clients on Apple platforms; impact depends on coordinated releases and app-side handling of the flag.
> 
> **Overview**
> Promotes the **`canShowV2ConnectCode`** sync sub-feature from **`internal`** to **`enabled`** in **`ios-override.json`** and **`macos-override.json`**, so eligible app builds can show the V2 sync connect code in the setup flow.
> 
> **`minSupportedVersion`** is unchanged (**7.225.0** on iOS, **1.195.0** on macOS), aligned with **`canUseV2ConnectFlow`** and **`scopedAccessCredentials`**. The PR description notes this should ship together with the same flag flip on other platforms.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit beabe84d33dc8c25b179e8b2731067c4993a2a16. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->