### PR TITLE
Add custom UA exception for ruedesjoueurs.com on Android

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -2058,6 +2058,10 @@
                 {
                     "domain": "jonesroadbeauty.com",
                     "reason": "https://github.com/duckduckgo/privacy-configuration/issues/4403"
+                },
+                {
+                    "domain": "ruedesjoueurs.com",
+                    "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5534"
                 }
             ]
         },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1206670747178362/task/1216333314186832?focus=true

## Description
<!-- 
  Please delete either or both process sections below.
-->

### Site breakage mitigation process:
#### Brief explanation
- Reported URL: ruedesjoueurs.com 
- Problems experienced: notification pop up creates an overlay and prevent the page to be accessible while not being dismissable
- Platforms affected:
  - [ ] iOS
  - [ x] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:c
- Feature being disabled/modified: UA (clientBrandHint) didn't work
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-domain Android privacy exception with no auth or data-path changes; minor UA/client-hint consistency tradeoff on one site.
> 
> **Overview**
> Adds an Android-only **`customUserAgent`** exception for **`ruedesjoueurs.com`** in `android-override.json`, linked to [privacy-configuration#5534](https://github.com/duckduckgo/privacy-configuration/pull/5534).
> 
> This is a site-breakage mitigation: a non-dismissable notification overlay was blocking the page. **`clientBrandHint`** was tried first and did not fix it, so the change falls back to exempting the domain from custom user-agent behavior so the default WebView UA is used on that site.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 072827a16b97db5bd381a3e044e9ddfd4e273ec5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->