### PR TITLE
Update content-blocker extension to 2026.7.3

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -4886,7 +4886,7 @@
             "minSupportedVersion": "0.148.0",
             "exceptions": [],
             "settings": {
-                "extensionUrl": "https://staticcdn.duckduckgo.com/extensions/content-blocker/content-blocker-extension-2026.6.23.crx"
+                "extensionUrl": "https://staticcdn.duckduckgo.com/extensions/content-blocker/content-blocker-extension-2026.7.3.crx"
             },
             "features": {
                 "onboardingEnabled": {


### PR DESCRIPTION
Update content-blocker extension to 2026.7.3.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single URL bump in remote config; behavior depends on the shipped CRX but no app code or auth paths change.
> 
> **Overview**
> Updates the Windows remote config for **adBlockV2Extension** so clients download the newer content-blocker CRX (`content-blocker-extension-2026.7.3.crx` instead of `2026.6.23.crx`). No other settings or feature flags in that block are changed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c167022b55ab3984909747270150a3d360e3f99. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->