### PR TITLE
Disable 0-count buckets

### DIFF
--- a/features/event-hub.json
+++ b/features/event-hub.json
@@ -52,7 +52,6 @@
                         "template": "counter",
                         "source": "adwall",
                         "buckets": {
-                            "0": { "gte": 0, "lt": 1 },
                             "1": { "gte": 1, "lt": 2 },
                             "2-3": { "gte": 2, "lt": 4 },
                             "4-7": { "gte": 4, "lt": 8 },
@@ -76,7 +75,6 @@
                         "template": "counter",
                         "source": "adwall",
                         "buckets": {
-                            "0": { "gte": 0, "lt": 1 },
                             "1": { "gte": 1, "lt": 2 },
                             "2-3": { "gte": 2, "lt": 4 },
                             "4-7": { "gte": 4, "lt": 8 },
@@ -100,7 +98,6 @@
                         "template": "counter",
                         "source": "admiralAdwall",
                         "buckets": {
-                            "0": { "gte": 0, "lt": 1 },
                             "1": { "gte": 1, "lt": 2 },
                             "2-3": { "gte": 2, "lt": 4 },
                             "4-7": { "gte": 4, "lt": 8 },
@@ -124,7 +121,6 @@
                         "template": "counter",
                         "source": "admiralAdwall",
                         "buckets": {
-                            "0": { "gte": 0, "lt": 1 },
                             "1": { "gte": 1, "lt": 2 },
                             "2-3": { "gte": 2, "lt": 4 },
                             "4-7": { "gte": 4, "lt": 8 },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1205278999335242/task/1214573800950081?focus=true

## Description

Disables 0-count buckets for adwalls as we can use the baseline counts now.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only telemetry bucket change for adwall metrics; may shift how zero counts appear in dashboards but does not touch runtime logic.
> 
> **Overview**
> Removes the **`"0"`** count bucket (`gte: 0, lt: 1`) from adwall telemetry in **`features/event-hub.json`**, for both **`adwall`** and **`admiralAdwall`** sources on **day** and **week** triggers (`webTelemetry_adwalls_*` and `webTelemetry_admiralAdwalls_*`). Buckets now start at **1** adwall; zero-adwall volume is expected to come from the existing **baseline** counters (`eventHub_baseline_*` with **`0+`**), not duplicate zero buckets on adwall metrics.
> 
> Captcha and other telemetry entries are unchanged and still include **`0`** buckets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c081453624cd490bffe09d7810aa3f87fe8f2751. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->