### PR TITLE
Roll out edge-to-edge to 5% on Android for all buckets

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -2445,6 +2445,102 @@
                 }
             }
         },
+        "edgeToEdge": {
+            "state": "enabled",
+            "exceptions": [],
+            "features": {
+                "browser": {
+                    "state": "enabled",
+                    "rollout": {
+                        "steps": [
+                            {
+                                "percent": 5
+                            }
+                        ]
+                    }
+                },
+                "settings": {
+                    "state": "enabled",
+                    "rollout": {
+                        "steps": [
+                            {
+                                "percent": 5
+                            }
+                        ]
+                    }
+                },
+                "autofill": {
+                    "state": "enabled",
+                    "rollout": {
+                        "steps": [
+                            {
+                                "percent": 5
+                            }
+                        ]
+                    }
+                },
+                "sync": {
+                    "state": "enabled",
+                    "rollout": {
+                        "steps": [
+                            {
+                                "percent": 5
+                            }
+                        ]
+                    }
+                },
+                "vpn": {
+                    "state": "enabled",
+                    "rollout": {
+                        "steps": [
+                            {
+                                "percent": 5
+                            }
+                        ]
+                    }
+                },
+                "webview": {
+                    "state": "enabled",
+                    "rollout": {
+                        "steps": [
+                            {
+                                "percent": 5
+                            }
+                        ]
+                    }
+                },
+                "onboarding": {
+                    "state": "enabled",
+                    "rollout": {
+                        "steps": [
+                            {
+                                "percent": 5
+                            }
+                        ]
+                    }
+                },
+                "misc": {
+                    "state": "enabled",
+                    "rollout": {
+                        "steps": [
+                            {
+                                "percent": 5
+                            }
+                        ]
+                    }
+                },
+                "bottomSheets": {
+                    "state": "enabled",
+                    "rollout": {
+                        "steps": [
+                            {
+                                "percent": 5
+                            }
+                        ]
+                    }
+                }
+            }
+        },
         "incontextSignup": {
             "exceptions": [],
             "state": "enabled",


### PR DESCRIPTION

**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1212608036467427/task/1216509604666857?focus=true

## Description
Adds the edgeToEdge feature to the Android config with an initial 5% rollout step for every sub-feature bucket (browser, settings, autofill, sync, vpn, webview, onboarding, misc, bottomSheets), matching the EdgeToEdgeFeature toggles defined in the Android app. The parent feature is enabled so the sub-feature rollouts evaluate.


### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [x] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [x] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [x] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Edge-to-edge affects layout across major surfaces (browser, settings, VPN, etc.) for ~5% of users; risk is mitigated by a small rollout but UI regressions are possible without app changes in this PR.
> 
> **Overview**
> Adds a new **`edgeToEdge`** entry to the Android privacy config so remote feature flags can drive the app’s edge-to-edge UI rollout.
> 
> The parent feature is **enabled** with no exceptions. Nine nested buckets—**browser**, **settings**, **autofill**, **sync**, **vpn**, **webview**, **onboarding**, **misc**, and **bottomSheets**—are each **enabled** with a single rollout step at **5%**, aligned with the Android `EdgeToEdgeFeature` toggles.
> 
> This is config-only: no app code in this repo; clients that already read these keys will start evaluating the new rollouts once the config ships.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 76d39c01a60ab97e01b9ef86774de0f97d94e33b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->