### PR TITLE
remove grey overlay on tiendaselectron-com and trustedhousesitters-com

### DIFF
--- a/features/autoconsent.json
+++ b/features/autoconsent.json
@@ -878,6 +878,14 @@
         {
             "domain": "planet.fr",
             "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5463"
+        },
+        {
+            "domain": "tiendaselectron.com",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5487"
+        },
+        {
+            "domain": "trustedhousesitters.com",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5487"
         }
     ],
     "settings": {


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1206670747178362/task/1216262712802796?focus=true
https://app.asana.com/1/137249556945/project/1206670747178362/task/1216088269871102?focus=true

## Description

### Site breakage mitigation process:
#### Brief explanation
- Reported URL: tiendaselectron.com, trustedhousesitters.com
- Problems experienced:
- Platforms affected:
  - [x ] iOS
  - [x ] Android
  - [ x] Windows
  - [x ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked: NA
- Feature being disabled/modified: autoconsent
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only exception entries following the existing breakage-mitigation pattern; autoconsent is disabled only on two domains.
> 
> **Overview**
> Adds **tiendaselectron.com** and **trustedhousesitters.com** to the autoconsent **exceptions** list so automatic cookie-consent handling is skipped on those sites, addressing reported grey-overlay site breakage on iOS, Android, Windows, and macOS.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fc5b3e54ad067a61395d5870722f1d1e24656485. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->