### PR TITLE
Disable sendIncidentCrashReports

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -5089,7 +5089,7 @@
                     "state": "enabled"
                 },
                 "sendIncidentCrashReports": {
-                    "state": "preview",
+                    "state": "disabled",
                     "settings": {
                         "ExceptionTypes": [
                             "System.OutOfMemoryException"


### PR DESCRIPTION
**Asana Task/Github Issue:**

## Description
Disable sendIncidentCrashReports

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line remote config toggle with no code or schema changes; main effect is reduced crash telemetry for Windows clients that had the preview feature on.
> 
> **Overview**
> Turns off **incident crash report uploads** for the DuckDuckGo Windows browser by changing the `extendedCrashReporting.sendIncidentCrashReports` sub-feature in `windows-override.json` from **`preview` to `disabled`**.
> 
> Existing `settings.ExceptionTypes` (still listing `System.OutOfMemoryException`) is unchanged; only the feature gate is flipped so clients should no longer send those incident reports while other `extendedCrashReporting` sub-features (e.g. process status tracking, detect installed AV) stay as configured.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7a8d57c36be5449d81888326653a546e55de69f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->