### PR TITLE
Redirect from chasetravel to chase doesn't apply existing UA exception

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -1388,6 +1388,10 @@
                         "reason": "Login issues"
                     },
                     {
+                        "domain": "chasetravel.com",
+                        "reason": "Login issues"
+                    },
+                    {
                         "domain": "www.canva.com",
                         "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1818"
                     },
@@ -1616,6 +1620,10 @@
                 "omitApplicationSites": [
                     {
                         "domain": "chase.com",
+                        "reason": "Login issues"
+                    },
+                    {
+                        "domain": "chasetravel.com",
                         "reason": "Login issues"
                     },
                     {

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -1453,6 +1453,10 @@
                         "reason": "https://github.com/duckduckgo/privacy-configuration/issues/988"
                     },
                     {
+                        "domain": "chasetravel.com",
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/issues/988"
+                    },
+                    {
                         "domain": "web.whatsapp.com",
                         "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1780"
                     },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1204912272578138/task/1215601012086041?focus=true

## Description
Despite our existing UA mitigation on chase.com, it's not applying for users coming from chasetravel.com and being redirected to chase.com. Adding another exception for chasetravel.com appears to solve the issue.