### PR TITLE
Enable customizeResponses (Android)

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -561,6 +561,10 @@
                 "showNewAddressBarPickerScreen": {
                     "state": "enabled",
                     "minSupportedVersion": 52840000
+                },
+                "customizeResponses": {
+                    "state": "enabled",
+                    "minSupportedVersion": 52860000
                 }
             }
         },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1200204095367872/task/1216107908170249?focus=true

## Description

- Enables customize responses in the native input for 5.286.0

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [x] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single enabled feature flag with a min version; no rollout, exceptions, or app code in this repo.
> 
> **Overview**
> Turns on the **`customizeResponses`** sub-feature under **`aiChat.features`** in `android-override.json`, gated to Android app version **52860000** (5.286.0).
> 
> This remote-config change exposes **customize responses** in the Duck.ai **native input** path for clients that already read nested `aiChat` feature flags (alongside flags like `nativeInputField`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6d1c9521c45d7a009b746f401471da73e36e614f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->