### PR TITLE
Disable product surface telemetry for Android

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -4353,12 +4353,12 @@
             }
         },
         "productSurfaceTelemetry": {
-            "state": "enabled",
+            "state": "disabled",
             "exceptions": [],
             "minSupportedVersion": 52751000,
             "features": {
                 "enableTelemetry": {
-                    "state": "enabled",
+                    "state": "disabled",
                     "minSupportedVersion": 52751000
                 }
             }


### PR DESCRIPTION
**Asana Task/Github Issue:**https://app.asana.com/1/137249556945/task/1215831363616882?focus=true

## Description
Disable productSurfaceTelemetry feature flag in the Android config

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [x] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only remote flag flip with no code or credential changes; main effect is stopping product-surface telemetry collection on Android clients that read this override.
> 
> **Overview**
> Turns off **product surface telemetry** for Android by updating `overrides/android-override.json`.
> 
> Both `productSurfaceTelemetry.state` and nested `features.enableTelemetry.state` change from **enabled** to **disabled**. `minSupportedVersion` and exceptions are unchanged; only the kill switch flips.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0c561f60ebc72960c117a6ec04a591cc66d388a7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->