### PR TITLE
Disable aiChatSyncPromo on iOS

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -1913,6 +1913,9 @@
                     "state": "enabled",
                     "minSupportedVersion": "7.208.2"
                 },
+                "aiChatSyncPromo": {
+                    "state": "disabled"
+                },
                 "simplifiedSyncSetupExperiment": {
                     "state": "enabled",
                     "minSupportedVersion": "7.219.0",


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/task/1216084825209587

## Description

Adds the `aiChatSyncPromo` sync subfeature to the iOS override with state `disabled`, stopping the Duck.ai sync promo card from showing. The iOS app defaults this flag to `enabled` when it's absent from config, so it must be defined explicitly to turn it off remotely.

This is a stop-gap so our sync promo doesn't appear back-to-back with the O-O paid Duck.ai promo, until a unified promo queue exists. iOS-only — macOS does not read this flag.

### Feature change process:

- [ ] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single iOS remote-config toggle with no app code changes; impact is limited to suppressing one promo surface.
> 
> **Overview**
> Adds **`aiChatSyncPromo`** under **`sync.features`** in **`ios-override.json`** with **`state: "disabled"`**, so iOS clients stop showing the Duck.ai sync promo card via remote config.
> 
> Because iOS treats this subfeature as **enabled when it is missing** from config, the flag must be present and explicitly disabled to turn the promo off remotely. This is a temporary measure to avoid back-to-back promos with the paid Duck.ai campaign until a unified promo queue exists; **macOS does not use this flag**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 67b15963b783829a81b79be4a5f3bc9eee0e2ecb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->