### PR TITLE
[Autofill] antarestech.com login form boundary

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -1135,6 +1135,18 @@
                                         }
                                     }
                                 ]
+                            },
+                            {
+                                "condition": [
+                                    { "domain": "antarestech.com" }
+                                ],
+                                "patchSettings": [
+                                    {
+                                        "path": "/formBoundarySelector",
+                                        "op": "replace",
+                                        "value": ".auth_dialog"
+                                    }
+                                ]
                             }
                         ]
                     }

--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -1287,6 +1287,18 @@
                                         }
                                     }
                                 ]
+                            },
+                            {
+                                "condition": [
+                                    { "domain": "antarestech.com" }
+                                ],
+                                "patchSettings": [
+                                    {
+                                        "path": "/formBoundarySelector",
+                                        "op": "replace",
+                                        "value": ".auth_dialog"
+                                    }
+                                ]
                             }
                         ]
                     }

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -1265,6 +1265,18 @@
                                         }
                                     }
                                 ]
+                            },
+                            {
+                                "condition": [
+                                    { "domain": "antarestech.com" }
+                                ],
+                                "patchSettings": [
+                                    {
+                                        "path": "/formBoundarySelector",
+                                        "op": "replace",
+                                        "value": ".auth_dialog"
+                                    }
+                                ]
                             }
                         ]
                     }

--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -2055,6 +2055,18 @@
                                         }
                                     }
                                 ]
+                            },
+                            {
+                                "condition": [
+                                    { "domain": "antarestech.com" }
+                                ],
+                                "patchSettings": [
+                                    {
+                                        "path": "/formBoundarySelector",
+                                        "op": "replace",
+                                        "value": ".auth_dialog"
+                                    }
+                                ]
                             }
                         ]
                     }


### PR DESCRIPTION
Expand the autofill form boundary on antarestech.com to the auth dialog wrapper so the heuristic scorer can see the login signals (active 'SIGN IN' tab, 'Forgot Password' link) that currently sit outside the narrow `<form>` element. The form was being misclassified as signup with a score of 0.

Adds a formBoundarySelector site-specific fix targeting '.auth_dialog' on antarestech.com across iOS, Android, macOS and Windows.

**Asana Task/Github Issue:**

## Description
<!-- 
  Please delete either or both process sections below.
-->

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Remote config-only, single-domain autofill boundary tweak with no auth or data-model changes; scope is limited to antarestech.com.
> 
> **Overview**
> Adds an **autofill site-specific fix** for **antarestech.com** on **Android, iOS, macOS, and Windows**: when that domain loads, `formBoundarySelector` is set to **`.auth_dialog`** instead of the default narrow `<form>` scope.
> 
> That widens the DOM region used for form-type heuristics so login cues outside the raw form (e.g. active “SIGN IN” tab, “Forgot Password”) are included, addressing misclassification as signup with a score of 0.
> 
> The change mirrors existing **`formBoundarySelector`** patches for other domains (e.g. Netflix, GameStop) inside **`autofill` → `siteSpecificFixes` → `conditionalChanges`** in each platform **`overrides/*-override.json`** file.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5d0dc17687d0324d1ac5ec2ae58107e3bff0d03a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->