### PR TITLE
disable product surface telemetry on iOS

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -2727,7 +2727,7 @@
                     }
                 },
                 "productTelemetrySurfaceUsage": {
-                    "state": "enabled",
+                    "state": "disabled",
                     "minSupportedVersion": "7.199.0",
                     "description": "Temporarily gather telemetry around product surfaces being used."
                 },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/392891325557410/task/1215831363616880?focus=true

## Description
Disable product surface telemetry

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 12f9dfceb19e2dbdc6801202cdc4a98692b9c999. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->