### PR TITLE
Mitigate servustv.com: allowlist Facebook Pixel and hide empty ad slots

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -3674,6 +3674,10 @@
                     {
                         "selector": "[class*='ad-wrap']",
                         "type": "hide-empty"
+                    },
+                    {
+                        "selector": "[data-slot*='adslot-']",
+                        "type": "hide-empty"
                     }
                 ]
             },

--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -1862,6 +1862,15 @@
             "facebook.net": {
                 "rules": [
                     {
+                        "rule": "connect.facebook.net/en_US/fbevents.js",
+                        "domains": [
+                            "servustv.com"
+                        ],
+                        "reason": [
+                            "servustv.com - Facebook Pixel (fbevents.js) blocked causes site breakage."
+                        ]
+                    },
+                    {
                         "rule": "connect.facebook.net/en_US/sdk.js",
                         "domains": [
                             "bandsintown.com",

--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -1867,7 +1867,7 @@
                             "servustv.com"
                         ],
                         "reason": [
-                            "servustv.com - Facebook Pixel (fbevents.js) blocked causes site breakage."
+                            "servustv.com - Facebook Pixel (fbevents.js) blocked causes site breakage. https://github.com/duckduckgo/privacy-configuration/pull/5567"
                         ]
                     },
                     {

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -1961,6 +1961,13 @@
                                 ]
                             },
                             {
+                                "rule": "connect.facebook.net/en_US/fbevents.js",
+                                "domains": [
+                                    "nextdoor.com"
+                                ],
+                                "reason": "nextdoor.com - https://github.com/duckduckgo/privacy-configuration/pull/4645"
+                            },
+                            {
                                 "rule": "facebook.net",
                                 "domains": [
                                     "nextdoor.com"


### PR DESCRIPTION

**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/11472677167855/task/1216473259676104
## Description
<!-- 
  Please delete either or both process sections below.
-->
- Add a dedicated tracker-allowlist rule for connect.facebook.net/en_US/fbevents.js on servustv.com (Facebook Pixel blocking caused site breakage).
- Add element-hiding rule [data-slot*='adslot-'] (hide-empty) for servustv.com to collapse blank "Advertisement" placeholders.
- Propagate nextdoor.com onto the macOS fbevents.js override so its broad facebook.net allowlist keeps working ahead of the new, more-specific rule.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Scoped site-breakage mitigations that unblock a tracking script on servustv.com and touch platform-specific allowlist layering for nextdoor.com; limited blast radius but reduces blocking for Facebook Pixel on those sites.
> 
> **Overview**
> Fixes **servustv.com** breakage by adding a **tracker allowlist** entry for `connect.facebook.net/en_US/fbevents.js` on that domain only, so Facebook Pixel is no longer blocked when it was breaking the site.
> 
> Adds an **element-hiding** `hide-empty` rule for `[data-slot*='adslot-']` on servustv.com to collapse blank “Advertisement” placeholders after ads are blocked.
> 
> Adds a **macOS override** allowlisting the same `fbevents.js` URL for **nextdoor.com**, so nextdoor keeps working alongside the new global, path-specific Facebook rule without relying only on the broader `facebook.net` exception.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e381642d218ed1f779ab07703e2cb6937ea159b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->