### PR TITLE
Allowlist oci.oraclecloud.com on fleetfarm.com to fix login

### DIFF
--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -3404,7 +3404,7 @@
                         "domains": [
                             "fleetfarm.com"
                         ],
-                        "reason": "fleetfarm.com - oci.oraclecloud.com blocked breaks login."
+                        "reason": "fleetfarm.com - oci.oraclecloud.com blocked breaks login. https://github.com/duckduckgo/privacy-configuration/pull/5573"
                     }
                 ]
             },

--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -3397,6 +3397,17 @@
                     }
                 ]
             },
+            "oraclecloud.com": {
+                "rules": [
+                    {
+                        "rule": "oci.oraclecloud.com",
+                        "domains": [
+                            "fleetfarm.com"
+                        ],
+                        "reason": "fleetfarm.com - oci.oraclecloud.com blocked breaks login."
+                    }
+                ]
+            },
             "osano.com": {
                 "rules": [
                     {


### PR DESCRIPTION

**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1204912272578138/task/1216578942050150

## Description
<!-- 
  Please delete either or both process sections below.
-->
Add a tracker-allowlist rule for oci.oraclecloud.com scoped to fleetfarm.com; blocking this request broke the site's login flow.


### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-domain allowlist exception in privacy config; no auth or core app code changes, narrowly scoped to one retailer site.
> 
> **Overview**
> Adds a **site-scoped tracker allowlist** exception so `oci.oraclecloud.com` is not blocked on **fleetfarm.com**, restoring a broken **login** flow when that Oracle Cloud endpoint was treated as a tracker.
> 
> The new `oraclecloud.com` entry in `tracker-allowlist.json` uses a single rule limited to `fleetfarm.com` (not `<all>`), matching the usual breakage-mitigation pattern in this config.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fdb890daaa87a9935c3191a43f7c089fe4cfa6c4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->