### PR TITLE
Mitigate blurry Google Docs issue on macOS

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -2071,7 +2071,7 @@
                         "type": "hide"
                     },
                     {
-                        "selector": "div[role='banner']:has(div > a[href='https://support.google.com/a/answer/33864'])",
+                        "selector": "div[role='banner']:has(div > a[href='https://support.google.com/a/answer/33864']):not([aria-label=\"Menu bar\"])",
                         "type": "hide"
                     }
                 ]

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -818,16 +818,6 @@
                 },
                 "domains": [
                     {
-                        "domain": "docs.google.com",
-                        "patchSettings": [
-                            {
-                                "op": "replace",
-                                "path": "/windowSizing",
-                                "value": "disabled"
-                            }
-                        ]
-                    },
-                    {
                         "domain": [
                             "www.cbsnews.com",
                             "myhome.experian.co.uk",
@@ -1701,10 +1691,6 @@
                     {
                         "domain": "nationalmssociety.org",
                         "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1963"
-                    },
-                    {
-                        "domain": "docs.google.com",
-                        "reason": "https://github.com/duckduckgo/privacy-configuration/issues/5562"
                     }
                 ]
             }

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -1701,6 +1701,10 @@
                     {
                         "domain": "nationalmssociety.org",
                         "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1963"
+                    },
+                    {
+                        "domain": "docs.google.com",
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/issues/5562"
                     }
                 ]
             }


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1207340338530322/task/1216456479318750?focus=true

## Description
Remove `windowSizing` exception for docs.google.com to prevent blurry issue from occurring. 

### Site breakage mitigation process:
#### Brief explanation
- Reported URL: docs.google.com
- Problems experienced: document text is blurry
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [x] MacOS
  - [ ] Extensions
- Feature being disabled/modified: Use webview UA

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Site-specific macOS webCompat and Google DOM hiding changes could affect Docs rendering or which UI chrome is visible if selectors drift.
> 
> **Overview**
> Addresses **blurry text on Google Docs for macOS** by dropping the `docs.google.com` **webCompat** override that forced `windowSizing` to `disabled`, so the webview user-agent path used for that fix can apply without that conflicting setting.
> 
> Because that UA can surface Google’s **“browser no longer supported”** promo, the shared Google **element-hiding** rule for banners linking to `support.google.com/a/answer/33864` now adds `:not([aria-label="Menu bar"])` so the Docs **menu bar** is not hidden along with the promo.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3326d069aa3b9cb01bc4bc4b6bb6ff693bacde33. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->