### PR TITLE
Update content-blocker extension to 2026.7.20

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -4950,7 +4950,7 @@
             "minSupportedVersion": "0.148.0",
             "exceptions": [],
             "settings": {
-                "extensionUrl": "https://staticcdn.duckduckgo.com/extensions/content-blocker/content-blocker-extension-2026.7.6.crx"
+                "extensionUrl": "https://staticcdn.duckduckgo.com/extensions/content-blocker/content-blocker-extension-2026.7.20.crx"
             },
             "features": {
                 "onboardingEnabled": {


### PR DESCRIPTION
Update content-blocker extension to 2026.7.20.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single URL bump in remote config; behavior depends on the packaged extension but no app logic changes here.
> 
> **Overview**
> Updates the Windows remote-config **`adBlockV2Extension`** setting so clients download the newer content-blocker CRX (**`2026.7.20`** instead of **`2026.7.6`**). No other flags, version gates, or feature toggles change in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit be4d1d5e0c342f0c7bc5621b39d7d520bafd8b00. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->