### PR TITLE
Revert UA string override for docs.google.com (macOS)

### DIFF
--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -1687,10 +1687,6 @@
                     {
                         "domain": "hulu.com",
                         "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5327"
-                    },
-                    {
-                        "domain": "docs.google.com",
-                        "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5555"
                     }
                 ],
                 "webViewDefault": [


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/1206670747178362/task/1216468991742834?focus=true

## Description
### Site breakage mitigation process:
#### Brief explanation
- Reported URL: docs.google.com
- Problems experienced: Removed entry for 'docs.google.com' from macOS overrides, reverting #5555 
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [x] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked: N/A
- Feature being disabled/modified: Custom UA string
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-domain config revert on macOS only; limited to custom UA behavior for Google Docs with no auth or data-path changes.
> 
> **Overview**
> Removes **`docs.google.com`** from the macOS **`customUserAgent`** `defaultSites` list in `overrides/macos-override.json`, undoing the custom user-agent string override added in #5555 after site breakage reports.
> 
> macOS will again use the normal branded UA on Google Docs instead of the site-specific policy. Other platforms and macOS **`webCompat`** settings for `docs.google.com` (e.g. `windowSizing`) are unchanged by this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 865946d8531cea6b96fdd909b9cdf2cd295e15e9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->