### PR TITLE
Android: Enable removeChatHistory

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -656,6 +656,10 @@
                 "duckAiSettings": {
                     "state": "enabled",
                     "minSupportedVersion": 52870000
+                },
+                "removeChatHistory": {
+                    "state": "enabled",
+                    "minSupportedVersion": 52880000
                 }
             }
         },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/task/1216429654756052?focus=true

## Description
Enable the changes in https://app.asana.com/1/137249556945/project/72649045549333/task/1213733111339611?focus=true to all users 

### Feature change process:
- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> It changes user-visible Duck.ai data handling (chat history removal) for all qualifying Android users via remote config, though scope is limited to a single feature toggle.
> 
> **Overview**
> Turns on the **`removeChatHistory`** sub-feature under **`aiChat`** in the Android privacy override so eligible clients can expose Duck.ai chat history removal (aligned with the broader rollout described in the linked Asana work).
> 
> The flag is **`enabled`** with **`minSupportedVersion`: `52880000`**, so only builds at or above that version receive the behavior; no rollout steps or cohorts are added in this change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3e31e8db452334460f720e0658d47ce13ba4eb74. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->