### PR TITLE
Fix endless reloads on macOS

### DIFF
--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -2116,6 +2116,20 @@
                                     "scrolller.com"
                                 ],
                                 "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1968"
+                            },
+                            {
+                                "rule": "www.google.com/measurement/1p-conversion",
+                                "domains": [
+                                    "architecturaldesigns.com",
+                                    "furniturerow.com",
+                                    "printerval.com",
+                                    "iseehair.com",
+                                    "generation.org",
+                                    "poshmark.com",
+                                    "partselect.com",
+                                    "golfavenue.ca"
+                                ],
+                                "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5637"
                             }
                         ]
                     },


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/1206670747178362/task/1216745443087938?focus=true


## Description
<!-- 
  Please delete either or both process sections below.
-->
### Site breakage mitigation process:
#### Brief explanation
- Reported URLs:
  - https://www.architecturaldesigns.com/house-plans/collections/adu
  - https://poshmark.com/search?query=Shirt&type=listings&src=dir
  - https://www.partselect.com/PS341974-Whirlpool-3360629-Gearcase.htm
  - https://denvermattress.furniturerow.com/
  - https://www.golfavenue.ca/en/taylormade-kalea-gold-iron-set
  - https://printerval.com/jojo-s-adventure-bizarre-shirt-p24152736
  - https://m.iseehair.com/iseehair-machine-made-wig-kinky-curly-sew-in-wig-human-hair-wigs-with-bangs.html
  - https://usa.generation.org/find-a-career/
- Problems experienced: Pages reload repeatedly. See also #5632 
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [x] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked: `www.google.com/measurement/1p-conversion`
- Feature being disabled/modified: N/A
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only site-specific tracker exception with no app logic changes; slightly reduces blocking on listed domains only.
> 
> **Overview**
> Adds a **macOS-only** tracker allowlist rule so `www.google.com/measurement/1p-conversion` is not blocked on eight retail and content sites where users reported **endless page reloads** (e.g. Poshmark, PartSelect, Architectural Designs).
> 
> The change lives under `trackerAllowlist` → `google.com` in `overrides/macos-override.json`, matching the breakage mitigation for a blocked Google first-party conversion/measurement request that sites appear to depend on for normal navigation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 29dc470871ec27fb4603c32eb561853669684b0f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->