### PR TITLE
Kill switch: disable aiChatSyncPromo on iOS

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -2025,8 +2025,7 @@
                     "minSupportedVersion": "7.208.2"
                 },
                 "aiChatSyncPromo": {
-                    "state": "enabled",
-                    "minSupportedVersion": "7.228.0"
+                    "state": "disabled"
                 },
                 "simplifiedSyncSetupExperiment": {
                     "state": "enabled",


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1214200115953388/task/1216262276830791?focus=true

## Description

**Kill switch (draft).** Disables the `aiChatSyncPromo` sync subfeature on iOS, hiding the Duck.ai sync promo card on all versions. Kept as a draft so it can be merged quickly if the re-enable (#5556) causes problems in production.

`state: "disabled"` turns the promo off regardless of app version, so no `minSupportedVersion` is needed here.

iOS-only — macOS does not read this flag.

### Feature change process:

- [ ] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
