### PR TITLE
Roll out cookie pop-up opt-in dialog to 5% on iOS and macOS

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -963,6 +963,9 @@
                         "steps": [
                             {
                                 "percent": 2
+                            },
+                            {
+                                "percent": 5
                             }
                         ]
                     }

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -886,6 +886,9 @@
                         "steps": [
                             {
                                 "percent": 2
+                            },
+                            {
+                                "percent": 5
                             }
                         ]
                     }


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1203936086921904/task/1216510918501727

## Description

Adds a 5% rollout step (after the existing 2% step) for the autoconsent `cookiePopupOptInDialog` feature in the iOS and macOS overrides.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only rollout percentage bump for an already-enabled feature; no application code changes.
> 
> **Overview**
> Advances the staged rollout for autoconsent **`cookiePopupOptInDialog`** on **iOS** and **macOS** by adding a second rollout step at **5%**, after the existing **2%** step. No other feature flags or platforms are changed in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 12ae34fe01407353af6cbbd3a00678eda804707f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->