### PR TITLE
[iOS] Enable rich duck.ai tab cells for internal users

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -208,6 +208,10 @@
                     "state": "enabled",
                     "minSupportedVersion": "7.155.0"
                 },
+                "tabSwitcherRichCard": {
+                    "state": "internal",
+                    "minSupportedVersion": "7.227.0"
+                },
                 "addressBarShortcut": {
                     "state": "enabled",
                     "minSupportedVersion": "7.155.0"


### PR DESCRIPTION
**Asana Task/Github Issue: https://app.asana.com/1/137249556945/project/1211767540372501/task/1216018671927671?focus=true**

## Description
Enables the feature flag for rich duck.ai tab cells for internal users.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single JSON override with internal-only scope; no auth, data, or broad rollout.
> 
> **Overview**
> Adds a new **`aiChat`** sub-feature **`tabSwitcherRichCard`** in **`overrides/ios-override.json`**, gated with **`state: "internal"`** and **`minSupportedVersion: "7.227.0"`**.
> 
> This turns on rich Duck.ai tab switcher cells for internal iOS builds only; general users are unchanged until the flag is moved out of internal.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a0504329f306a1b7ea972ced7405ece57f021d26. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->