### PR TITLE
Custom UA override for docs.google.com on macOS

### DIFF
--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -1687,6 +1687,10 @@
                     {
                         "domain": "hulu.com",
                         "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5327"
+                    },
+                    {
+                        "domain": "docs.google.com",
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5555"
                     }
                 ],
                 "webViewDefault": [


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/1200277586140538/task/1216468991742834?focus=true

## Description
### Site breakage mitigation process:
#### Brief explanation
- Reported URL: docs.google.com
- Problems experienced: macOS users reporting blurry content, e.g. blurred cells in Google Sheets.
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [x] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked: N/A
- Feature being disabled/modified: Custom user agent string.
- [x] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-domain macOS remote-config exception with no auth or data-path changes; limited blast radius if rendering regresses elsewhere on Google Docs.
> 
> **Overview**
> Adds **`docs.google.com`** to the macOS **`customUserAgent`** `defaultSites` list so those pages use the **brand** default policy UA instead of DuckDuckGo’s normal string.
> 
> This is a **speculative site-breakage mitigation** for macOS reports of **blurry UI** (e.g. Google Sheets cells). Change is **macOS-only** in `overrides/macos-override.json`; other platforms are untouched.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 42d2856f001a32fb69a96ae2de783e1581ecdcb3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->