### PR TITLE
Enable nativeInputNavBar (Android)

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -670,6 +670,10 @@
                 "removeChatHistory": {
                     "state": "enabled",
                     "minSupportedVersion": 52880000
+                },
+                "nativeInputNavBar": {
+                    "state": "enabled",
+                    "minSupportedVersion": 52890000
                 }
             }
         },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1200204095367872/task/1216655892492557?focus=true

## Description
Enables the main navigation (back button and main buttons in unfocussed mode) for users on 5.289.0+ for toggle-enabled users.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [x] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single remote feature-flag entry with a version gate; no app logic or security-sensitive changes in this repo.
> 
> **Overview**
> Turns on the **`nativeInputNavBar`** sub-feature under **`aiChat`** in the Android privacy config override so clients on **5.289.0+** (`minSupportedVersion`: 52890000) can show the native navigation bar around the Duck.ai chat input (back control and primary actions when the field is unfocused), for users who already have the related toggle enabled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 57a435592a6345e369563c1c4170524ac7915200. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->