### PR TITLE
Add subfeature for sentry CRCID to windows overrides

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -5146,10 +5146,10 @@
                             "System.OutOfMemoryException"
                         ]
                     }
+                },
+                "sendCrcidWithSentry": {
+                    "state": "enabled"
                 }
-            },
-            "sendCrcidWithSentry": {
-                "state": "enabled"
             }
         },
         "nativeCrashReporting": {

--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -5147,6 +5147,9 @@
                         ]
                     }
                 }
+            },
+            "sendCrcidWithSentry": {
+                "state": "enabled"
             }
         },
         "nativeCrashReporting": {


### PR DESCRIPTION
**Asana Task/Github Issue:**  https://app.asana.com/1/137249556945/project/1207390136205919/task/1209024686925182?focus=true

## Description
Adds subfeature for sentry CRCID to windows overrides

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single Windows override flag with no application code changes; only affects whether CRCID is sent with Sentry when the client honors the feature.
> 
> **Overview**
> Turns on the **`sendCrcidWithSentry`** subfeature under **`extendedCrashReporting`** in `overrides/windows-override.json`, so Windows clients can include CRCID with Sentry crash reporting when the app reads this config.
> 
> No other platforms or subfeatures are changed in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 13f613323df0fdefc3598df675e0470832660fe0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->