### PR TITLE
Force disable old experiments

### DIFF
--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -4454,24 +4454,6 @@
                     }
                 ]
             },
-            "merequartz.com": {
-                "rules": [
-                    {
-                        "rule": "merequartz.com",
-                        "domains": [
-                            "nbcsports.com",
-                            "pagesix.com",
-                            "weather.com",
-                            "gameskinny.com",
-                            "nj.com"
-                        ],
-                        "reason": [
-                            "nbcsports.com, pagesix.com - https://github.com/duckduckgo/privacy-configuration/pull/5114",
-                            "weather.com, gameskinny.com, nj.com - https://github.com/duckduckgo/privacy-configuration/pull/5197"
-                        ]
-                    }
-                ]
-            },
             "phoneresult.com": {
                 "rules": [
                     {
@@ -4524,17 +4506,6 @@
                             "deadline.com"
                         ],
                         "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5127"
-                    }
-                ]
-            },
-            "fishingtoolsbox.com": {
-                "rules": [
-                    {
-                        "rule": "fishingtoolsbox.com",
-                        "domains": [
-                            "parade.com"
-                        ],
-                        "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5197"
                     }
                 ]
             },

--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -142,83 +142,41 @@
             "state": "enabled",
             "exceptions": [],
             "features": {
+                "tdsNextExperiment001": {
+                    "state": "disabled",
+                    "minSupportedVersion": 52361000
+                },
+                "tdsNextExperiment002": {
+                    "state": "disabled",
+                    "minSupportedVersion": 52361000
+                },
+                "tdsNextExperiment003": {
+                    "state": "disabled",
+                    "minSupportedVersion": 52361000
+                },
+                "tdsNextExperiment004": {
+                    "state": "disabled",
+                    "minSupportedVersion": 52361000
+                },
+                "tdsNextExperiment005": {
+                    "state": "disabled",
+                    "minSupportedVersion": 52361000
+                },
+                "tdsNextExperiment006": {
+                    "state": "disabled",
+                    "minSupportedVersion": 52361000
+                },
                 "tdsNextExperiment007": {
                     "state": "disabled",
-                    "minSupportedVersion": 52361000,
-                    "rollout": {
-                        "steps": [
-                            {
-                                "percent": 25
-                            }
-                        ]
-                    },
-                    "settings": {
-                        "controlUrl": "v5/experiments/202604v1-android-tds-control.json",
-                        "treatmentUrl": "v5/experiments/202604v1-android-tds-treatment.json"
-                    },
-                    "cohorts": [
-                        {
-                            "name": "control",
-                            "weight": 1
-                        },
-                        {
-                            "name": "treatment",
-                            "weight": 1
-                        }
-                    ]
+                    "minSupportedVersion": 52361000
                 },
                 "tdsNextExperiment008": {
                     "state": "disabled",
-                    "minSupportedVersion": 52361000,
-                    "rollout": {
-                        "steps": [
-                            {
-                                "percent": 100
-                            }
-                        ]
-                    },
-                    "settings": {
-                        "controlUrl": "v5/experiments/202604v3-android-tds-control.json",
-                        "treatmentUrl": "v5/experiments/202604v3-android-tds-treatment.json"
-                    },
-                    "cohorts": [
-                        {
-                            "name": "control",
-                            "weight": 1
-                        },
-                        {
-                            "name": "treatment",
-                            "weight": 1
-                        }
-                    ]
+                    "minSupportedVersion": 52361000
                 },
                 "tdsNextExperiment009": {
                     "state": "disabled",
-                    "minSupportedVersion": 52361000,
-                    "rollout": {
-                        "steps": [
-                            {
-                                "percent": 25
-                            },
-                            {
-                                "percent": 100
-                            }
-                        ]
-                    },
-                    "settings": {
-                        "controlUrl": "v5/experiments/202605adm01-android-tds-control.json",
-                        "treatmentUrl": "v5/experiments/202605adm01-android-tds-treatment.json"
-                    },
-                    "cohorts": [
-                        {
-                            "name": "control",
-                            "weight": 1
-                        },
-                        {
-                            "name": "treatment",
-                            "weight": 1
-                        }
-                    ]
+                    "minSupportedVersion": 52361000
                 },
                 "tdsNextExperiment010": {
                     "state": "enabled",

--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -582,80 +582,32 @@
             "state": "enabled",
             "exceptions": [],
             "features": {
+                "tdsNextExperiment001": {
+                    "state": "disabled"
+                },
+                "tdsNextExperiment002": {
+                    "state": "disabled"
+                },
+                "tdsNextExperiment003": {
+                    "state": "disabled"
+                },
+                "tdsNextExperiment004": {
+                    "state": "disabled"
+                },
+                "tdsNextExperiment005": {
+                    "state": "disabled"
+                },
+                "tdsNextExperiment006": {
+                    "state": "disabled"
+                },
                 "tdsNextExperiment007": {
-                    "state": "disabled",
-                    "rollout": {
-                        "steps": [
-                            {
-                                "percent": 25
-                            }
-                        ]
-                    },
-                    "settings": {
-                        "controlUrl": "v5/experiments/202604v1-ios-tds-control.json",
-                        "treatmentUrl": "v5/experiments/202604v1-ios-tds-treatment.json"
-                    },
-                    "cohorts": [
-                        {
-                            "name": "control",
-                            "weight": 1
-                        },
-                        {
-                            "name": "treatment",
-                            "weight": 1
-                        }
-                    ]
+                    "state": "disabled"
                 },
                 "tdsNextExperiment008": {
-                    "state": "disabled",
-                    "rollout": {
-                        "steps": [
-                            {
-                                "percent": 100
-                            }
-                        ]
-                    },
-                    "settings": {
-                        "controlUrl": "v5/experiments/202604v3-ios-tds-control.json",
-                        "treatmentUrl": "v5/experiments/202604v3-ios-tds-treatment.json"
-                    },
-                    "cohorts": [
-                        {
-                            "name": "control",
-                            "weight": 1
-                        },
-                        {
-                            "name": "treatment",
-                            "weight": 1
-                        }
-                    ]
+                    "state": "disabled"
                 },
                 "tdsNextExperiment009": {
-                    "state": "disabled",
-                    "rollout": {
-                        "steps": [
-                            {
-                                "percent": 25
-                            },
-                            {
-                                "percent": 100
-                            }
-                        ]
-                    },
-                    "settings": {
-                        "controlUrl": "v5/experiments/202605adm01-ios-tds-control.json",
-                        "treatmentUrl": "v5/experiments/202605adm01-ios-tds-treatment.json"
-                    },
-                    "cohorts": [
-                        {
-                            "name": "control",
-                            "weight": 1
-                        },
-                        {
-                            "name": "treatment",
-                            "weight": 1
-                        }
-                    ]
+                    "state": "disabled"
                 },
                 "tdsNextExperiment010": {
                     "state": "enabled",

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -546,80 +546,32 @@
                 }
             ],
             "features": {
+                "tdsNextExperiment001": {
+                    "state": "disabled"
+                },
+                "tdsNextExperiment002": {
+                    "state": "disabled"
+                },
+                "tdsNextExperiment003": {
+                    "state": "disabled"
+                },
+                "tdsNextExperiment004": {
+                    "state": "disabled"
+                },
+                "tdsNextExperiment005": {
+                    "state": "disabled"
+                },
+                "tdsNextExperiment006": {
+                    "state": "disabled"
+                },
                 "tdsNextExperiment007": {
-                    "state": "disabled",
-                    "rollout": {
-                        "steps": [
-                            {
-                                "percent": 25
-                            }
-                        ]
-                    },
-                    "settings": {
-                        "controlUrl": "v6/experiments/202604v1-macos-tds-control.json",
-                        "treatmentUrl": "v6/experiments/202604v1-macos-tds-treatment.json"
-                    },
-                    "cohorts": [
-                        {
-                            "name": "control",
-                            "weight": 1
-                        },
-                        {
-                            "name": "treatment",
-                            "weight": 1
-                        }
-                    ]
+                    "state": "disabled"
                 },
                 "tdsNextExperiment008": {
-                    "state": "disabled",
-                    "rollout": {
-                        "steps": [
-                            {
-                                "percent": 100
-                            }
-                        ]
-                    },
-                    "settings": {
-                        "controlUrl": "v6/experiments/202604v3-macos-tds-control.json",
-                        "treatmentUrl": "v6/experiments/202604v3-macos-tds-treatment.json"
-                    },
-                    "cohorts": [
-                        {
-                            "name": "control",
-                            "weight": 1
-                        },
-                        {
-                            "name": "treatment",
-                            "weight": 1
-                        }
-                    ]
+                    "state": "disabled"
                 },
                 "tdsNextExperiment009": {
-                    "state": "disabled",
-                    "rollout": {
-                        "steps": [
-                            {
-                                "percent": 25
-                            },
-                            {
-                                "percent": 100
-                            }
-                        ]
-                    },
-                    "settings": {
-                        "controlUrl": "v6/experiments/202605adm01-macos-tds-control.json",
-                        "treatmentUrl": "v6/experiments/202605adm01-macos-tds-treatment.json"
-                    },
-                    "cohorts": [
-                        {
-                            "name": "control",
-                            "weight": 1
-                        },
-                        {
-                            "name": "treatment",
-                            "weight": 1
-                        }
-                    ]
+                    "state": "disabled"
                 },
                 "tdsNextExperiment010": {
                     "state": "enabled",


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1200277586140538/task/1216107275873369?focus=true

## Description
<!-- 
  Please delete either or both process sections below.
-->

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Disabling TDS experiments and stripping allowlist rules can change tracker blocking on affected sites; scope is config-only but may cause site breakage if those allowlists were still needed.
> 
> **Overview**
> Shuts down **tdsNextExperiment001–009** across Android, iOS, and macOS overrides by setting them to **disabled** and, for **007–009**, removing rollout percentages, control/treatment JSON URLs, and cohort weights so those experiments cannot run from remote config. **tdsNextExperiment010** is unchanged (still enabled with rollout).
> 
> Removes two tracker allowlist entries: **merequartz.com** (nbcsports, pagesix, weather.com, gameskinny, nj.com) and **fishingtoolsbox.com** (parade.com), so those domains are no longer exempt from blocking for those tracker hosts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b08a4b5035eebdf02e48a95a96d072f524c8d040. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->