### PR TITLE
Clean up the use of pull request target.

### DIFF
--- a/.github/workflows/auto-respond-pr.yml
+++ b/.github/workflows/auto-respond-pr.yml
@@ -15,7 +15,7 @@ name: Auto Respond to PR
 
 on:
     pull_request_review:
-    pull_request_target:
+    pull_request:
         types:
             - opened
             - edited

--- a/.github/workflows/auto-respond-pr.yml
+++ b/.github/workflows/auto-respond-pr.yml
@@ -29,7 +29,7 @@ jobs:
     # Closes tasks for both merged PRs and abandoned PRs to clean up dead tasks
     # Runs independently of the main workflow
     sync_asana_on_close:
-        if: github.event.action == 'closed' && !github.event.pull_request.head.repo.fork
+        if: github.event.action == 'closed'
         runs-on: ubuntu-latest
         steps:
             - uses: duckduckgo/action-asana-sync@v11
@@ -42,7 +42,7 @@ jobs:
                   ASSIGN_PR_AUTHOR: 'true'
 
     auto_respond:
-        if: github.event.action != 'closed' && !github.event.pull_request.head.repo.fork && github.event.pull_request.user.login != 'dependabot[bot]'
+        if: github.event.action != 'closed' && github.event.pull_request.user.login != 'dependabot[bot]'
         runs-on: ubuntu-latest
         concurrency: auto-respond-${{ github.event.pull_request.number }}
 


### PR DESCRIPTION
**Asana Task/Github Issue:**

## Description

Pull request target allows external forks to be usable with the repo, which we have explicitly disabled, and so I've removed the bailout checks and switched over to pull request. This has been a point of contention in that it would previously, without these checks, allowed some of these automations to run, which we do not want as it allows privileged behaviour.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how privileged PR automation (secrets, Asana sync, auto-approve) is triggered; the intent is to reduce fork-related privilege exposure, but behavior for edge-case PR sources should be verified.
> 
> **Overview**
> **Tightens CI security** for the auto-respond PR workflow by dropping `pull_request_target` in favor of standard `pull_request` events for opened/edited/closed and related actions.
> 
> Because external forks are not meant to drive these automations, the PR also **removes fork bailout conditions** on `sync_asana_on_close` and `auto_respond` (the `!github.event.pull_request.head.repo.fork` checks). With `pull_request`, fork PRs no longer get the elevated base-repo context that made those guards necessary.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 38454c57f33dcd3f36ea944b71f00f38dfdf5262. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->