### PR TITLE
Enable `wpf/swallowLostDwmIpcMessage` feature/subfeature

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -6070,11 +6070,11 @@
             "exceptions": []
         },
         "wpf": {
-            "state": "internal",
+            "state": "enabled",
             "exceptions": [],
             "features": {
                 "swallowLostDwmIpcMessage": {
-                    "state": "internal"
+                    "state": "enabled"
                 }
             }
         }


### PR DESCRIPTION
**Asana Task/Github Issue:**

## Description
* Enables `wpf/swallowLostDwmIpcMessage` feature/subfeature

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only rollout in the Windows override file with no auth, data, or shared logic changes.
> 
> **Overview**
> Rolls out the Windows **`wpf`** feature and its **`swallowLostDwmIpcMessage`** subfeature for DuckDuckGo on Windows by updating `overrides/windows-override.json`: both entries move from **`internal`** to **`enabled`**, so clients pick up the behavior outside internal-only builds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e862f76b163a14a909cbf3e00b5f92f38cb4c8e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->