### PR TITLE
Update ad-blocking extension scriptlets for v2026.7.20

### DIFF
--- a/features/ad-blocking-extension.json
+++ b/features/ad-blocking-extension.json
@@ -4,28 +4,28 @@
     },
     "exceptions": [],
     "settings": {
-        "version": "2026.7.6",
+        "version": "2026.7.20",
         "enabledByDefault": false,
         "scriptlets": {
             "scriptlets/isolated/ublock-filters.js": {
-                "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/23765714b14e17988e02bc9056a26bee9dc7f16cf94e54aa3178458571d5810a.js",
-                "signature": "MEQCIEBFxsHn+W1dQn5yF7ohup9ScW7NmzohqqL8+fG1QFwUAiBiNRQ4rs7fCMkYjpwL8q+lqCHGAdKsABT9UxS9R3Q2zA=="
+                "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/56e8765a2e6bfc35594d0c83840b62ad8d4fef7388bb5aecda1fc411e7697a66.js",
+                "signature": "MEQCIErTF5jJsG/BpIixayrnsewT9PyjVob1VnpJKrvSKNjLAiAXDmhXIEt5wJp0yqfCD7k6hU7FiE0Xt0FrCz1CsLMerQ=="
             },
             "scriptlets/main/ublock-filters.js": {
-                "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/c9de572d02e840bfd60b1b88a592fafc7ce2722957ab43f2fb37c71eb8187d00.js",
-                "signature": "MEYCIQDFA5iCu7gzqj78dRkggoiyfwToyl485gV9LHs/kHFx2wIhAJkIPWf2qtYHyWSPqex3Yo2SfCkUHHvm33/dhcuVG37l"
+                "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/6b328817148ffce49c795532435d5a9f2840e5bcaf9a8c745441ffe829024308.js",
+                "signature": "MEYCIQCXEbccqDx8JS0lCBIIzxUbjZjrgDOtcnthxHyqrOcqUwIhAPkoy/scxvVsT5Ga7YntRx3oGqJVJfkQAYZ3wfLz8OU2"
             },
             "scriptlets/main/ublock-experimental.js": {
                 "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855.js",
-                "signature": "MEQCICK9SyAb0FbMcIZCpLZImtP4SBrCG1UVQOBkkIjok8LgAiAzagemTCVDH6EvaNJxFHHRid/jcrZe1wqFnnK6xuPy2g=="
+                "signature": "MEQCIBpiMPFCN5IHj9wTHQJZAkKD3Uf/5CdNW89WHPjYbbcTAiA9HM9n1XHJm5cur3Ok/Cam6JvsyeIObmvUd8OtvXT+4Q=="
             },
             "scriptlets/isolated/ublock-experimental.js": {
                 "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855.js",
-                "signature": "MEQCIFYv4I42jEZwOY31our0CfglozjmglRregIsDDUoNpUyAiBhafXpqf3QlWXC+rGc5Bo0KMjEAhhLwKyuHgJyoZVWnQ=="
+                "signature": "MEYCIQDpPjyDrXDC1nCQ/biYX3S5Yw6qMpK2Iuthw3wCU5nHsQIhANEYKwVcIC+ASJJ3pWPYhyjY4AJmyuiQt1731Ze2XS06"
             },
             "rules/youtube.json": {
                 "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/2337db6aa7466667595226f780b6590779db3007ac0a65ef3833f89610c92824.json",
-                "signature": "MEQCIG1GUASUdXGM9aQJhpD4YZfhQ3EJ7IQ9sSy7qt55gcOpAiBjvVKTFypweU9FlJEjITPUbaMLB3+mY2+jRk04hBXCdA=="
+                "signature": "MEUCIQD/PNv9mjxwXkF8w/1WGptt76YcOOB46HmCNzm1iJkiBgIgUIlZ7OsI9iMsvhsRB2h5spKAYZYcU2E4vrFkI8cVJW4="
             }
         }
     }


### PR DESCRIPTION
Update ad-blocking extension scriptlets for v2026.7.20.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only change to pinned CDN scriptlets and signatures; no application logic in this repo.
> 
> **Overview**
> Bumps the macOS/iOS ad-blocking extension config from **2026.7.6** to **2026.7.20**.
> 
> **`ublock-filters`** (isolated and main) get new CDN scriptlet URLs and signatures. **`ublock-experimental`** scriptlets keep the same URLs but receive updated signatures. **`rules/youtube.json`** keeps the same URL with an updated signature.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4141e058cd4f28ffe92abd852b63ab6dbdef803e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->