### PR TITLE
remove adblock banner on hdporncomics

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -2113,6 +2113,26 @@
                 ]
             },
             {
+                "domain": "hdporncomics.com",
+                "rules": [
+                    {
+                        "type": "disable-default"
+                    },
+                    {
+                        "selector": "ins.adsbyexoclick",
+                        "type": "hide-empty"
+                    },
+                    {
+                        "selector": "#adverBox",
+                        "type": "closest-empty"
+                    },
+                    {
+                        "selector": ".adSingle",
+                        "type": "hide-empty"
+                    }
+                ]
+            },
+            {
                 "domain": "healthline.com",
                 "rules": [
                     {


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1206670747178362/task/1216228701600576?focus=true

## Description


### Site breakage mitigation process:
#### Brief explanation
- Reported URL: [https://hdporncomics.com/](https://hdporncomics.com/two-foxes-one-bun-sex-comic/)
- Problems experienced: ad block banner
- Platforms affected:
  - [ x] iOS
  - [ x] Android
  - [x ] Windows
  - [x ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked: NA
- Feature being disabled/modified: element-hiding
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-domain privacy config change with no auth or data handling; `disable-default` only affects one site’s element-hiding behavior.
> 
> **Overview**
> Adds a **site-specific element-hiding entry** for `hdporncomics.com` to address reported **ad-block / anti-adblock banner** breakage on iOS, Android, Windows, and macOS.
> 
> The config **turns off global default hiding rules** on that domain (`disable-default`), then applies **targeted rules** only: hide empty `ins.adsbyexoclick` and `.adSingle`, and collapse empty ancestors of `#adverBox` (`closest-empty`). This matches the usual breakage-mitigation pattern used elsewhere in `element-hiding.json` when broad selectors trigger site UI instead of real ad slots.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 59310016d8599889927b686db52754e7467e3a55. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->