### PR TITLE
Fixing repeated page loads on iOS

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -2422,7 +2422,7 @@
                                 "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1968"
                             },
                             {
-                                "rule": "www.google.com/measurement/1p-conversion/",
+                                "rule": "www.google.com/measurement/1p-conversion",
                                 "domains": [
                                     "architecturaldesigns.com",
                                     "furniturerow.com",

--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -2420,6 +2420,20 @@
                                     "scrolller.com"
                                 ],
                                 "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1968"
+                            },
+                            {
+                                "rule": "www.google.com/measurement/1p-conversion/",
+                                "domains": [
+                                    "architecturaldesigns.com",
+                                    "furniturerow.com",
+                                    "printerval.com",
+                                    "iseehair.com",
+                                    "generation.org",
+                                    "poshmark.com",
+                                    "partselect.com",
+                                    "golfavenue.ca"
+                                ],
+                                "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5632"
                             }
                         ]
                     },


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/1206670747178362/task/1216745443087938?focus=true

## Description
### Site breakage mitigation process:
#### Brief explanation
- Reported URLs:
  - https://www.architecturaldesigns.com/house-plans/collections/adu
  - https://poshmark.com/search?query=Shirt&type=listings&src=dir
  - https://www.partselect.com/PS341974-Whirlpool-3360629-Gearcase.htm
  - https://denvermattress.furniturerow.com/
  - https://www.golfavenue.ca/en/taylormade-kalea-gold-iron-set
  - https://printerval.com/jojo-s-adventure-bizarre-shirt-p24152736
  - https://m.iseehair.com/iseehair-machine-made-wig-kinky-curly-sew-in-wig-human-hair-wigs-with-bangs.html
  - https://usa.generation.org/find-a-career/
- Problems experienced: Pages reload repeatedly. See also #5637 
- Platforms affected:
  - [x] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked: `www.google.com/measurement/1p-conversion`
- Feature being disabled/modified: 
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow, domain-scoped allowlist change in privacy config only; allows a Google measurement endpoint on specific broken sites without broader feature toggles.
> 
> **Overview**
> Adds an **iOS-only tracker allowlist** entry so `www.google.com/measurement/1p-conversion` is no longer blocked on eight retail/listing sites where users reported **pages reloading in a loop**.
> 
> The new rule lives under `trackerAllowlist` → `google.com` in `ios-override.json`, scoped to `architecturaldesigns.com`, `furniturerow.com`, `printerval.com`, `iseehair.com`, `generation.org`, `poshmark.com`, `partselect.com`, and `golfavenue.ca`. This is a **speculative site-breakage mitigation** tied to blocking that Google measurement endpoint on iOS.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d95529a61ee91713cf8bc5c0cc209f37ba579722. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->