### PR TITLE
Roll out native crash reporting dialog to 100%

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -5251,6 +5251,7 @@
             "features": {
                 "canShowNativeCrashReportingDialog": {
                     "state": "enabled",
+                    "minSupportedVersion": "0.167.3",
                     "rollout": {
                         "steps": [
                             {
@@ -5258,6 +5259,9 @@
                             },
                             {
                                 "percent": 20
+                            },
+                            {
+                                "percent": 100
                             }
                         ]
                     }


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1213372238252701/task/1216805705165464?focus=true

## Description

Expands `canShowNativeCrashReportingDialog` on Windows to 100% for app versions 0.167.3 and newer.

### Validation

- Generated all platform configs successfully.
- 2,336 unit and schema tests passed.
- ESLint, targeted Prettier, and git diff checks passed.

### Feature change process

- [ ] I have added a schema to validate this feature change.
- [x] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit c8bb507faf2b97078950dffe12e7906b121783bf. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->