### PR TITLE
Set canShowNativeCrashReportingDialog to internal

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -5136,7 +5136,7 @@
             "exceptions": [],
             "features": {
                 "canShowNativeCrashReportingDialog": {
-                    "state": "disabled",
+                    "state": "internal",
                     "rollout": {
                         "steps": [
                             {


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/72649045549333/task/1213085049992378?focus=true

## Description

Set canShowNativeCrashReportingDialog to internal, as we already see from pixel data that a few internal users hit native crashes too.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single feature-flag state change in Windows override JSON with no auth, data, or app logic changes.
> 
> **Overview**
> Updates the Windows privacy config so **`canShowNativeCrashReportingDialog`** under **`nativeCrashReporting`** uses **`internal`** instead of **`disabled`**, while keeping the existing **5% rollout** steps unchanged.
> 
> This lets internal users see the native crash reporting dialog when they hit native crashes, aligned with pixel data showing internal traffic still experiences those crashes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit acae1891b5c56c3d91ebb18dfb9a860a5e2b1096. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->