### PR TITLE
Add aiPageContextBlocklist to macOS pageContext settings

### DIFF
--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -2470,7 +2470,56 @@
                             }
                         ]
                     }
-                ]
+                ],
+                "aiPageContextBlocklist": {
+                    "pdf": {
+                        "urlExtensions": [
+                            ".pdf"
+                        ],
+                        "contentTypes": [
+                            "application/pdf"
+                        ]
+                    },
+                    "image": {
+                        "urlExtensions": [
+                            ".png",
+                            ".jpg",
+                            ".jpeg",
+                            ".gif",
+                            ".webp",
+                            ".svg",
+                            ".bmp"
+                        ],
+                        "contentTypePrefixes": [
+                            "image/"
+                        ]
+                    },
+                    "video": {
+                        "urlExtensions": [
+                            ".mp4",
+                            ".webm",
+                            ".avi",
+                            ".mov",
+                            ".mkv"
+                        ],
+                        "contentTypePrefixes": [
+                            "video/"
+                        ]
+                    },
+                    "audio": {
+                        "urlExtensions": [
+                            ".mp3",
+                            ".wav",
+                            ".ogg",
+                            ".flac",
+                            ".aac",
+                            ".m4a"
+                        ],
+                        "contentTypePrefixes": [
+                            "audio/"
+                        ]
+                    }
+                }
             }
         },
         "popupBlocking": {


### PR DESCRIPTION
**Asana Task/Github Issue:**

## Description
Mirrors the Windows override (PR #5283): adds the pdf/image/video/audio media blocklist under pageContext settings so the macOS Duck.ai page-context attachability gate activates. Enables end-to-end testing of the native gate.
### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Remote config-only change that mirrors an existing Windows blocklist; it narrows attachable page context rather than changing auth or data pipelines.
> 
> **Overview**
> Adds **`aiPageContextBlocklist`** under macOS **`pageContext`** settings, matching the Windows override from PR #5283.
> 
> The blocklist tells the native Duck.ai **page-context attachability** gate to treat PDFs, images, video, and audio as non-attachable, using URL extensions and MIME **`contentTypes`** / **`contentTypePrefixes`** per media category. macOS clients that read this config can enforce the same media exclusions as Windows and support end-to-end testing of the gate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d17394d3bb0c16161168f24de5f9d91942ca4e56. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->