### PR TITLE
Windows: Enable new address bar for 20% on stable

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -5885,7 +5885,14 @@
                 },
                 "addressBarOverlay": {
                     "minSupportedVersion": "0.164.0",
-                    "state": "preview"
+                    "state": "enabled",
+                    "rollout": {
+                        "steps": [
+                            {
+                                "percent": 20
+                            }
+                        ]
+                    }
                 }
             }
         },


### PR DESCRIPTION
https://app.asana.com/1/137249556945/project/1209072953775241/task/1214731349243339?focus=true

## Description

Set enabled at 20% for the address bar overlay on 164.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Remote feature-flag config only; uses the same rollout pattern as other Windows overrides with a capped 20% exposure.
> 
> **Overview**
> On **Windows stable**, the **`addressBarOverlay`** flag under **`addressBar`** moves from **`preview`** to **`enabled`**, with a **20%** rollout step for clients on **0.164.0+** (`minSupportedVersion` unchanged).
> 
> This exposes the new address bar overlay UI to a fifth of eligible stable users instead of preview-only access.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 73bf965ad987801c225e5d4af0220f7eaa05fdbf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->