### PR TITLE
iOS: Enable search token experiment 

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -3244,6 +3244,25 @@
                 },
                 "webScrollFreezeObservability": {
                     "state": "disabled"
+                },
+                "searchTokenExperiment": {
+                    "state": "enabled",
+                    "minSupportedVersion": "7.230.0",
+                    "settings": {
+                        "tokenTTLSeconds": 300,
+                        "refreshWindowSeconds": 120
+                    },
+                    "description": "NA experiment: search token to speed up SERP by combining Index/Deep responses.",
+                    "cohorts": [
+                        {
+                            "name": "control",
+                            "weight": 1
+                        },
+                        {
+                            "name": "treatment",
+                            "weight": 1
+                        }
+                    ]
                 }
             }
         },

--- a/schema/features/ios-browser-config.ts
+++ b/schema/features/ios-browser-config.ts
@@ -12,6 +12,15 @@ type SubFeatures<VersionType> = {
             idleThresholdSeconds: number;
         }
     >;
+    searchTokenExperiment?: SubFeature<
+        VersionType,
+        {
+            // Lifetime of the search token in seconds
+            tokenTTLSeconds: number;
+            // Time before expiry within which the token is proactively refreshed, in seconds
+            refreshWindowSeconds: number;
+        }
+    >;
 };
 
 export type IOSBrowserConfig<VersionType> = Feature<


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/task/1216365830146839

## Description
Enables the search token experiment for all iOS users on version 7.230.0 and higher.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Remote feature-flag and experiment config only; no application logic changes in this repo.
> 
> **Overview**
> Turns on the **search token experiment** for iOS browser clients at **7.230.0+** via `ios-override.json`. Eligible users are split evenly between **control** and **treatment** cohorts.
> 
> Remote settings define a **300s** token lifetime and a **120s** proactive refresh window before expiry. The experiment is described as combining Index/Deep responses to speed up SERP.
> 
> The iOS browser config **schema** adds a typed `searchTokenExperiment` subfeature so those two settings are validated like other browser subfeatures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2bf4ad59bd01a9f0a8ccd2a83f6ee143923e18e6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->