### PR TITLE
Enable native control for AI Features on macOS

### DIFF
--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -379,6 +379,10 @@
                 "showHideAiGeneratedImages": {
                     "state": "enabled"
                 },
+                "aiFeaturesNativeControls": {
+                    "state": "enabled",
+                    "minSupportedVersion": "1.197.0"
+                },
                 "supportsSyncChatsDeletion": {
                     "state": "enabled",
                     "minSupportedVersion": "1.178.3"


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1199230911884351/task/1216382435684970?focus=true

## Description
Enables `aiFeaturesNativeControls` on macOS for latest release.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [x] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single macOS remote-config toggle with a version gate; no auth, data, or infrastructure changes.
> 
> **Overview**
> Turns on the **`aiFeaturesNativeControls`** sub-feature under **`aiChat`** in the macOS privacy config override so the browser can use native UI for AI feature controls on supported builds.
> 
> The flag is **`enabled`** with **`minSupportedVersion`: `1.197.0`**, so only macOS app versions at or above that release receive the change; older clients keep prior behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc6eb2722275e667af477a8452e8f42e65055ff1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->