### PR TITLE
Disable autoconsent exception for duck.ai

### DIFF
--- a/features/autoconsent.json
+++ b/features/autoconsent.json
@@ -32,6 +32,10 @@
             "reason": "https://github.com/duckduckgo/privacy-configuration/issues/326"
         },
         {
+            "domain": "duck.ai",
+            "reason": "Cookie pop-up management incorrectly dismisses a legitimate Terms of Service pop-up."
+        },
+        {
             "domain": "duden.de",
             "reason": "https://github.com/duckduckgo/privacy-configuration/issues/326"
         },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1211654189969294/task/1216315751686973?focus=true

## Description

Exclude duck.ai from autoconsent.


### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-domain config exception with no auth, data, or broad behavior changes.
> 
> **Overview**
> Adds **duck.ai** to the autoconsent `exceptions` list so automatic cookie-consent handling no longer runs on that domain.
> 
> Autoconsent was treating Duck.ai’s Terms of Service dialog like a cookie banner and dismissing it; skipping the site restores the legitimate ToS flow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fecdc98775f07e64b1463a13fe30b4a00a7f757a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->