### PR TITLE
Enabled surrogates for PIR webviews

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -1539,6 +1539,9 @@
                 },
                 "trackerBlocking": {
                     "state": "enabled"
+                },
+                "surrogates": {
+                    "state": "enabled"
                 }
             },
             "settings": {


### PR DESCRIPTION
**Asana Task/Github Issue:**https://app.asana.com/1/137249556945/project/1212592783523117/task/1215754872283820?focus=true

## Description
Enabled surrogates for PIR Agent embedded webviews.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Remote config toggle only for Windows PIR webviews; limited scope and no auth or data-path changes in this PR.
> 
> **Overview**
> Turns on the **`surrogates`** feature for Windows under **`dbp`** (Personal Info Removal), alongside the already-enabled **`trackerBlocking`**, so PIR Agent embedded webviews can use surrogate scripts when blocking trackers.
> 
> This is a single config flag in `overrides/windows-override.json`; no app code changes in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bcc22c252abe17e599087558e2f2120fbd58a65f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->