### PR TITLE
Enable setTabTitleEarly internally for Windows

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -6103,6 +6103,10 @@
             "state": "internal",
             "exceptions": []
         },
+        "setTabTitleEarly": {
+            "state": "internal",
+            "exceptions": []
+        },
         "wpf": {
             "state": "enabled",
             "exceptions": [],

--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -4771,6 +4771,9 @@
                 "browserLaunchAttempts": {
                     "state": "enabled",
                     "settings": { "attemptCount": 5 }
+                },
+                "setTabTitleEarly": {
+                    "state": "internal"
                 }
             },
             "exceptions": []
@@ -6100,10 +6103,6 @@
             }
         },
         "ntpSearchSuggestionsDeletion": {
-            "state": "internal",
-            "exceptions": []
-        },
-        "setTabTitleEarly": {
             "state": "internal",
             "exceptions": []
         },


### PR DESCRIPTION
**Asana Task/Github Issue:**

## Description
<!-- 
  Please delete either or both process sections below.
-->

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single JSON override with internal-only rollout; legacy Windows clients strip `internal` to `disabled` in v3 compatibility handling.
> 
> **Overview**
> Turns on the **`setTabTitleEarly`** webview sub-feature for Windows by adding it to `overrides/windows-override.json` with **`state: "internal"`**, so only internal Windows browser builds get early tab title updates while general release clients stay unchanged until the flag is promoted.
> 
> This is a config-only change alongside existing webview sub-features (e.g. `browserLaunchAttempts`); no schema or other platform overrides are modified in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3bf92c5b74043611f3f57a9bcc1f56221543d4b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->