### PR TITLE
Add Facebook SDK exception for Deezer

### DIFF
--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -2439,7 +2439,8 @@
                             "bingoblitzvip.com",
                             "centurygames.com",
                             "mytrackman.com",
-                            "solitaired.com"
+                            "solitaired.com",
+                            "deezer.com"
                         ],
                         "reason": [
                             "bandsintown.com - Ticket page renders blank. With this exception the page redirects to ticketspice.com.",
@@ -2460,7 +2461,8 @@
                             "bingoblitzvip.com - https://github.com/duckduckgo/privacy-configuration/pull/5604",
                             "centurygames.com - https://github.com/duckduckgo/privacy-configuration/pull/5604",
                             "mytrackman.com - https://github.com/duckduckgo/privacy-configuration/issues/1426",
-                            "solitaired.com - https://github.com/duckduckgo/privacy-configuration/pull/2329"
+                            "solitaired.com - https://github.com/duckduckgo/privacy-configuration/pull/2329",
+                            "deezer.com - https://github.com/duckduckgo/privacy-configuration/pull/5605"
                         ]
                     },
                     {


### PR DESCRIPTION
The SSO login buttons on Deezer were broken, let's allow the Facebook SDK for
now to fix those.

**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/task/1216208388522818?focus=true
