### PR TITLE
Update content-blocker extension to 2026.7.6

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -4886,7 +4886,7 @@
             "minSupportedVersion": "0.148.0",
             "exceptions": [],
             "settings": {
-                "extensionUrl": "https://staticcdn.duckduckgo.com/extensions/content-blocker/content-blocker-extension-2026.7.3.crx"
+                "extensionUrl": "https://staticcdn.duckduckgo.com/extensions/content-blocker/content-blocker-extension-2026.7.6.crx"
             },
             "features": {
                 "onboardingEnabled": {


### PR DESCRIPTION
Update content-blocker extension to 2026.7.6.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single CDN URL version bump in Windows override config; no logic or security surface changes in-repo.
> 
> **Overview**
> Updates the Windows remote config for **adBlockV2Extension** so clients download the newer packaged extension.
> 
> The only change is `extensionUrl` in `overrides/windows-override.json`, from `content-blocker-extension-2026.7.3.crx` to `content-blocker-extension-2026.7.6.crx`. Feature flags and other `adBlockV2Extension` settings are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ac8f33b6fb8ff783a6823673ba0a7f046ce2246. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->