### PR TITLE
Android: Enable contextualSheetImprovements to all users

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -590,6 +590,10 @@
                 "customizeResponses": {
                     "state": "enabled",
                     "minSupportedVersion": 52860000
+                },
+                "contextualSheetImprovements": {
+                    "state": "enabled",
+                    "minSupportedVersion": 52860000
                 }
             }
         },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/task/1215965593158934?focus=true

## Description
Enable the contextualSheetImprovements feature to all users from 5.286.0 and up.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single Android privacy-config override with a version-gated feature flag; no app code or security-sensitive logic in this PR.
> 
> **Overview**
> Turns on the **`contextualSheetImprovements`** sub-feature under **`aiChat`** in **`android-override.json`** for Android app builds **52860000 (5.286.0) and above**, with **`state: enabled`** and no rollout steps—so eligible clients get the flag for all users, not a partial experiment.
> 
> The change also fixes JSON structure under **`aiChat.features`** by properly closing **`customizeResponses`** before adding the new sibling flag (same version floor as **`customizeResponses`**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8e2bdb8fa668d0359ceb24a4a19e5feb9bb61d97. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->