### PR TITLE
Disable Windows captcha web-detection auto polling (Cloudflare/Turnstile loops)

### DIFF
--- a/features/web-detection.json
+++ b/features/web-detection.json
@@ -292,10 +292,6 @@
                     {
                         "injectName": "android",
                         "minSupportedVersion": 52720000
-                    },
-                    {
-                        "injectName": "windows",
-                        "minSupportedVersion": "0.164.0"
                     }
                 ],
                 "patchSettings": [


### PR DESCRIPTION
https://app.asana.com/1/137249556945/project/1204912272578138/task/1216370152300683?focus=true

## Description

### Site breakage mitigation process:
#### Brief explanation
- Reported URL: bikeforums.net, boxrec.com, valueresearchonline.com, inaturalist.org, and ~20 other user reports on 0.164.x (see Windows feedback project)
- Problems experienced: Cloudflare / Turnstile verification loops; challenge never completes in DDG browser while Edge/Chrome work
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [x] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked: N/A
- Feature being disabled/modified: `webDetection` — removes the Windows `≥ 0.164.0` `conditionalChanges` block that enabled captcha detector auto-polling (`intervalMs` 500–5000ms) and `fireEvent` telemetry for recaptcha, hcaptcha, turnstile, cloudflare, and other providers (added in #5407)
- [ ] This change is a speculative mitigation to fix reported breakage.

## Root cause

At Windows platform version `≥ 0.164.0`, privacy-config applies conditional patches that add `triggers.auto` polling and `fireEvent` actions to captcha web-detection detectors. Polling visible Cloudflare challenge DOM (`#cf-wrapper`, `#challenge-running`, `.cf-turnstile`, etc.) interferes with live challenges.

Validated locally by simulating `0.164.1.0` in the Windows browser:
- With captcha `conditionalChanges` intact → bikeforums loops
- With captcha `conditionalChanges` stripped → bikeforums works

Captcha detector definitions (selectors only) are left in place; only the runtime triggers/actions patch is removed. Adwall `conditionalChanges` are unchanged.

## Test plan
- [x] `npm run build`
- [x] `npm run unit-tests` (1356 passing)
- [ ] Verify generated Windows test config via PR automation link
- [ ] Load bikeforums.net and other Cloudflare sites on 0.164.x with test config override


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Targets reported production breakage on Windows but disables captcha web-detection telemetry/runtime behavior on that platform while leaving Android behavior intact.
> 
> **Overview**
> **Mitigates Cloudflare/Turnstile verification loops on Windows** by narrowing who gets captcha `webDetection` runtime patches.
> 
> The second `conditionalChanges` block in `features/web-detection.json` previously applied captcha `triggers.auto` polling (500–5000ms) and `fireEvent` actions for recaptcha, hcaptcha, turnstile, cloudflare, and other detectors when **Android ≥ 52720000** or **Windows ≥ 0.164.0**. This change **drops the Windows branch** from that block’s `condition`, so those patches apply **only on Android** at the same version threshold.
> 
> Captcha detector definitions (selectors/match rules) are unchanged. The earlier adwall `conditionalChanges` block still includes both Android and Windows (`≥ 0.162.0`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dbb694e3089e5bd56080d15258ec071e68b95278. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->