### PR TITLE
Add deferredSecureVaultInit feature flag for PIR iOS

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -3256,6 +3256,10 @@
                 "optOutRetryError96Hours": {
                     "state": "enabled",
                     "minSupportedVersion": "7.226.0"
+                },
+                "deferredSecureVaultInit": {
+                    "state": "enabled",
+                    "minSupportedVersion": "7.231.0"
                 }
             },
             "minSupportedVersion": "7.201.1"


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1211834678943996/task/1216731632905182?focus=true

## Description

Adds the `deferredSecureVaultInit` sub-feature under `dbp` in the iOS privacy override config, enabled with `minSupportedVersion` `7.231.0` — the first release containing the deferred PIR secure-vault init code. This lets eligible iOS builds defer secure vault initialization via remote toggle.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only addition gated by min app version; no runtime code in this repo, though the client behavior it toggles touches secure vault init timing.
> 
> **Overview**
> Adds a new **`dbp`** sub-feature **`deferredSecureVaultInit`** in `overrides/ios-override.json`, set to **enabled** with **`minSupportedVersion` `7.231.0`**.
> 
> That remote flag lets iOS builds that ship deferred PIR secure-vault initialization turn the behavior on or off without a new app release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6569ac6425fc38051b7aa95c047953b0629dcc79. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->