### PR TITLE
Update autoconsent to v16.12.0

### DIFF
--- a/features/autoconsent.json
+++ b/features/autoconsent.json
@@ -1885,7 +1885,7 @@
                 "#consent-page button[value=reject]",
                 ".cookie-manager",
                 ".cookie-manager .cookie-notice.open",
-                ".cookie-notice [data-test=reject]",
+                ".cookie-notice button.owid-btn--outline-dark-blue.cookie-notice__button",
                 "footer .ccpabanner",
                 ".BusinessCookieConsent",
                 ".BusinessCookieConsent [data-id=cookie-consent-banner-buttons]",
@@ -28229,7 +28229,7 @@
                     1,
                     "reddit.com",
                     2,
-                    "^https://www\\.reddit\\.com/",
+                    "^https://(www|old)\\.reddit\\.com/",
                     22,
                     [
                         1380


### PR DESCRIPTION
Asana Task/Github Issue: https://app.asana.com/1/137249556945/project/1201844467387842/task/1216674514416566

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Routine third-party autoconsent rule sync with narrow selector and URL-pattern tweaks; no app logic or security surface changes.
> 
> **Overview**
> Bumps bundled **autoconsent** rules to **v16.12.0** with two selector/site fixes in the compact rule list.
> 
> The **cookie-notice** reject action now targets `.cookie-notice button.owid-btn--outline-dark-blue.cookie-notice__button` instead of `.cookie-notice [data-test=reject]`, matching updated markup (e.g. Our World in Data).
> 
> **Reddit** autoconsent coverage widens the URL match from `^https://www\.reddit\.com/` to `^https://(www|old)\.reddit\.com/` so **old.reddit.com** gets the same CMP handling as www.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a05788ffc29c21592019a84ed531e1c667a78d05. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->