### PR TITLE
Set webview env launch attempts to 5

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -4739,6 +4739,10 @@
                 "removeRedirectionBitmapAllWinVersions": {
                     "state": "enabled",
                     "minSupportedVersion": "0.165.1"
+                },
+                "browserLaunchAttempts": {
+                    "state": "enabled",
+                    "settings": { "attemptCount": 5 }
                 }
             },
             "exceptions": []

--- a/schema/config.ts
+++ b/schema/config.ts
@@ -18,6 +18,7 @@ import { NetworkProtection } from './features/network-protection';
 import { AiChatConfig } from './features/ai-chat';
 import { ScriptletsFeature } from './features/scriptlets';
 import { WindowsWebViewFailures } from './features/windows-webview-failures';
+import { WebViewConfig } from './features/webview';
 import { CustomUserAgentFeature } from './features/custom-user-agent';
 import { BurnFeature } from './features/burn';
 import { ClientBrandHintFeature } from './features/client-brand-hint';
@@ -90,6 +91,7 @@ export type ConfigV5<VersionType> = {
         webDetection?: WebDetectionFeature<VersionType>;
         webEvents?: WebEventsFeature<VersionType>;
         windowsWebviewFailures?: WindowsWebViewFailures<VersionType>;
+        webview?: WebViewConfig<VersionType>;
         customUserAgent?: CustomUserAgentFeature<VersionType>;
         downloadManager?: DownloadManager<VersionType>;
         elementHiding?: ElementHidingFeature<VersionType>;

--- a/schema/features/webview.ts
+++ b/schema/features/webview.ts
@@ -1,0 +1,16 @@
+import { Feature, SubFeature } from '../feature';
+
+type SubFeatures<VersionType> = {
+    browserLaunchAttempts?: SubFeature<
+        VersionType,
+        {
+            attemptCount: number;
+        }
+    >;
+};
+
+export type WebViewConfig<VersionType> = Feature<
+    Record<string, string>,
+    VersionType,
+    SubFeatures<VersionType> & Record<string, SubFeature<VersionType>>
+>;


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1208671518706472/task/1216619594500207?focus=true

## Description
<!-- 
  Please delete either or both process sections below.
-->



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small Windows-only remote config and schema typing for a retry count; no auth, security, or data-handling changes.
> 
> **Overview**
> Windows remote config now enables **`browserLaunchAttempts`** under the existing **`webview`** feature with **`attemptCount: 5`**, so clients can retry WebView environment launches up to five times.
> 
> The change adds **`WebViewConfig`** typing in **`schema/features/webview.ts`** (including the **`browserLaunchAttempts`** subfeature and its **`attemptCount`** setting) and registers **`webview`** on the V5 config schema in **`schema/config.ts`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6923c675b7d571a198ed67386d71090a30f330c0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->