### PR TITLE
Enabling websitePermissionsV2 internally for Windows

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -5996,11 +5996,11 @@
             "exceptions": []
         },
         "websitePermissions": {
-            "state": "disabled",
+            "state": "internal",
             "exceptions": [],
             "features": {
                 "websitePermissionsV2": {
-                    "state": "disabled"
+                    "state": "internal"
                 }
             }
         }


### PR DESCRIPTION
**Asana Task/Github Issue:**

## Description
<!-- 
  Please delete either or both process sections below.
-->

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-platform remote feature-flag change with no code changes; internal state limits blast radius compared to a full enable.
> 
> **Overview**
> Turns on **website permissions** for the Windows browser via remote config by changing `websitePermissions` and nested **`websitePermissionsV2`** from **`disabled`** to **`internal`** in `windows-override.json`.
> 
> **Internal** rollout limits exposure to internal/dogfood builds rather than enabling the feature for all Windows users.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f6332bfccd843e4caefe512371098eabf29622eb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->