### PR TITLE
Enable contextualUnifiedToggleInput flag for iOS (min 7.230.0)

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -391,6 +391,11 @@
                         ]
                     }
                 },
+                "contextualUnifiedToggleInput": {
+                    "state": "enabled",
+                    "description": "Contextual Unified Toggle Input (UTI) for Duck.ai",
+                    "minSupportedVersion": "7.230.0"
+                },
                 "aiChatAtb": {
                     "state": "enabled",
                     "description": "Add ATB to Duck.ai",


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1206488453854252/task/1216268790567238

## Description

Enables the `aiChat.contextualUnifiedToggleInput` subfeature (`AIChatSubfeature.contextualUnifiedToggleInput`) for iOS users on app version **7.230.0** and above. This is the contextual variant of the Unified Toggle Input (UTI) for Duck.ai.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single JSON flag addition with a version floor; no auth, data, or infrastructure changes.
> 
> **Overview**
> Turns on the **`aiChat.contextualUnifiedToggleInput`** subfeature in `ios-override.json` for iOS **7.230.0+**, with no rollout steps—eligible clients get it immediately once they meet the version gate.
> 
> This is the contextual variant of Unified Toggle Input (UTI), added alongside the existing `unifiedToggleInput` entry (which still uses a phased rollout from 7.226.0).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 06cc64be6facfa8e5f4105b6eae959ea4bead6bc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->