### PR TITLE
disable CPM due to paywall

### DIFF
--- a/features/autoconsent.json
+++ b/features/autoconsent.json
@@ -878,6 +878,10 @@
         {
             "domain": "rumble.com",
             "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5462"
+        },
+        {
+            "domain": "planet.fr",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5463"
         }
     ],
     "settings": {


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1203268166580279/task/1215657283952570?focus=true

## Description
paywall on planet.fr

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-domain configuration exception with no logic or security changes; only reduces autoconsent coverage on planet.fr.
> 
> **Overview**
> Adds **`planet.fr`** to the autoconsent **`exceptions`** list in `features/autoconsent.json`, so DuckDuckGo will not auto-handle cookie consent on that site.
> 
> This follows the same pattern as other domain carve-outs (e.g. paywall or breakage) and references privacy-configuration PR **5463** in the entry’s `reason` field.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 83db51e6a972b9923c99dac73465cecf1fb082be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->