### PR TITLE
Update autoconsent to v16.2.0

### DIFF
--- a/features/autoconsent.json
+++ b/features/autoconsent.json
@@ -1819,8 +1819,8 @@
                 "div#cookieWarning",
                 "a#btnCookiesDenyAll",
                 "[class*=ConsentManager]",
-                "[class*=ConsentManager_row] input[type=radio][id$=no]",
-                "[class*=ConsentManager_continue]",
+                "[class*=ConsentManager_cookieBar]",
+                "xpath///button[contains(@class, \"ConsentManager_cookieBarButton\") and contains(., \"weigeren\")]",
                 "[data-testid=cookie-dialog-root]",
                 "input[type=radio][id$=-declineLabel]",
                 "[data-testid=confirm-choice-button]",
@@ -27193,19 +27193,16 @@
                     ],
                     [
                         {
-                            "e": 932
+                            "e": 933
                         }
                     ],
                     [
                         {
-                            "v": 932
+                            "check": "any",
+                            "v": 933
                         }
                     ],
                     [
-                        {
-                            "all": true,
-                            "c": 933
-                        },
                         {
                             "c": 934
                         }


### PR DESCRIPTION
Asana Task/Github Issue: https://app.asana.com/1/137249556945/project/1201844467387842/task/1216135711089001

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only cookie-banner automation selectors and one site-specific rule; no auth, data, or core app logic.
> 
> **Overview**
> Bumps embedded **autoconsent** rules toward **v16.2.0**, with two targeted consent-handler fixes in `features/autoconsent.json`.
> 
> For **ConsentManager** CMPs, the shared hide/click selector list drops the old radio + “continue” pattern and instead targets the cookie bar and an **XPath** button whose label contains **“weigeren”** (Dutch reject).
> 
> The **nhnieuws.nl** site rule shifts its detection/click steps to updated rule indices (**932 → 933**), adds an **`"check": "any"`** visibility condition, and removes a prior **`all: true`** bulk-click step so the flow relies on the remaining click plus **`EVAL_NHNIEUWS_TEST`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 15cf03adc657692d0578a5adb54e32358f57c7d8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->