### PR TITLE
Update autoconsent to v16.3.0

### DIFF
--- a/features/autoconsent.json
+++ b/features/autoconsent.json
@@ -1735,9 +1735,9 @@
                 "[data-testid=cookieModal] input[type=radio][value=false]:not(:checked):not(:disabled)",
                 "[data-testid=cookieModal__acceptButton]",
                 "gdpr__",
-                ".duet--cta--cookie-banner",
-                ".duet--cta--cookie-banner button.tracking-12 > span",
-                "_duet_gdpr_acknowledged=1",
+                "[class*=CookieConsent__root___]",
+                "[class*=CookieConsent__modal___]",
+                "[class*=CookieConsent__modal___] > div > button[class*=secondary]:nth-child(2)",
                 "[data-test-id=cookies_section]",
                 ".cc-window.cc-visible",
                 ".cc-window .cc-dialog",
@@ -2382,10 +2382,7 @@
                 "div.cookie.flex.flex-wrap",
                 "xpath///div[contains(@class,'cookie')]//button[normalize-space()='Deny']",
                 "#footer-container > div",
-                "#cookiesPortletDiv",
-                "[class*=CookieConsent__root___]",
-                "[class*=CookieConsent__modal___]",
-                "[class*=CookieConsent__modal___] > div > button[class*=secondary]:nth-child(2)"
+                "#cookiesPortletDiv"
             ],
             "r": [
                 [
@@ -28222,21 +28219,21 @@
                     "^https://www\\.svt\\.se/",
                     22,
                     [
-                        1497
+                        849
                     ],
                     [
                         {
-                            "e": 1497
+                            "e": 849
                         }
                     ],
                     [
                         {
-                            "v": 1498
+                            "v": 850
                         }
                     ],
                     [
                         {
-                            "c": 1499
+                            "c": 851
                         }
                     ],
                     [
@@ -28377,39 +28374,6 @@
                         }
                     ],
                     {}
-                ],
-                [
-                    1,
-                    "theverge",
-                    2,
-                    "^https://(www)?\\.theverge\\.com",
-                    10,
-                    [
-                        849
-                    ],
-                    [
-                        {
-                            "e": 849
-                        }
-                    ],
-                    [
-                        {
-                            "v": 849
-                        }
-                    ],
-                    [
-                        {
-                            "k": 850
-                        }
-                    ],
-                    [
-                        {
-                            "cc": 851
-                        }
-                    ],
-                    {
-                        "intermediate": false
-                    }
                 ],
                 [
                     1,
@@ -29029,7 +28993,7 @@
                 ],
                 "specificRuleRange": [
                     191,
-                    772
+                    771
                 ],
                 "genericStringEnd": 755,
                 "frameStringEnd": 790


### PR DESCRIPTION
Asana Task/Github Issue: https://app.asana.com/1/137249556945/project/1201844467387842/task/1216185308615467

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Data-only autoconsent rule refresh; main user-facing risk is cookie-banner behavior on The Verge and svt.se if the new selectors no longer match live sites.
> 
> **Overview**
> Updates the bundled **autoconsent** rule set to **v16.3.0** in `features/autoconsent.json`.
> 
> **The Verge** handling shifts from site-specific rules and old `duet--cta--cookie-banner` selectors to shared **`CookieConsent__*`** patterns in the generic selector list; the dedicated **`theverge`** site block is removed. Duplicate CookieConsent entries elsewhere in the file are cleaned up so those patterns live in one place.
> 
> **svt.se** rule references are retargeted to lower rule indices (**849–851** vs **1497–1499**), consistent with rule renumbering after dropping a specific rule. The **`specificRuleRange`** upper bound decreases by one (**771** vs **772**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e8ce2cf0c77c6ab2760126cd3c77e2a7827d0c2c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->