### PR TITLE
Add aiChat nativeStorageMigrationLockedLaunchFix subfeature at 5% rollout

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -273,6 +273,17 @@
                         ]
                     }
                 },
+                "nativeStorageMigrationLockedLaunchFix": {
+                    "state": "enabled",
+                    "minSupportedVersion": "7.226.0",
+                    "rollout": {
+                        "steps": [
+                            {
+                                "percent": 5
+                            }
+                        ]
+                    }
+                },
                 "showAIChatAddressBarChoiceScreen": {
                     "state": "enabled",
                     "minSupportedVersion": "7.220.0",


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/task/1215937363091651?focus=true

## Description
Add aiChat nativeStorageMigrationLockedLaunchFix subfeature at 5% rollout

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only iOS feature flag at 5% rollout; behavior lives in the app, not in this repo.
> 
> **Overview**
> Adds a new **`aiChat`** subfeature **`nativeStorageMigrationLockedLaunchFix`** in **`overrides/ios-override.json`**, enabled for iOS **7.226.0+** with a **5%** rollout step. It sits alongside existing Duck.ai native storage flags (e.g. **`nativeStoragePathMigration`**) and turns on client-side behavior for a migration/locked-launch fix via remote config only—no other platforms or files in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4209a84516164a8f6f30fc912d2bfa9edd23a1a2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->