### PR TITLE
Update autoconsent to v16.11.0

### DIFF
--- a/features/autoconsent.json
+++ b/features/autoconsent.json
@@ -2422,7 +2422,9 @@
                 "#voyager-gdpr-2025 button:last-of-type",
                 "body > div#wrapper > div:nth-child(4):not([id]) > button:nth-child(3):not([id])",
                 "body > div#frame-modals > div:not([id]) > div:nth-child(2):not([id]) > div:not([id]) > div:not([id]) > div:nth-child(2):not([id]) > div:nth-child(2):not([id]) > button:nth-child(1):not([id])",
-                "[data-testid=\"cookies_reject\"]"
+                "[data-testid=\"cookies_reject\"]",
+                "adc-cookie-banner",
+                "cookie_banner=closed"
             ],
             "r": [
                 [
@@ -11020,6 +11022,46 @@
                         }
                     ],
                     [],
+                    {}
+                ],
+                [
+                    1,
+                    "aa-cookie-banner",
+                    2,
+                    "^https://(www\\.)?(aa|envoyair|psaairlines)\\.com/",
+                    22,
+                    [
+                        1521
+                    ],
+                    [
+                        {
+                            "exists": [
+                                "adc-cookie-banner",
+                                "#cookie-banner"
+                            ]
+                        }
+                    ],
+                    [
+                        {
+                            "visible": [
+                                "adc-cookie-banner",
+                                "#cookie-banner"
+                            ]
+                        }
+                    ],
+                    [
+                        {
+                            "waitForThenClick": [
+                                "adc-cookie-banner",
+                                "#toast-dismiss-button"
+                            ]
+                        }
+                    ],
+                    [
+                        {
+                            "cc": 1522
+                        }
+                    ],
                     {}
                 ],
                 [
@@ -29359,7 +29401,7 @@
                 ],
                 "specificRuleRange": [
                     194,
-                    777
+                    778
                 ],
                 "genericStringEnd": 771,
                 "frameStringEnd": 806


### PR DESCRIPTION
Asana Task/Github Issue: https://app.asana.com/1/137249556945/project/1201844467387842/task/1216548078973026

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Cookie-consent rule additions only; no application logic or security-sensitive code changes.
> 
> **Overview**
> Bumps the bundled **autoconsent** ruleset to **v16.11.0** in `features/autoconsent.json`.
> 
> Adds two shared selector/cookie strings (`adc-cookie-banner`, `cookie_banner=closed`) to the global string table used by dismiss rules. Introduces a new site rule **`aa-cookie-banner`** for `aa.com`, `envoyair.com`, and `psaairlines.com` that waits for `adc-cookie-banner` / `#cookie-banner`, then clicks through `adc-cookie-banner` and `#toast-dismiss-button`, with follow-up via rule refs `1521`/`1522`. The metadata **`specificRuleRange`** end index increases by one to account for the new rule.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a5927c7772d4f388ae0a5b00ea18905b23abe7a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->