### PR TITLE
Enable duckAiOnboarding feature for Android

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -3513,6 +3513,15 @@
                     "state": "enabled",
                     "minSupportedVersion": 52750000
                 },
+                "duckAiOnboarding": {
+                    "state": "enabled",
+                    "minSupportedVersion": 52850000,
+                    "targets": [
+                        {
+                            "localeLanguage": "en"
+                        }
+                    ]
+                },
                 "onboardingDuckAiExperimentMay26": {
                     "state": "enabled",
                     "minSupportedVersion": 52790000,


### PR DESCRIPTION
## Summary
- Enables the `duckAiOnboarding` sub-feature under `aiChat` for Android
- Min supported version: 5.285.0 (`52850000`)
- Targeted to English-only users (`localeLanguage: "en"`)

## Asana task
https://app.asana.com/1/137249556945/project/1205648422731273/task/1216032811593477

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single remote-config flag addition with version and locale gating; no app code or security-sensitive logic changes in this diff.
> 
> **Overview**
> Turns on the **`duckAiOnboarding`** sub-feature under **`extendedOnboarding`** in `android-override.json` so eligible Android clients can show Duck.ai onboarding.
> 
> The new block sets **`state`** to **enabled**, requires app version **≥ 5.285.0** (`52850000`), and limits delivery to **`localeLanguage: "en"`** via **`targets`**. It sits alongside existing onboarding flags such as **`subscriptionPromoModalCta`** and the separate **`onboardingDuckAiExperimentMay26`** cohort experiment.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b5129e61ab6cdc775598337dc17bc5ba635e15c5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->