### PR TITLE
Enable tdsNextExperiment012 at 100%, disable 010

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -221,7 +221,7 @@
                     ]
                 },
                 "tdsNextExperiment010": {
-                    "state": "enabled",
+                    "state": "disabled",
                     "minSupportedVersion": 52361000,
                     "rollout": {
                         "steps": [
@@ -258,6 +258,31 @@
                     "settings": {
                         "controlUrl": "v5/experiments/202606ctl01-android-tds-control.json",
                         "treatmentUrl": "v5/experiments/202606ctl01-android-tds-treatment.json"
+                    },
+                    "cohorts": [
+                        {
+                            "name": "control",
+                            "weight": 1
+                        },
+                        {
+                            "name": "treatment",
+                            "weight": 1
+                        }
+                    ]
+                },
+                "tdsNextExperiment012": {
+                    "state": "enabled",
+                    "minSupportedVersion": 52361000,
+                    "rollout": {
+                        "steps": [
+                            {
+                                "percent": 100
+                            }
+                        ]
+                    },
+                    "settings": {
+                        "controlUrl": "v5/experiments/202606v2-android-tds-control.json",
+                        "treatmentUrl": "v5/experiments/202606v2-android-tds-treatment.json"
                     },
                     "cohorts": [
                         {

--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -670,7 +670,7 @@
                     ]
                 },
                 "tdsNextExperiment010": {
-                    "state": "enabled",
+                    "state": "disabled",
                     "rollout": {
                         "steps": [
                             {
@@ -705,6 +705,30 @@
                     "settings": {
                         "controlUrl": "v5/experiments/202606ctl01-ios-tds-control.json",
                         "treatmentUrl": "v5/experiments/202606ctl01-ios-tds-treatment.json"
+                    },
+                    "cohorts": [
+                        {
+                            "name": "control",
+                            "weight": 1
+                        },
+                        {
+                            "name": "treatment",
+                            "weight": 1
+                        }
+                    ]
+                },
+                "tdsNextExperiment012": {
+                    "state": "enabled",
+                    "rollout": {
+                        "steps": [
+                            {
+                                "percent": 100
+                            }
+                        ]
+                    },
+                    "settings": {
+                        "controlUrl": "v5/experiments/202606v2-ios-tds-control.json",
+                        "treatmentUrl": "v5/experiments/202606v2-ios-tds-treatment.json"
                     },
                     "cohorts": [
                         {

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -626,7 +626,7 @@
                     ]
                 },
                 "tdsNextExperiment010": {
-                    "state": "enabled",
+                    "state": "disabled",
                     "rollout": {
                         "steps": [
                             {
@@ -637,6 +637,30 @@
                     "settings": {
                         "controlUrl": "v6/experiments/202606v1-macos-tds-control.json",
                         "treatmentUrl": "v6/experiments/202606v1-macos-tds-treatment.json"
+                    },
+                    "cohorts": [
+                        {
+                            "name": "control",
+                            "weight": 1
+                        },
+                        {
+                            "name": "treatment",
+                            "weight": 1
+                        }
+                    ]
+                },
+                "tdsNextExperiment012": {
+                    "state": "enabled",
+                    "rollout": {
+                        "steps": [
+                            {
+                                "percent": 100
+                            }
+                        ]
+                    },
+                    "settings": {
+                        "controlUrl": "v6/experiments/202606v2-macos-tds-control.json",
+                        "treatmentUrl": "v6/experiments/202606v2-macos-tds-treatment.json"
                     },
                     "cohorts": [
                         {


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1200342317600122/task/1215509678058932?focus=true

Enables the 202606v2 TDS blocklist experiment at 100%

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Switches live tracker-blocking list experiment for all rolled-in users, which can change site breakage or blocking behavior until results are validated.
> 
> **Overview**
> Rotates the **TDS Next** blocklist A/B test on Android, iOS, and macOS: **`tdsNextExperiment010`** (202606v1 lists, 25% rollout) is turned **off**, and **`tdsNextExperiment012`** is turned **on** at **100%** rollout with **202606v2** control/treatment list URLs (`v5` on mobile, `v6` on macOS). Eligible clients still split 50/50 between control and treatment cohorts; only which experiment and list revision is active changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fb475795bf929e0f06e23c19ba4e5fb7c5d32e1e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->