### PR TITLE
Add more Facebook SDK Tracker Allowlist entries

### DIFF
--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -2440,7 +2440,21 @@
                             "centurygames.com",
                             "mytrackman.com",
                             "solitaired.com",
-                            "deezer.com"
+                            "deezer.com",
+                            "houseoffun.com",
+                            "justapinch.com",
+                            "grubhub.com",
+                            "mykonamiplus.com",
+                            "boredpanda.com",
+                            "lapost.com",
+                            "taongafarm.com",
+                            "myvegas.com",
+                            "puzzlywords.com",
+                            "wordbattle.com",
+                            "mapotic.com",
+                            "vipspades.com",
+                            "goldmachine.com",
+                            "vipgames.com"
                         ],
                         "reason": [
                             "bandsintown.com - Ticket page renders blank. With this exception the page redirects to ticketspice.com.",
@@ -2462,7 +2476,21 @@
                             "centurygames.com - https://github.com/duckduckgo/privacy-configuration/pull/5604",
                             "mytrackman.com - https://github.com/duckduckgo/privacy-configuration/issues/1426",
                             "solitaired.com - https://github.com/duckduckgo/privacy-configuration/pull/2329",
-                            "deezer.com - https://github.com/duckduckgo/privacy-configuration/pull/5605"
+                            "deezer.com - https://github.com/duckduckgo/privacy-configuration/pull/5605",
+                            "houseoffun.com - https://github.com/duckduckgo/privacy-configuration/pull/5614",
+                            "justapinch.com - https://github.com/duckduckgo/privacy-configuration/pull/5614",
+                            "grubhub.com - https://github.com/duckduckgo/privacy-configuration/pull/5614",
+                            "mykonamiplus.com - https://github.com/duckduckgo/privacy-configuration/pull/5614",
+                            "boredpanda.com - https://github.com/duckduckgo/privacy-configuration/pull/5614",
+                            "lapost.com - https://github.com/duckduckgo/privacy-configuration/pull/5614",
+                            "taongafarm.com - https://github.com/duckduckgo/privacy-configuration/pull/5614",
+                            "myvegas.com - https://github.com/duckduckgo/privacy-configuration/pull/5614",
+                            "puzzlywords.com - https://github.com/duckduckgo/privacy-configuration/pull/5614",
+                            "wordbattle.com - https://github.com/duckduckgo/privacy-configuration/pull/5614",
+                            "mapotic.com - https://github.com/duckduckgo/privacy-configuration/pull/5614",
+                            "vipspades.com - https://github.com/duckduckgo/privacy-configuration/pull/5614",
+                            "goldmachine.com - https://github.com/duckduckgo/privacy-configuration/pull/5614",
+                            "vipgames.com - https://github.com/duckduckgo/privacy-configuration/pull/5614"
                         ]
                     },
                     {
@@ -2487,11 +2515,13 @@
                         "rule": "connect.facebook.net/en_US/all.js",
                         "domains": [
                             "nordicwellness.se",
-                            "playwsop.com"
+                            "playwsop.com",
+                            "varaaheti.fi"
                         ],
                         "reason": [
                             "nordicwellness.se - https://github.com/duckduckgo/privacy-configuration/issues/1453",
-                            "playwsop.com - https://github.com/duckduckgo/privacy-configuration/pull/5604"
+                            "playwsop.com - https://github.com/duckduckgo/privacy-configuration/pull/5604",
+                            "varaaheti.fi - https://github.com/duckduckgo/privacy-configuration/pull/5614"
                         ]
                     },
                     {


### PR DESCRIPTION
Since we have started blocking the Facebook SDK more often, there have been more
cases of website breakage (e.g. broken "Login with Facebook" buttons for web
games), let's add some more Tracker Allowlist entries to mitigate cases that
users are reporting.

**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/task/1216208388522818?focus=true