### PR TITLE
Autofill: raise maxInputsPerPage for wealthr.co.uk

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -817,6 +817,18 @@
                         "conditionalChanges": [
                             {
                                 "condition": [
+                                    { "domain": "wealthr.co.uk" }
+                                ],
+                                "patchSettings": [
+                                    {
+                                        "path": "/failsafeSettings/maxInputsPerPage",
+                                        "op": "add",
+                                        "value": 160
+                                    }
+                                ]
+                            },
+                            {
+                                "condition": [
                                     { "domain": "ring.com" }
                                 ],
                                 "patchSettings": [

--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -967,6 +967,18 @@
                         "conditionalChanges": [
                             {
                                 "condition": [
+                                    { "domain": "wealthr.co.uk" }
+                                ],
+                                "patchSettings": [
+                                    {
+                                        "path": "/failsafeSettings/maxInputsPerPage",
+                                        "op": "add",
+                                        "value": 160
+                                    }
+                                ]
+                            },
+                            {
+                                "condition": [
                                     { "domain": "ring.com" }
                                 ],
                                 "patchSettings": [

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -913,6 +913,18 @@
                         "conditionalChanges": [
                             {
                                 "condition": [
+                                    { "domain": "wealthr.co.uk" }
+                                ],
+                                "patchSettings": [
+                                    {
+                                        "path": "/failsafeSettings/maxInputsPerPage",
+                                        "op": "add",
+                                        "value": 160
+                                    }
+                                ]
+                            },
+                            {
+                                "condition": [
                                     { "domain": "ring.com" }
                                 ],
                                 "patchSettings": [

--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -1631,6 +1631,20 @@
                             {
                                 "condition": [
                                     {
+                                        "domain": "wealthr.co.uk"
+                                    }
+                                ],
+                                "patchSettings": [
+                                    {
+                                        "path": "/failsafeSettings/maxInputsPerPage",
+                                        "op": "add",
+                                        "value": 160
+                                    }
+                                ]
+                            },
+                            {
+                                "condition": [
+                                    {
                                         "domain": "ring.com"
                                     }
                                 ],


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1200930669568058/task/1216180442448845?focus=true

## Description
<!-- 
  Please delete either or both process sections below.
-->
wealthr.co.uk has 154 input fields on the page, which exceeds the default maxInputsPerPage failsafe (100), causing the autofill scanner to stop scanning. Add a siteSpecificFixes rule bumping maxInputsPerPage to 160 for the domain across iOS, macOS, Android and Windows.


### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only, domain-scoped site fix with no auth or global behavior changes; slightly higher scan work on that site only.
> 
> **Overview**
> Adds a **site-specific autofill fix** for `wealthr.co.uk` so the page scanner can finish on sites with very large forms (reported ~154 inputs vs the default **100** `maxInputsPerPage` failsafe).
> 
> The new rule is inserted at the top of `autofill` → `siteSpecificFixes` → `conditionalChanges` in the Android, iOS, macOS, and Windows override configs, patching `failsafeSettings/maxInputsPerPage` to **160** when the domain matches—same pattern as existing overrides like `coolors.co`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b2750015062696daba05a005e4f016f83a36400f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->