### PR TITLE
Allow run.app on iabprivacy.com

### DIFF
--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -5644,6 +5644,13 @@
                             "kotn.com"
                         ],
                         "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5615"
+                    },
+                    {
+                        "rule": "tools-portal-api-prod-1021459915211.us-central1.run.app/",
+                        "domains": [
+                            "iabprivacy.com"
+                        ],
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5631"
                     }
                 ]
             }


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1206670747178362/task/1216811460331253?focus=true

## Description
Table on https://www.iabprivacy.com/optout.html doesn’t load because we’re blocking the run.app scripts.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-domain allowlist entry in privacy configuration with no auth or data-path changes.
> 
> **Overview**
> Adds a **tracker allowlist** exception so `iabprivacy.com` can load scripts from `tools-portal-api-prod-1021459915211.us-central1.run.app/`, fixing the opt-out table on `optout.html` that was blocked as `run.app` tracking.
> 
> The new rule sits alongside the existing `kotn.com` `run.app` entry under `features/tracker-allowlist.json`, scoped only to `iabprivacy.com`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d8059e66910439491cafa3794ee736cbcb96c82c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->