### PR TITLE
Storage partitioning to start with internal only

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -2499,7 +2499,7 @@
         },
         "storagePartitioning": {
             "state": "internal",
-            "exceptions": [],
+            "exceptions": []
         },
         "customUserAgent": {
             "settings": {

--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -2497,6 +2497,10 @@
                 ]
             }
         },
+        "storagePartitioning": {
+            "state": "internal",
+            "exceptions": [],
+        },
         "customUserAgent": {
             "settings": {
                 "omitApplicationSites": [],


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1212608041264997/task/1216570285754753?focus=true

## Description

Prepare for rollout of storage partitioning.  Once this lands we want it to initially be only for internal users.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Storage partitioning affects how site data/cookies are isolated and can break third-party login flows; limiting to internal users reduces blast radius but the behavior is still privacy- and compatibility-sensitive.
> 
> **Overview**
> Adds a **`storagePartitioning`** entry to the Windows remote config override so the feature can ship behind an **internal-only** flag before a wider rollout.
> 
> The new block sets **`state`: `internal`** and an empty **`exceptions`** list, consistent with other staged Windows features (e.g. `verticalTabs`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 317cefb24a2ca1ca331174a6607e02c18d05217f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->