### PR TITLE
Enable aiChatSyncPromo on iOS (min version 7.228.0)

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -2025,7 +2025,7 @@
                     "minSupportedVersion": "7.208.2"
                 },
                 "aiChatSyncPromo": {
-                    "state": "disabled"
+                    "state": "enabled"
                 },
                 "simplifiedSyncSetupExperiment": {
                     "state": "enabled",

--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -2025,7 +2025,8 @@
                     "minSupportedVersion": "7.208.2"
                 },
                 "aiChatSyncPromo": {
-                    "state": "enabled"
+                    "state": "enabled",
+                    "minSupportedVersion": "7.228.0"
                 },
                 "simplifiedSyncSetupExperiment": {
                     "state": "enabled",


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/task/1216084825209587

## Description

Re-enables the `aiChatSyncPromo` sync subfeature on iOS by flipping its state from `disabled` to `enabled`, restoring the Duck.ai sync promo card. This reverses the toggle from #5444 while keeping the flag explicitly present in the iOS override.

Gated behind `minSupportedVersion: "7.228.0"` so the promo only shows on builds that carry the clash-avoidance fix ([apple-browsers#5625](https://github.com/duckduckgo/apple-browsers/pull/5625), first shipped in 7.228.0). Older builds (< 7.228.0) evaluate the subfeature as `appVersionNotSupported`, which returns `false` and overrides the app's enabled-by-default behavior — so they keep the promo hidden.

iOS-only — macOS does not read this flag.

### Feature change process:

- [ ] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
