### PR TITLE
allow scrolling on dresden-de

### DIFF
--- a/features/autoconsent.json
+++ b/features/autoconsent.json
@@ -886,6 +886,10 @@
         {
             "domain": "trustedhousesitters.com",
             "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5487"
+        },
+        {
+            "domain": "dresden.de",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5532"
         }
     ],
     "settings": {

--- a/features/autoconsent.json
+++ b/features/autoconsent.json
@@ -886,10 +886,6 @@
         {
             "domain": "trustedhousesitters.com",
             "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5487"
-        },
-        {
-            "domain": "dresden.de",
-            "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5532"
         }
     ],
     "settings": {

--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -736,6 +736,10 @@
                 {
                     "domain": "ashleyfurniture.com",
                     "reason": "https://github.com/duckduckgo/privacy-configuration/pull/3908"
+                },
+                {
+                    "domain": "dresden.de",
+                    "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5532"
                 }
             ],
             "features": {


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1206670747178362/task/1216378826966000?focus=true

## Description


### Site breakage mitigation process:
#### Brief explanation
- Reported URL: dresden.de
- Problems experienced: page can't be scrolled down
- Platforms affected:
  - [ ] iOS
  - [ x] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-domain exception in remote privacy config; no auth, data, or core browser logic changes.
> 
> **Overview**
> Adds **`dresden.de`** to the Android **`autoconsent.exceptions`** list in `android-override.json`, so automatic cookie-consent handling is not applied on that site.
> 
> This is a **site-breakage mitigation** for Android users who could not scroll the page; the change is scoped to Android only and matches the pattern used for other domains (e.g. `kvb.koeln`, `ashleyfurniture.com`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e50aa4abdd1809f3a4e715df8a494ed356e153a0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->