### PR TITLE
Allow posthog request on privacy.com

### DIFF
--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -5630,7 +5630,8 @@
                     {
                         "rule": "posthog.com/static/array.js",
                         "domains": [
-                            "amicable.io"
+                            "amicable.io",
+                            "privacy.com"
                         ],
                         "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5597"
                     }


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1206670747178362/task/1216743749794442?focus=true

## Description
Blocking this requests makes the cookie popup’s buttons not work.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-domain addition to an existing PostHog allowlist rule; no auth, data, or infrastructure changes.
> 
> **Overview**
> Adds **privacy.com** to the tracker allowlist for `posthog.com/static/array.js`, alongside the existing **amicable.io** entry.
> 
> DuckDuckGo was blocking that PostHog script on privacy.com, which broke the site’s cookie consent UI (buttons stopped working). Allowing the request restores expected behavior on that domain only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit af51574d6b7cb9d7d9a7716ba563f978dbed4a83. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->