### PR TITLE
Enable webview pixels rollout beyond internal users

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -4625,8 +4625,8 @@
                     }
                 },
                 "pixelReporting": {
-                    "state": "internal",
-                    "minSupportedVersion": "0.163.0"
+                    "state": "enabled",
+                    "minSupportedVersion": "0.165.0.25"
                 },
                 "useSingleWebViewEnvironment": {
                     "state": "enabled",

--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -4626,7 +4626,7 @@
                 },
                 "pixelReporting": {
                     "state": "enabled",
-                    "minSupportedVersion": "0.165.0.25"
+                    "minSupportedVersion": "0.165.1"
                 },
                 "useSingleWebViewEnvironment": {
                     "state": "enabled",


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1212608041264997/task/1216017860324646

## Description

Restrict enabling by version to ensure that the WIndows browser contains the [throttling update](https://app.asana.com/1/137249556945/project/1209275629397858/task/1216084704585035) for the otherwise much heavier pixel volumes for post-message pixels.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Broadens webview telemetry/pixel reporting to non-internal Windows users; the version floor mitigates performance risk from unthrottled post-message pixels on older builds.
> 
> **Overview**
> **Windows webview `pixelReporting`** moves from **`internal`** to **`enabled`**, so pixel reporting is no longer limited to internal users on the Windows override config.
> 
> The **minimum supported browser version** is raised from **`0.163.0`** to **`0.165.1`** so only builds that include throttling for heavier post-message pixel traffic receive the flag.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bc0f59bdc21916601ada5b56bf2e189b5be75ff9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->