### PR TITLE
Send FaultedException crashes to Sentry in preview

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -5229,10 +5229,10 @@
                     "state": "enabled"
                 },
                 "sendIncidentCrashReports": {
-                    "state": "disabled",
+                    "state": "preview",
                     "settings": {
                         "ExceptionTypes": [
-                            "System.OutOfMemoryException"
+                            "FaultedException"
                         ]
                     }
                 },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1210132634900450/task/1216783640031960?focus=true

## Description
Send FaultedException crashes to Sentry in preview

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Preview-only privacy-configuration toggle with a narrower exception type list; no auth or data-model changes.
> 
> **Overview**
> **Windows** remote config turns on **`sendIncidentCrashReports`** for the **preview** cohort (was **disabled**) so matching incidents can be sent to **Sentry**.
> 
> The **`ExceptionTypes`** filter is updated from **`System.OutOfMemoryException`** to **`FaultedException`**, narrowing which crash types are reported under this sub-feature.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd1161c8cf73428ad94626c0249ab6acdea13754. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->