### PR TITLE
[Autofill] auth.ibx.com: suppress autofill on OTP input

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -1184,6 +1184,21 @@
                                         "value": ".auth_dialog"
                                     }
                                 ]
+                            },
+                            {
+                                "condition": [
+                                    { "domain": "auth.ibx.com" }
+                                ],
+                                "patchSettings": [
+                                    {
+                                        "path": "/inputTypeSettings/-",
+                                        "op": "add",
+                                        "value": {
+                                            "selector": "input#floatingLabelInput109",
+                                            "type": "unknown"
+                                        }
+                                    }
+                                ]
                             }
                         ]
                     }

--- a/overrides/extension-override.json
+++ b/overrides/extension-override.json
@@ -8,7 +8,35 @@
             }
         },
         "autofill": {
-            "state": "enabled"
+            "state": "enabled",
+            "features": {
+                "siteSpecificFixes": {
+                    "state": "enabled",
+                    "settings": {
+                        "formTypeSettings": [],
+                        "inputTypeSettings": [],
+                        "formBoundarySelector": "",
+                        "failsafeSettings": {},
+                        "conditionalChanges": [
+                            {
+                                "condition": [
+                                    { "domain": "auth.ibx.com" }
+                                ],
+                                "patchSettings": [
+                                    {
+                                        "path": "/inputTypeSettings/-",
+                                        "op": "add",
+                                        "value": {
+                                            "selector": "input#floatingLabelInput109",
+                                            "type": "unknown"
+                                        }
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                }
+            }
         },
         "incontextSignup": {
             "state": "enabled",

--- a/overrides/extension-override.json
+++ b/overrides/extension-override.json
@@ -8,35 +8,7 @@
             }
         },
         "autofill": {
-            "state": "enabled",
-            "features": {
-                "siteSpecificFixes": {
-                    "state": "enabled",
-                    "settings": {
-                        "formTypeSettings": [],
-                        "inputTypeSettings": [],
-                        "formBoundarySelector": "",
-                        "failsafeSettings": {},
-                        "conditionalChanges": [
-                            {
-                                "condition": [
-                                    { "domain": "auth.ibx.com" }
-                                ],
-                                "patchSettings": [
-                                    {
-                                        "path": "/inputTypeSettings/-",
-                                        "op": "add",
-                                        "value": {
-                                            "selector": "input#floatingLabelInput109",
-                                            "type": "unknown"
-                                        }
-                                    }
-                                ]
-                            }
-                        ]
-                    }
-                }
-            }
+            "state": "enabled"
         },
         "incontextSignup": {
             "state": "enabled",

--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -1326,6 +1326,21 @@
                                         "value": ".auth_dialog"
                                     }
                                 ]
+                            },
+                            {
+                                "condition": [
+                                    { "domain": "auth.ibx.com" }
+                                ],
+                                "patchSettings": [
+                                    {
+                                        "path": "/inputTypeSettings/-",
+                                        "op": "add",
+                                        "value": {
+                                            "selector": "input#floatingLabelInput109",
+                                            "type": "unknown"
+                                        }
+                                    }
+                                ]
                             }
                         ]
                     }

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -1305,6 +1305,21 @@
                                         "value": ".auth_dialog"
                                     }
                                 ]
+                            },
+                            {
+                                "condition": [
+                                    { "domain": "auth.ibx.com" }
+                                ],
+                                "patchSettings": [
+                                    {
+                                        "path": "/inputTypeSettings/-",
+                                        "op": "add",
+                                        "value": {
+                                            "selector": "input#floatingLabelInput109",
+                                            "type": "unknown"
+                                        }
+                                    }
+                                ]
                             }
                         ]
                     }

--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -2067,6 +2067,21 @@
                                         "value": ".auth_dialog"
                                     }
                                 ]
+                            },
+                            {
+                                "condition": [
+                                    { "domain": "auth.ibx.com" }
+                                ],
+                                "patchSettings": [
+                                    {
+                                        "path": "/inputTypeSettings/-",
+                                        "op": "add",
+                                        "value": {
+                                            "selector": "input#floatingLabelInput109",
+                                            "type": "unknown"
+                                        }
+                                    }
+                                ]
                             }
                         ]
                     }


### PR DESCRIPTION
The 'One Time Password' input on auth.ibx.com renders with type=password (ForgeRock floating-label component), so autofill misclassifies it as credentials.password.current and decorates / offers to save the OTP as a password.

Force the field to type 'unknown' via siteSpecificFixes so autofill skips decoration (canBeAutofilled returns false for unknown main type) and skips the save prompt (Form.submitHandler).

Applied to all 5 platform overrides:
- macos, ios, android, windows: added entry to existing siteSpecificFixes.settings.conditionalChanges array.
- extension: introduced siteSpecificFixes subfeature (first occurrence in this override). The autofill bundle already supports the feature via Settings.getsiteSpecificFeature on all platforms; older extension versions without that code path will simply ignore the new settings.

Selector: input#floatingLabelInput109 (per request). Note the numeric suffix looks auto-generated by the floating-label component; if the input order on the page changes the suffix may shift and the rule will need to be re-keyed (e.g. on name=callback_5 + data-vv-as).

**Asana Task/Github Issue:**

## Description
<!-- 
  Please delete either or both process sections below.
-->

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only autofill override for one domain; no app logic changes, with minor risk the floating-label ID suffix changes and the rule stops matching.
> 
> **Overview**
> Adds a **siteSpecificFixes** rule for **auth.ibx.com** on Android, iOS, macOS, and Windows so the ForgeRock one-time password field (`input#floatingLabelInput109`) is forced to type **`unknown`** instead of being treated like a current password.
> 
> That stops autofill from decorating the OTP box and from prompting to save the code as a password when the page renders it as `type=password`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 502d3e319c23f061f53a8d59f94928cf18917f20. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->