### PR TITLE
Update autoconsent to v16.8.1

### DIFF
--- a/features/autoconsent.json
+++ b/features/autoconsent.json
@@ -2258,7 +2258,7 @@
                 "body > div[class][tabindex] > div > div > div:nth-child(2) > div:nth-child(2) > button:nth-child(2)",
                 "body > div[class][id][tabindex][role][aria-labelledby][aria-modal][style] > div > div > div:nth-child(3) > div > div > p > button:nth-child(3)",
                 "body > div[id] > div:nth-child(2) > div:nth-child(4) > div > div:nth-child(2) > button:nth-child(2)",
-                "#gdpr-new-container .btn-more",
+                "#gdpr-new-container button:nth-of-type(3)",
                 "body > div#cassie-widget > div:nth-child(4)#cassie_cookie_module > div:nth-child(2)#cassie_pre_banner > div:nth-child(3)#cassie_pre_banner__footer > button:nth-child(2)#cassie_reject_all_pre_banner",
                 "body > div:not([id]) > div:nth-child(17):not([id]) > div:not([id]) > a:nth-child(3):not([id])",
                 "body:not([id]) > div#__next > div:not([id]) > main:nth-child(3):not([id]) > div:not([id]) > div:nth-child(1):not([id]) > div:not([id]) > div:nth-child(27):not([id]) > div:not([id]) > div:not([id]) > div:nth-child(2):not([id]) > div:not([id]) > div:nth-child(2):not([id]) > button:nth-child(2):not([id])",
@@ -2380,9 +2380,9 @@
                 "#voyager-gdpr > div > div > button:nth-child(2)",
                 ".ind-cbar[data-testid=\"ind-cbar\"]",
                 ".ind-cbar[data-testid=\"ind-cbar\"] button[save-cookie][data-value=\"0\"]",
-                "#gdpr-new-container .gdpr-dialog-switcher",
-                "#gdpr-new-container .switcher-on",
-                "#gdpr-new-container .btn-save",
+                "#gdpr-new-container button:nth-of-type(2)",
+                "#gdpr-new-container button:first-of-type",
+                "#voyager-gdpr-2025",
                 "dialog.cookieconsent__dialog",
                 ".cookieconsent__base[data-component=\"cookieconsent\"]",
                 ".cookieconsent__buttonAcceptNecessary",
@@ -2418,7 +2418,8 @@
                 "body > div#termsfeed-pc1-notice-banner > div:nth-child(2):not([id]) > div:not([id]) > div:nth-child(3):not([id]) > div:not([id]) > button:nth-child(2)#termsfeed_privacy_consent_banner_button_reject_all",
                 "body > div#accn-cookie-consent-wrapper > div#accn-cookie-consent > div:nth-child(2)#accn-statement-scroller > div:nth-child(2):not([id]) > div:nth-child(3):not([id]) > button:not([id])",
                 "#cookie-notification",
-                "#cookie-notification .cookie_pref_wrapper .pref-opt.refuse"
+                "#cookie-notification .cookie_pref_wrapper .pref-opt.refuse",
+                "#voyager-gdpr-2025 button:last-of-type"
             ],
             "r": [
                 [
@@ -11057,6 +11058,7 @@
                     ],
                     [
                         {
+                            "check": "any",
                             "v": 1473
                         }
                     ],
@@ -11072,18 +11074,26 @@
                             ],
                             "else": [
                                 {
-                                    "c": 1356
-                                },
-                                {
-                                    "w": 1478
-                                },
-                                {
-                                    "all": true,
-                                    "optional": true,
-                                    "k": 1479
-                                },
-                                {
-                                    "k": 1480
+                                    "if": {
+                                        "e": 1356
+                                    },
+                                    "then": [
+                                        {
+                                            "c": 1478
+                                        }
+                                    ],
+                                    "else": [
+                                        {
+                                            "c": 1479
+                                        },
+                                        {
+                                            "timeout": 5000,
+                                            "wv": 1480
+                                        },
+                                        {
+                                            "c": 1517
+                                        }
+                                    ]
                                 }
                             ]
                         }


### PR DESCRIPTION
Asana Task/Github Issue: https://app.asana.com/1/137249556945/project/1201844467387842/task/1216387858127453

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Data-only changes to third-party autoconsent rules; wrong selectors could mis-click banners on affected sites but no app logic or security surface changes.
> 
> **Overview**
> Updates **`features/autoconsent.json`** for autoconsent **v16.8.1**, mainly refreshing cookie-banner selectors and one site-specific consent flow.
> 
> **LinkedIn / Voyager GDPR:** Replaces class-based `#gdpr-new-container` targets (e.g. `.btn-more`, `.gdpr-dialog-switcher`, `.btn-save`) with **`button:nth-of-type` / `first-of-type`** selectors, adds **`#voyager-gdpr-2025`** as a detection target, and adds **`#voyager-gdpr-2025 button:last-of-type`** for dismissal.
> 
> **AliExpress:** The consent rule is restructured: visibility check uses **`check: "any"`**, and the previous linear click/wait/optional-key sequence becomes a **nested if/else** (branch on element **1356** vs alternate path with click **1479**, **5s wait** on **1480**, then click **1517**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2022f46161ab672e281408748597456e50584224. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->