### PR TITLE
Enable omnibar and NTP customize responses on Windows.

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -1422,6 +1422,12 @@
                     "state": "enabled",
                     "minSupportedVersion": "0.166.0"
                 },
+                "omnibarCustomizeResponses": {
+                    "state": "enabled"
+                },
+                "ntpCustomizeResponses": {
+                    "state": "enabled"
+                },
                 "omnibarReasoningEffort": {
                     "state": "enabled",
                     "minSupportedVersion": "0.157.0"

--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -1423,10 +1423,12 @@
                     "minSupportedVersion": "0.166.0"
                 },
                 "omnibarCustomizeResponses": {
-                    "state": "enabled"
+                    "state": "enabled",
+                    "minSupportedVersion": "0.168.0"
                 },
                 "ntpCustomizeResponses": {
-                    "state": "enabled"
+                    "state": "enabled",
+                    "minSupportedVersion": "0.168.0"
                 },
                 "omnibarReasoningEffort": {
                     "state": "enabled",


### PR DESCRIPTION
https://app.asana.com/1/137249556945/project/72649045549333/task/1215104465827545?focus=true

## Summary
- Enable `aiChat.omnibarCustomizeResponses` on Windows
- Enable `aiChat.ntpCustomizeResponses` on Windows

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only change in `windows-override.json` with no application logic; rollout is gated by minimum version.
> 
> **Overview**
> Turns on two **aiChat** remote-config features for Windows: **`omnibarCustomizeResponses`** and **`ntpCustomizeResponses`**, each set to `enabled` with **`minSupportedVersion` `0.168.0`**.
> 
> This exposes customize-responses UI/behavior in the omnibar and new-tab-page AI chat surfaces for clients on that build or newer.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 94bdc3148e245cdb583affb45cdfb0462e226fc4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->