### PR TITLE
Enable cookiePopupOptInDialog internally on iOS and macOS

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -926,6 +926,10 @@
                 },
                 "cookiePopupPreferenceSetting": {
                     "state": "internal"
+                },
+                "cookiePopupOptInDialog": {
+                    "state": "internal",
+                    "minSupportedVersion": "7.228.0"
                 }
             }
         },

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -867,6 +867,10 @@
                 },
                 "cookiePopupPreferenceSetting": {
                     "state": "internal"
+                },
+                "cookiePopupOptInDialog": {
+                    "state": "internal",
+                    "minSupportedVersion": "1.198.0"
                 }
             }
         },


### PR DESCRIPTION
**Asana Task/Github Issue:** N/A

## Description

Enables the `cookiePopupOptInDialog` sub-feature of `autoconsent` at the `internal` state for iOS and macOS, so it's available to internal builds only. Sets `minSupportedVersion` to `7.228.0` (iOS) and `1.198.0` (macOS).

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small privacy-config flag additions scoped to internal builds with version gates; no production rollout in this diff.
> 
> **Overview**
> Turns on the **`cookiePopupOptInDialog`** sub-feature under **`autoconsent`** for **iOS** and **macOS** platform overrides at **`internal`**, so only internal builds see the opt-in dialog.
> 
> Each platform gets a **`minSupportedVersion`**: **`7.228.0`** on iOS and **`1.198.0`** on macOS. No rollout or public **`enabled`** state is introduced.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5bf053f55296aa0f28c6449ac45852f1b5061254. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->