### PR TITLE
Increase PIR goToMarket rollout to 100% on iOS

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -3234,6 +3234,9 @@
                         "steps": [
                             {
                                 "percent": 50
+                            },
+                            {
+                                "percent": 100
                             }
                         ]
                     }


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1203581873609357/task/1213763847118555?focus=true

## Description

Increases the `dbp.goToMarket` iOS rollout from **50% to 100%**, completing the staged re-enable of the PIR go-to-market surfaces (Settings **NEW** badge + provisional first-scan notification) started in #5315. `minSupportedVersion` stays at 7.227.0; targeting is unchanged.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [x] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only rollout expansion for an already-enabled, partially rolled-out feature; no logic or targeting changes beyond audience size.
> 
> **Overview**
> Completes the staged iOS rollout for **`dbp.goToMarket`** by adding a **100%** step to the existing rollout ladder (previously capped at **50%**). Eligible clients on **7.227.0+** can now receive the full audience for PIR go-to-market surfaces (e.g. Settings **NEW** badge and provisional first-scan notification); feature state, `minSupportedVersion`, and other `dbp` flags are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 98bd028321501506b7a7cebb558bab9b39a44615. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->