### PR TITLE
Cursor/force cc form type 415d

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -817,19 +817,19 @@
                         "conditionalChanges": [
                             {
                                 "condition": [
-                                    { "domain": "vterm.c9pg.com" }
+                                    { "domain": "blindbarber.com" }
                                 ],
                                 "patchSettings": [
                                     {
                                         "path": "/formBoundarySelector",
                                         "op": "replace",
-                                        "value": "form"
+                                        "value": "app-createcardtoken form"
                                     },
                                     {
                                         "path": "/formTypeSettings/-",
                                         "op": "add",
                                         "value": {
-                                            "selector": "form",
+                                            "selector": "app-createcardtoken form",
                                             "type": "cc"
                                         }
                                     }

--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -817,6 +817,18 @@
                         "conditionalChanges": [
                             {
                                 "condition": [
+                                    { "domain": "vterm.c9pg.com" }
+                                ],
+                                "patchSettings": [
+                                    {
+                                        "path": "/formBoundarySelector",
+                                        "op": "replace",
+                                        "value": "app-createcardtoken"
+                                    }
+                                ]
+                            },
+                            {
+                                "condition": [
                                     { "domain": "wealthr.co.uk" }
                                 ],
                                 "patchSettings": [

--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -823,7 +823,7 @@
                                     {
                                         "path": "/formBoundarySelector",
                                         "op": "replace",
-                                        "value": "app-createcardtoken"
+                                        "value": "form"
                                     }
                                 ]
                             },

--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -824,6 +824,14 @@
                                         "path": "/formBoundarySelector",
                                         "op": "replace",
                                         "value": "form"
+                                    },
+                                    {
+                                        "path": "/formTypeSettings/-",
+                                        "op": "add",
+                                        "value": {
+                                            "selector": "form",
+                                            "type": "cc"
+                                        }
                                     }
                                 ]
                             },

--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -973,7 +973,7 @@
                                     {
                                         "path": "/formBoundarySelector",
                                         "op": "replace",
-                                        "value": "app-createcardtoken"
+                                        "value": "form"
                                     }
                                 ]
                             },

--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -967,6 +967,18 @@
                         "conditionalChanges": [
                             {
                                 "condition": [
+                                    { "domain": "vterm.c9pg.com" }
+                                ],
+                                "patchSettings": [
+                                    {
+                                        "path": "/formBoundarySelector",
+                                        "op": "replace",
+                                        "value": "app-createcardtoken"
+                                    }
+                                ]
+                            },
+                            {
+                                "condition": [
                                     { "domain": "wealthr.co.uk" }
                                 ],
                                 "patchSettings": [

--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -967,19 +967,19 @@
                         "conditionalChanges": [
                             {
                                 "condition": [
-                                    { "domain": "vterm.c9pg.com" }
+                                    { "domain": "blindbarber.com" }
                                 ],
                                 "patchSettings": [
                                     {
                                         "path": "/formBoundarySelector",
                                         "op": "replace",
-                                        "value": "form"
+                                        "value": "app-createcardtoken form"
                                     },
                                     {
                                         "path": "/formTypeSettings/-",
                                         "op": "add",
                                         "value": {
-                                            "selector": "form",
+                                            "selector": "app-createcardtoken form",
                                             "type": "cc"
                                         }
                                     }

--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -974,6 +974,14 @@
                                         "path": "/formBoundarySelector",
                                         "op": "replace",
                                         "value": "form"
+                                    },
+                                    {
+                                        "path": "/formTypeSettings/-",
+                                        "op": "add",
+                                        "value": {
+                                            "selector": "form",
+                                            "type": "cc"
+                                        }
                                     }
                                 ]
                             },

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -913,19 +913,19 @@
                         "conditionalChanges": [
                             {
                                 "condition": [
-                                    { "domain": "vterm.c9pg.com" }
+                                    { "domain": "blindbarber.com" }
                                 ],
                                 "patchSettings": [
                                     {
                                         "path": "/formBoundarySelector",
                                         "op": "replace",
-                                        "value": "form"
+                                        "value": "app-createcardtoken form"
                                     },
                                     {
                                         "path": "/formTypeSettings/-",
                                         "op": "add",
                                         "value": {
-                                            "selector": "form",
+                                            "selector": "app-createcardtoken form",
                                             "type": "cc"
                                         }
                                     }

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -920,6 +920,14 @@
                                         "path": "/formBoundarySelector",
                                         "op": "replace",
                                         "value": "form"
+                                    },
+                                    {
+                                        "path": "/formTypeSettings/-",
+                                        "op": "add",
+                                        "value": {
+                                            "selector": "form",
+                                            "type": "cc"
+                                        }
                                     }
                                 ]
                             },

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -919,7 +919,7 @@
                                     {
                                         "path": "/formBoundarySelector",
                                         "op": "replace",
-                                        "value": "app-createcardtoken"
+                                        "value": "form"
                                     }
                                 ]
                             },

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -913,6 +913,18 @@
                         "conditionalChanges": [
                             {
                                 "condition": [
+                                    { "domain": "vterm.c9pg.com" }
+                                ],
+                                "patchSettings": [
+                                    {
+                                        "path": "/formBoundarySelector",
+                                        "op": "replace",
+                                        "value": "app-createcardtoken"
+                                    }
+                                ]
+                            },
+                            {
+                                "condition": [
                                     { "domain": "wealthr.co.uk" }
                                 ],
                                 "patchSettings": [

--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -1633,6 +1633,18 @@
                         "conditionalChanges": [
                             {
                                 "condition": [
+                                    { "domain": "vterm.c9pg.com" }
+                                ],
+                                "patchSettings": [
+                                    {
+                                        "path": "/formBoundarySelector",
+                                        "op": "replace",
+                                        "value": "app-createcardtoken"
+                                    }
+                                ]
+                            },
+                            {
+                                "condition": [
                                     {
                                         "domain": "wealthr.co.uk"
                                     }

--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -1640,6 +1640,14 @@
                                         "path": "/formBoundarySelector",
                                         "op": "replace",
                                         "value": "form"
+                                    },
+                                    {
+                                        "path": "/formTypeSettings/-",
+                                        "op": "add",
+                                        "value": {
+                                            "selector": "form",
+                                            "type": "cc"
+                                        }
                                     }
                                 ]
                             },

--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -1633,19 +1633,19 @@
                         "conditionalChanges": [
                             {
                                 "condition": [
-                                    { "domain": "vterm.c9pg.com" }
+                                    { "domain": "blindbarber.com" }
                                 ],
                                 "patchSettings": [
                                     {
                                         "path": "/formBoundarySelector",
                                         "op": "replace",
-                                        "value": "form"
+                                        "value": "app-createcardtoken form"
                                     },
                                     {
                                         "path": "/formTypeSettings/-",
                                         "op": "add",
                                         "value": {
-                                            "selector": "form",
+                                            "selector": "app-createcardtoken form",
                                             "type": "cc"
                                         }
                                     }

--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -1639,7 +1639,7 @@
                                     {
                                         "path": "/formBoundarySelector",
                                         "op": "replace",
-                                        "value": "app-createcardtoken"
+                                        "value": "form"
                                     }
                                 ]
                             },

--- a/schema/features/autofill.ts
+++ b/schema/features/autofill.ts
@@ -25,7 +25,7 @@ type ImportBookmarksFromGoogleTakeoutSettings = {
 
 export type FormTypeSetting = {
     selector: string;
-    type: 'login' | 'signup' | 'cc';
+    type: 'login' | 'signup' | 'hybrid' | 'cc';
 };
 
 export type InputTypeSetting = {

--- a/schema/features/autofill.ts
+++ b/schema/features/autofill.ts
@@ -25,7 +25,7 @@ type ImportBookmarksFromGoogleTakeoutSettings = {
 
 export type FormTypeSetting = {
     selector: string;
-    type: 'login' | 'signup';
+    type: 'login' | 'signup' | 'cc';
 };
 
 export type InputTypeSetting = {


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1200930669568058/task/1214787241405867?focus=true

## Description
<!-- 
  Please delete either or both process sections below.
-->
Add remote autofill rule for blindbarber.com credit card page

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only, domain-scoped autofill site fix with a small schema extension; no broad behavior change outside blindbarber.com.
> 
> **Overview**
> Adds a **site-specific autofill fix** for `blindbarber.com` on Android, iOS, macOS, and Windows so the checkout card flow is handled as a credit-card form instead of being mis-detected.
> 
> When the domain matches, `siteSpecificFixes` sets `formBoundarySelector` to `app-createcardtoken form` and adds a `formTypeSettings` entry with **type `cc`** for that selector.
> 
> The autofill schema **`FormTypeSetting.type`** union is extended to include **`hybrid`** and **`cc`**, so the new override value validates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa89aea433218ba63d4339371dd2a886dc511112. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->