### PR TITLE
Add `wpf/swallowLostDwmIpcMessage` feature as internal

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -6046,6 +6046,15 @@
         "ntpSearchSuggestionsDeletion": {
             "state": "internal",
             "exceptions": []
+        },
+        "wpf": {
+            "state": "internal",
+            "exceptions": [],
+            "features": {
+                "swallowLostDwmIpcMessage": {
+                    "state": "internal"
+                }
+            }
         }
     },
     "unprotectedTemporary": []


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/72649045549333/task/1216208845904676?focus=true

## Description
Adds a new `wpf` feature and an associated `swallowLostDwmIpcMessage` sub-feature for controlling mitigations within the wpf fork.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only addition of internal feature flags with no runtime logic changes in this PR.
> 
> **Overview**
> Adds a new **Windows-only** privacy-config feature entry **`wpf`** (state **`internal`**) with nested **`swallowLostDwmIpcMessage`** also set to **`internal`**, so the WPF fork can gate that DWM IPC mitigation via remote configuration.
> 
> No other override files or schema changes are included in this diff—only `overrides/windows-override.json`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bebc2bd54adc7110b30f2fdc597cfe8b8f9619b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->