### PR TITLE
Enable adblock for all users by default

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -4849,6 +4849,9 @@
                         "steps": [
                             {
                                 "percent": 10
+                            },
+                            {
+                                "percent": 100
                             }
                         ]
                     }


### PR DESCRIPTION
**Asana Task/Github Issue:**

## Description
<!-- 
  Please delete either or both process sections below.
-->

- Enables adblock v2 by default for all users (except ones who opted out of it previously)

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Broadens ad-block extension exposure on Windows, which can increase site breakage reports even though the change is config-only and version-gated.
> 
> **Overview**
> **Windows** privacy config update for **`adBlockV2Extension`** **`partialLaunch`**: the rollout **`steps`** array gains a second step at **`percent`: 100**, so the staged launch moves from the existing **10%** cohort to **full** exposure for clients on **`minSupportedVersion`** **0.162.2+**.
> 
> This matches enabling the **ad block v2 extension** for all eligible Windows users by default (PR intent), without changing other **`adBlockV2Extension`** flags such as **`softLaunch`**, migration, or the CRX **`extensionUrl`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa82caace4cf243f913b1b9aa7161fe97c42d3e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->