### PR TITLE
Re-disable all Windows captcha pixels

### DIFF
--- a/features/web-detection.json
+++ b/features/web-detection.json
@@ -286,58 +286,6 @@
                         "value": { "fireEvent": { "state": "enabled", "type": "admiralAdwall" } }
                     }
                 ]
-            },
-            {
-                "condition": [
-                    {
-                        "injectName": "windows",
-                        "minSupportedVersion": "0.164.0"
-                    }
-                ],
-                "patchSettings": [
-                    {
-                        "op": "add",
-                        "path": "/detectors/captcha/recaptcha/triggers",
-                        "value": { "auto": { "state": "enabled", "when": { "intervalMs": [
-                                        500,
-                                        1000,
-                                        5000
-                                    ] } } }
-                    },
-                    {
-                        "op": "add",
-                        "path": "/detectors/captcha/recaptcha/actions",
-                        "value": { "fireEvent": { "state": "enabled", "type": "captcha_recaptcha" } }
-                    },
-                    {
-                        "op": "add",
-                        "path": "/detectors/captcha/hcaptcha/triggers",
-                        "value": { "auto": { "state": "enabled", "when": { "intervalMs": [
-                                        500,
-                                        1000,
-                                        5000
-                                    ] } } }
-                    },
-                    {
-                        "op": "add",
-                        "path": "/detectors/captcha/hcaptcha/actions",
-                        "value": { "fireEvent": { "state": "enabled", "type": "captcha_hcaptcha" } }
-                    },
-                    {
-                        "op": "add",
-                        "path": "/detectors/captcha/other/triggers",
-                        "value": { "auto": { "state": "enabled", "when": { "intervalMs": [
-                                        500,
-                                        1000,
-                                        5000
-                                    ] } } }
-                    },
-                    {
-                        "op": "add",
-                        "path": "/detectors/captcha/other/actions",
-                        "value": { "fireEvent": { "state": "enabled", "type": "captcha_other" } }
-                    }
-                ]
             }
         ]
     }


### PR DESCRIPTION
Reverts duckduckgo/privacy-configuration#5527

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only rollback that disables optional detection/telemetry on Windows; no auth, data handling, or core logic changes.
> 
> **Overview**
> **Reverts Windows-only captcha telemetry** by removing a `conditionalChanges` block from `web-detection.json` that had enabled auto triggers and `fireEvent` actions for **reCAPTCHA**, **hCaptcha**, and **other** captcha detectors on Windows clients at `minSupportedVersion` **0.164.0**.
> 
> Adwall detector patches for Android and Windows are unchanged; only the captcha pixel rollout for Windows is rolled back (revert of privacy-configuration#5527).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa963828ff0742f15f1a50c8389f4ad4ff586344. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->