### PR TITLE
Unblock mapkit tiles

### DIFF
--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -4948,6 +4948,17 @@
                         "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5197"
                     }
                 ]
+            },
+            "apple-mapkit.com": {
+                "rules": [
+                    {
+                        "rule": "cdn.apple-mapkit.com/ti/tile",
+                        "domains": [
+                            "<all>"
+                        ],
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5595"
+                    }
+                ]
             }
         }
     },

--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -4952,7 +4952,7 @@
             "apple-mapkit.com": {
                 "rules": [
                     {
-                        "rule": "cdn.apple-mapkit.com/ti/tile",
+                        "rule": "apple-mapkit.com/ti/tile",
                         "domains": [
                             "<all>"
                         ],


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1204912272578138/task/1216708068841711?focus=true

## Description
The last blocklist update started blocking mapkit tiles. This breaks sites using the SDK to display maps.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single JSON allowlist rule scoped to map tile paths; no application code or auth changes.
> 
> **Overview**
> Adds a **tracker allowlist** entry for `apple-mapkit.com/ti/tile` on **all sites**, so DuckDuckGo’s tracker blocking no longer stops Apple MapKit **map tile** loads.
> 
> This is a targeted regression fix after a recent blocklist change that broke embedded Apple maps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8467fdf4737d4fc164fd99dff3d47c910cf5eecd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->