### PR TITLE
Expand allow rule for run.app domain

### DIFF
--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -4622,6 +4622,17 @@
                     }
                 ]
             },
+            "run.app": {
+                "rules": [
+                    {
+                        "rule": "run.app",
+                        "domains": [
+                            "<all>"
+                        ],
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5634"
+                    }
+                ]
+            },
             "sail-horizon.com": {
                 "rules": [
                     {
@@ -5633,24 +5644,6 @@
                             "<all>"
                         ],
                         "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5595"
-                    }
-                ]
-            },
-            "run.app": {
-                "rules": [
-                    {
-                        "rule": "kotn-consumer-service-next-685779125599.us-central1.run.app/",
-                        "domains": [
-                            "kotn.com"
-                        ],
-                        "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5615"
-                    },
-                    {
-                        "rule": "tools-portal-api-prod-1021459915211.us-central1.run.app/",
-                        "domains": [
-                            "iabprivacy.com"
-                        ],
-                        "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5631"
                     }
                 ]
             }


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/1206670747178362/task/1216811460331253?focus=true

## Description
### Site breakage mitigation process:
#### Brief explanation
- Reported URL: kotn.com, iabprivacy.com, likely others. 
- Problems experienced: Some page content not being loaded. Replaces #5615, #5631 
- Platforms affected:
  - [x] iOS
  - [x] Android
  - [x] Windows
  - [x] MacOS
  - [x] Extensions
- Tracker(s) being unblocked: `run.app`
- Feature being disabled/modified: N/A
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Broadens tracker allowlisting from two URLs on two sites to the entire `run.app` domain everywhere, which increases exposure to third-party requests but is limited to config data.
> 
> **Overview**
> **Replaces two site-specific `run.app` Cloud Run URL exceptions** (kotn.com and iabprivacy.com) with a **single global allowlist rule** for `run.app` on **all domains** (`<all>`).
> 
> The entry is added in the main tracker allowlist block and the duplicate narrower rules are removed from the other section, so Google Cloud Run backends can load without per-site entries when tracker blocking caused missing page content.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9f1717eb9bccced8a51ddf46f00d1cf3fd023ec9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->