### PR TITLE
Enable header order alignment from 0.166.0

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -4262,7 +4262,8 @@
             }
         },
         "preserveHeaderOrder": {
-            "state": "internal",
+            "state": "enabled",
+            "minSupportedVersion": "0.166.0",
             "exceptions": [],
             "settings": {
                 "placements": [


### PR DESCRIPTION
**Asana Task/Github Issue:**

## Description
Enable header order alignment from 0.166.0

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [X] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only toggle with a version floor; no application code changes in this PR.
> 
> **Overview**
> Turns on the **`preserveHeaderOrder`** remote-config feature for Windows by changing its state from **`internal`** to **`enabled`**, and gates rollout with **`minSupportedVersion`: `0.166.0`**.
> 
> Existing placement rules (e.g. positioning **`Sec-GPC`** relative to **`sec-fetch-site`**) are unchanged; only visibility and eligibility for clients at or above that version are updated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf4cac695ea437776bb98daf6e90bcbf44b7be36. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->