### PR TITLE
Disable default element hiding on telecinco.es (adblocker wall)

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -3911,6 +3911,14 @@
                 ]
             },
             {
+                "domain": "telecinco.es",
+                "rules": [
+                    {
+                        "type": "disable-default"
+                    }
+                ]
+            },
+            {
                 "domain": "theatlantic.com",
                 "rules": [
                     {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1206670747178362/task/1216783983104506?focus=true

## Description

telecinco.es shows an adblocker wall on a-la-carta video pages when DuckDuckGo default element-hiding rules are active. Disabling default element hiding for the domain removes the wall.

Validated with the Chrome MV3 privacy extension loading a locally hosted privacy-config:

- **Before:** full-page wall: “Desactiva tu adblocker en nuestra web para disfrutar el contenido”
- **After (`disable-default`):** wall gone; page content loads
- Without the extension: no wall

Request blocking alone is not sufficient (ads still blocked after the fix; wall is gone).

Related: https://github.com/duckduckgo/privacy-configuration/issues/5620

### Site breakage mitigation process:
#### Brief explanation
- Reported URL: https://www.telecinco.es/television/a-la-carta/20260513/isla-tentaciones-temporada-10-programa-14-video-completo_18_019159107.html
- Problems experienced: Adblocker wall / interstitial blocking video page content
- Platforms affected:
  - [x] iOS
  - [x] Android
  - [x] Windows
  - [x] MacOS
  - [x] Extensions
- Tracker(s) being unblocked: N/A
- Feature being disabled/modified: `elementHiding` (domain rule: `disable-default`)
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3f271f81-496f-40a8-a16d-e2b6e18aed38"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3f271f81-496f-40a8-a16d-e2b6e18aed38"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

