### PR TITLE
Enable cookiePopupPreferenceSetting on macOS and iOS

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -932,7 +932,8 @@
                     "state": "enabled"
                 },
                 "cookiePopupPreferenceSetting": {
-                    "state": "internal"
+                    "state": "enabled",
+                    "minSupportedVersion": "7.228.0"
                 },
                 "cookiePopupOptInDialog": {
                     "state": "internal",

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -870,7 +870,8 @@
                     ]
                 },
                 "cookiePopupPreferenceSetting": {
-                    "state": "internal"
+                    "state": "enabled",
+                    "minSupportedVersion": "1.198.0"
                 },
                 "cookiePopupOptInDialog": {
                     "state": "internal",


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/38424471409662/task/1213990702372115?focus=true

## Description
Enable the new cookiePopupPreferenceSetting for versions with the latest design:
 - iOS 7.228.0
 - macOS 1.198.0


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Autoconsent behavior on real sites can cause breakage if preference UI or heuristics misfire; version gating limits exposure to builds with the new design.
> 
> **Overview**
> Rolls out **cookie popup preference settings** for autoconsent on iOS and macOS by promoting `cookiePopupPreferenceSetting` from `internal` to **enabled**, gated to app versions that ship the updated UI (**iOS 7.228.0**, **macOS 1.198.0**).
> 
> `cookiePopupOptInDialog` is unchanged and remains **internal** at the same minimum versions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 40ae0f010c4b0a59c5b0e43ddfe4e8fb45980eb7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->