### PR TITLE
Add EventHub baseline pixels

### DIFF
--- a/features/event-hub.json
+++ b/features/event-hub.json
@@ -6,6 +6,40 @@
     "exceptions": [],
     "settings": {
         "telemetry": {
+            "eventHub_baseline_day": {
+                "state": "enabled",
+                "trigger": {
+                    "period": {
+                        "days": 1
+                    }
+                },
+                "parameters": {
+                    "baseline": {
+                        "template": "counter",
+                        "source": "baseline",
+                        "buckets": {
+                            "0+": { "gte": 0 }
+                        }
+                    }
+                }
+            },
+            "eventHub_baseline_week": {
+                "state": "enabled",
+                "trigger": {
+                    "period": {
+                        "days": 7
+                    }
+                },
+                "parameters": {
+                    "baseline": {
+                        "template": "counter",
+                        "source": "baseline",
+                        "buckets": {
+                            "0+": { "gte": 0 }
+                        }
+                    }
+                }
+            },
             "webTelemetry_adwalls_day": {
                 "state": "enabled",
                 "trigger": {

--- a/tests/config-tests.js
+++ b/tests/config-tests.js
@@ -429,9 +429,15 @@ describe('EventHub validation tests', () => {
                         if (!name.startsWith(BASELINE_NAME_PREFIX)) continue;
                         const param = (entry.parameters || {}).baseline;
                         expect(param, `Baseline pixel '${name}' must declare a 'baseline' parameter`).to.be.an('object');
-                        expect(param.template).to.equal('counter', `Baseline pixel '${name}' baseline parameter must use the 'counter' template`);
+                        expect(param.template).to.equal(
+                            'counter',
+                            `Baseline pixel '${name}' baseline parameter must use the 'counter' template`,
+                        );
                         expect(param.source).to.equal('baseline', `Baseline pixel '${name}' baseline parameter source must be 'baseline'`);
-                        expect(param.buckets).to.deep.equal({ '0+': { gte: 0 } }, `Baseline pixel '${name}' baseline parameter buckets must be exactly 0+`);
+                        expect(param.buckets).to.deep.equal(
+                            { '0+': { gte: 0 } },
+                            `Baseline pixel '${name}' baseline parameter buckets must be exactly 0+`,
+                        );
                     }
                 });
             });

--- a/tests/config-tests.js
+++ b/tests/config-tests.js
@@ -398,6 +398,44 @@ describe('EventHub validation tests', () => {
                 });
             });
 
+            // `eventHub_baseline_*` pixels fire purely on their period to
+            // provide a baseline / denominator: the `baseline` parameter is a
+            // counter sourced from an empty "baseline" stream, so its count
+            // stays at 0 and the single unbounded `0+` bucket always matches.
+            // For now these pixels may carry no other parameters.
+            const BASELINE_NAME_PREFIX = 'eventHub_baseline_';
+            describe('baseline telemetry entries', () => {
+                it('eventHub_baseline_* pixels may only declare the baseline parameter', () => {
+                    for (const [
+                        name,
+                        entry,
+                    ] of Object.entries(telemetry)) {
+                        if (!name.startsWith(BASELINE_NAME_PREFIX)) continue;
+                        const paramNames = Object.keys(entry.parameters || {});
+                        expect(paramNames).to.deep.equal(
+                            [
+                                'baseline',
+                            ],
+                            `Baseline pixel '${name}' may only declare the 'baseline' parameter (no other parameters allowed for now), got: ${paramNames.join(', ')}`,
+                        );
+                    }
+                });
+
+                it('the baseline parameter is a counter sourced from "baseline" (fired even if no detector emits it)', () => {
+                    for (const [
+                        name,
+                        entry,
+                    ] of Object.entries(telemetry)) {
+                        if (!name.startsWith(BASELINE_NAME_PREFIX)) continue;
+                        const param = (entry.parameters || {}).baseline;
+                        expect(param, `Baseline pixel '${name}' must declare a 'baseline' parameter`).to.be.an('object');
+                        expect(param.template).to.equal('counter', `Baseline pixel '${name}' baseline parameter must use the 'counter' template`);
+                        expect(param.source).to.equal('baseline', `Baseline pixel '${name}' baseline parameter source must be 'baseline'`);
+                        expect(param.buckets).to.deep.equal({ '0+': { gte: 0 } }, `Baseline pixel '${name}' baseline parameter buckets must be exactly 0+`);
+                    }
+                });
+            });
+
             for (const [
                 entryName,
                 entry,
@@ -597,6 +635,16 @@ describe('EventHub schema source rules', () => {
         },
     });
 
+    const baselineEntry = (name) => ({
+        telemetry: {
+            [name]: {
+                state: 'enabled',
+                trigger: { period: { seconds: 86400 } },
+                parameters: { baseline: { template: 'counter', source: 'baseline', buckets: { '0+': { gte: 0 } } } },
+            },
+        },
+    });
+
     it('accepts a period data param that specifies a source', () => {
         const settings = periodEntry({ template: 'data', source: 'someStream', dataKey: 'loginState' });
         expect(validate(settings), formatErrors(validate.errors)).to.equal(true);
@@ -609,6 +657,11 @@ describe('EventHub schema source rules', () => {
 
     it('accepts an immediate data param that omits its source', () => {
         const settings = immediateEntry({ template: 'data', dataKey: 'loginState' });
+        expect(validate(settings), formatErrors(validate.errors)).to.equal(true);
+    });
+
+    it('accepts an eventHub_baseline_* pixel whose baseline counter has no matching detector source', () => {
+        const settings = baselineEntry('eventHub_baseline_day');
         expect(validate(settings), formatErrors(validate.errors)).to.equal(true);
     });
 });


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/69071770703008/task/1215500944734455?focus=true

## Description

Adds EventHub baseline pixels.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only telemetry definitions under a disabled feature, with new validation tests; no auth or runtime logic changes in this repo.
> 
> **Overview**
> Adds **Event Hub baseline pixels** `eventHub_baseline_day` and `eventHub_baseline_week` so clients can fire period-based telemetry used as a **denominator / baseline** alongside existing `webTelemetry_*` counters.
> 
> Each pixel is enabled in config with a **1-day or 7-day period trigger** and a single **`baseline` counter** parameter: source `baseline`, template `counter`, and one unbounded **`0+`** bucket (intended to match even when no detector events arrive).
> 
> **Tests** lock in this contract: `eventHub_baseline_*` entries may only declare `baseline` with that exact shape, and the Event Hub settings schema **accepts** a baseline pixel whose counter source has no matching detector stream.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 71f1342343e3b8e4703049da2e6b74ab261303cc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->