### PR TITLE
Disable sending automatic Sentry reports

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -5233,7 +5233,7 @@
                     "state": "enabled"
                 },
                 "sendIncidentCrashReports": {
-                    "state": "preview",
+                    "state": "disabled",
                     "settings": {
                         "ExceptionTypes": [
                             "FaultedException"


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1210072207875152/task/1216783909912517?focus=true

## Description
Disable sending automatic Sentry reports

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single remote-config flag change with no code or schema edits; reduces crash telemetry rather than changing core app behavior.
> 
> **Overview**
> Turns off **automatic Sentry incident crash reports** on Windows by setting the `sendIncidentCrashReports` sub-feature from `preview` to **`disabled`** in `windows-override.json`.
> 
> The existing settings (e.g. `ExceptionTypes` including `FaultedException`) are left in place; only the feature state changes so clients should stop sending those automatic reports.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db3c4eb4f0d3de2a0607fad14d522e3683e33acc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->