### PR TITLE
iOS: Add monthlyFreeTrialExperiment subfeature (annual-trials experiment)

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -2311,6 +2311,25 @@
                     ],
                     "minSupportedVersion": "7.157.0"
                 },
+                "monthlyFreeTrialExperiment": {
+                    "state": "enabled",
+                    "targets": [
+                        {
+                            "localeCountry": "US"
+                        }
+                    ],
+                    "cohorts": [
+                        {
+                            "name": "control",
+                            "weight": 1
+                        },
+                        {
+                            "name": "treatment",
+                            "weight": 1
+                        }
+                    ],
+                    "minSupportedVersion": "7.231.0"
+                },
                 "privacyProOnboardingCTAMarch25": {
                     "state": "enabled",
                     "targets": [


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/task/1217019880137550

## Description

Adds the `monthlyFreeTrialExperiment` subfeature under `privacyPro.features` in `overrides/ios-override.json`, activating the iOS annual-trials experiment.

- **State:** `enabled`
- **Targets:** US (`localeCountry: US`)
- **Cohorts:** `control` / `treatment`, 50/50 split (weight 1 each)
- **minSupportedVersion:** `7.231.0`.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Config-only but affects Privacy Pro subscription/trial UX for US iOS users on recent builds; incorrect cohort or targeting could skew monetization experiment results.
> 
> **Overview**
> Adds **`monthlyFreeTrialExperiment`** as a new `privacyPro.features` subfeature in `overrides/ios-override.json`, turning on the iOS annual-trials / monthly free-trial experiment for eligible clients.
> 
> The flag is **enabled**, scoped to **US** users, with a **50/50** `control` / `treatment` cohort split (equal weights). Only app versions **≥ 7.231.0** receive it. It sits alongside existing free-trial experiments such as `privacyProFreeTrialJan25` (which routes US users entirely to treatment).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 09b6bc4f22e75b73e1e80c6c42ef80044ebeeca0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->