### PR TITLE
Enable ad blocking by default to 5% users

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -40,12 +40,19 @@
             "state": "enabled",
             "features": {
                 "enabledByDefault": {
-                    "state": "internal",
-                    "minSupportedVersion": 52880003
+                    "state": "enabled",
+                    "minSupportedVersion": 52890000,
+                    "rollout": {
+                        "steps": [
+                            {
+                                "percent": 5
+                            }
+                        ]
+                    }
                 },
                 "adBlockingUXImprovements": {
-                    "state": "internal",
-                    "minSupportedVersion": 52880003
+                    "state": "enabled",
+                    "minSupportedVersion": 52890000
                 }
             },
             "minSupportedVersion": 52840000


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1212951208799468/task/1216708066070916?focus=true

## Description
Rollout ad blocking by default to 5%

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [x] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [x] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Enabling default ad blocking for a subset of users can change page behavior and drive site-breakage reports, though exposure is capped at 5% and gated by app version.
> 
> **Overview**
> **Android remote config** moves the ad blocking extension out of internal-only testing and into a limited production rollout.
> 
> For **`enabledByDefault`**, the flag goes from `internal` to **`enabled`**, **`minSupportedVersion`** bumps from `52880003` to **`52890000`**, and a **`rollout`** is added with a single step at **5%** of eligible clients. **`adBlockingUXImprovements`** is also promoted from `internal` to **`enabled`** on the same minimum app version, without a separate rollout percentage in this diff.
> 
> Together, up to 5% of Android users on 52890000+ can get ad blocking on by default plus the related UX changes, instead of only internal builds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 866a2731f0f4fae31d097dd16e43788512c55b78. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->