### PR TITLE
Re-enable CPM heuristic mode on Windows and Android.

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -658,7 +658,8 @@
                     }
                 },
                 "heuristicAction": {
-                    "state": "disabled"
+                    "state": "enabled",
+                    "minSupportedVersion": 52841000
                 }
             }
         },

--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -2088,7 +2088,8 @@
                     "state": "disabled"
                 },
                 "heuristicAction": {
-                    "state": "disabled"
+                    "state": "enabled",
+                    "minSupportedVersion": "0.163.0"
                 }
             },
             "exceptions": [


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/38424471409662/task/1215907159961590?focus=true

## Description
Re-enabled CPM heuristic mode on Windows and Android. This was disabled due to a performance regression. This is now fixed in Windows 0.163.0 and Android 5.284.1.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Re-enabling page-level heuristic consent behavior can affect performance and site compatibility on eligible clients, though version floors limit exposure to fixed builds.
> 
> **Overview**
> Re-enables **autoconsent** `heuristicAction` (CPM heuristic cookie-popup handling) on **Android** and **Windows**, where it had been turned off after a performance regression.
> 
> Each platform now gates the feature with **`minSupportedVersion`**: Android `52841000` (5.284.1+) and Windows `"0.163.0"`, so only builds with the fix receive heuristic mode again. iOS/macOS overrides are unchanged in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 19946f0e517fba7af0169b7618fd22eb7cc0c2c1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->