### PR TITLE
Change bookmarkAllOpenTabs state to enabled

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -2149,7 +2149,8 @@
                     "state": "enabled"
                 },
                 "bookmarkAllOpenTabs": {
-                    "state": "internal"
+                    "state": "enabled",
+                    "minSupportedVersion": "0.160.0"
                 }
             }
         },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/72649045549333/task/1207131845494224?focus=true

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only feature-flag change with a version gate; no application logic or security paths modified.
> 
> **Overview**
> **Rolls out** the bookmarks sub-feature **`bookmarkAllOpenTabs`** on Windows by changing its remote-config state from **`internal`** to **`enabled`**, so eligible clients can expose “bookmark all open tabs” outside internal-only rollout.
> 
> Adds **`minSupportedVersion`: `0.160.0`** so only Windows app builds at or above that version receive the flag.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c1ddc5074974a6b55da89e5058b3618351cfae20. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->