### PR TITLE
Enabling the native AI SERP controls on Windows from version 166.

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -1418,6 +1418,10 @@
                         ]
                     }
                 },
+                "aiFeaturesNativeControls": {
+                    "state": "enabled",
+                    "minSupportedVersion": "0.166.0"
+                },
                 "omnibarReasoningEffort": {
                     "state": "enabled",
                     "minSupportedVersion": "0.157.0"


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/72649045549333/task/1215774145384397?focus=true

## Description
Enables the native AI SERP controls in the Windows browser from version 166 (when the change was introduced).

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [x] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single remote feature-flag entry in privacy configuration; no application logic or security-sensitive code changes.
> 
> **Overview**
> Turns on **native AI SERP controls** for the Windows browser via remote config by adding `aiFeaturesNativeControls` to `windows-override.json`, matching the pattern already used on Android and macOS.
> 
> The flag is **enabled** with `minSupportedVersion` **0.166.0**, so only clients at or above that build receive the feature.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e93412d954bf84dff84b7991366b6072229f416a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->