### PR TITLE
Enable DBP opt-out retry error flag

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -2802,6 +2802,10 @@
                 },
                 "webViewUserAgent": {
                     "state": "disabled"
+                },
+                "optOutRetryError96Hours": {
+                    "state": "enabled",
+                    "minSupportedVersion": "7.226.0"
                 }
             },
             "minSupportedVersion": "7.201.1"

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -524,6 +524,10 @@
                 "webViewUserAgent": {
                     "state": "disabled",
                     "minSupportedVersion": "1.182.0"
+                },
+                "optOutRetryError96Hours": {
+                    "state": "enabled",
+                    "minSupportedVersion": "1.196.0"
                 }
             },
             "minSupportedVersion": "1.70.0"


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/492600419927320/task/1212843034975366?focus=true

## Description
<!-- 
  Please delete either or both process sections below.
—>

Adds `optOutRetryError96Hours` feature flags for macOS and iOS experiment. 

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Config-only change, but it gates DBP opt-out retry behavior for paying users; wrong version floors or premature enablement could affect removal job retries in production.
> 
> **Overview**
> Turns on the **`optOutRetryError96Hours`** sub-feature under **`dbp`** in the iOS and macOS privacy override configs so eligible app builds can use the new opt-out retry-on-error behavior (96-hour window) as part of a DBP experiment.
> 
> On **iOS**, the flag is **`enabled`** with **`minSupportedVersion`** **`7.226.0`**, added alongside existing **`dbp.features`** entries (e.g. after **`webViewUserAgent`**). On **macOS**, it is also **`enabled`** with floor **`1.196.0`** in the same **`dbp.features`** block. No other platforms or settings are changed in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc3f0a1a2b51e63aec4a4ff0705ee684bf99a3e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->