### PR TITLE
Enable sidebar suggested prompts internally on Windows.

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -1369,6 +1369,9 @@
                     "state": "enabled",
                     "minSupportedVersion": "0.157.0"
                 },
+                "sidebarSuggestedPrompts": {
+                    "state": "internal"
+                },
                 "suggestionsDeletion": {
                     "state": "internal",
                     "minSupportedVersion": "0.155.0"
@@ -5042,6 +5045,7 @@
             "exceptions": [],
             "settings": {
                 "includeIframes": "disabled",
+                "includePageTypeSignals": "enabled",
                 "maxContentLength": 9500,
                 "excludeSelectors": [
                     ".ad",


### PR DESCRIPTION
https://app.asana.com/1/137249556945/project/72649045549333/task/1213669294774005?focus=true

## Description
Turn on pageContext includePageTypeSignals and gate native sidebar suggested prompts behind internal-only access.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only changes in a platform override file; no application logic modified, with internal gating limiting exposure of the new prompts feature.
> 
> **Overview**
> Updates the **Windows** feature override config to roll out native **sidebar suggested prompts** for **internal** users only via a new `sidebarSuggestedPrompts` flag (`state: internal`).
> 
> Also turns on **`pageContext.settings.includePageTypeSignals`** (`enabled`), so page context sent to the product can include page-type signals—likely to support those sidebar prompts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 44856415e97865e5b805d7c52cc80b3a308c2c3a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->