### PR TITLE
Zap dark footer on merriam-webster.com

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -2732,6 +2732,15 @@
                 ]
             },
             {
+                "domain": "merriam-webster.com",
+                "rules": [
+                    {
+                        "selector": "#mw-ad-slot-fixed-footer",
+                        "type": "hide-empty"
+                    }
+                ]
+            },
+            {
                 "domain": "messenger.com",
                 "rules": [
                     {


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1206670747178362/task/1215992468487068?focus=true

## Description

### Site breakage mitigation process:
#### Brief explanation
- Reported URL: https://www.merriam-webster.com/games/blossom-word-game/
- Problems experienced: dark footer
- Platforms affected:
  - [x] all (all browsers, everywhere, nothing we're blocking)
- Feature being disabled/modified: element hiding
