### PR TITLE
Enable iPadDuckAIBarControls flag for iOS (min 7.229.0)

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -404,6 +404,10 @@
                     "state": "enabled",
                     "minSupportedVersion": "7.213.0"
                 },
+                "iPadDuckAIBarControls": {
+                    "state": "enabled",
+                    "minSupportedVersion": "7.229.0"
+                },
                 "supportsSyncChatsDeletion": {
                     "state": "enabled",
                     "minSupportedVersion": "7.208.2"


### PR DESCRIPTION
**Asana Task/Github Issue:**
[Enable iPadDuckAIBarControls](https://app.asana.com/1/137249556945/project/72649045549333/task/1216447011980473?focus=true)

## Description
Enable iPadDuckAIBarControls flag for iOS (min 7.229.0)
### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single feature-flag entry in iOS privacy config; UI behavior is gated by app version with no auth or data-path changes in this diff.
> 
> **Overview**
> Turns on the **`iPadDuckAIBarControls`** sub-feature under **`aiChat`** in `overrides/ios-override.json` for iOS clients at **7.229.0** and above, alongside existing iPad Duck.ai flags like `iPadAIChatToggle` and `iPadPageContext`.
> 
> This is a remote-config-only change: no rollout steps or cohorts—**`state: enabled`** with a version gate so older builds keep their current behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7aed27cb3a6d8d9f7b209a1bb1a55449ea5d6115. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->