### PR TITLE
Add serp message bridge

### DIFF
--- a/features/message-bridge.json
+++ b/features/message-bridge.json
@@ -7,6 +7,7 @@
         "aiChat": "disabled",
         "subscriptions": "disabled",
         "serpSettings": "disabled",
+        "serp": "disabled",
         "domains": []
     }
 }

--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -2264,6 +2264,7 @@
                 "aiChat": "disabled",
                 "subscriptions": "disabled",
                 "serpSettings": "disabled",
+                "serp": "disabled",
                 "duckAiNativeStorage": "disabled",
                 "domains": [
                     {
@@ -2286,6 +2287,11 @@
                             {
                                 "op": "replace",
                                 "path": "/serpSettings",
+                                "value": "enabled"
+                            },
+                            {
+                                "op": "replace",
+                                "path": "/serp",
                                 "value": "enabled"
                             },
                             {

--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -135,6 +135,7 @@
                 "aiChat": "disabled",
                 "subscriptions": "disabled",
                 "serpSettings": "disabled",
+                "serp": "disabled",
                 "duckAiNativeStorage": "disabled",
                 "domains": [
                     {

--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -162,6 +162,11 @@
                             },
                             {
                                 "op": "replace",
+                                "path": "/serp",
+                                "value": "enabled"
+                            },
+                            {
+                                "op": "replace",
                                 "path": "/duckAiNativeStorage",
                                 "value": "enabled"
                             }

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -245,6 +245,7 @@
                 "aiChat": "disabled",
                 "subscriptions": "disabled",
                 "serpSettings": "disabled",
+                "serp": "disabled",
                 "duckAiNativeStorage": "disabled",
                 "domains": [
                     {
@@ -267,6 +268,11 @@
                             {
                                 "op": "replace",
                                 "path": "/serpSettings",
+                                "value": "enabled"
+                            },
+                            {
+                                "op": "replace",
+                                "path": "/serp",
                                 "value": "enabled"
                             },
                             {

--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -2258,6 +2258,7 @@
                 "subscriptions": "disabled",
                 "subscriptionPages": "disabled",
                 "serpSettings": "disabled",
+                "serp": "disabled",
                 "duckAiNativeStorage": "disabled",
                 "domains": [
                     {
@@ -2285,6 +2286,11 @@
                             {
                                 "op": "replace",
                                 "path": "/serpSettings",
+                                "value": "enabled"
+                            },
+                            {
+                                "op": "replace",
+                                "path": "/serp",
                                 "value": "enabled"
                             },
                             {

--- a/schema/features/message-bridge.ts
+++ b/schema/features/message-bridge.ts
@@ -5,6 +5,7 @@ export type MessageBridgeSettings = CSSInjectFeatureSettings<{
     subscriptions?: FeatureState;
     subscriptionPages?: FeatureState;
     serpSettings?: FeatureState;
+    serp?: FeatureState;
     duckAiNativeStorage?: FeatureState;
 }>;
 


### PR DESCRIPTION


**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/task/1215859134164544

## Description
Adds a new `serp` setting to the messageBridge feature, following the same pattern as the existing serpSettings bridge.

- Enabled for DDG domains on macOS, Windows, iOS and Android
- Disabled by default in base config.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only change scoped to messageBridge flags on first-party domains; no auth or third-party surface expansion.
> 
> **Overview**
> Introduces a new **`serp`** toggle on the **messageBridge** feature so SERP pages can use native↔web messaging separately from **`serpSettings`**.
> 
> The base **`features/message-bridge.json`** default is **`disabled`**. Platform overrides (Android, iOS, macOS, Windows) add **`serp`: `disabled`** in default bridge settings and a domain patch that sets **`/serp`** to **`enabled`** for `duckduckgo.com`, `duck.co`, and `duck.ai`, matching the existing **`serpSettings`** pattern. **`schema/features/message-bridge.ts`** adds optional **`serp?: FeatureState`** to **`MessageBridgeSettings`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0bc891762bd90e931a382224d0e605d4122c6cd6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->