### PR TITLE
Re-enable Windows captcha pixels (non-Cloudflare)

### DIFF
--- a/features/web-detection.json
+++ b/features/web-detection.json
@@ -286,6 +286,58 @@
                         "value": { "fireEvent": { "state": "enabled", "type": "admiralAdwall" } }
                     }
                 ]
+            },
+            {
+                "condition": [
+                    {
+                        "injectName": "windows",
+                        "minSupportedVersion": "0.164.0"
+                    }
+                ],
+                "patchSettings": [
+                    {
+                        "op": "add",
+                        "path": "/detectors/captcha/recaptcha/triggers",
+                        "value": { "auto": { "state": "enabled", "when": { "intervalMs": [
+                                        500,
+                                        1000,
+                                        5000
+                                    ] } } }
+                    },
+                    {
+                        "op": "add",
+                        "path": "/detectors/captcha/recaptcha/actions",
+                        "value": { "fireEvent": { "state": "enabled", "type": "captcha_recaptcha" } }
+                    },
+                    {
+                        "op": "add",
+                        "path": "/detectors/captcha/hcaptcha/triggers",
+                        "value": { "auto": { "state": "enabled", "when": { "intervalMs": [
+                                        500,
+                                        1000,
+                                        5000
+                                    ] } } }
+                    },
+                    {
+                        "op": "add",
+                        "path": "/detectors/captcha/hcaptcha/actions",
+                        "value": { "fireEvent": { "state": "enabled", "type": "captcha_hcaptcha" } }
+                    },
+                    {
+                        "op": "add",
+                        "path": "/detectors/captcha/other/triggers",
+                        "value": { "auto": { "state": "enabled", "when": { "intervalMs": [
+                                        500,
+                                        1000,
+                                        5000
+                                    ] } } }
+                    },
+                    {
+                        "op": "add",
+                        "path": "/detectors/captcha/other/actions",
+                        "value": { "fireEvent": { "state": "enabled", "type": "captcha_other" } }
+                    }
+                ]
             }
         ]
     }


### PR DESCRIPTION
## Description

Re-enables captcha auto-detection and immediate `fireEvent` pixels on **Windows** for the `recaptcha`, `hcaptcha`, and `other` detectors only. `turnstile` and `cloudflare` stay disabled.

Background: #5407 enabled captcha auto-detection on Windows; it caused Cloudflare/Turnstile verification loops ([Asana](https://app.asana.com/1/137249556945/project/1204912272578138/task/1216370152300683)) and was fully disabled in #5513 (Windows) and #5514 (Android). That removed detection for *all* captcha vendors, not just the Cloudflare family that was implicated. This restores the non-Cloudflare detectors so we regain reCAPTCHA / hCaptcha / other telemetry on Windows while the root cause is investigated ([Asana](https://app.asana.com/1/137249556945/project/1215218660135895/task/1216371377969997)).

Scope:
- Adds a Windows-only (`injectName: windows`, `minSupportedVersion: 0.164.0`) captcha `conditionalChanges` block patching `triggers.auto` (`intervalMs [500, 1000, 5000]`) and `fireEvent` onto the `recaptcha`, `hcaptcha`, and `other` detectors.
- Does NOT touch `turnstile` or `cloudflare`.

### Risk
**Medium.** The `recaptcha` / `hcaptcha` detectors use the same element visibility check (`getComputedStyle` / `getBoundingClientRect` at poll intervals) that is the suspected trigger of the Cloudflare loop (see [root-cause note](https://app.asana.com/1/137249556945/task/1216371377969997/comment/1216397901149479)). reCAPTCHA / hCaptcha may be less timing-sensitive than Cloudflare Turnstile, but this reintroduces that mechanism for those providers. `other` is text-pattern based and carries no such risk. Recommend watching Windows breakage feedback after rollout.

### Site breakage mitigation process
- Platforms affected: **Windows**
- Feature being modified: `webDetection` captcha detectors (re-enable recaptcha / hcaptcha / other; Cloudflare family stays off)
- Reliable Cloudflare test case (must remain unaffected): https://bikeforums.net

Related: #5407, #5475, #5513, #5514

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Reintroduces element visibility polling for reCAPTCHA/hCaptcha on Windows—the same mechanism implicated in Cloudflare/Turnstile loops—while leaving Cloudflare-family detectors disabled.
> 
> **Overview**
> Re-enables **Windows** captcha auto-detection and `fireEvent` telemetry for **`recaptcha`**, **`hcaptcha`**, and **`other`** only, gated by `injectName: windows` and `minSupportedVersion: 0.164.0`.
> 
> Each detector gets the same pattern as adwall Windows patches: `triggers.auto` with `intervalMs` `[500, 1000, 5000]` and a typed `fireEvent` (`captcha_recaptcha`, `captcha_hcaptcha`, `captcha_other`). **`turnstile`** and **`cloudflare`** are unchanged and stay without these patches.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3751e2981c23b4c3b27ef75ff8be871afb849272. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->