### PR TITLE
fix add to cart on michaels-com

### DIFF
--- a/features/autoconsent.json
+++ b/features/autoconsent.json
@@ -886,6 +886,10 @@
         {
             "domain": "trustedhousesitters.com",
             "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5487"
+        },
+        {
+            "domain": "michaels.com",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5542"
         }
     ],
     "settings": {

--- a/features/gpc.json
+++ b/features/gpc.json
@@ -103,6 +103,10 @@
         {
             "domain": "naturium.com",
             "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5506"
+        },
+        {
+            "domain": "michaels.com",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5542"
         }
     ],
     "settings": {


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1206670747178362/task/1216419596350751?focus=true

## Description

### Site breakage mitigation process:
#### Brief explanation
- Reported URL: https://www.michaels.com/product/canson-xl-mix-media-pad-10145801
- Problems experienced: users were unable to add product to the cart
- Platforms affected:
  - [x ] iOS
  - [x ] Android
  - [x ] Windows
  - [x ] MacOS
  - [ x] Extensions
- Tracker(s) being unblocked: NA
- Feature being disabled/modified: CPM & GPC
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Configuration-only domain exceptions with no logic changes; slightly reduces privacy protections on michaels.com only.
> 
> **Overview**
> Adds **michaels.com** to the **autoconsent** and **GPC** exception lists so those privacy features are not applied on the site, restoring **add to cart** on product pages (reported breakage across clients).
> 
> Each entry points to privacy-configuration PR **5542** for traceability, matching the usual per-domain breakage mitigation pattern.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b54f339f77e07e9c86c9f91f96e43743db85c50. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->