### PR TITLE
Unblock Optimizely due to site breakage

### DIFF
--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -3316,25 +3316,11 @@
                         "reason": "https://github.com/duckduckgo/privacy-configuration/issues/916"
                     },
                     {
-                        "rule": "cdn.optimizely.com/js/24096340716.js",
+                        "rule": "cdn.optimizely.com/js/",
                         "domains": [
-                            "hgtv.com"
+                            "<all>"
                         ],
-                        "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1904"
-                    },
-                    {
-                        "rule": "cdn.optimizely.com/js/271989291.js",
-                        "domains": [
-                            "my.zipcar.com"
-                        ],
-                        "reason": "https://github.com/duckduckgo/privacy-configuration/issues/916"
-                    },
-                    {
-                        "rule": "cdn.optimizely.com/js/28562140225.js",
-                        "domains": [
-                            "shipsticks.com"
-                        ],
-                        "reason": "https://github.com/duckduckgo/privacy-configuration/pull/4152"
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/issues/5521"
                     }
                 ]
             },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1200277586140538/task/1216334057499688?focus=true

## Description
Unblocking the cdn.optimizely.com/js/ request path in order to mitigate site breakage.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL: https://www.cinemark.com & others
- Problems experienced:
- Platforms affected:
  - [x] iOS
  - [x] Android
  - [x] Windows
  - [x] MacOS
  - [x] Extensions
- Tracker(s) being unblocked: cdn.optimizely.com/js/
- Feature being disabled/modified:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit ee99404f682fe7890e6b6a91bb9bf2416ebfb608. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->