### PR TITLE
Allowlist Ketch consent management on cc.com (southpark.cc.com)

### DIFF
--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -2815,7 +2815,7 @@
                         "domains": [
                             "cc.com"
                         ],
-                        "reason": "cc.com - Ketch consent management blocked breaks the site; scoped to cc.com only."
+                        "reason": "cc.com - Ketch consent management blocked breaks the site; scoped to cc.com only. https://github.com/duckduckgo/privacy-configuration/pull/5570"
                     }
                 ]
             },

--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -2808,6 +2808,17 @@
                     }
                 ]
             },
+            "ketchcdn.com": {
+                "rules": [
+                    {
+                        "rule": "global.ketchcdn.com",
+                        "domains": [
+                            "cc.com"
+                        ],
+                        "reason": "cc.com - Ketch consent management blocked breaks the site; scoped to cc.com only."
+                    }
+                ]
+            },
             "klarnaservices.com": {
                 "rules": [
                     {


### PR DESCRIPTION

**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/11472677167855/task/1216542228032547

## Description
<!-- 
  Please delete either or both process sections below.
-->
Add a tracker-allowlist rule for global.ketchcdn.com scoped to cc.com so the Ketch consent management flow (bootstrap, config, IP, consent APIs) is not blocked on southpark.cc.com. Scoped to cc.com only.
### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-domain allowlist for a consent CMP host; no auth or broad `<all>` scope.
> 
> **Overview**
> Adds a **tracker allowlist** exception so **`global.ketchcdn.com`** (Ketch consent management) is not blocked on **`cc.com`**, fixing breakage on sites such as southpark.cc.com where bootstrap, config, IP, and consent API calls were failing.
> 
> The new **`ketchcdn.com`** entry is **scoped to `cc.com` only**, consistent with existing **`cc.com`** mitigations elsewhere in `tracker-allowlist.json` (e.g. video-related doubleclick rules).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b86e95b51e2f0df7b3f462291f3b6512e8c57f4a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->