### PR TITLE
Remove autoconsent exception for elpais.com

### DIFF
--- a/features/autoconsent.json
+++ b/features/autoconsent.json
@@ -860,10 +860,6 @@
             "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5220"
         },
         {
-            "domain": "elpais.com",
-            "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5245"
-        },
-        {
             "domain": "rhebs.com",
             "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5259"
         },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1203268166580279/task/1216399198050284?focus=true

## Description
<!-- 
  Please delete either or both process sections below.
-->

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-domain config change in autoconsent exceptions only; may affect elpais.com UX if the prior exception was masking breakage.
> 
> **Overview**
> Removes **`elpais.com`** from the autoconsent **`exceptions`** list in `features/autoconsent.json`, so automatic cookie-consent handling runs on that site again instead of being skipped.
> 
> The removed entry referenced [privacy-configuration#5245](https://github.com/duckduckgo/privacy-configuration/pull/5245) as the reason it was originally excepted.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit abd2822265adde56951284c3c23a90976de629a7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->