### PR TITLE
Unblock facebook SDK on varaaheti.fi

### DIFF
--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -2380,12 +2380,21 @@
             "facebook.net": {
                 "rules": [
                     {
+                        "rule": "connect.facebook.net/signals/config/",
+                        "domains": [
+                            "varaaheti.fi"
+                        ],
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5617"
+                    },
+                    {
                         "rule": "connect.facebook.net/en_US/fbevents.js",
                         "domains": [
-                            "servustv.com"
+                            "servustv.com",
+                            "varaaheti.fi"
                         ],
                         "reason": [
-                            "servustv.com - Facebook Pixel (fbevents.js) blocked causes site breakage. https://github.com/duckduckgo/privacy-configuration/pull/5567"
+                            "servustv.com - Facebook Pixel (fbevents.js) blocked causes site breakage. https://github.com/duckduckgo/privacy-configuration/pull/5567",
+                            "varaaheti.fi - https://github.com/duckduckgo/privacy-configuration/pull/5617"
                         ]
                     },
                     {


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1206670747178362/task/1216780049597036?focus=true

## Description
Blocking the FB sdk here breaks the site.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Site-specific tracker allowlist updates only; no application logic or security-sensitive code changes.
> 
> **Overview**
> Adds **varaaheti.fi** to the `facebook.net` tracker allowlist so Facebook scripts needed for the site are not blocked.
> 
> A new allowlist rule covers `connect.facebook.net/signals/config/`, and **varaaheti.fi** is also added to the existing `connect.facebook.net/en_US/fbevents.js` entry (alongside servustv.com), with reasons pointing to privacy-configuration PR #5617.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 445bd758130c3becba88a83c7ec2a2b6d8ae9019. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->