### PR TITLE
Enable native crash reporting dialog for 20% of Windows users

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -5215,11 +5215,11 @@
             "exceptions": [],
             "features": {
                 "canShowNativeCrashReportingDialog": {
-                    "state": "internal",
+                    "state": "enabled",
                     "rollout": {
                         "steps": [
                             {
-                                "percent": 5
+                                "percent": 20
                             }
                         ]
                     }

--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -5219,6 +5219,9 @@
                     "rollout": {
                         "steps": [
                             {
+                                "percent": 5
+                            },
+                            {
                                 "percent": 20
                             }
                         ]


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/72649045549333/task/1216630818862274?focus=true

## Description

Enables `canShowNativeCrashReportingDialog` on Windows and increases its incremental rollout from 5% to 20%.

This makes the native crash reporting dialog available to a larger Windows audience while retaining a controlled rollout.

### Validation

- Generated all platform configs successfully.
- 2,336 unit and schema tests passed.
- ESLint, TypeScript, lockfile validation, targeted Prettier, and git diff checks passed.

### Feature change process

- [ ] I have added a schema to validate this feature change.
- [x] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only feature-flag change with incremental rollout; affects crash-reporting UX, not auth, payments, or core data paths.
> 
> **Overview**
> **Windows** config now exposes the native crash reporting dialog to more users via a staged rollout.
> 
> `canShowNativeCrashReportingDialog` moves from **`internal`** to **`enabled`**, and rollout steps go from a single **5%** step to **5% → 20%**, so eligible Windows clients can show the dialog for a larger slice of the population while keeping incremental exposure.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fcc21c454f6fb28b9ff0670527dcd5466307c4fb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->