### PR TITLE
Enable TDS 202606v1 at 25%

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -219,6 +219,31 @@
                             "weight": 1
                         }
                     ]
+                },
+                "tdsNextExperiment010": {
+                    "state": "enabled",
+                    "minSupportedVersion": 52361000,
+                    "rollout": {
+                        "steps": [
+                            {
+                                "percent": 25
+                            }
+                        ]
+                    },
+                    "settings": {
+                        "controlUrl": "v5/experiments/202606v1-android-tds-control.json",
+                        "treatmentUrl": "v5/experiments/202606v1-android-tds-treatment.json"
+                    },
+                    "cohorts": [
+                        {
+                            "name": "control",
+                            "weight": 1
+                        },
+                        {
+                            "name": "treatment",
+                            "weight": 1
+                        }
+                    ]
                 }
             }
         },

--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -628,6 +628,30 @@
                             "weight": 1
                         }
                     ]
+                },
+                "tdsNextExperiment010": {
+                    "state": "enabled",
+                    "rollout": {
+                        "steps": [
+                            {
+                                "percent": 25
+                            }
+                        ]
+                    },
+                    "settings": {
+                        "controlUrl": "v5/experiments/202606v1-ios-tds-control.json",
+                        "treatmentUrl": "v5/experiments/202606v1-ios-tds-treatment.json"
+                    },
+                    "cohorts": [
+                        {
+                            "name": "control",
+                            "weight": 1
+                        },
+                        {
+                            "name": "treatment",
+                            "weight": 1
+                        }
+                    ]
                 }
             }
         },

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -614,6 +614,30 @@
                             "weight": 1
                         }
                     ]
+                },
+                "tdsNextExperiment010": {
+                    "state": "enabled",
+                    "rollout": {
+                        "steps": [
+                            {
+                                "percent": 25
+                            }
+                        ]
+                    },
+                    "settings": {
+                        "controlUrl": "v6/experiments/202606v1-macos-tds-control.json",
+                        "treatmentUrl": "v6/experiments/202606v1-macos-tds-treatment.json"
+                    },
+                    "cohorts": [
+                        {
+                            "name": "control",
+                            "weight": 1
+                        },
+                        {
+                            "name": "treatment",
+                            "weight": 1
+                        }
+                    ]
                 }
             }
         },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1200342317600122/task/1215509678058920?focus=true

Enables the 202606v1 TDS blocklist experiment at 25% 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> A 25% rollout changes which TDS blocklist some users get, which can affect site breakage and blocking behavior on three platforms.
> 
> **Overview**
> Turns on **`tdsNextExperiment010`** under **`blockList`** in the Android, iOS, and macOS privacy overrides so clients can run the **202606v1** TDS blocklist A/B test at **25%** rollout with equal **control** / **treatment** cohorts.
> 
> Each platform points cohorts at platform-specific experiment JSON (`202606v1-*-tds-control.json` / `treatment.json`; macOS uses the `v6/experiments/` path). Android also sets **`minSupportedVersion`: 52361000**, matching nearby TDS next experiments.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4dd72cb3f842102c68c230a593b41332b1451b6c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->