### PR TITLE
iOS: add aiPageContextBlocklist to page context settings

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -3072,7 +3072,56 @@
                             }
                         ]
                     }
-                ]
+                ],
+                "aiPageContextBlocklist": {
+                    "pdf": {
+                        "urlExtensions": [
+                            ".pdf"
+                        ],
+                        "contentTypes": [
+                            "application/pdf"
+                        ]
+                    },
+                    "image": {
+                        "urlExtensions": [
+                            ".png",
+                            ".jpg",
+                            ".jpeg",
+                            ".gif",
+                            ".webp",
+                            ".svg",
+                            ".bmp"
+                        ],
+                        "contentTypePrefixes": [
+                            "image/"
+                        ]
+                    },
+                    "video": {
+                        "urlExtensions": [
+                            ".mp4",
+                            ".webm",
+                            ".avi",
+                            ".mov",
+                            ".mkv"
+                        ],
+                        "contentTypePrefixes": [
+                            "video/"
+                        ]
+                    },
+                    "audio": {
+                        "urlExtensions": [
+                            ".mp3",
+                            ".wav",
+                            ".ogg",
+                            ".flac",
+                            ".aac",
+                            ".m4a"
+                        ],
+                        "contentTypePrefixes": [
+                            "audio/"
+                        ]
+                    }
+                }
             }
         },
         "webInterferenceDetection": {


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/414235014887631/task/1216590095234414?focus=true

## Description
iOS: add aiPageContextBlocklist to page context settings

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> iOS-only remote config addition with no app code in this repo; main risk is over-blocking page context on edge-case URLs or content types.
> 
> **Overview**
> Adds **`aiPageContextBlocklist`** under iOS **`pageContext`** settings so Duck.ai page-context capture can skip non-HTML resources.
> 
> The new blocklist groups **pdf**, **image**, **video**, and **audio** with URL file extensions and MIME rules (`contentTypes` for PDF, `contentTypePrefixes` for image/video/audio). iOS clients can use this to avoid attaching page context on direct media/PDF navigations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b9763521efab2f253df6fd5a0044d423a67b2fed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->