### PR TITLE
roll out cpm promo to 5% external

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -2179,14 +2179,7 @@
                 },
                 "cookiePopupPreferenceSetting": {
                     "state": "enabled",
-                    "minSupportedVersion": "0.167.1",
-                    "rollout": {
-                        "steps": [
-                            {
-                                "percent": 5
-                            }
-                        ]
-                    }
+                    "minSupportedVersion": "0.167.1"
                 },
                 "cookiePopupOptInDialog": {
                     "state": "enabled",

--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -2178,12 +2178,26 @@
                     "minSupportedVersion": "0.163.0"
                 },
                 "cookiePopupPreferenceSetting": {
-                    "state": "preview",
-                    "minSupportedVersion": "0.167.1"
+                    "state": "enabled",
+                    "minSupportedVersion": "0.167.1",
+                    "rollout": {
+                        "steps": [
+                            {
+                                "percent": 5
+                            }
+                        ]
+                    }
                 },
                 "cookiePopupOptInDialog": {
-                    "state": "preview",
-                    "minSupportedVersion": "0.167.1"
+                    "state": "enabled",
+                    "minSupportedVersion": "0.167.1",
+                    "rollout": {
+                        "steps": [
+                            {
+                                "percent": 5
+                            }
+                        ]
+                    }
                 }
             },
             "exceptions": [


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1200848783441532/task/1216748198791272?focus=true

## Description
<!-- 
  Please delete either or both process sections below.
-->

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Remote feature-flag and rollout percentage changes only; no application code or security-sensitive logic is modified.
> 
> **Overview**
> On **Windows**, cookie popup management promo config moves from **preview** to **enabled** for `cookiePopupPreferenceSetting` and `cookiePopupOptInDialog` (min version `0.167.1` unchanged).
> 
> `cookiePopupOptInDialog` now includes a **5% staged rollout** (`rollout.steps`), aligning Windows with the gradual external exposure pattern used on other platforms for the CPM opt-in dialog.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dbfce85e2a9399deb59bd9ea6b48d7c4c812fc6d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->