### PR TITLE
Disable canUseV2ConnectFlow on Android

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -2591,8 +2591,11 @@
                 "syncAutoRecoveryCapabilityDetectionRead": {
                     "state": "disabled"
                 },
+                "canUseV2ConnectFlow": {
+                    "state": "disabled"
+                },
                 "canShowV2ConnectCode": {
-                    "state": "enabled"
+                    "state": "disabled"
                 }
             }
         },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/608920331025315/task/1216050350146841?focus=true

## Description
<!-- 
  Please delete either or both process sections below.
-->

Disabling `canUseV2ConnectFlow` while we work through https://app.asana.com/1/137249556945/project/608920331025315/task/1216036261509973?focus=true

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only Android feature toggles; reverts/exposes users to prior sync connect UX without changing server auth logic in this repo.
> 
> **Overview**
> Turns off Android remote-config flags for the sync **V2 connect** experience in `overrides/android-override.json`.
> 
> **`canUseV2ConnectFlow`** is added under `sync.features` with **`state: "disabled"`**, so clients should not use the V2 connect flow on Android. **`canShowV2ConnectCode`** is changed from **`enabled`** to **`disabled`**, hiding V2 connect codes as well. Other platforms’ overrides are unchanged; this is a temporary Android kill switch while related work is in progress.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 41964e0d963eda9affc1169ec4c1e80a89732ae4. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->