### PR TITLE
 detection content enum

### DIFF
--- a/schema/features/web-detection.ts
+++ b/schema/features/web-detection.ts
@@ -42,8 +42,12 @@ export type ConditionTypes = {
     };
     element: {
         selector: MaybeArray<string>;
-        // 'content' is a layout-free content-presence proxy (no getComputedStyle/
-        // getBoundingClientRect); avoids the forced layout that 'visible'/'hidden' incur.
+        // How a matched element must present to count as a match:
+        // - 'visible': rendered and visible (uses getComputedStyle/getBoundingClientRect).
+        // - 'hidden':  present but not visible (also layout-reading).
+        // - 'any':     exists in the DOM, visibility ignored (default).
+        // - 'content': layout-free content-presence proxy - avoids the forced layout that
+        //   'visible'/'hidden' incur (which can perturb anti-bot challenge pages).
         visibility?: 'visible' | 'hidden' | 'any' | 'content';
     };
 };

--- a/schema/features/web-detection.ts
+++ b/schema/features/web-detection.ts
@@ -42,12 +42,6 @@ export type ConditionTypes = {
     };
     element: {
         selector: MaybeArray<string>;
-        // How a matched element must present to count as a match:
-        // - 'visible': rendered and visible (uses getComputedStyle/getBoundingClientRect).
-        // - 'hidden':  present but not visible (also layout-reading).
-        // - 'any':     exists in the DOM, visibility ignored (default).
-        // - 'content': layout-free content-presence proxy - avoids the forced layout that
-        //   'visible'/'hidden' incur (which can perturb anti-bot challenge pages).
         visibility?: 'visible' | 'hidden' | 'any' | 'content';
     };
 };

--- a/schema/features/web-detection.ts
+++ b/schema/features/web-detection.ts
@@ -42,7 +42,9 @@ export type ConditionTypes = {
     };
     element: {
         selector: MaybeArray<string>;
-        visibility?: 'visible' | 'hidden' | 'any';
+        // 'content' is a layout-free content-presence proxy (no getComputedStyle/
+        // getBoundingClientRect); avoids the forced layout that 'visible'/'hidden' incur.
+        visibility?: 'visible' | 'hidden' | 'any' | 'content';
     };
 };
 


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/72649045549333/task/1216542212155680

## Description
<!-- 
  Please delete either or both process sections below.
-->
Adding `content` type to schema now so we can get tests passing on https://github.com/duckduckgo/content-scope-scripts/pull/2861

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive optional enum value on a schema type; existing configs remain valid with no behavior change in this repository.
> 
> **Overview**
> Extends the **web-detection** schema so `element` match conditions can use **`visibility: 'content'`** in addition to `'visible'`, `'hidden'`, and `'any'`.
> 
> This is an additive type change only (no config or runtime behavior in this repo); it unblocks tests in the related content-scope-scripts work.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f891026a1a29462a98e38d0ba2e5d3714c986124. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->