### PR TITLE
Re-enable canUseV2ConnectFlow on Android

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -2592,10 +2592,10 @@
                     "state": "disabled"
                 },
                 "canUseV2ConnectFlow": {
-                    "state": "disabled"
+                    "state": "enabled"
                 },
                 "canShowV2ConnectCode": {
-                    "state": "disabled"
+                    "state": "enabled"
                 }
             }
         },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/608920331025315/task/1216050350146843?focus=true

## Description
<!-- 
  Please delete either or both process sections below.
-->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes sync pairing UX for all eligible Android builds via remote config; regression risk is limited to connect/setup flows, not broad app behavior.
> 
> **Overview**
> Turns **sync V2 device pairing** back on for Android by flipping two remote-config flags under `sync.features` in `android-override.json` from **disabled** to **enabled**: `canUseV2ConnectFlow` and `canShowV2ConnectCode`.
> 
> Android clients that already support the parent `sync` feature can again use the V2 connect UX and show the V2 connect code, aligning with iOS/macOS/Windows overrides where these flags are already enabled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit abe198e370937201dbb9736d386c0b956c65852e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->