### PR TITLE
Disable UI responsiveness pixels

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -1643,8 +1643,7 @@
                         "conditionalChanges": [
                             {
                                 "condition": [
-                                    { "domain": "blindbarber.com" }
-                                ],
+                                    { "domain": "blindbarber.com" }],
                                 "patchSettings": [
                                     {
                                         "path": "/formBoundarySelector",
@@ -2108,8 +2107,7 @@
                             },
                             {
                                 "condition": [
-                                    { "domain": "antarestech.com" }
-                                ],
+                                    { "domain": "antarestech.com" }],
                                 "patchSettings": [
                                     {
                                         "path": "/formBoundarySelector",
@@ -2120,8 +2118,7 @@
                             },
                             {
                                 "condition": [
-                                    { "domain": "auth.ibx.com" }
-                                ],
+                                    { "domain": "auth.ibx.com" }],
                                 "patchSettings": [
                                     {
                                         "path": "/inputTypeSettings/-",
@@ -5068,15 +5065,15 @@
             }
         },
         "uiResponsiveness": {
-            "state": "enabled",
+            "state": "disabled",
             "minSupportedVersion": "0.158.0",
             "features": {
                 "keypressToCharacterRender": {
-                    "state": "enabled",
+                    "state": "disabled",
                     "minSupportedVersion": "0.158.0"
                 },
                 "keypressToSuggestionRender": {
-                    "state": "enabled",
+                    "state": "disabled",
                     "minSupportedVersion": "0.158.0"
                 }
             }

--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -1643,7 +1643,8 @@
                         "conditionalChanges": [
                             {
                                 "condition": [
-                                    { "domain": "blindbarber.com" }],
+                                    { "domain": "blindbarber.com" }
+                                ],
                                 "patchSettings": [
                                     {
                                         "path": "/formBoundarySelector",
@@ -2107,7 +2108,8 @@
                             },
                             {
                                 "condition": [
-                                    { "domain": "antarestech.com" }],
+                                    { "domain": "antarestech.com" }
+                                ],
                                 "patchSettings": [
                                     {
                                         "path": "/formBoundarySelector",
@@ -2118,7 +2120,8 @@
                             },
                             {
                                 "condition": [
-                                    { "domain": "auth.ibx.com" }],
+                                    { "domain": "auth.ibx.com" }
+                                ],
                                 "patchSettings": [
                                     {
                                         "path": "/inputTypeSettings/-",


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1209667197557478/task/1214792082912704?focus=true

## Description
Disable UI responsiveness pixels (which are not currently being used due to uncertainty regarding their accuracy).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only flag flips with no runtime code changes; reduces telemetry rather than altering product behavior.
> 
> **Overview**
> Turns off **UI responsiveness** telemetry on Windows by setting `uiResponsiveness` and its nested metrics (`keypressToCharacterRender`, `keypressToSuggestionRender`) from **enabled** to **disabled** in `windows-override.json`.
> 
> This stops collection of those latency “pixels” until their accuracy is trusted again; no application logic changes—only override flags.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d80b32ef5605951e22981a301fd8948faedc2d67. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->