### PR TITLE
Disable tdsNextExperiment011

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -246,7 +246,7 @@
                     ]
                 },
                 "tdsNextExperiment011": {
-                    "state": "enabled",
+                    "state": "disabled",
                     "minSupportedVersion": 52361000,
                     "rollout": {
                         "steps": [

--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -694,7 +694,7 @@
                     ]
                 },
                 "tdsNextExperiment011": {
-                    "state": "enabled",
+                    "state": "disabled",
                     "rollout": {
                         "steps": [
                             {


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1201720254973470/task/1216208388522812?focus=true

## Description
<!-- 
  Please delete either or both process sections below.
-->

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-flag remote config change that stops an experiment rollout; no app code changes, with predictable reversion to default TDS behavior.
> 
> **Overview**
> Turns off the **`tdsNextExperiment011`** remote-config experiment on **Android** and **iOS** by setting its `state` from `enabled` to `disabled` in `android-override.json` and `ios-override.json`.
> 
> Clients will no longer enroll in this TDS A/B test (25% rollout with control/treatment list URLs under `blockList`); affected apps fall back to the standard tracker blocking configuration instead of the `202606ctl01` experiment lists.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 91556d1af2c74f90c3c9dd37770f2654aaf290a0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->