### PR TITLE
Enable `canShowV2ConnectCode` across the native platforms

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -2604,7 +2604,7 @@
                     "state": "enabled"
                 },
                 "canShowV2ConnectCode": {
-                    "state": "disabled"
+                    "state": "enabled"
                 }
             }
         },

--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -1908,7 +1908,7 @@
                     "minSupportedVersion": "7.225.0"
                 },
                 "canShowV2ConnectCode": {
-                    "state": "disabled",
+                    "state": "enabled",
                     "minSupportedVersion": "7.225.0"
                 }
             }

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -1668,7 +1668,7 @@
                     "minSupportedVersion": "1.195.0"
                 },
                 "canShowV2ConnectCode": {
-                    "state": "disabled",
+                    "state": "enabled",
                     "minSupportedVersion": "1.195.0"
                 }
             }

--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -3956,7 +3956,7 @@
                     "minSupportedVersion": "0.162.0"
                 },
                 "canShowV2ConnectCode": {
-                    "state": "disabled",
+                    "state": "enabled",
                     "minSupportedVersion": "0.162.0"
                 }
             }


### PR DESCRIPTION
**Asana Task/Github Issue:**

## Description
<!-- 
  Please delete either or both process sections below.
-->

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Enables user-visible sync pairing UI across all native apps; mis-gating or client bugs could affect device linking, though the change is a single flag flip with version floors unchanged on three platforms.
> 
> **Overview**
> Turns on the **`canShowV2ConnectCode`** sync sub-feature in platform overrides for **Android**, **iOS**, **macOS**, and **Windows**, changing **`state`** from **`disabled`** to **`enabled`**.
> 
> That flag sits next to the already-enabled **`canUseV2ConnectFlow`** under **`sync.features`**, so clients that support the V2 connect flow can now also show the V2 connect code in sync setup. iOS, macOS, and Windows keep their existing **`minSupportedVersion`** gates; Android’s entry has no version field in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0bc8408fab17261209a4635444527ddc228b39ac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->