### PR TITLE
Hide empty ad slot on astrologyanswers.com

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -869,6 +869,15 @@
                 ]
             },
             {
+                "domain": "astrologyanswers.com",
+                "rules": [
+                    {
+                        "selector": ".astro-entity-placement",
+                        "type": "hide-empty"
+                    }
+                ]
+            },
+            {
                 "domain": "asuracomic.net",
                 "rules": [
                     {


### PR DESCRIPTION
https://app.asana.com/1/137249556945/project/11472677167855/task/1216586755666868

## What

`astrologyanswers.com` renders `.astro-entity-placement` ad slots with a reserved `min-height` (~250px). When the ad is blocked, the slot stays empty and leaves a large blank band on the page (e.g. between the header and the "Read Your Daily Horoscope" heading).

## Change

`features/element-hiding.json`: add a site-scoped rule collapsing empty `.astro-entity-placement` slots with `hide-empty`.

```json
{
    "domain": "astrologyanswers.com",
    "rules": [
        { "selector": ".astro-entity-placement", "type": "hide-empty" }
    ]
}
```

## Notes

- Uses `hide-empty` (not `hide`) so only unfilled slots collapse — anything that legitimately renders is untouched.
- Targets the stable `.astro-entity-placement` class rather than the per-page dynamic id (`astro-<number>`), so it covers all empty placements on the site.
- Verified on the live site: the blank band collapses with the rule active.
