### PR TITLE
Unblock posthog request on amicable

### DIFF
--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -4948,6 +4948,17 @@
                         "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5197"
                     }
                 ]
+            },
+            "posthog.com": {
+                "rules": [
+                    {
+                        "rule": "eu-assets.i.posthog.com/static/array.js",
+                        "domains": [
+                            "amicable.io"
+                        ],
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5597"
+                    }
+                ]
             }
         }
     },

--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -4952,7 +4952,7 @@
             "posthog.com": {
                 "rules": [
                     {
-                        "rule": "eu-assets.i.posthog.com/static/array.js",
+                        "rule": "posthog.com/static/array.js",
                         "domains": [
                             "amicable.io"
                         ],

--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -4957,6 +4957,8 @@
                             "amicable.io"
                         ],
                         "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5597"
+                    }
+                ]
             },
             "apple-mapkit.com": {
                 "rules": [


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1206670747178362/task/1216708784362279?focus=true

## Description
Site gets stuck loading unless this request is allowed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-domain allowlist entry for one PostHog script path; no auth, payment, or broad tracker exceptions.
> 
> **Overview**
> Adds a **tracker allowlist** exception so DuckDuckGo does not block PostHog’s `posthog.com/static/array.js` on **amicable.io**, fixing a page that otherwise hangs on load.
> 
> The rule is scoped to that domain only (not `<all>`), matching other site-specific breakage entries in `tracker-allowlist.json`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 95a9ac11d0aff652214236bf0d93485d84db872e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->