### PR TITLE
Add 'theglobeandmail.com' to queryly.com exception

### DIFF
--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -3632,11 +3632,13 @@
                         "rule": "api.queryly.com/v4/search.aspx",
                         "domains": [
                             "fastcompany.com",
-                            "ctvnews.ca"
+                            "ctvnews.ca",
+                            "theglobeandmail.com"
                         ],
                         "reason": [
                             "fastcompany.com - https://github.com/duckduckgo/privacy-configuration/pull/3894",
-                            "ctvnews.ca - https://github.com/duckduckgo/privacy-configuration/pull/4713"
+                            "ctvnews.ca - https://github.com/duckduckgo/privacy-configuration/pull/4713",
+                            "theglobeandmail.com - https://github.com/duckduckgo/privacy-configuration/pull/5430"
                         ]
                     }
                 ]


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/1200277586140538/task/1216049849313606?focus=true

## Description
### Site breakage mitigation process:
#### Brief explanation
- Reported URL: https://www.theglobeandmail.com/
- Problems experienced: Search button not working because of blocked Queryly API (false positive in Tracker Radar).
- Platforms affected:
  - [x] iOS
  - [x] Android
  - [x] Windows
  - [x] MacOS
  - [x] Extensions
- Tracker(s) being unblocked: queryly.com
- Feature being disabled/modified: N/A
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-domain, path-scoped allowlist entry following an established breakage pattern; no auth or core product logic changes.
> 
> **Overview**
> Adds **theglobeandmail.com** to the existing tracker allowlist for `api.queryly.com/v4/search.aspx`, alongside `fastcompany.com` and `ctvnews.ca`.
> 
> This unblocks Queryly’s search API on that site so site search works again after Tracker Radar had blocked it as a false positive.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 564e4d2902ec11fccc7faae7852d4f7b1c01ba60. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->