### PR TITLE
Disable `canShowV2ConnectCode` across the native platforms

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -2604,7 +2604,7 @@
                     "state": "enabled"
                 },
                 "canShowV2ConnectCode": {
-                    "state": "enabled"
+                    "state": "disabled"
                 }
             }
         },

--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -1882,7 +1882,7 @@
                     "minSupportedVersion": "7.225.0"
                 },
                 "canShowV2ConnectCode": {
-                    "state": "enabled",
+                    "state": "disabled",
                     "minSupportedVersion": "7.225.0"
                 }
             }

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -1664,7 +1664,7 @@
                     "minSupportedVersion": "1.195.0"
                 },
                 "canShowV2ConnectCode": {
-                    "state": "enabled",
+                    "state": "disabled",
                     "minSupportedVersion": "1.195.0"
                 }
             }

--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -3956,7 +3956,7 @@
                     "minSupportedVersion": "0.162.0"
                 },
                 "canShowV2ConnectCode": {
-                    "state": "enabled",
+                    "state": "disabled",
                     "minSupportedVersion": "0.162.0"
                 }
             }


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/608920331025315/task/1216071247923790?focus=true

## Description
<!-- 
  Please delete either or both process sections below.
-->

Temporarily disable native clients showing the new v2 code format to give more rollout time for the v2-capable native apps. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Remote-config-only toggle with no code changes; it may delay v2 connect UI until re-enabled but does not alter auth or sync protocol behavior.
> 
> **Overview**
> Turns off the **`canShowV2ConnectCode`** sync feature flag on **Android, iOS, macOS, and Windows** by setting its `state` from `enabled` to **`disabled`** in each platform override.
> 
> Native clients will stop surfacing the **v2 connect code format** in sync setup while **`canUseV2ConnectFlow`** stays enabled, giving more time for v2-capable app versions to roll out before users see the new codes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f8f69fdb2f4ecf2476acf01bcbc9f7b681f1f7ed. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->