### PR TITLE
Update autoconsent to v16.10.0

### DIFF
--- a/features/autoconsent.json
+++ b/features/autoconsent.json
@@ -2421,7 +2421,8 @@
                 "#cookie-notification .cookie_pref_wrapper .pref-opt.refuse",
                 "#voyager-gdpr-2025 button:last-of-type",
                 "body > div#wrapper > div:nth-child(4):not([id]) > button:nth-child(3):not([id])",
-                "body > div#frame-modals > div:not([id]) > div:nth-child(2):not([id]) > div:not([id]) > div:not([id]) > div:nth-child(2):not([id]) > div:nth-child(2):not([id]) > button:nth-child(1):not([id])"
+                "body > div#frame-modals > div:not([id]) > div:nth-child(2):not([id]) > div:not([id]) > div:not([id]) > div:nth-child(2):not([id]) > div:nth-child(2):not([id]) > button:nth-child(1):not([id])",
+                "[data-testid=\"cookies_reject\"]"
             ],
             "r": [
                 [
@@ -11046,6 +11047,36 @@
                     [
                         {
                             "cc": 1429
+                        }
+                    ],
+                    {}
+                ],
+                [
+                    1,
+                    "abetterrouteplanner",
+                    2,
+                    "^https?://(www\\.)?abetterrouteplanner\\.com/",
+                    22,
+                    [],
+                    [
+                        {
+                            "e": 1520
+                        }
+                    ],
+                    [
+                        {
+                            "v": 1520
+                        }
+                    ],
+                    [
+                        {
+                            "c": 1520
+                        }
+                    ],
+                    [
+                        {
+                            "negated": true,
+                            "e": 1520
                         }
                     ],
                     {}
@@ -29328,7 +29359,7 @@
                 ],
                 "specificRuleRange": [
                     194,
-                    776
+                    777
                 ],
                 "genericStringEnd": 771,
                 "frameStringEnd": 806


### PR DESCRIPTION
Asana Task/Github Issue: https://app.asana.com/1/137249556945/project/1201844467387842/task/1216467523988469

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Data-only changes to third-party cookie-consent selectors and site rules; no authentication, security, or core application logic is modified.
> 
> **Overview**
> Bumps the bundled **autoconsent** rule set in `features/autoconsent.json` (v16.10.0), extending cookie-banner handling rather than changing extension runtime code.
> 
> Adds a shared reject selector `[data-testid="cookies_reject"]` to the global click list, and a new **abetterrouteplanner.com** site rule (URL `^https?://(www\.)?abetterrouteplanner\.com/`) wired to rule id **1520** for detect/hide/click flows. The metadata `specificRuleRange` upper bound is incremented by one to account for the extra site rule.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fc4915357ce752a12f9aef7a448fa6ca37003544. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->