### PR TITLE
Update queryly allowlist entry to include <all> domain

### DIFF
--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -3631,14 +3631,10 @@
                     {
                         "rule": "api.queryly.com/v4/search.aspx",
                         "domains": [
-                            "fastcompany.com",
-                            "ctvnews.ca",
-                            "theglobeandmail.com"
+                            "<all>"
                         ],
                         "reason": [
-                            "fastcompany.com - https://github.com/duckduckgo/privacy-configuration/pull/3894",
-                            "ctvnews.ca - https://github.com/duckduckgo/privacy-configuration/pull/4713",
-                            "theglobeandmail.com - https://github.com/duckduckgo/privacy-configuration/pull/5430"
+                            "https://github.com/duckduckgo/privacy-configuration/pull/5431"
                         ]
                     }
                 ]


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/1202630464207380/task/1216049849313606?focus=true

## Description
### Feature change process:
### Site breakage mitigation process:
#### Brief explanation
- Reported URL: https://www.theglobeandmail.com/
- Problems experienced: Search not working (a false positive mitigated in #5430) but likely to be on other sites too, therefore broadening the exception to all domains.
- Platforms affected:
  - [x] iOS
  - [x] Android
  - [x] Windows
  - [x] MacOS
  - [x] Extensions
- Tracker(s) being unblocked: queryly.com
- Feature being disabled/modified: N/A
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> A global allowlist exception lets Queryly’s search endpoint load on every site for that URL pattern, which slightly weakens tracker blocking but is limited to one search API path.
> 
> **Overview**
> Broadens the **queryly.com** tracker allowlist so `api.queryly.com/v4/search.aspx` applies to **`<all>`** domains instead of only `fastcompany.com`, `ctvnews.ca`, and `theglobeandmail.com`.
> 
> This change stops blocking Queryly’s search API site-wide so on-site search keeps working where tracker blocking was a false positive (e.g. theglobeandmail.com), without adding per-domain entries for every publisher that uses Queryly. The `reason` field is consolidated to PR #5431.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 64983107666fe96be06adca9a220723ff184aaf3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->