### PR TITLE
Update ad-blocking extension scriptlets for v2026.7.6

### DIFF
--- a/features/ad-blocking-extension.json
+++ b/features/ad-blocking-extension.json
@@ -4,28 +4,28 @@
     },
     "exceptions": [],
     "settings": {
-        "version": "2026.7.3",
+        "version": "2026.7.6",
         "enabledByDefault": false,
         "scriptlets": {
             "scriptlets/isolated/ublock-filters.js": {
-                "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/fba132f2069af8a0da8afc08f0081ffbccbd5a7172a6b711c34f6611a090448e.js",
-                "signature": "MEYCIQC92qUQpKrQOUtQTaJDRPNAzsgPgTJEC3uMgAbZuitpfwIhALyCuQdaHP4gELXiUToTF59HsVQ4fgUM/7JHEQOKwbPm"
+                "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/23765714b14e17988e02bc9056a26bee9dc7f16cf94e54aa3178458571d5810a.js",
+                "signature": "MEQCIEBFxsHn+W1dQn5yF7ohup9ScW7NmzohqqL8+fG1QFwUAiBiNRQ4rs7fCMkYjpwL8q+lqCHGAdKsABT9UxS9R3Q2zA=="
             },
             "scriptlets/main/ublock-filters.js": {
-                "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/f80a19244a1b4cb617a1680d4570c86b243a4a5eff7e7c0695716fb32a477815.js",
-                "signature": "MEUCIEmdbhkNAhnN0ra5rwlJcsTym1n+mXd9xuGsE9I7ofNiAiEA0jLrAMlocaBhFjAxwrc+h75G2MsY8kF/eBHs7enYp2I="
+                "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/c9de572d02e840bfd60b1b88a592fafc7ce2722957ab43f2fb37c71eb8187d00.js",
+                "signature": "MEYCIQDFA5iCu7gzqj78dRkggoiyfwToyl485gV9LHs/kHFx2wIhAJkIPWf2qtYHyWSPqex3Yo2SfCkUHHvm33/dhcuVG37l"
             },
             "scriptlets/main/ublock-experimental.js": {
                 "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855.js",
-                "signature": "MEYCIQDcSIpLEgCaTh0Z6VuVVivOX1/Vh8ZxFyZVSn5vaQBYGgIhAOKmLKACbog2csCZZ1eACQ+YbYt3g5IW8D9djF5OMnnH"
+                "signature": "MEQCICK9SyAb0FbMcIZCpLZImtP4SBrCG1UVQOBkkIjok8LgAiAzagemTCVDH6EvaNJxFHHRid/jcrZe1wqFnnK6xuPy2g=="
             },
             "scriptlets/isolated/ublock-experimental.js": {
                 "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855.js",
-                "signature": "MEUCIAPzA4H0Po83p7wdQqE/TS2IHE0hcNieJT4GkyF0ZvsJAiEAqJQ6kmzO4/vZ7PYvIEaIqLC3jBzKvQP0t5wf1ZtFZiU="
+                "signature": "MEQCIFYv4I42jEZwOY31our0CfglozjmglRregIsDDUoNpUyAiBhafXpqf3QlWXC+rGc5Bo0KMjEAhhLwKyuHgJyoZVWnQ=="
             },
             "rules/youtube.json": {
                 "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/2337db6aa7466667595226f780b6590779db3007ac0a65ef3833f89610c92824.json",
-                "signature": "MEYCIQDvwFHsRMRQDr2rlUf7KElHCIa8UqKJJyvcm3XLkYdQxQIhAOm1UsW11m7IiWKVlTn/DbfrQ1k2Oq1XGzSn3Sr2JuT6"
+                "signature": "MEQCIG1GUASUdXGM9aQJhpD4YZfhQ3EJ7IQ9sSy7qt55gcOpAiBjvVKTFypweU9FlJEjITPUbaMLB3+mY2+jRk04hBXCdA=="
             }
         }
     }


### PR DESCRIPTION
Update ad-blocking extension scriptlets for v2026.7.6.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only CDN URL and signature updates for content-blocker scriptlets; no application logic changes in this diff.
> 
> **Overview**
> Bumps the macOS/iOS ad-blocking extension feature config from **2026.7.3** to **2026.7.6**.
> 
> **`features/ad-blocking-extension.json`** updates the `settings.version` and refreshes CDN `url` + integrity `signature` pairs for the two uBlock filter scriptlets (`isolated` and `main`). Signatures are also rotated for the unchanged empty-hash uBlock experimental scriptlets and for `rules/youtube.json`; those entries keep the same URLs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a67185227c8c0403fe5284ef96e7772234fe1e64. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->