### PR TITLE
Disable webScrollFreezeObservability on iOS

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -2878,6 +2878,9 @@
                 "removeChatHistory": {
                     "state": "enabled",
                     "minSupportedVersion": "7.225.0"
+                },
+                "webScrollFreezeObservability": {
+                    "state": "disabled"
                 }
             }
         },


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/1206488453854252/task/1216268817913849?focus=true

## Description

Roll back web-scroll-freeze observability on iOS by disabling the `webScrollFreezeObservability` subfeature under `iOSBrowserConfig`.

This flag shipped **on-by-default** and remote-disableable in [apple-browsers#5491](https://github.com/duckduckgo/apple-browsers/pull/5491) (`FeatureFlag.webScrollFreezeObservability` → `.enabled`, `.remoteReleasable(iOSBrowserConfigSubfeature.webScrollFreezeObservability)`). Setting the subfeature `state` to `disabled` here turns the observer (passive scroll-failure recognizer + symptom/mechanism pixels) off for the whole population.

iOS-only; verified absent from the generated Android/macOS configs.

```json
"webScrollFreezeObservability": {
    "state": "disabled"
}
```

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single iOS privacy-config flag flip with no app logic changes; impact is stopping observability telemetry, not user-facing browsing behavior.
> 
> **Overview**
> Rolls back **web scroll freeze observability** on iOS by adding `webScrollFreezeObservability` under `iOSBrowserConfig` in `ios-override.json` with **`state`: `disabled`**.
> 
> That remote subfeature turns off the passive scroll-failure observer and related symptom/mechanism pixels for all iOS clients once config is picked up—complementing the on-by-default app wiring from apple-browsers#5491.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7bd2adc5c02a957344fe3c48c83d766c14613c84. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->