### PR TITLE
Fix the "Sign In with Facebook" button on TrustedHousesitters

### DIFF
--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -1802,11 +1802,13 @@
                         "domains": [
                             "bandsintown.com",
                             "nextdoor.co.uk",
-                            "nextdoor.com"
+                            "nextdoor.com",
+                            "trustedhousesitters.com"
                         ],
                         "reason": [
                             "bandsintown.com - Ticket page renders blank. With this exception the page redirects to ticketspice.com.",
-                            "nextdoor.co.uk, nextdoor.com - Facebook login option appears greyed out and cannot be clicked."
+                            "nextdoor.co.uk, nextdoor.com - Facebook login option appears greyed out and cannot be clicked.",
+                            "trustedhousesitters.com - https://github.com/duckduckgo/privacy-configuration/pull/5488"
                         ]
                     },
                     {


### PR DESCRIPTION
When clicked, the "Sign In with Facebook" button on TrustedHousesitters didn't
do anything. To get that working, let's allow the Facebook SDK to load on that
website.

**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1201720254973470/task/1216208388522812?focus=true