### PR TITLE
Prevent Cursor format hook hanging on Windows stdin.

### DIFF
--- a/.cursor/hooks.json
+++ b/.cursor/hooks.json
@@ -3,7 +3,8 @@
     "hooks": {
         "afterFileEdit": [
             {
-                "command": ".cursor/hooks/format.sh"
+                "command": ".cursor/hooks/format.sh",
+                "timeout": 15
             }
         ]
     }

--- a/.cursor/hooks/format.sh
+++ b/.cursor/hooks/format.sh
@@ -1,7 +1,30 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-payload="$(cat)"
+# Cursor sends hook JSON on stdin. On Windows, hooks often run as
+# `bash --login -i`, and stdin may never close — unbounded `cat` hangs forever.
+read_payload() {
+    local line payload=""
+
+    # Wait briefly for the first line of JSON; exit empty on timeout.
+    if IFS= read -r -t 2 line; then
+        payload="$line"
+    elif [[ -n "${line:-}" ]]; then
+        # EOF without a trailing newline still leaves data in $line.
+        payload="$line"
+    else
+        return 0
+    fi
+
+    # Drain any remaining lines briefly (payload is usually one line).
+    while IFS= read -r -t 0.2 line; do
+        payload+=$'\n'"$line"
+    done || true
+
+    printf '%s' "$payload"
+}
+
+payload="$(read_payload)"
 
 if [[ -z "$payload" ]]; then
     exit 0


### PR DESCRIPTION
## Summary
- Replace unbounded `cat` in `.cursor/hooks/format.sh` with a timed stdin read so Windows `bash --login -i` hooks do not hang forever when stdin never closes
- Add a 15s `timeout` on the `afterFileEdit` hook in `.cursor/hooks.json` as a backstop

## Test plan
- [ ] On Windows, trigger an agent file edit and confirm the format hook returns promptly
- [ ] Confirm `bash -i .cursor/hooks/format.sh` with open/empty stdin exits within ~2s instead of hanging
- [ ] Confirm a normal payload still formats: `echo '{"file_path":".cursor/hooks.json"}' | bash .cursor/hooks/format.sh`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dev-tooling hook behavior only; no runtime app, auth, or data paths affected.
> 
> **Overview**
> Fixes **afterFileEdit** format hooks that could block indefinitely on Windows when Cursor runs them under interactive bash and **stdin never closes**.
> 
> **`.cursor/hooks/format.sh`** no longer uses unbounded `cat` for the hook JSON. It reads stdin with **timed `read`** (~2s for the first line, short drain for any follow-up lines) and exits cleanly with no payload when nothing arrives.
> 
> **`.cursor/hooks.json`** sets a **15s `timeout`** on the format hook as a backstop if the script still misbehaves.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da2639df45c19bdc96dbbaf7918a30ec01026b18. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->