### PR TITLE
Add customAiOnboarding feature toggle to android-override, disabled

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -4814,6 +4814,10 @@
                     ]
                 }
             }
+        },
+        "customAiOnboarding": {
+            "state": "disabled",
+            "exceptions": []
         }
     },
     "unprotectedTemporary": [],


### PR DESCRIPTION
## Summary
- Adds a new `customAiOnboarding` feature flag to `overrides/android-override.json`, set to `disabled`

## Test plan
- [x] `npm run build` generates configs cleanly and `customAiOnboarding` appears disabled in `generated/v4/android-config.json`
- [x] `npm run lint`
- [x] `npm run unit-tests`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only addition with the feature off by default; no rollout or behavior change until enabled elsewhere.
> 
> **Overview**
> Adds a new top-level **`customAiOnboarding`** feature entry to `overrides/android-override.json` for the Android privacy config.
> 
> The flag is introduced with **`state: "disabled"`** and an empty **`exceptions`** list, so generated Android config will expose the toggle but no clients should see the flow until it is turned on in a follow-up change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a6ffec71b9aee8ee4fa1a2094da69e523f8d09eb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->