### PR TITLE
[iOS] Enable rich duck.ai tab cells for all users

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -215,7 +215,7 @@
                     "minSupportedVersion": "7.155.0"
                 },
                 "tabSwitcherRichCard": {
-                    "state": "internal",
+                    "state": "enabled",
                     "minSupportedVersion": "7.227.0"
                 },
                 "addressBarShortcut": {


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1211767540372501/task/1216068956859407

## Description
Enables the feature flag for rich duck.ai tab cells for all iOS users.


### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single feature-flag flip in remote config with no code or version gate changes; UI exposure only for an already-shipped capability.
> 
> **Overview**
> Turns on the **`aiChat.tabSwitcherRichCard`** iOS privacy-config flag for general availability by changing its **`state`** from **`internal`** to **`enabled`** in `ios-override.json`. **`minSupportedVersion`** remains **`7.227.0`**, so only clients on that build or newer will show the rich Duck.ai tab cells in the tab switcher.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dfa680c5ce4b34ebe14d242212296480a1d470fa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->