### PR TITLE
Enable CTL experiment at 25%

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -244,6 +244,31 @@
                             "weight": 1
                         }
                     ]
+                },
+                "tdsNextExperiment011": {
+                    "state": "enabled",
+                    "minSupportedVersion": 52361000,
+                    "rollout": {
+                        "steps": [
+                            {
+                                "percent": 25
+                            }
+                        ]
+                    },
+                    "settings": {
+                        "controlUrl": "v5/experiments/202606ctl01-android-tds-control.json",
+                        "treatmentUrl": "v5/experiments/202606ctl01-android-tds-treatment.json"
+                    },
+                    "cohorts": [
+                        {
+                            "name": "control",
+                            "weight": 1
+                        },
+                        {
+                            "name": "treatment",
+                            "weight": 1
+                        }
+                    ]
                 }
             }
         },

--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -686,6 +686,30 @@
                             "weight": 1
                         }
                     ]
+                },
+                "tdsNextExperiment011": {
+                    "state": "enabled",
+                    "rollout": {
+                        "steps": [
+                            {
+                                "percent": 25
+                            }
+                        ]
+                    },
+                    "settings": {
+                        "controlUrl": "v5/experiments/202606ctl01-ios-tds-control.json",
+                        "treatmentUrl": "v5/experiments/202606ctl01-ios-tds-treatment.json"
+                    },
+                    "cohorts": [
+                        {
+                            "name": "control",
+                            "weight": 1
+                        },
+                        {
+                            "name": "treatment",
+                            "weight": 1
+                        }
+                    ]
                 }
             }
         },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1200811069326255/task/1216208388522812?focus=true

## Description
<!-- 
  Please delete either or both process sections below.
-->

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Enabling a live TDS blocklist experiment can change tracker blocking for a quarter of eligible mobile users and may cause site breakage if the treatment list differs materially from control.
> 
> **Overview**
> Turns on a new **blockList** TDS A/B experiment, **`tdsNextExperiment011`**, for **Android** and **iOS** at a **25%** rollout with equal **control** / **treatment** cohorts.
> 
> Clients in the experiment load alternate tracker blocklists from **`202606ctl01-*-tds-control.json`** vs **`202606ctl01-*-tds-treatment.json`**. Android also sets **`minSupportedVersion`: 52361000**, matching the other recent TDS next experiments on that platform.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 21f3ec0f7001cf447d6f96c201c69882e50545ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->