### PR TITLE
Enable duckAiOnboarding for non-English users (Android)

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -3560,12 +3560,7 @@
                 },
                 "duckAiOnboarding": {
                     "state": "enabled",
-                    "minSupportedVersion": 52850000,
-                    "targets": [
-                        {
-                            "localeLanguage": "en"
-                        }
-                    ]
+                    "minSupportedVersion": 52860000
                 },
                 "onboardingDuckAiExperimentMay26": {
                     "state": "enabled",


### PR DESCRIPTION
## Summary

- Removes `localeLanguage: "en"` targeting from `duckAiOnboarding` flag, enabling it for all languages
- Bumps `minSupportedVersion` from 5.285.0 to 5.286.0

## Asana task

https://app.asana.com/1/137249556945/project/1205617573940217/task/1216095949211776?focus=true

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single feature-flag JSON change with no app logic; main risk is wider onboarding exposure and ensuring 5.286+ supports non-English Duck.ai onboarding UX.
> 
> **Overview**
> **Android remote config** update for `extendedOnboarding.duckAiOnboarding`: the English-only `targets` block (`localeLanguage: "en"`) is removed so Duck.ai extended onboarding can apply to **all locales**, not just English.
> 
> The flag’s **`minSupportedVersion`** is raised from **52850000** (5.285.0) to **52860000** (5.286.0), tying the broader rollout to a newer app build.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 92ec970989b8115dad746e083df40e9712358525. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->