### PR TITLE
Enable removeRedirectionBitmapAllWinVersions for >=0.164.0

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -4625,6 +4625,10 @@
                 "useSingleWebViewEnvironment": {
                     "state": "enabled",
                     "minSupportedVersion": "0.155.0"
+                },
+                "removeRedirectionBitmapAllWinVersions": {
+                    "state": "preview",
+                    "minSupportedVersion": "0.164.0"
                 }
             },
             "exceptions": []


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/72649045549333/task/1216005562662978?focus=true

## Description
Related to this project https://app.asana.com/1/137249556945/project/72649045549333/task/1213509468242868?focus=true

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [x] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Preview webview rendering changes can affect tab/window behavior or visual glitches across Windows versions; scope is limited by preview state and a minimum app version.
> 
> **Overview**
> Turns on a new **Windows webview** remote-config flag, **`removeRedirectionBitmapAllWinVersions`**, for DuckDuckGo Browser builds **0.164.0 and newer**.
> 
> The flag is set to **`preview`** (not full rollout) and is added as a sibling feature under **`webview.features`**, next to existing toggles like **`useSingleWebViewEnvironment`**. Clients that read this config can start applying redirection-bitmap removal across Windows versions for preview-channel users only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 164a51146fb4b10d762637b53a216be11f9c096f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->