### PR TITLE
mitigate x-com Android login via UA omit

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -2015,8 +2015,26 @@
                     "state": "enabled",
                     "versions": []
                 },
-                "omitApplicationSites": [],
-                "omitVersionSites": []
+                "omitApplicationSites": [
+                    {
+                        "domain": "x.com",
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5512"
+                    },
+                    {
+                        "domain": "twitter.com",
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5512"
+                    }
+                ],
+                "omitVersionSites": [
+                    {
+                        "domain": "x.com",
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5512"
+                    },
+                    {
+                        "domain": "twitter.com",
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5512"
+                    }
+                ]
             },
             "exceptions": [
                 {


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1200277586140538/task/1216258084613872?focus=true

## Description

### Site breakage mitigation process:
#### Brief explanation
- Reported URL: https://x.com/i/jf/onboarding/web/sso
- Problems experienced: x.com Android login stuck at username 
- Platforms affected:
  - [ ] iOS
  - [x ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked: na
- Feature being disabled/modified: ua
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Legacy Android UA omit lists for a major auth flow; limited to two domains but could still affect login or site behavior if the mitigation is wrong.
> 
> **Overview**
> Adds **Android-only** `customUserAgent` site lists for **`x.com`** and **`twitter.com`** in both **`omitApplicationSites`** and **`omitVersionSites`**, so DuckDuckGo-specific user-agent pieces are not sent on those domains.
> 
> This is a **speculative breakage mitigation** for Android users stuck at the username step on X/Twitter SSO (e.g. `x.com/i/jf/onboarding/web/sso`), with entries tied to PR #5512.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 85e5960244a1f27a6cb7cb0e6acdb87ecee23bcb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->