### PR TITLE
Add autoconsent exception for 3bmeteo.com

### DIFF
--- a/features/autoconsent.json
+++ b/features/autoconsent.json
@@ -4,6 +4,10 @@
     },
     "exceptions": [
         {
+            "domain": "3bmeteo.com",
+            "reason": "Requested exception for 3bmeteo.com."
+        },
+        {
             "domain": "allocine.fr",
             "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1241"
         },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1207686573307971/task/1215955524086797?focus=true

### Site breakage mitigation process:
#### Brief explanation
- Reported URL: 3bmeteo.com
- Problems experienced: site requires cookies or subscription, so users are blocked if we deny permissions automatically
- Platforms affected:
  - [x] Browsers
  - [ ] Extensions
- Feature being disabled/modified: autoconsent
