### PR TITLE
fix search pagination on homedepot-com

### DIFF
--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -1054,6 +1054,15 @@
             "demdex.net": {
                 "rules": [
                     {
+                        "rule": "adobedc.demdex.net/ee",
+                        "domains": [
+                            "homedepot.com"
+                        ],
+                        "reason": [
+                            "https://github.com/duckduckgo/privacy-configuration/pull/5538"
+                        ]
+                    },
+                    {
                         "rule": "dpm.demdex.net/id",
                         "domains": [
                             "dhl.de",

--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -1054,15 +1054,6 @@
             "demdex.net": {
                 "rules": [
                     {
-                        "rule": "adobedc.demdex.net/ee",
-                        "domains": [
-                            "homedepot.com"
-                        ],
-                        "reason": [
-                            "https://github.com/duckduckgo/privacy-configuration/pull/5538"
-                        ]
-                    },
-                    {
                         "rule": "dpm.demdex.net/id",
                         "domains": [
                             "dhl.de",

--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -2789,6 +2789,15 @@
                                     "tracfone.com"
                                 ],
                                 "reason": "https://github.com/duckduckgo/privacy-configuration/issues/4322"
+                            },
+                            {
+                                "rule": "adobedc.demdex.net/ee",
+                                "domains": [
+                                    "homedepot.com"
+                                ],
+                                "reason": [
+                                    "https://github.com/duckduckgo/privacy-configuration/pull/5538"
+                                ]
                             }
                         ]
                     },

--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -4192,6 +4192,15 @@
                                     "<all>"
                                 ],
                                 "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1534"
+                            },
+                            {
+                                "rule": "adobedc.demdex.net/ee",
+                                "domains": [
+                                    "homedepot.com"
+                                ],
+                                "reason": [
+                                    "https://github.com/duckduckgo/privacy-configuration/pull/5538"
+                                ]
                             }
                         ]
                     },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1206670747178362/task/1216413297432016?focus=true

## Description
<!-- 
  Please delete either or both process sections below.
-->

### Site breakage mitigation process:
#### Brief explanation
- Reported URL: https://www.homedepot.com/s/electric%20chipper
- Problems experienced: users can't get to the next page of a search result
- Platforms affected:
  - [ ] iOS
  - [ x] Android
  - [x ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked: adobedc.demdex.net/ee
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow, platform-specific breakage exception for one retailer site; increases exposure to an Adobe tracking endpoint only on homedepot.com, with no auth or payment logic changes.
> 
> **Overview**
> Adds a **site-specific tracker allowlist** so **search pagination on homedepot.com** works when DuckDuckGo’s tracker blocking would otherwise break the page (reported on search URLs such as `/s/electric%20chipper`).
> 
> The new rule **`adobedc.demdex.net/ee`** is scoped to **`homedepot.com`** in **`overrides/android-override.json`** and **`overrides/windows-override.json`** only (not iOS/macOS/extensions in this diff). The base config already allowlists a different Adobe endpoint for Home Depot (`dpm.demdex.net/id`); this change covers the **`/ee`** path tied to the breakage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 37dc0d8ece68bd101d2a26bd7c84a2cf53f98b3f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->