### PR TITLE
Block adwalls on several sites

### DIFF
--- a/features/request-blocklist.json
+++ b/features/request-blocklist.json
@@ -34,18 +34,7 @@
                         "domains": [
                             "<all>"
                         ],
-                        "reason": "Freestar Recovered adwall: block Recovered UI config CDN so the adwall modal cannot load"
-                    }
-                ]
-            },
-            "config.config-factory.com": {
-                "rules": [
-                    {
-                        "rule": "config.config-factory.com",
-                        "domains": [
-                            "<all>"
-                        ],
-                        "reason": "Freestar Recovered adwall: block Recovered UI config CDN so the adwall modal cannot load"
+                        "reason": "TBD"
                     }
                 ]
             },
@@ -56,18 +45,7 @@
                         "domains": [
                             "<all>"
                         ],
-                        "reason": "Freestar Recovered adwall: block Recovered UI config CDN fallback so the adwall modal cannot load"
-                    }
-                ]
-            },
-            "config.content-settings.com": {
-                "rules": [
-                    {
-                        "rule": "config.content-settings.com",
-                        "domains": [
-                            "<all>"
-                        ],
-                        "reason": "Freestar Recovered adwall: block Recovered UI config CDN fallback so the adwall modal cannot load"
+                        "reason": "TBD"
                     }
                 ]
             },
@@ -78,18 +56,7 @@
                         "domains": [
                             "<all>"
                         ],
-                        "reason": "Freestar Recovered adwall: block Recovered telemetry/config host used by the adwall"
-                    }
-                ]
-            },
-            "config.site-config.com": {
-                "rules": [
-                    {
-                        "rule": "config.site-config.com",
-                        "domains": [
-                            "<all>"
-                        ],
-                        "reason": "Freestar Recovered adwall: block Recovered UI config CDN fallback so the adwall modal cannot load"
+                        "reason": "TBD"
                     }
                 ]
             }

--- a/features/request-blocklist.json
+++ b/features/request-blocklist.json
@@ -34,7 +34,7 @@
                         "domains": [
                             "<all>"
                         ],
-                        "reason": "TBD"
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5644"
                     }
                 ]
             },
@@ -45,7 +45,7 @@
                         "domains": [
                             "<all>"
                         ],
-                        "reason": "TBD"
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5644"
                     }
                 ]
             },
@@ -56,7 +56,7 @@
                         "domains": [
                             "<all>"
                         ],
-                        "reason": "TBD"
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5644"
                     }
                 ]
             }

--- a/features/request-blocklist.json
+++ b/features/request-blocklist.json
@@ -26,6 +26,72 @@
                         "reason": "Testing rule for the privacy test page, see https://privacy-test-pages.site/privacy-protections/request-blocklist/"
                     }
                 ]
+            },
+            "config-factory.com": {
+                "rules": [
+                    {
+                        "rule": "config-factory.com",
+                        "domains": [
+                            "<all>"
+                        ],
+                        "reason": "Freestar Recovered adwall: block Recovered UI config CDN so the adwall modal cannot load"
+                    }
+                ]
+            },
+            "config.config-factory.com": {
+                "rules": [
+                    {
+                        "rule": "config.config-factory.com",
+                        "domains": [
+                            "<all>"
+                        ],
+                        "reason": "Freestar Recovered adwall: block Recovered UI config CDN so the adwall modal cannot load"
+                    }
+                ]
+            },
+            "content-settings.com": {
+                "rules": [
+                    {
+                        "rule": "content-settings.com",
+                        "domains": [
+                            "<all>"
+                        ],
+                        "reason": "Freestar Recovered adwall: block Recovered UI config CDN fallback so the adwall modal cannot load"
+                    }
+                ]
+            },
+            "config.content-settings.com": {
+                "rules": [
+                    {
+                        "rule": "config.content-settings.com",
+                        "domains": [
+                            "<all>"
+                        ],
+                        "reason": "Freestar Recovered adwall: block Recovered UI config CDN fallback so the adwall modal cannot load"
+                    }
+                ]
+            },
+            "site-config.com": {
+                "rules": [
+                    {
+                        "rule": "site-config.com",
+                        "domains": [
+                            "<all>"
+                        ],
+                        "reason": "Freestar Recovered adwall: block Recovered telemetry/config host used by the adwall"
+                    }
+                ]
+            },
+            "config.site-config.com": {
+                "rules": [
+                    {
+                        "rule": "config.site-config.com",
+                        "domains": [
+                            "<all>"
+                        ],
+                        "reason": "Freestar Recovered adwall: block Recovered UI config CDN fallback so the adwall modal cannot load"
+                    }
+                ]
             }
         }
     },

--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -2902,7 +2902,7 @@
                                 "domains": [
                                     "<all>"
                                 ],
-                                "reason": "TBD"
+                                "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5644"
                             }
                         ]
                     },
@@ -2913,7 +2913,7 @@
                                 "domains": [
                                     "<all>"
                                 ],
-                                "reason": "TBD"
+                                "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5644"
                             }
                         ]
                     },
@@ -2924,7 +2924,7 @@
                                 "domains": [
                                     "<all>"
                                 ],
-                                "reason": "TBD"
+                                "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5644"
                             }
                         ]
                     }

--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -2894,6 +2894,72 @@
                                 "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5389"
                             }
                         ]
+                    },
+                    "config-factory.com": {
+                        "rules": [
+                            {
+                                "rule": "config-factory.com",
+                                "domains": [
+                                    "<all>"
+                                ],
+                                "reason": "Freestar Recovered adwall: block Recovered UI config CDN so the adwall modal cannot load"
+                            }
+                        ]
+                    },
+                    "config.config-factory.com": {
+                        "rules": [
+                            {
+                                "rule": "config.config-factory.com",
+                                "domains": [
+                                    "<all>"
+                                ],
+                                "reason": "Freestar Recovered adwall: block Recovered UI config CDN so the adwall modal cannot load"
+                            }
+                        ]
+                    },
+                    "content-settings.com": {
+                        "rules": [
+                            {
+                                "rule": "content-settings.com",
+                                "domains": [
+                                    "<all>"
+                                ],
+                                "reason": "Freestar Recovered adwall: block Recovered UI config CDN fallback so the adwall modal cannot load"
+                            }
+                        ]
+                    },
+                    "config.content-settings.com": {
+                        "rules": [
+                            {
+                                "rule": "config.content-settings.com",
+                                "domains": [
+                                    "<all>"
+                                ],
+                                "reason": "Freestar Recovered adwall: block Recovered UI config CDN fallback so the adwall modal cannot load"
+                            }
+                        ]
+                    },
+                    "site-config.com": {
+                        "rules": [
+                            {
+                                "rule": "site-config.com",
+                                "domains": [
+                                    "<all>"
+                                ],
+                                "reason": "Freestar Recovered adwall: block Recovered telemetry/config host used by the adwall"
+                            }
+                        ]
+                    },
+                    "config.site-config.com": {
+                        "rules": [
+                            {
+                                "rule": "config.site-config.com",
+                                "domains": [
+                                    "<all>"
+                                ],
+                                "reason": "Freestar Recovered adwall: block Recovered UI config CDN fallback so the adwall modal cannot load"
+                            }
+                        ]
                     }
                 }
             }

--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -2902,18 +2902,7 @@
                                 "domains": [
                                     "<all>"
                                 ],
-                                "reason": "Freestar Recovered adwall: block Recovered UI config CDN so the adwall modal cannot load"
-                            }
-                        ]
-                    },
-                    "config.config-factory.com": {
-                        "rules": [
-                            {
-                                "rule": "config.config-factory.com",
-                                "domains": [
-                                    "<all>"
-                                ],
-                                "reason": "Freestar Recovered adwall: block Recovered UI config CDN so the adwall modal cannot load"
+                                "reason": "TBD"
                             }
                         ]
                     },
@@ -2924,18 +2913,7 @@
                                 "domains": [
                                     "<all>"
                                 ],
-                                "reason": "Freestar Recovered adwall: block Recovered UI config CDN fallback so the adwall modal cannot load"
-                            }
-                        ]
-                    },
-                    "config.content-settings.com": {
-                        "rules": [
-                            {
-                                "rule": "config.content-settings.com",
-                                "domains": [
-                                    "<all>"
-                                ],
-                                "reason": "Freestar Recovered adwall: block Recovered UI config CDN fallback so the adwall modal cannot load"
+                                "reason": "TBD"
                             }
                         ]
                     },
@@ -2946,18 +2924,7 @@
                                 "domains": [
                                     "<all>"
                                 ],
-                                "reason": "Freestar Recovered adwall: block Recovered telemetry/config host used by the adwall"
-                            }
-                        ]
-                    },
-                    "config.site-config.com": {
-                        "rules": [
-                            {
-                                "rule": "config.site-config.com",
-                                "domains": [
-                                    "<all>"
-                                ],
-                                "reason": "Freestar Recovered adwall: block Recovered UI config CDN fallback so the adwall modal cannot load"
+                                "reason": "TBD"
                             }
                         ]
                     }

--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -5560,18 +5560,7 @@
                                 "domains": [
                                     "<all>"
                                 ],
-                                "reason": "Freestar Recovered adwall: block Recovered UI config CDN so the adwall modal cannot load"
-                            }
-                        ]
-                    },
-                    "config.config-factory.com": {
-                        "rules": [
-                            {
-                                "rule": "config.config-factory.com",
-                                "domains": [
-                                    "<all>"
-                                ],
-                                "reason": "Freestar Recovered adwall: block Recovered UI config CDN so the adwall modal cannot load"
+                                "reason": "TBD"
                             }
                         ]
                     },
@@ -5582,18 +5571,7 @@
                                 "domains": [
                                     "<all>"
                                 ],
-                                "reason": "Freestar Recovered adwall: block Recovered UI config CDN fallback so the adwall modal cannot load"
-                            }
-                        ]
-                    },
-                    "config.content-settings.com": {
-                        "rules": [
-                            {
-                                "rule": "config.content-settings.com",
-                                "domains": [
-                                    "<all>"
-                                ],
-                                "reason": "Freestar Recovered adwall: block Recovered UI config CDN fallback so the adwall modal cannot load"
+                                "reason": "TBD"
                             }
                         ]
                     },
@@ -5604,18 +5582,7 @@
                                 "domains": [
                                     "<all>"
                                 ],
-                                "reason": "Freestar Recovered adwall: block Recovered telemetry/config host used by the adwall"
-                            }
-                        ]
-                    },
-                    "config.site-config.com": {
-                        "rules": [
-                            {
-                                "rule": "config.site-config.com",
-                                "domains": [
-                                    "<all>"
-                                ],
-                                "reason": "Freestar Recovered adwall: block Recovered UI config CDN fallback so the adwall modal cannot load"
+                                "reason": "TBD"
                             }
                         ]
                     }

--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -5560,7 +5560,7 @@
                                 "domains": [
                                     "<all>"
                                 ],
-                                "reason": "TBD"
+                                "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5644"
                             }
                         ]
                     },
@@ -5571,7 +5571,7 @@
                                 "domains": [
                                     "<all>"
                                 ],
-                                "reason": "TBD"
+                                "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5644"
                             }
                         ]
                     },
@@ -5582,7 +5582,7 @@
                                 "domains": [
                                     "<all>"
                                 ],
-                                "reason": "TBD"
+                                "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5644"
                             }
                         ]
                     }

--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -5552,6 +5552,72 @@
                                 "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5218"
                             }
                         ]
+                    },
+                    "config-factory.com": {
+                        "rules": [
+                            {
+                                "rule": "config-factory.com",
+                                "domains": [
+                                    "<all>"
+                                ],
+                                "reason": "Freestar Recovered adwall: block Recovered UI config CDN so the adwall modal cannot load"
+                            }
+                        ]
+                    },
+                    "config.config-factory.com": {
+                        "rules": [
+                            {
+                                "rule": "config.config-factory.com",
+                                "domains": [
+                                    "<all>"
+                                ],
+                                "reason": "Freestar Recovered adwall: block Recovered UI config CDN so the adwall modal cannot load"
+                            }
+                        ]
+                    },
+                    "content-settings.com": {
+                        "rules": [
+                            {
+                                "rule": "content-settings.com",
+                                "domains": [
+                                    "<all>"
+                                ],
+                                "reason": "Freestar Recovered adwall: block Recovered UI config CDN fallback so the adwall modal cannot load"
+                            }
+                        ]
+                    },
+                    "config.content-settings.com": {
+                        "rules": [
+                            {
+                                "rule": "config.content-settings.com",
+                                "domains": [
+                                    "<all>"
+                                ],
+                                "reason": "Freestar Recovered adwall: block Recovered UI config CDN fallback so the adwall modal cannot load"
+                            }
+                        ]
+                    },
+                    "site-config.com": {
+                        "rules": [
+                            {
+                                "rule": "site-config.com",
+                                "domains": [
+                                    "<all>"
+                                ],
+                                "reason": "Freestar Recovered adwall: block Recovered telemetry/config host used by the adwall"
+                            }
+                        ]
+                    },
+                    "config.site-config.com": {
+                        "rules": [
+                            {
+                                "rule": "config.site-config.com",
+                                "domains": [
+                                    "<all>"
+                                ],
+                                "reason": "Freestar Recovered adwall: block Recovered UI config CDN fallback so the adwall modal cannot load"
+                            }
+                        ]
                     }
                 }
             }


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/inbox/11472677167854/item/1214739215307469/story/1214942683370028

## Description
<!-- 
  Please delete either or both process sections below.
-->
Fixes adwalls showing up on several sites. 

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [x] Android
  - [x] Windows
  - [ ] MacOS
  - [x] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Site-wide request blocking can break pages if these hosts serve non-adwall traffic; scope is limited to three named domains tied to adwall mitigation.
> 
> **Overview**
> Adds **request blocklist** entries for `config-factory.com`, `content-settings.com`, and `site-config.com` so browsers block those requests (mitigating adwalls on affected sites).
> 
> Each rule uses **`domains: ["<all>"]`**, so the block applies on every site, not a single publisher domain. The same three hosts are wired in the base `request-blocklist` feature config and mirrored under **`requestBlocklist`** in the **Android** and **Windows** platform overrides (alongside existing rules such as YouTube ad-break blocking).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 12715c4d55dc12ff454b768e704cdd8c0109f466. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->