### PR TITLE
autofill: add siteSpecificFixes rule for fedex.com password input

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -872,6 +872,21 @@
                         "conditionalChanges": [
                             {
                                 "condition": [
+                                    { "domain": "fedex.com" }
+                                ],
+                                "patchSettings": [
+                                    {
+                                        "path": "/inputTypeSettings/-",
+                                        "op": "add",
+                                        "value": {
+                                            "selector": "input#password[autocomplete=\"current-password\"]",
+                                            "type": "credentials.password.current"
+                                        }
+                                    }
+                                ]
+                            },
+                            {
+                                "condition": [
                                     { "domain": "blindbarber.com" }
                                 ],
                                 "patchSettings": [

--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -1034,6 +1034,21 @@
                         "conditionalChanges": [
                             {
                                 "condition": [
+                                    { "domain": "fedex.com" }
+                                ],
+                                "patchSettings": [
+                                    {
+                                        "path": "/inputTypeSettings/-",
+                                        "op": "add",
+                                        "value": {
+                                            "selector": "input#password[autocomplete=\"current-password\"]",
+                                            "type": "credentials.password.current"
+                                        }
+                                    }
+                                ]
+                            },
+                            {
+                                "condition": [
                                     { "domain": "blindbarber.com" }
                                 ],
                                 "patchSettings": [

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -933,6 +933,21 @@
                         "conditionalChanges": [
                             {
                                 "condition": [
+                                    { "domain": "fedex.com" }
+                                ],
+                                "patchSettings": [
+                                    {
+                                        "path": "/inputTypeSettings/-",
+                                        "op": "add",
+                                        "value": {
+                                            "selector": "input#password[autocomplete=\"current-password\"]",
+                                            "type": "credentials.password.current"
+                                        }
+                                    }
+                                ]
+                            },
+                            {
+                                "condition": [
                                     { "domain": "blindbarber.com" }
                                 ],
                                 "patchSettings": [

--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -1651,6 +1651,21 @@
                         "conditionalChanges": [
                             {
                                 "condition": [
+                                    { "domain": "fedex.com" }
+                                ],
+                                "patchSettings": [
+                                    {
+                                        "path": "/inputTypeSettings/-",
+                                        "op": "add",
+                                        "value": {
+                                            "selector": "input#password[autocomplete=\"current-password\"]",
+                                            "type": "credentials.password.current"
+                                        }
+                                    }
+                                ]
+                            },
+                            {
+                                "condition": [
                                     { "domain": "blindbarber.com" }
                                 ],
                                 "patchSettings": [


### PR DESCRIPTION
**Asana Task/Github Issue:**

## Description
<!-- 
  Please delete either or both process sections below.
-->

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only, domain-scoped autofill mapping using an established siteSpecificFixes pattern; no auth or core logic changes.
> 
> **Overview**
> Adds a **fedex.com** entry to `autofill` → `siteSpecificFixes` → `conditionalChanges` on **Android, iOS, macOS, and Windows** platform overrides.
> 
> When users are on fedex.com, autofill will treat `input#password[autocomplete="current-password"]` as **`credentials.password.current`**, so saved passwords can be offered/filled on FedEx login where generic field detection may miss that input.
> 
> The change is the same JSON-patch block in each override file, inserted ahead of the existing `blindbarber.com` rule.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b7d4442c79c894b314465c9ea132c600126b2637. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->