### PR TITLE
Update autoconsent to v16.5.0

### DIFF
--- a/features/autoconsent.json
+++ b/features/autoconsent.json
@@ -1648,6 +1648,15 @@
                 "#lanyard_root button[class*=confirmButton], #lanyard_root div[class*=actions_] > button:nth-child(1), #lanyard_root button[class*=actionButton], #ketch-modal button[aria-label='Confirm'], #ketch-purposes-modal button[aria-label='Confirm'], #ketch-modal button[aria-label='Save Settings'], #ketch-purposes-modal button[aria-label='Save Settings']",
                 "#lanyard_root div[class*=buttons] > button[class*=secondaryButton], #lanyard_root button[class*=buttons-secondary], #ketch-banner-button-secondary",
                 "#lanyard_root input[type=checkbox][role=switch][aria-checked=true]:not(:disabled)",
+                ".cookie-wrapper .cookie-tip",
+                ".cookie-wrapper .cookie-tip__container",
+                ".cookie-wrapper .cookie-tip__text",
+                ".cookie-wrapper .cookie-tip__button > .button",
+                ".el-dialog.cookie-dialog",
+                ".el-dialog.cookie-dialog .el-switch.is-checked",
+                ".el-dialog.cookie-dialog .el-dialog__footer button.el-button--primary",
+                "allow_analysis=%22false%22",
+                "allow_analysis=false",
                 "body > div#root > div#ccpa-iframe-theme-provider[data-testid=\"ccpa-iframe-theme-provider\"] > div#ccpa-iframe[data-testid=\"ccpa-iframe\"] > div#ccpa_consent_banner[data-testid=\"ccpa_consent_banner\"] > div:not([id]) > div:nth-child(3):not([id]) > span:not([id]) > span:not([id]) > div:nth-child(2):not([id]) > span:nth-child(1):not([id]) > button#decline_cookies_button[data-testid=\"decline_cookies_button\"]",
                 "body:not([id]) > div#banner-0 > div:nth-child(1)#grouped-pageload-Banner > div:not([id]) > div:not([id]) > div:not([id]) > div:nth-child(3):not([id]) > button:nth-child(2):not([id])",
                 "body > div#iubenda-cs-banner > div:not([id]) > div:not([id]) > div:not([id]) > div:nth-child(5):not([id]) > div:nth-child(2):not([id]) > button:nth-child(1):not([id])",
@@ -1683,15 +1692,6 @@
                 "span[role=checkbox][aria-checked=true]",
                 "#save-all-pur",
                 "#reminder",
-                "body > div#cookie-policy > div:not([id]) > div:nth-child(2):not([id]) > button:nth-child(2):not([id])",
-                "body > div#BannerRegion > div:nth-child(1)#Banner_cookie_0 > div:nth-child(2):not([id]) > div:not([id]) > div:nth-child(2):not([id]) > div:not([id]) > button:nth-child(2)#rejectAllBtn",
-                "body > div:not([id]) > div:nth-child(3):not([id]) > div:not([id]) > div:nth-child(2):not([id]) > button:nth-child(2):not([id])",
-                "body > div#messages > div:nth-child(1)#shopify-section-cookie-banner > section#shopify-section-cookie-banner > div:nth-child(1):not([id]) > button:nth-child(2):not([id])",
-                "body > div#messages > div:nth-child(2)#shopify-section-newsletter-banner > section:nth-child(1):not([id]) > div:not([id]) > button:nth-child(1):not([id])",
-                "body > form#trackingConsent > button:nth-child(2):not([id])",
-                "body > pnp-root:not([id]) > div:not([id]) > ui-storefront:not([id]) > footer:nth-child(8):not([id]) > cx-page-layout:not([id]) > cx-page-slot:not([id]) > cms-popia-component:nth-child(3):not([id]) > div:not([id]) > div:not([id]) > div:nth-child(2):not([id]) > button:nth-child(1):not([id])",
-                "body > div#___gatsby > div:nth-child(1)#gatsby-focus-wrapper > div:nth-child(3):not([id]) > div:not([id]) > div:nth-child(2):not([id]) > div:nth-child(1):not([id]) > button:not([id])",
-                "body > div:not([id]) > div:not([id]) > div:nth-child(1):not([id]) > div#c-cookiebanner > section:not([id]) > div:not([id]) > div:not([id]) > div:nth-child(4):not([id]) > p:nth-child(1):not([id]) > button:not([id])",
                 "body > div#termsfeed-pc1-notice-banner > div:nth-child(2):not([id]) > div:not([id]) > div:nth-child(3):not([id]) > div:not([id]) > button:nth-child(2)#termsfeed_privacy_consent_banner_button_reject_all",
                 "body > div#accn-cookie-consent-wrapper > div#accn-cookie-consent > div:nth-child(2)#accn-statement-scroller > div:nth-child(2):not([id]) > div:nth-child(3):not([id]) > button:not([id])",
                 "body > div#wrapper > div:nth-child(4):not([id]) > button:nth-child(3):not([id])",
@@ -2393,7 +2393,16 @@
                 ".cmp-sdk-container",
                 "#cmp-reject-all-handler",
                 "OptanonAlertBoxClosed",
-                "cookie-consent-1={\"optedIn\":true,\"functionality\":false,\"statistics\":false}"
+                "cookie-consent-1={\"optedIn\":true,\"functionality\":false,\"statistics\":false}",
+                "body > div#cookie-policy > div:not([id]) > div:nth-child(2):not([id]) > button:nth-child(2):not([id])",
+                "body > div#messages > div:nth-child(1)#shopify-section-cookie-banner > section#shopify-section-cookie-banner > div:nth-child(1):not([id]) > button:nth-child(2):not([id])",
+                "body > div#messages > div:nth-child(2)#shopify-section-newsletter-banner > section:nth-child(1):not([id]) > div:not([id]) > button:nth-child(1):not([id])",
+                "body > form#trackingConsent > button:nth-child(2):not([id])",
+                "body > pnp-root:not([id]) > div:not([id]) > ui-storefront:not([id]) > footer:nth-child(8):not([id]) > cx-page-layout:not([id]) > cx-page-slot:not([id]) > cms-popia-component:nth-child(3):not([id]) > div:not([id]) > div:not([id]) > div:nth-child(2):not([id]) > button:nth-child(1):not([id])",
+                "body > div#___gatsby > div:nth-child(1)#gatsby-focus-wrapper > div:nth-child(3):not([id]) > div:not([id]) > div:nth-child(2):not([id]) > div:nth-child(1):not([id]) > button:not([id])",
+                "body > div:not([id]) > div:not([id]) > div:nth-child(1):not([id]) > div#c-cookiebanner > section:not([id]) > div:not([id]) > div:not([id]) > div:nth-child(4):not([id]) > p:nth-child(1):not([id]) > button:not([id])",
+                "body > div#BannerRegion > div:nth-child(1)#Banner_cookie_0 > div:nth-child(2):not([id]) > div:not([id]) > div:nth-child(2):not([id]) > div:not([id]) > button:nth-child(2)#rejectAllBtn",
+                "body > div:not([id]) > div:nth-child(3):not([id]) > div:not([id]) > div:nth-child(2):not([id]) > button:nth-child(2):not([id])"
             ],
             "r": [
                 [
@@ -7426,6 +7435,55 @@
                 ],
                 [
                     1,
+                    "pikpak",
+                    2,
+                    "",
+                    22,
+                    [
+                        758
+                    ],
+                    [
+                        {
+                            "e": 759
+                        }
+                    ],
+                    [
+                        {
+                            "v": 760
+                        }
+                    ],
+                    [
+                        {
+                            "c": 761
+                        },
+                        {
+                            "wv": 762
+                        },
+                        {
+                            "all": true,
+                            "optional": true,
+                            "k": 763
+                        },
+                        {
+                            "c": 764
+                        }
+                    ],
+                    [
+                        {
+                            "any": [
+                                {
+                                    "cc": 765
+                                },
+                                {
+                                    "cc": 766
+                                }
+                            ]
+                        }
+                    ],
+                    {}
+                ],
+                [
+                    1,
                     "pmc",
                     1,
                     "",
@@ -9975,303 +10033,6 @@
                     [],
                     [
                         {
-                            "e": 758
-                        }
-                    ],
-                    [
-                        {
-                            "v": 758
-                        }
-                    ],
-                    [
-                        {
-                            "wait": 500
-                        },
-                        {
-                            "c": 758
-                        }
-                    ],
-                    [
-                        {
-                            "timeout": 1000,
-                            "check": "none",
-                            "wv": 758
-                        }
-                    ],
-                    {}
-                ],
-                [
-                    1,
-                    "auto_CA_coasthotels.com_f8m",
-                    0,
-                    "^https?://(www\\.)?coasthotels\\.com/",
-                    1,
-                    [],
-                    [
-                        {
-                            "e": 759
-                        }
-                    ],
-                    [
-                        {
-                            "v": 759
-                        }
-                    ],
-                    [
-                        {
-                            "c": 759
-                        }
-                    ],
-                    [],
-                    {}
-                ],
-                [
-                    1,
-                    "auto_CA_epihunter.eu_hd4",
-                    0,
-                    "^https?://(www\\.)?combell\\.com/",
-                    1,
-                    [],
-                    [
-                        {
-                            "e": 760
-                        }
-                    ],
-                    [
-                        {
-                            "v": 760
-                        }
-                    ],
-                    [
-                        {
-                            "wait": 500
-                        },
-                        {
-                            "c": 760
-                        }
-                    ],
-                    [
-                        {
-                            "timeout": 1000,
-                            "check": "none",
-                            "wv": 760
-                        }
-                    ],
-                    {}
-                ],
-                [
-                    1,
-                    "auto_CA_nationalarchives.gov.uk_rx0",
-                    0,
-                    "^https?://(www\\.)?webarchive\\.nationalarchives\\.gov\\.uk/",
-                    1,
-                    [],
-                    [
-                        {
-                            "e": 761
-                        }
-                    ],
-                    [
-                        {
-                            "v": 761
-                        }
-                    ],
-                    [
-                        {
-                            "wait": 500
-                        },
-                        {
-                            "c": 761
-                        }
-                    ],
-                    [
-                        {
-                            "timeout": 1000,
-                            "check": "none",
-                            "wv": 761
-                        }
-                    ],
-                    {}
-                ],
-                [
-                    1,
-                    "auto_CA_natureconservancy.ca_3pp",
-                    0,
-                    "^https?://(www\\.)?natureconservancy\\.ca/",
-                    1,
-                    [],
-                    [
-                        {
-                            "e": 762
-                        }
-                    ],
-                    [
-                        {
-                            "v": 762
-                        }
-                    ],
-                    [
-                        {
-                            "wait": 500
-                        },
-                        {
-                            "c": 762
-                        }
-                    ],
-                    [
-                        {
-                            "timeout": 1000,
-                            "check": "none",
-                            "wv": 762
-                        }
-                    ],
-                    {}
-                ],
-                [
-                    1,
-                    "auto_CA_ontariospca.ca_k32",
-                    0,
-                    "^https?://(www\\.)?widget-next\\.clym-sdk\\.net/",
-                    1,
-                    [],
-                    [
-                        {
-                            "e": 763
-                        }
-                    ],
-                    [
-                        {
-                            "v": 763
-                        }
-                    ],
-                    [
-                        {
-                            "wait": 500
-                        },
-                        {
-                            "c": 763
-                        }
-                    ],
-                    [
-                        {
-                            "timeout": 1000,
-                            "check": "none",
-                            "wv": 763
-                        }
-                    ],
-                    {}
-                ],
-                [
-                    1,
-                    "auto_CA_phoenixnap.com_hrb",
-                    0,
-                    "^https?://(www\\.)?widget-next\\.clym-sdk\\.net/",
-                    1,
-                    [],
-                    [
-                        {
-                            "e": 764
-                        }
-                    ],
-                    [
-                        {
-                            "v": 764
-                        }
-                    ],
-                    [
-                        {
-                            "wait": 500
-                        },
-                        {
-                            "c": 764
-                        }
-                    ],
-                    [
-                        {
-                            "timeout": 1000,
-                            "check": "none",
-                            "wv": 764
-                        }
-                    ],
-                    {}
-                ],
-                [
-                    1,
-                    "auto_CH_phoenixnap.com_lx5",
-                    0,
-                    "^https?://(www\\.)?widget-next\\.clym-sdk\\.net/",
-                    1,
-                    [],
-                    [
-                        {
-                            "e": 765
-                        }
-                    ],
-                    [
-                        {
-                            "v": 765
-                        }
-                    ],
-                    [
-                        {
-                            "wait": 500
-                        },
-                        {
-                            "c": 765
-                        }
-                    ],
-                    [
-                        {
-                            "timeout": 1000,
-                            "check": "none",
-                            "wv": 765
-                        }
-                    ],
-                    {}
-                ],
-                [
-                    1,
-                    "auto_CH_swisscare.com_arx",
-                    0,
-                    "^https?://(www\\.)?swisscare\\.com/",
-                    1,
-                    [],
-                    [
-                        {
-                            "e": 766
-                        }
-                    ],
-                    [
-                        {
-                            "v": 766
-                        }
-                    ],
-                    [
-                        {
-                            "wait": 500
-                        },
-                        {
-                            "c": 766
-                        }
-                    ],
-                    [
-                        {
-                            "timeout": 1000,
-                            "check": "none",
-                            "wv": 766
-                        }
-                    ],
-                    {}
-                ],
-                [
-                    1,
-                    "auto_DE_alfaromeo.de_gvg_+2",
-                    0,
-                    "^https?://(www\\.)?cookielaw\\.emea\\.fcagroup\\.com/|^https?://(www\\.)?cookielaw\\.emea\\.fcagroup\\.com/|^https?://(www\\.)?cookielaw\\.emea\\.fcagroup\\.com/",
-                    1,
-                    [],
-                    [
-                        {
                             "e": 767
                         }
                     ],
@@ -10299,9 +10060,9 @@
                 ],
                 [
                     1,
-                    "auto_DE_huss-licht-ton.de_jj0",
+                    "auto_CA_coasthotels.com_f8m",
                     0,
-                    "^https?://(www\\.)?huss-licht-ton\\.de/",
+                    "^https?://(www\\.)?coasthotels\\.com/",
                     1,
                     [],
                     [
@@ -10316,26 +10077,17 @@
                     ],
                     [
                         {
-                            "wait": 500
-                        },
-                        {
                             "c": 768
                         }
                     ],
-                    [
-                        {
-                            "timeout": 1000,
-                            "check": "none",
-                            "wv": 768
-                        }
-                    ],
+                    [],
                     {}
                 ],
                 [
                     1,
-                    "auto_DE_modellbau-berlinski.de_8vm",
+                    "auto_CA_epihunter.eu_hd4",
                     0,
-                    "^https?://(www\\.)?modellbau-berlinski\\.de/",
+                    "^https?://(www\\.)?combell\\.com/",
                     1,
                     [],
                     [
@@ -10367,9 +10119,9 @@
                 ],
                 [
                     1,
-                    "auto_DE_phoenixnap.com_xq7",
+                    "auto_CA_nationalarchives.gov.uk_rx0",
                     0,
-                    "^https?://(www\\.)?widget-next\\.clym-sdk\\.net/",
+                    "^https?://(www\\.)?webarchive\\.nationalarchives\\.gov\\.uk/",
                     1,
                     [],
                     [
@@ -10401,9 +10153,9 @@
                 ],
                 [
                     1,
-                    "auto_FR_fiat.fr_3fh",
+                    "auto_CA_natureconservancy.ca_3pp",
                     0,
-                    "^https?://(www\\.)?cookielaw\\.emea\\.fcagroup\\.com/",
+                    "^https?://(www\\.)?natureconservancy\\.ca/",
                     1,
                     [],
                     [
@@ -10435,43 +10187,9 @@
                 ],
                 [
                     1,
-                    "auto_FR_stellantis.com_67q",
+                    "auto_CA_ontariospca.ca_k32",
                     0,
-                    "^https?://(www\\.)?cookielaw\\.emea\\.fcagroup\\.com/",
-                    1,
-                    [],
-                    [
-                        {
-                            "e": 771
-                        }
-                    ],
-                    [
-                        {
-                            "v": 771
-                        }
-                    ],
-                    [
-                        {
-                            "wait": 500
-                        },
-                        {
-                            "c": 771
-                        }
-                    ],
-                    [
-                        {
-                            "timeout": 1000,
-                            "check": "none",
-                            "wv": 771
-                        }
-                    ],
-                    {}
-                ],
-                [
-                    1,
-                    "auto_GB_dropbox.com_0_+1",
-                    0,
-                    "^https?://(www\\.)?dropbox\\.com/|^https?://(www\\.)?dropbox\\.com/",
+                    "^https?://(www\\.)?widget-next\\.clym-sdk\\.net/",
                     1,
                     [],
                     [
@@ -10486,17 +10204,26 @@
                     ],
                     [
                         {
+                            "wait": 500
+                        },
+                        {
                             "c": 772
                         }
                     ],
-                    [],
+                    [
+                        {
+                            "timeout": 1000,
+                            "check": "none",
+                            "wv": 772
+                        }
+                    ],
                     {}
                 ],
                 [
                     1,
-                    "auto_GB_investing.thisismoney.co.uk_0",
+                    "auto_CA_phoenixnap.com_hrb",
                     0,
-                    "^https?://(www\\.)?thisismoney\\.co\\.uk/",
+                    "^https?://(www\\.)?widget-next\\.clym-sdk\\.net/",
                     1,
                     [],
                     [
@@ -10511,17 +10238,26 @@
                     ],
                     [
                         {
+                            "wait": 500
+                        },
+                        {
                             "c": 773
                         }
                     ],
-                    [],
+                    [
+                        {
+                            "timeout": 1000,
+                            "check": "none",
+                            "wv": 773
+                        }
+                    ],
                     {}
                 ],
                 [
                     1,
-                    "auto_GB_village-hotels.co.uk_hsa",
+                    "auto_CH_phoenixnap.com_lx5",
                     0,
-                    "^https?://(www\\.)?village-hotels\\.co\\.uk/",
+                    "^https?://(www\\.)?widget-next\\.clym-sdk\\.net/",
                     1,
                     [],
                     [
@@ -10553,43 +10289,9 @@
                 ],
                 [
                     1,
-                    "auto_NL_fiat.nl_trv_+1",
+                    "auto_CH_swisscare.com_arx",
                     0,
-                    "^https?://(www\\.)?cookielaw\\.emea\\.fcagroup\\.com/|^https?://(www\\.)?cookielaw\\.emea\\.fcagroup\\.com/",
-                    1,
-                    [],
-                    [
-                        {
-                            "e": 771
-                        }
-                    ],
-                    [
-                        {
-                            "v": 771
-                        }
-                    ],
-                    [
-                        {
-                            "wait": 500
-                        },
-                        {
-                            "c": 771
-                        }
-                    ],
-                    [
-                        {
-                            "timeout": 1000,
-                            "check": "none",
-                            "wv": 771
-                        }
-                    ],
-                    {}
-                ],
-                [
-                    1,
-                    "auto_NL_flitsmeister.nl_ws8",
-                    0,
-                    "^https?://(www\\.)?cookies\\.flitsmeister\\.com/",
+                    "^https?://(www\\.)?swisscare\\.com/",
                     1,
                     [],
                     [
@@ -10621,9 +10323,9 @@
                 ],
                 [
                     1,
-                    "auto_NL_interpolis.nl_jk9",
+                    "auto_DE_alfaromeo.de_gvg_+2",
                     0,
-                    "^https?://(www\\.)?interpolis\\.nl/",
+                    "^https?://(www\\.)?cookielaw\\.emea\\.fcagroup\\.com/|^https?://(www\\.)?cookielaw\\.emea\\.fcagroup\\.com/|^https?://(www\\.)?cookielaw\\.emea\\.fcagroup\\.com/",
                     1,
                     [],
                     [
@@ -10655,9 +10357,9 @@
                 ],
                 [
                     1,
-                    "auto_US_dropbox.com_0_+1",
+                    "auto_DE_huss-licht-ton.de_jj0",
                     0,
-                    "^https?://(www\\.)?dropbox\\.com/|^https?://(www\\.)?dropbox\\.com/",
+                    "^https?://(www\\.)?huss-licht-ton\\.de/",
                     1,
                     [],
                     [
@@ -10672,8 +10374,364 @@
                     ],
                     [
                         {
-                            "text": "Decline",
+                            "wait": 500
+                        },
+                        {
                             "c": 777
+                        }
+                    ],
+                    [
+                        {
+                            "timeout": 1000,
+                            "check": "none",
+                            "wv": 777
+                        }
+                    ],
+                    {}
+                ],
+                [
+                    1,
+                    "auto_DE_modellbau-berlinski.de_8vm",
+                    0,
+                    "^https?://(www\\.)?modellbau-berlinski\\.de/",
+                    1,
+                    [],
+                    [
+                        {
+                            "e": 778
+                        }
+                    ],
+                    [
+                        {
+                            "v": 778
+                        }
+                    ],
+                    [
+                        {
+                            "wait": 500
+                        },
+                        {
+                            "c": 778
+                        }
+                    ],
+                    [
+                        {
+                            "timeout": 1000,
+                            "check": "none",
+                            "wv": 778
+                        }
+                    ],
+                    {}
+                ],
+                [
+                    1,
+                    "auto_DE_phoenixnap.com_xq7",
+                    0,
+                    "^https?://(www\\.)?widget-next\\.clym-sdk\\.net/",
+                    1,
+                    [],
+                    [
+                        {
+                            "e": 779
+                        }
+                    ],
+                    [
+                        {
+                            "v": 779
+                        }
+                    ],
+                    [
+                        {
+                            "wait": 500
+                        },
+                        {
+                            "c": 779
+                        }
+                    ],
+                    [
+                        {
+                            "timeout": 1000,
+                            "check": "none",
+                            "wv": 779
+                        }
+                    ],
+                    {}
+                ],
+                [
+                    1,
+                    "auto_FR_fiat.fr_3fh",
+                    0,
+                    "^https?://(www\\.)?cookielaw\\.emea\\.fcagroup\\.com/",
+                    1,
+                    [],
+                    [
+                        {
+                            "e": 780
+                        }
+                    ],
+                    [
+                        {
+                            "v": 780
+                        }
+                    ],
+                    [
+                        {
+                            "wait": 500
+                        },
+                        {
+                            "c": 780
+                        }
+                    ],
+                    [
+                        {
+                            "timeout": 1000,
+                            "check": "none",
+                            "wv": 780
+                        }
+                    ],
+                    {}
+                ],
+                [
+                    1,
+                    "auto_FR_stellantis.com_67q",
+                    0,
+                    "^https?://(www\\.)?cookielaw\\.emea\\.fcagroup\\.com/",
+                    1,
+                    [],
+                    [
+                        {
+                            "e": 780
+                        }
+                    ],
+                    [
+                        {
+                            "v": 780
+                        }
+                    ],
+                    [
+                        {
+                            "wait": 500
+                        },
+                        {
+                            "c": 780
+                        }
+                    ],
+                    [
+                        {
+                            "timeout": 1000,
+                            "check": "none",
+                            "wv": 780
+                        }
+                    ],
+                    {}
+                ],
+                [
+                    1,
+                    "auto_GB_dropbox.com_0_+1",
+                    0,
+                    "^https?://(www\\.)?dropbox\\.com/|^https?://(www\\.)?dropbox\\.com/",
+                    1,
+                    [],
+                    [
+                        {
+                            "e": 781
+                        }
+                    ],
+                    [
+                        {
+                            "v": 781
+                        }
+                    ],
+                    [
+                        {
+                            "c": 781
+                        }
+                    ],
+                    [],
+                    {}
+                ],
+                [
+                    1,
+                    "auto_GB_investing.thisismoney.co.uk_0",
+                    0,
+                    "^https?://(www\\.)?thisismoney\\.co\\.uk/",
+                    1,
+                    [],
+                    [
+                        {
+                            "e": 782
+                        }
+                    ],
+                    [
+                        {
+                            "v": 782
+                        }
+                    ],
+                    [
+                        {
+                            "c": 782
+                        }
+                    ],
+                    [],
+                    {}
+                ],
+                [
+                    1,
+                    "auto_GB_village-hotels.co.uk_hsa",
+                    0,
+                    "^https?://(www\\.)?village-hotels\\.co\\.uk/",
+                    1,
+                    [],
+                    [
+                        {
+                            "e": 783
+                        }
+                    ],
+                    [
+                        {
+                            "v": 783
+                        }
+                    ],
+                    [
+                        {
+                            "wait": 500
+                        },
+                        {
+                            "c": 783
+                        }
+                    ],
+                    [
+                        {
+                            "timeout": 1000,
+                            "check": "none",
+                            "wv": 783
+                        }
+                    ],
+                    {}
+                ],
+                [
+                    1,
+                    "auto_NL_fiat.nl_trv_+1",
+                    0,
+                    "^https?://(www\\.)?cookielaw\\.emea\\.fcagroup\\.com/|^https?://(www\\.)?cookielaw\\.emea\\.fcagroup\\.com/",
+                    1,
+                    [],
+                    [
+                        {
+                            "e": 780
+                        }
+                    ],
+                    [
+                        {
+                            "v": 780
+                        }
+                    ],
+                    [
+                        {
+                            "wait": 500
+                        },
+                        {
+                            "c": 780
+                        }
+                    ],
+                    [
+                        {
+                            "timeout": 1000,
+                            "check": "none",
+                            "wv": 780
+                        }
+                    ],
+                    {}
+                ],
+                [
+                    1,
+                    "auto_NL_flitsmeister.nl_ws8",
+                    0,
+                    "^https?://(www\\.)?cookies\\.flitsmeister\\.com/",
+                    1,
+                    [],
+                    [
+                        {
+                            "e": 784
+                        }
+                    ],
+                    [
+                        {
+                            "v": 784
+                        }
+                    ],
+                    [
+                        {
+                            "wait": 500
+                        },
+                        {
+                            "c": 784
+                        }
+                    ],
+                    [
+                        {
+                            "timeout": 1000,
+                            "check": "none",
+                            "wv": 784
+                        }
+                    ],
+                    {}
+                ],
+                [
+                    1,
+                    "auto_NL_interpolis.nl_jk9",
+                    0,
+                    "^https?://(www\\.)?interpolis\\.nl/",
+                    1,
+                    [],
+                    [
+                        {
+                            "e": 785
+                        }
+                    ],
+                    [
+                        {
+                            "v": 785
+                        }
+                    ],
+                    [
+                        {
+                            "wait": 500
+                        },
+                        {
+                            "c": 785
+                        }
+                    ],
+                    [
+                        {
+                            "timeout": 1000,
+                            "check": "none",
+                            "wv": 785
+                        }
+                    ],
+                    {}
+                ],
+                [
+                    1,
+                    "auto_US_dropbox.com_0_+1",
+                    0,
+                    "^https?://(www\\.)?dropbox\\.com/|^https?://(www\\.)?dropbox\\.com/",
+                    1,
+                    [],
+                    [
+                        {
+                            "e": 786
+                        }
+                    ],
+                    [
+                        {
+                            "v": 786
+                        }
+                    ],
+                    [
+                        {
+                            "text": "Decline",
+                            "c": 786
                         }
                     ],
                     [],
@@ -10688,25 +10746,25 @@
                     [],
                     [
                         {
-                            "e": 778
+                            "e": 787
                         }
                     ],
                     [
                         {
-                            "v": 778
+                            "v": 787
                         }
                     ],
                     [
                         {
-                            "k": 779
+                            "k": 788
                         },
                         {
                             "all": true,
                             "optional": true,
-                            "k": 780
+                            "k": 789
                         },
                         {
-                            "k": 781
+                            "k": 790
                         }
                     ],
                     [
@@ -10725,49 +10783,49 @@
                     "^https://cmp-consent-tool\\.privacymanager\\.io/",
                     1,
                     [
-                        782,
-                        783
+                        791,
+                        792
                     ],
                     [
                         {
-                            "e": 784
+                            "e": 793
                         }
                     ],
                     [
                         {
-                            "v": 784
+                            "v": 793
                         }
                     ],
                     [
                         {
                             "if": {
-                                "e": 785
+                                "e": 794
                             },
                             "then": [
                                 {
-                                    "k": 785
+                                    "k": 794
                                 },
                                 {
-                                    "c": 786
+                                    "c": 795
                                 }
                             ],
                             "else": [
                                 {
-                                    "c": 787
+                                    "c": 796
                                 },
                                 {
-                                    "w": 788
+                                    "w": 797
                                 },
                                 {
-                                    "w": 789
+                                    "w": 798
                                 },
                                 {
                                     "all": true,
                                     "optional": true,
-                                    "k": 790
+                                    "k": 799
                                 },
                                 {
-                                    "k": 789
+                                    "k": 798
                                 }
                             ]
                         }
@@ -10784,20 +10842,20 @@
                     [],
                     [
                         {
-                            "e": 791
+                            "e": 800
                         },
                         {
-                            "e": 792
+                            "e": 801
                         }
                     ],
                     [
                         {
-                            "v": 792
+                            "v": 801
                         }
                     ],
                     [
                         {
-                            "c": 792
+                            "c": 801
                         }
                     ],
                     [],
@@ -11516,12 +11574,12 @@
                     [],
                     [
                         {
-                            "e": 793
+                            "e": 1504
                         }
                     ],
                     [
                         {
-                            "v": 793
+                            "v": 1504
                         }
                     ],
                     [
@@ -11529,14 +11587,14 @@
                             "wait": 500
                         },
                         {
-                            "c": 793
+                            "c": 1504
                         }
                     ],
                     [
                         {
                             "timeout": 1000,
                             "check": "none",
-                            "wv": 793
+                            "wv": 1504
                         }
                     ],
                     {}
@@ -11617,12 +11675,12 @@
                     [],
                     [
                         {
-                            "e": 796
+                            "e": 1505
                         }
                     ],
                     [
                         {
-                            "v": 796
+                            "v": 1505
                         }
                     ],
                     [
@@ -11630,14 +11688,14 @@
                             "wait": 500
                         },
                         {
-                            "c": 796
+                            "c": 1505
                         }
                     ],
                     [
                         {
                             "timeout": 1000,
                             "check": "none",
-                            "wv": 796
+                            "wv": 1505
                         }
                     ],
                     {}
@@ -11651,12 +11709,12 @@
                     [],
                     [
                         {
-                            "e": 797
+                            "e": 1506
                         }
                     ],
                     [
                         {
-                            "v": 797
+                            "v": 1506
                         }
                     ],
                     [
@@ -11664,14 +11722,14 @@
                             "wait": 500
                         },
                         {
-                            "c": 797
+                            "c": 1506
                         }
                     ],
                     [
                         {
                             "timeout": 1000,
                             "check": "none",
-                            "wv": 797
+                            "wv": 1506
                         }
                     ],
                     {}
@@ -11685,12 +11743,12 @@
                     [],
                     [
                         {
-                            "e": 798
+                            "e": 1507
                         }
                     ],
                     [
                         {
-                            "v": 798
+                            "v": 1507
                         }
                     ],
                     [
@@ -11698,14 +11756,14 @@
                             "wait": 500
                         },
                         {
-                            "c": 798
+                            "c": 1507
                         }
                     ],
                     [
                         {
                             "timeout": 1000,
                             "check": "none",
-                            "wv": 798
+                            "wv": 1507
                         }
                     ],
                     {}
@@ -11753,12 +11811,12 @@
                     [],
                     [
                         {
-                            "e": 799
+                            "e": 1508
                         }
                     ],
                     [
                         {
-                            "v": 799
+                            "v": 1508
                         }
                     ],
                     [
@@ -11766,14 +11824,14 @@
                             "wait": 500
                         },
                         {
-                            "c": 799
+                            "c": 1508
                         }
                     ],
                     [
                         {
                             "timeout": 1000,
                             "check": "none",
-                            "wv": 799
+                            "wv": 1508
                         }
                     ],
                     {}
@@ -11787,12 +11845,12 @@
                     [],
                     [
                         {
-                            "e": 800
+                            "e": 1509
                         }
                     ],
                     [
                         {
-                            "v": 800
+                            "v": 1509
                         }
                     ],
                     [
@@ -11800,14 +11858,14 @@
                             "wait": 500
                         },
                         {
-                            "c": 800
+                            "c": 1509
                         }
                     ],
                     [
                         {
                             "timeout": 1000,
                             "check": "none",
-                            "wv": 800
+                            "wv": 1509
                         }
                     ],
                     {}
@@ -11855,12 +11913,12 @@
                     [],
                     [
                         {
-                            "e": 801
+                            "e": 1510
                         }
                     ],
                     [
                         {
-                            "v": 801
+                            "v": 1510
                         }
                     ],
                     [
@@ -11868,14 +11926,14 @@
                             "wait": 500
                         },
                         {
-                            "c": 801
+                            "c": 1510
                         }
                     ],
                     [
                         {
                             "timeout": 1000,
                             "check": "none",
-                            "wv": 801
+                            "wv": 1510
                         }
                     ],
                     {}
@@ -15772,12 +15830,12 @@
                     [],
                     [
                         {
-                            "e": 794
+                            "e": 1511
                         }
                     ],
                     [
                         {
-                            "v": 794
+                            "v": 1511
                         }
                     ],
                     [
@@ -15785,14 +15843,14 @@
                             "wait": 500
                         },
                         {
-                            "c": 794
+                            "c": 1511
                         }
                     ],
                     [
                         {
                             "timeout": 1000,
                             "check": "none",
-                            "wv": 794
+                            "wv": 1511
                         }
                     ],
                     {}
@@ -21312,12 +21370,12 @@
                     [],
                     [
                         {
-                            "e": 795
+                            "e": 1512
                         }
                     ],
                     [
                         {
-                            "v": 795
+                            "v": 1512
                         }
                     ],
                     [
@@ -21325,14 +21383,14 @@
                             "wait": 500
                         },
                         {
-                            "c": 795
+                            "c": 1512
                         }
                     ],
                     [
                         {
                             "timeout": 1000,
                             "check": "none",
-                            "wv": 795
+                            "wv": 1512
                         }
                     ],
                     {}
@@ -29066,18 +29124,18 @@
             "index": {
                 "genericRuleRange": [
                     0,
-                    191
+                    192
                 ],
                 "frameRuleRange": [
-                    190,
-                    216
+                    191,
+                    217
                 ],
                 "specificRuleRange": [
-                    191,
-                    772
+                    192,
+                    773
                 ],
-                "genericStringEnd": 758,
-                "frameStringEnd": 793
+                "genericStringEnd": 767,
+                "frameStringEnd": 802
             }
         }
     }


### PR DESCRIPTION
Asana Task/Github Issue: https://app.asana.com/1/137249556945/project/1201844467387842/task/1216254619336480

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Data-only consent-rule updates with no application code changes; main risk is occasional false positives/negatives on affected sites if a selector misfires.
> 
> **Overview**
> Bumps the **autoconsent** cookie-popup rules in `features/autoconsent.json` to **v16.5.0**, expanding how DuckDuckGo can detect and reject consent UI.
> 
> New **generic** patterns cover `.cookie-wrapper` tip banners, Element UI `.el-dialog.cookie-dialog` flows (including checked switches and primary footer buttons), and cookie values that set `allow_analysis` to false. Several existing site-specific selectors (e.g. `#cookie-policy`, Shopify cookie/newsletter banners, `#BannerRegion` reject) are **moved** within the string table rather than dropped.
> 
> A new **site rule** for **pikpak** is added (detect, hide, click/reject, optional cookie writes). Upstream reindexing shifts shared string IDs across many auto-generated and named rules (`coinbase`, `privacymanager.io`, `web.de`, Dropbox, etc.), and the bundled **index** ranges are updated (`genericRuleRange` +1 rule, higher `genericStringEnd` / `frameStringEnd`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c0e67d68a762ff88dd32db9b6791f8f59cfd7b54. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->