### PR TITLE
Enable ad blocking improvements to internal users

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -38,6 +38,16 @@
         "adBlockingExtension": {
             "exceptions": [],
             "state": "enabled",
+            "features": {
+                "enabledByDefault": {
+                    "state": "internal",
+                    "minSupportedVersion": 52880003
+                },
+                "adBlockingUXImprovements": {
+                    "state": "internal",
+                    "minSupportedVersion": 52880003
+                }
+            },
             "minSupportedVersion": 52840000
         },
         "additionalCampaignPixelParams": {


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1212227266948491/task/1216621188194625?focus=true

## Description
* Enable Ad Blocking Phase 2 for internal users
*
### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [x] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [x] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only Android override scoped to internal users and a minimum app version; no broad production rollout.
> 
> **Overview**
> Turns on **Ad Blocking Phase 2** for Android **internal** builds by adding two sub-features under `adBlockingExtension` in `android-override.json`.
> 
> **`enabledByDefault`** and **`adBlockingUXImprovements`** are both set to `state: "internal"` with **`minSupportedVersion`: 52880003**, so only internal clients on that build or newer get default-on ad blocking and the updated UX. General users are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9342982e273728c5470f7cd0af0dd158ed22d1da. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->