### PR TITLE
Enable flag in Production - aiFeaturesNativeControls

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -623,6 +623,10 @@
                 "contextualSheetImprovements": {
                     "state": "enabled",
                     "minSupportedVersion": 52860000
+                },
+                "aiFeaturesNativeControls": {
+                    "state": "enabled",
+                    "minSupportedVersion": 52870000
                 }
             }
         },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/task/1216143486443888?focus=true

## Description
<!-- 
  Please delete either or both process sections below.
-->
Android: Add `aiFeaturesNativeControls` feature flag under `aiChat` as `enabled` with min version `52870000`.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [X] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single JSON override with a version-gated feature flag; no logic or security surface changes in this repo.
> 
> **Overview**
> Turns on the **`aiFeaturesNativeControls`** sub-feature under **`aiChat`** in `android-override.json` for production Android clients.
> 
> The flag is set to **`enabled`** with **`minSupportedVersion`: `52870000`**, so only app builds at or above that version receive native AI feature controls. There is no staged rollout block—it's a straight config enable alongside sibling flags like `contextualSheetImprovements`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8aa56746a38be6185cee079709cfc51c90ee73ce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->