### PR TITLE
Enable webViewSessionPersistence to 10%

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -1869,6 +1869,16 @@
                 "sendPostIdleSessionWideEvent": {
                     "state": "enabled",
                     "minSupportedVersion": 52810000
+                },
+                "webViewSessionPersistence": {
+                    "state": "enabled",
+                    "rollout": {
+                        "steps": [
+                            {
+                                "percent": 10
+                            }
+                        ]
+                    }
                 }
             }
         },


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/1142021229838617/task/1216168419930603?focus=true

## Description
Enables webSessionPersistance FF to 10%.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Gradual rollout limits blast radius, but WebView session persistence can change tab restore and site state behavior for affected users.
> 
> **Overview**
> Turns on the **`webViewSessionPersistence`** sub-feature under **`androidBrowserConfig`** for Android clients, with a **10%** incremental rollout step.
> 
> This is a remote privacy-configuration override only (`overrides/android-override.json`); no app code changes in this PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 898114822429849f94449445d513a4a3365a3661. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->