### PR TITLE
Remove unused willSoonDropBigSurSupport flag override from macOS config

### DIFF
--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -2261,9 +2261,6 @@
         "macOSBrowserConfig": {
             "state": "enabled",
             "features": {
-                "willSoonDropBigSurSupport": {
-                    "state": "enabled"
-                },
                 "hangReporting": {
                     "state": "disabled"
                 },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1203108348835387/task/1215118634345544?focus=true

## Description

Removes the `willSoonDropBigSurSupport` feature from `macOSBrowserConfig`. The macOS app no longer reads this flag — the upcoming-OS-drop messaging was repurposed to the `osSupportWarning` flag, leaving this entry dead in config.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [x] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config cleanup only; removes an unused flag with no runtime behavior change for clients that already ignore it.
> 
> **Overview**
> Removes the unused **`willSoonDropBigSurSupport`** feature entry from **`macOSBrowserConfig`** in `overrides/macos-override.json`. The macOS client no longer consumes this flag; upcoming OS drop messaging is handled via **`osSupportWarning`**, so this override was dead config only.
> 
> No other macOS browser feature toggles in that block are changed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ba6e3abe9ce8adb2401e0052504f65c921a1b1c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->