### PR TITLE
Enable canShowV2ConnectCode on Android

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -2591,7 +2591,7 @@
                 "syncAutoRecoveryCapabilityDetectionRead": {
                     "state": "disabled"
                 },
-                "canShowV2ConnectCode" : {
+                "canShowV2ConnectCode": {
                     "state": "enabled"
                 }
             }

--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -2590,6 +2590,9 @@
                 },
                 "syncAutoRecoveryCapabilityDetectionRead": {
                     "state": "disabled"
+                },
+                "canShowV2ConnectCode" : {
+                    "state": "enabled"
                 }
             }
         },


### PR DESCRIPTION
**Asana Task/Github Issue:**

## Description
Enable canShowV2ConnectCode on Android

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Remote feature-flag-only change in Android overrides; no application logic in this repo, with limited blast radius to sync connect-code UI gating.
> 
> **Overview**
> Turns on the **`canShowV2ConnectCode`** feature under Android’s **`sync.features`** in `android-override.json`, setting **`state`** to **`enabled`**.
> 
> This aligns Android with other platforms that already define the same flag (often still **`internal`** elsewhere) and should allow the app to show the **V2 connect code** path in sync setup when it reads this remote config.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 26f44a67ea6edc0d469ddf13b47917b73c998888. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->