### PR TITLE
Re-enable webViewSessionPersistence to 50%

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -1908,7 +1908,7 @@
                     "minSupportedVersion": 52810000
                 },
                 "webViewSessionPersistence": {
-                    "state": "disabled",
+                    "state": "enabled",
                     "rollout": {
                         "steps": [
                             {


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/1214749231578703/task/1216269007024242?focus=true

## Description
Re-enable and back to 50%

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Turning WebView session persistence back on for up to 50% of Android users can affect tab/session restore and storage behavior; rollout limits blast radius but behavior is user-facing.
> 
> **Overview**
> Re-enables the **`webViewSessionPersistence`** flag under **`androidBrowserConfig`** in `android-override.json`, switching **`state`** from **`disabled`** to **`enabled`**.
> 
> The existing staged rollout is unchanged (**10%** then **50%**), so eligible Android clients can again receive WebView session persistence for roughly half of the rolled-out population after the feature was turned off.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b9a73e06dc30791be1f47a62b596d4ac96bfd706. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->