### PR TITLE
Allow kotn's run.app endpoint on kotn.com

### DIFF
--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -5626,6 +5626,17 @@
                         "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5595"
                     }
                 ]
+            },
+            "run.app": {
+                "rules": [
+                    {
+                        "rule": "kotn-consumer-service-next-685779125599.us-central1.run.app/",
+                        "domains": [
+                            "kotn.com"
+                        ],
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5615"
+                    }
+                ]
             }
         }
     },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1206670747178362/task/1216774222054517?focus=true
 
## Description
Unblocks kotn’s run.app (Google Cloud Run) endpoint.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-site allowlist addition in privacy config with no auth, data, or application logic changes.
> 
> **Overview**
> Adds a **tracker allowlist** rule under `run.app` so requests to `kotn-consumer-service-next-685779125599.us-central1.run.app/` are permitted **only on `kotn.com`**, unblocking kotn’s Google Cloud Run consumer service from tracker protection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 67019a698eb826c86d19b052f8ab7521ee4d5a08. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->