### PR TITLE
Roll out cookiePopupOptInDialog at 2% on iOS and macOS

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -936,8 +936,15 @@
                     "minSupportedVersion": "7.228.0"
                 },
                 "cookiePopupOptInDialog": {
-                    "state": "internal",
-                    "minSupportedVersion": "7.228.0"
+                    "state": "enabled",
+                    "minSupportedVersion": "7.228.0",
+                    "rollout": {
+                        "steps": [
+                            {
+                                "percent": 2
+                            }
+                        ]
+                    }
                 }
             }
         },

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -874,8 +874,15 @@
                     "minSupportedVersion": "1.198.0"
                 },
                 "cookiePopupOptInDialog": {
-                    "state": "internal",
-                    "minSupportedVersion": "1.198.0"
+                    "state": "enabled",
+                    "minSupportedVersion": "1.198.0",
+                    "rollout": {
+                        "steps": [
+                            {
+                                "percent": 2
+                            }
+                        ]
+                    }
                 }
             }
         },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1203936086921904/task/1216510918501723

## Description

Begins the rollout of the `cookiePopupOptInDialog` autoconsent subfeature on iOS and macOS by flipping its state from `internal` to `enabled` and adding a single 2% rollout step.

Existing `minSupportedVersion` values are preserved (iOS `7.228.0`, macOS `1.198.0`), so only builds carrying the required support will evaluate the subfeature as enabled; the 2% step gates it to a small fraction of eligible users.

### Feature change process:

- [ ] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Remote config-only change with a 2% rollout and unchanged version floors; no application code modified.
> 
> **Overview**
> Starts a limited production rollout of the **`cookiePopupOptInDialog`** autoconsent subfeature on **iOS** and **macOS** by changing its state from **`internal`** to **`enabled`** and adding a **2%** rollout step in each platform override.
> 
> Existing **`minSupportedVersion`** gates are unchanged (iOS `7.228.0`, macOS `1.198.0`), so only supported app builds are eligible; the rollout percentage further limits exposure to a small slice of those users.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ed11bd35472b2658e376c04472a3c77b8814ff5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->