### PR TITLE
Fix duplicate player controls

### DIFF
--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -889,6 +889,18 @@
                         "reason": "https://github.com/duckduckgo/privacy-configuration/issues/768"
                     },
                     {
+                        "rule": "assets.connatix.com",
+                        "domains": [
+                            "accuweather.com",
+                            "dailymail.co.uk",
+                            "nypost.com"
+                        ],
+                        "reason": [
+                            "https://github.com/duckduckgo/privacy-configuration/issues/768",
+                            "https://github.com/duckduckgo/privacy-configuration/pull/5533"
+                        ]
+                    },
+                    {
                         "rule": "connatix.com",
                         "domains": [
                             "accuweather.com",


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1206670747178362/task/1216286502060153?focus=true

## Description

### Site breakage mitigation process:
#### Brief explanation
- Reported URL: nypost.com/2026/07/08/world-news/trump-says-iran-peace-deal-likely-dead-he-no-longer-will-deal-with-sick-people/
- Problems experienced: video player layout is broken
- Platforms affected:
  - [ x] iOS
  - [x ] Android
  - [ x] Windows
  - [ x] MacOS
  - [ x] Extensions
- Tracker(s) being unblocked: assets.connatix.com
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single JSON allowlist exception with narrow domain scope; increases third-party load on listed sites only, not a core product or auth change.
> 
> **Overview**
> Adds a **site-scoped tracker allowlist** entry for `assets.connatix.com` on `accuweather.com`, `dailymail.co.uk`, and `nypost.com` so Connatix player assets can load when other Connatix hosts are already partially allowlisted.
> 
> This targets reported **broken Connatix video UI** (e.g. duplicate/misaligned player controls on nypost.com) by unblocking that asset host only on those publishers, not globally like several other `*.connatix.com` rules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit df33884d50c662c157435eea48ecd2329a1ae21f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->