### PR TITLE
Bump unifiedToggleInput rollout to 25%

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -378,6 +378,9 @@
                         "steps": [
                             {
                                 "percent": 5
+                            },
+                            {
+                                "percent": 25
                             }
                         ]
                     }


### PR DESCRIPTION
## Summary

Bumps the `unifiedToggleInput` (Unified Toggle Input / UTI for Duck.ai) rollout in the iOS override from **5% → 25%**, continuing the narrow rollout.

The rollout step is **appended** (not replaced), matching the repo convention of preserving rollout history.

```diff
 "rollout": {
     "steps": [
         {
             "percent": 5
+        },
+        {
+            "percent": 25
         }
     ]
 }
```

## Validation

- `npm run build` — passes
- `npm run lint` (check-lockfile + eslint + prettier) — passes
- Only `overrides/ios-override.json` changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single override JSON change that follows the standard append-only rollout pattern; no logic or security surface changes.
> 
> **Overview**
> Advances the iOS **Unified Toggle Input (UTI)** Duck.ai rollout by appending a **25%** step to `aiChat.unifiedToggleInput` in `overrides/ios-override.json`, keeping the existing **5%** step for rollout history.
> 
> No feature flags, version gates, or other overrides change—only the staged rollout percentage increases for eligible iOS clients (min **7.226.0**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 94e3cb909b82711f4ebcaba2824bc3ac0134153e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->