### PR TITLE
Update ad-blocking extension scriptlets for v2026.7.3

### DIFF
--- a/features/ad-blocking-extension.json
+++ b/features/ad-blocking-extension.json
@@ -4,28 +4,28 @@
     },
     "exceptions": [],
     "settings": {
-        "version": "2026.6.23",
+        "version": "2026.7.3",
         "enabledByDefault": false,
         "scriptlets": {
             "scriptlets/isolated/ublock-filters.js": {
-                "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/dd60a3329b8dacaf619a7ff6b15fbf22c65333c9f73f9fd3083d234daa644898.js",
-                "signature": "MEQCIEyb1e0BQzIkqrexlzXF4RZWm0mRyEmDw1YSrDZU0I6dAiAlnxa4UMzGiKqY7++KupBkG/hQJz4w4BJEcj2BfMaGkA=="
+                "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/fba132f2069af8a0da8afc08f0081ffbccbd5a7172a6b711c34f6611a090448e.js",
+                "signature": "MEYCIQC92qUQpKrQOUtQTaJDRPNAzsgPgTJEC3uMgAbZuitpfwIhALyCuQdaHP4gELXiUToTF59HsVQ4fgUM/7JHEQOKwbPm"
             },
             "scriptlets/main/ublock-filters.js": {
-                "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/202dc5c3cef849bb0613ca02efe78ac45bf6a886d4b1df6c13684336d134b320.js",
-                "signature": "MEUCIQDNvjOu9AzTlZAgy8Gb6hRezLu0KtRX5WjKJsXwiV7jWgIgZlNbmBdylMB2QVcK5Rsm6tDO6LUsWZY2Sf4txmo6VOQ="
+                "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/f80a19244a1b4cb617a1680d4570c86b243a4a5eff7e7c0695716fb32a477815.js",
+                "signature": "MEUCIEmdbhkNAhnN0ra5rwlJcsTym1n+mXd9xuGsE9I7ofNiAiEA0jLrAMlocaBhFjAxwrc+h75G2MsY8kF/eBHs7enYp2I="
             },
             "scriptlets/main/ublock-experimental.js": {
                 "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855.js",
-                "signature": "MEUCIA7mNbZKETLQBvybfipWAY6Feat1Zw+yRtBacN39OjztAiEA7ACVxagN8FY7iYXxAE7cIh+qZuQtSK7xgGxjheWoxaA="
+                "signature": "MEYCIQDcSIpLEgCaTh0Z6VuVVivOX1/Vh8ZxFyZVSn5vaQBYGgIhAOKmLKACbog2csCZZ1eACQ+YbYt3g5IW8D9djF5OMnnH"
             },
             "scriptlets/isolated/ublock-experimental.js": {
                 "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855.js",
-                "signature": "MEYCIQDE7wWUwTS90egBzLzxB7baNcUYdYwgvwoXtd2oUNa+eQIhALigPi5usQ+t6xgitCG1qJeHXR4+hxmxWGFtqfEyXuBo"
+                "signature": "MEUCIAPzA4H0Po83p7wdQqE/TS2IHE0hcNieJT4GkyF0ZvsJAiEAqJQ6kmzO4/vZ7PYvIEaIqLC3jBzKvQP0t5wf1ZtFZiU="
             },
             "rules/youtube.json": {
                 "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/2337db6aa7466667595226f780b6590779db3007ac0a65ef3833f89610c92824.json",
-                "signature": "MEUCIBaJ33YqDMP3mYOuvtzMRKXediIDCs+p7atFMPGdXyd8AiEAmj7Tiy9X50teLttyYYig90CKs0MZ3G8+RBOZ5JGYQNU="
+                "signature": "MEYCIQDvwFHsRMRQDr2rlUf7KElHCIa8UqKJJyvcm3XLkYdQxQIhAOm1UsW11m7IiWKVlTn/DbfrQ1k2Oq1XGzSn3Sr2JuT6"
             }
         }
     }


### PR DESCRIPTION
Update ad-blocking extension scriptlets for v2026.7.3.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which signed scriptlets clients download for content blocking; bad URLs or signatures could break ad blocking until the next config fix.
> 
> **Overview**
> Bumps the macOS/iOS ad-blocking extension feature config from **2026.6.23** to **2026.7.3**.
> 
> Updates CDN **URLs** and **signatures** for the uBlock filter scriptlets (isolated and main), both uBlock experimental scriptlet entries (URLs unchanged, signatures rotated), and **rules/youtube.json**. No structural or behavioral flag changes beyond the new scriptlet artifacts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 938d105f04c205b157dfae5c24d8bb22129d5475. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->