### PR TITLE
Hide dark overlay on navitime.co.jp

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -2933,6 +2933,15 @@
                 ]
             },
             {
+                "domain": "navitime.co.jp",
+                "rules": [
+                    {
+                        "selector": "#pfx_interstitial",
+                        "type": "hide"
+                    }
+                ]
+            },
+            {
                 "domain": "nbcsports.com",
                 "rules": [
                     {


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/1206670747178362/task/1215828739344340?focus=true

## Description
### Site breakage mitigation process:
#### Brief explanation
- Reported URL: https://www.navitime.co.jp
- Problems experienced: Dark interstitial overlay caused by tracker blocking.
- Platforms affected:
  - [x] iOS
  - [x] Android
  - [x] Windows
  - [x] MacOS
  - [x] Extensions
- Tracker(s) being unblocked: N/A
- Feature being disabled/modified: Element hiding. Need to use `hide` because `hide-empty` and `closest-empty` are not effective due content within the overlay.
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-domain cosmetic breakage fix in privacy config; no auth, data, or broad rule changes beyond one selector on navitime.co.jp.
> 
> **Overview**
> Adds a **site-specific element-hiding** entry for `navitime.co.jp` so `#pfx_interstitial` is removed with a **`hide`** rule, matching the existing `walkerplus.com` pattern for the same overlay id.
> 
> This targets a **dark full-page interstitial** left on the page when related requests are blocked; **`hide-empty` / `closest-empty` were not sufficient** because the overlay still contains DOM content.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 24575e086da78f440d1ad4eb0d8c278c9c270896. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->