### PR TITLE
Element hiding: address app nag on Reddit

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -3518,7 +3518,7 @@
                         "type": "hide"
                     },
                     {
-                        "selector": "shreddit-experience-tree[active-experiences*=\"app_selector\"]",
+                        "selector": "shreddit-experience-tree[active-experiences*=\"app_selector\"], .XPromoBlockingModal, .XPromoInFeed, .xPromoAppStoreFooter, #configured-xpromo-blocking_xpromo_nsfw_blocking, #configured-xpromo-unrated_block, #xpromo-bottom-sheet[aria-label*=\"See Reddit in...\"], #xpromo-bottom-sheet[aria-label*=\"See this post in...\"], .AppSelectorModal__body, .XPromoBottomBar, [bundlename=\"bottom_bar_xpromo\"], [data-testid=\"bottom-cell-wrapper\"], [data-testid=\"bottom-sheet-upsell-wrapper\"], [slot=\"use-app\"], bottom-bar[app-link-params], xpromo-app-selector, .mobile-web-redirect-bar, .upsell_banner",
                         "type": "hide"
                     }
                 ]

--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -3518,7 +3518,7 @@
                         "type": "hide"
                     },
                     {
-                        "selector": "shreddit-experience-tree[active-experiences*="app_selector"]",
+                        "selector": "shreddit-experience-tree[active-experiences*=\"app_selector\"]",
                         "type": "hide"
                     }
                 ]

--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -3516,6 +3516,10 @@
                     {
                         "selector": "[devicetype=\"desktop\"] .grid:not([style='filter: blur(4px);']) ~ shreddit-experience-tree:not([active-experiences='[\"nsfw_bypassable\"]'])",
                         "type": "hide"
+                    },
+                    {
+                        "selector": "shreddit-experience-tree[active-experiences*="app_selector"]",
+                        "type": "hide"
                     }
                 ]
             },

--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -3518,7 +3518,7 @@
                         "type": "hide"
                     },
                     {
-                        "selector": "shreddit-experience-tree[active-experiences*=\"app_selector\"], .XPromoBlockingModal, .XPromoInFeed, .xPromoAppStoreFooter, #configured-xpromo-blocking_xpromo_nsfw_blocking, #configured-xpromo-unrated_block, #xpromo-bottom-sheet[aria-label*=\"See Reddit in...\"], #xpromo-bottom-sheet[aria-label*=\"See this post in...\"], .AppSelectorModal__body, .XPromoBottomBar, [bundlename=\"bottom_bar_xpromo\"], [data-testid=\"bottom-cell-wrapper\"], [data-testid=\"bottom-sheet-upsell-wrapper\"], [slot=\"use-app\"], bottom-bar[app-link-params], xpromo-app-selector, .mobile-web-redirect-bar, .upsell_banner",
+                        "selector": "shreddit-experience-tree[active-experiences*=\"app_selector\"], .XPromoBlockingModal, .XPromoInFeed, .xPromoAppStoreFooter, #configured-xpromo-blocking_xpromo_nsfw_blocking, #configured-xpromo-unrated_block, #xpromo-bottom-sheet[aria-label*=\"See Reddit in...\"], #xpromo-bottom-sheet[aria-label*=\"See this post in...\"], #app-upsell-blocking-bottom-sheet-seo, #app-upsell-blocking-bottom-sheet-direct, .AppSelectorModal__body, .XPromoBottomBar, [bundlename=\"bottom_bar_xpromo\"], [data-testid=\"bottom-sheet-upsell-wrapper\"], [slot=\"use-app\"], bottom-bar[app-link-params], xpromo-app-selector, .mobile-web-redirect-bar, .upsell_banner",
                         "type": "hide"
                     }
                 ]


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1200277586140538/task/1216108495342168?focus=true

## Description
Hides app nag that blocks use of Reddit website on mobile.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [x] iOS
  - [x] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Broad selectors on a high-traffic site could hide legitimate UI if Reddit reuses the same classes/IDs, but scope is limited to known promo elements and matches existing site-specific breakage mitigations.
> 
> **Overview**
> Adds a **reddit.com**-specific element-hiding rule so DuckDuckGo can remove Reddit’s mobile **“use the app”** / xpromo UI that blocks or interrupts the mobile web experience (iOS/Android per the PR description).
> 
> The new rule uses `type: "hide"` and one combined selector targeting app-selector experiences (`shreddit-experience-tree[active-experiences*="app_selector"]`), blocking modals and bottom sheets (e.g. `#xpromo-bottom-sheet`, `#app-upsell-blocking-*`), in-feed promos, bottom bars, and related upsell elements. It sits alongside existing Reddit rules (legacy class hides and desktop NSFW experience-tree handling) without changing those entries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 119f4598d4ce2416e55e3f88d10390e4811346fa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->