### PR TITLE
Add default-enabled FFs for CSS scripts

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -2154,19 +2154,19 @@
                 }
             ]
         },
-        "windowsContentScopeScriptInjection": {
+        "contentScopeScriptInjection": {
             "state": "enabled",
             "exceptions": []
         },
-        "windowsAutoconsentScriptInjection": {
+        "autoconsentScriptInjection": {
             "state": "enabled",
             "exceptions": []
         },
-        "windowsAutofillScriptInjection": {
+        "autofillScriptInjection": {
             "state": "enabled",
             "exceptions": []
         },
-        "windowsFaviconScriptInjection": {
+        "faviconScriptInjection": {
             "state": "enabled",
             "exceptions": []
         },

--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -2154,6 +2154,18 @@
                 }
             ]
         },
+        "windowsContentScopeScriptInjection": {
+            "state": "enabled"
+        },
+        "windowsAutoconsentScriptInjection": {
+            "state": "enabled"
+        },
+        "windowsAutofillScriptInjection": {
+            "state": "enabled"
+        },
+        "windowsFaviconScriptInjection": {
+            "state": "enabled"
+        },
         "googleRejected": {
             "state": "disabled",
             "exceptions": []

--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -2155,16 +2155,20 @@
             ]
         },
         "windowsContentScopeScriptInjection": {
-            "state": "enabled"
+            "state": "enabled",
+            "exceptions": []
         },
         "windowsAutoconsentScriptInjection": {
-            "state": "enabled"
+            "state": "enabled",
+            "exceptions": []
         },
         "windowsAutofillScriptInjection": {
-            "state": "enabled"
+            "state": "enabled",
+            "exceptions": []
         },
         "windowsFaviconScriptInjection": {
-            "state": "enabled"
+            "state": "enabled",
+            "exceptions": []
         },
         "googleRejected": {
             "state": "disabled",


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1209077031784564/task/1213510637932136?focus=true

## Description
Enables by-default on kill-switches added in https://github.com/duckduckgo/windows-browser/pull/8271

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only rollout in windows-override.json; no application code changes, though it turns on client script-injection behavior for all Windows users until exceptions are added.
> 
> **Overview**
> Adds four **default-on** Windows privacy-config feature flags for CSS-related script injection: `contentScopeScriptInjection`, `autoconsentScriptInjection`, `autofillScriptInjection`, and `faviconScriptInjection`. Each is set to **`enabled`** with an empty **`exceptions`** list in `overrides/windows-override.json`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c6465deb594109c3a6e4512426290a1c33f16e06. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->