### PR TITLE
[macOS] Enable page suggestions

### DIFF
--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -2646,6 +2646,7 @@
             "minSupportedVersion": "1.179.0",
             "exceptions": [],
             "settings": {
+                "includePageTypeSignals": "enabled",
                 "maxContentLength": 9500,
                 "mainContentSelector": "main, article, .content, .main, #content, #main",
                 "excludeSelectors": [


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/72649045549333/task/1216710738615520?focus=true

## Description
Enable feature flag from C-S-S

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [x] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [x] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single remote-config flag on an already-enabled feature; no auth, data, or rollout logic changes.
> 
> **Overview**
> Turns on **`includePageTypeSignals`** under the macOS **`pageContext`** feature in `overrides/macos-override.json`, matching the remote/content-scope configuration used for page suggestions.
> 
> macOS clients that already ship **`pageContext`** (≥ 1.179.0) will now include page-type signals when building page context, without changing content length limits, selectors, or domain-specific patches.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0ca2ba4df478b9a53857cf099a5919e79586c841. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->