### PR TITLE
Add NTP chat and search deletion feature flags

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -1447,6 +1447,9 @@
                 "onboardingToggleAffectsNtpAndDdg": {
                     "state": "enabled",
                     "minSupportedVersion": "0.162.0"
+                },
+                "ntpSuggestionsDeletion": {
+                    "state": "internal"
                 }
             },
             "minSupportedVersion": "0.100.0",
@@ -6039,6 +6042,10 @@
                     "state": "internal"
                 }
             }
+        },
+        "ntpSearchSuggestionsDeletion": {
+            "state": "internal",
+            "exceptions": []
         }
     },
     "unprotectedTemporary": []


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1210407179200832/task/1213796978089027?focus=true

## Description
Add NTP chat and search deletion feature flags

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only additions with internal state; no runtime logic or user-facing rollout in this diff.
> 
> **Overview**
> Adds two **internal** Windows privacy-config flags to gate NTP suggestion deletion: **`ntpSuggestionsDeletion`** nested under the existing AI/chat feature group, and a top-level **`ntpSearchSuggestionsDeletion`** entry with empty exceptions.
> 
> Both are **`state: internal`**, so they only affect internal builds until rolled out further—no behavior change for public users until clients read and enable them.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b8283a8ac75d0efb3fcbf1ba6516cf14ba17bdc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->