### PR TITLE
Increase defaultExistingIPhoneUsersToNewTabAfterIdle rollout to 10 percent

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -2857,6 +2857,9 @@
                         "steps": [
                             {
                                 "percent": 2
+                            },
+                            {
+                                "percent": 10
                             }
                         ]
                     }


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1204186595873227/task/1216512702270926

## Description

Extends the staged rollout of the iOS `defaultExistingIPhoneUsersToNewTabAfterIdle` sub-feature by adding a new rollout step at **10%** (previously 2%).

```diff
 "rollout": {
     "steps": [
-        { "percent": 2 }
+        { "percent": 2 },
+        { "percent": 10 }
     ]
 }
```

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.