### PR TITLE
Remove distributionSource state from windows-override.json

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -5415,9 +5415,6 @@
                             "paid"
                         ]
                     }
-                },
-                "distributionSource": {
-                    "state": "enabled"
                 }
             }
         },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1205278999335242/task/1213548804255302

## Description

- This removes the 'distributionSource' state from the JSON configuration.
- I removed from Windows Browser by https://github.com/duckduckgo/windows-browser/pull/8274

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [x] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-key removal from a platform override JSON with no auth or data-path changes; risk is limited to Windows clients that might still expect the key (intentionally removed with the browser change).
> 
> **Overview**
> Removes the **`distributionSource`** sub-feature entry (previously **`state: enabled`**) from the **`attributed-metrics`** block in **`windows-override.json`**, aligning Windows privacy config with the feature removal in Windows Browser.
> 
> No other platforms or **`sendOriginParam`** / attributed-metrics toggles are changed in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cbb85be4375b03670ab052eeb7a4a409fee85dba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->