### PR TITLE
Add contextualSuggestedPrompts & includePageTypeSignals

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -419,6 +419,10 @@
                 "voiceShortcut": {
                     "state": "enabled",
                     "minSupportedVersion": "7.216.0"
+                },
+                "contextualSuggestedPrompts": {
+                    "state": "internal",
+                    "minSupportedVersion": "7.228.0"
                 }
             },
             "settings": {
@@ -2988,6 +2992,7 @@
             "exceptions": [],
             "settings": {
                 "additionalCheck": "enabled",
+                "includePageTypeSignals": "enabled",
                 "activeCaptureOnFirstMessage": "enabled",
                 "maxContentLength": 9500,
                 "mainContentSelector": "main, article, .content, .main, #content, #main",

--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -447,7 +447,7 @@
                 },
                 "contextualSuggestedPrompts": {
                     "state": "internal",
-                    "minSupportedVersion": "7.228.0"
+                    "minSupportedVersion": "7.231.0"
                 }
             },
             "settings": {


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1210947754188321/task/1216448502695014?focus=true

## Description
Adds contextualSuggestedPrompts (internal) and includePageTypeSignals (enabled)

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [x] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only iOS override changes with internal gating for suggested prompts; no auth or rollout to all users for the new feature flag.
> 
> **Overview**
> Updates **iOS privacy configuration** for Duck.ai contextual features.
> 
> Under **`aiChat`**, adds **`contextualSuggestedPrompts`** as an **`internal`** sub-feature with **`minSupportedVersion` `7.231.0`**, alongside existing contextual Duck.ai toggles like **`contextualFireButton`** and **`voiceShortcut`**.
> 
> Under **`pageContext`**, sets **`includePageTypeSignals`** to **`enabled`** in settings (same pattern as macOS and Windows overrides), so page-context capture can include page-type signals when building AI context.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 69794408b75343a5adc272338301b0b08ad94021. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->