### PR TITLE
Enable removeRedirectionBitmapAllWinVersions for stable@0.165.0

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -4698,8 +4698,8 @@
                     "minSupportedVersion": "0.155.0"
                 },
                 "removeRedirectionBitmapAllWinVersions": {
-                    "state": "preview",
-                    "minSupportedVersion": "0.164.0"
+                    "state": "enabled",
+                    "minSupportedVersion": "0.165.1"
                 }
             },
             "exceptions": []


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1209077031784564/task/1213509468242868?focus=true

## Description
Enabling at the same level as pixelReporting

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single remote-config flag flip with a version gate; no code changes in this PR, though client rendering/redirection behavior may change for users who pick up the new config.
> 
> **Overview**
> Promotes the Windows privacy config flag **`removeRedirectionBitmapAllWinVersions`** from **preview** to **enabled**, and raises **`minSupportedVersion`** from **0.164.0** to **0.165.1** in `overrides/windows-override.json`.
> 
> Stable Windows clients on **0.165.1+** will receive the updated remote config and turn on redirection-bitmap removal across Windows versions (behavior already implemented in the app; this change only controls rollout).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dca34ccfe49b2b3b655934311e97e1d9867853e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->