### PR TITLE
Update autoconsent to v16.15.0

### DIFF
--- a/features/autoconsent.json
+++ b/features/autoconsent.json
@@ -1663,6 +1663,8 @@
                 "datagrail_consent",
                 ".disclaimer-opened #disclaimer-cookies",
                 "#disclaimer-reject_cookies",
+                ".cookieinfo",
+                ".cookieinfo-close",
                 "body > div#root > div#ccpa-iframe-theme-provider[data-testid=\"ccpa-iframe-theme-provider\"] > div#ccpa-iframe[data-testid=\"ccpa-iframe\"] > div#ccpa_consent_banner[data-testid=\"ccpa_consent_banner\"] > div:not([id]) > div:nth-child(3):not([id]) > span:not([id]) > span:not([id]) > div:nth-child(2):not([id]) > span:nth-child(1):not([id]) > button#decline_cookies_button[data-testid=\"decline_cookies_button\"]",
                 "body:not([id]) > div#banner-0 > div:nth-child(1)#grouped-pageload-Banner > div:not([id]) > div:not([id]) > div:not([id]) > div:nth-child(3):not([id]) > button:nth-child(2):not([id])",
                 "body > div#iubenda-cs-banner > div:not([id]) > div:not([id]) > div:not([id]) > div:nth-child(5):not([id]) > div:nth-child(2):not([id]) > button:nth-child(1):not([id])",
@@ -1698,8 +1700,6 @@
                 "span[role=checkbox][aria-checked=true]",
                 "#save-all-pur",
                 "#reminder",
-                "body > aside:not([id]) > div:nth-child(2)#cookie-consent-modal > div:not([id]) > div:not([id]) > div:not([id]) > div:not([id]) > div:not([id]) > div:not([id]) > div:nth-child(2):not([id]) > button:nth-child(2):not([id])",
-                "body > div:not([id]) > div#csm-wrapper > div:not([id]) > div:not([id]) > div:nth-child(2):not([id]) > button:nth-child(2):not([id])",
                 "body > div#app > div:nth-child(1)#__nuxt > div#__layout > div:not([id]) > div:nth-child(4):not([id]) > div:not([id]) > div:nth-child(4):not([id]) > a:nth-child(2):not([id])",
                 "body > div:not([id]) > div:nth-child(1):not([id]) > div:nth-child(1):not([id]) > button:not([id])",
                 "body > div#wrapwrap > div:nth-child(5)#website_cookies_bar > div:not([id]) > div:not([id]) > div:not([id]) > section:not([id]) > div:not([id]) > div:not([id]) > div:nth-child(2):not([id]) > a:nth-child(1)#cookie-banner-essential",
@@ -2419,7 +2419,11 @@
                 "[data-role=\"cookies-modal\"]",
                 "[data-role=\"cookies-modal\"] [data-opt-hydration=\"cookies-dialog-eu\"]",
                 "[data-role=\"cookies-modal\"] [class*=experimentalButtons] button:nth-of-type(2)",
-                "[data-role=\"cookies-modal\"] [class*=container]"
+                "[data-role=\"cookies-modal\"] [class*=container]",
+                "body > div:not([id]) > div#csm-wrapper > div:not([id]) > div:not([id]) > div:nth-child(2):not([id]) > button:nth-child(2):not([id])",
+                "body > aside:not([id]) > div:nth-child(2)#cookie-consent-modal > div:not([id]) > div:not([id]) > div:not([id]) > div:not([id]) > div:not([id]) > div:not([id]) > div:nth-child(2):not([id]) > button:nth-child(2):not([id])",
+                "#cookieBanner.cbShort",
+                "#cookieBanner.cbShort .cbCloseButton"
             ],
             "r": [
                 [
@@ -4659,6 +4663,33 @@
                             "cc": 262
                         }
                     ],
+                    {}
+                ],
+                [
+                    1,
+                    "cookieinfo",
+                    1,
+                    "",
+                    22,
+                    [
+                        773
+                    ],
+                    [
+                        {
+                            "e": 773
+                        }
+                    ],
+                    [
+                        {
+                            "v": 773
+                        }
+                    ],
+                    [
+                        {
+                            "c": 774
+                        }
+                    ],
+                    [],
                     {}
                 ],
                 [
@@ -10217,65 +10248,6 @@
                     [],
                     [
                         {
-                            "e": 773
-                        }
-                    ],
-                    [
-                        {
-                            "v": 773
-                        }
-                    ],
-                    [
-                        {
-                            "wait": 500
-                        },
-                        {
-                            "c": 773
-                        }
-                    ],
-                    [
-                        {
-                            "timeout": 1000,
-                            "check": "none",
-                            "wv": 773
-                        }
-                    ],
-                    {}
-                ],
-                [
-                    1,
-                    "auto_CA_coasthotels.com_f8m",
-                    0,
-                    "^https?://(www\\.)?coasthotels\\.com/",
-                    1,
-                    [],
-                    [
-                        {
-                            "e": 774
-                        }
-                    ],
-                    [
-                        {
-                            "v": 774
-                        }
-                    ],
-                    [
-                        {
-                            "c": 774
-                        }
-                    ],
-                    [],
-                    {}
-                ],
-                [
-                    1,
-                    "auto_CA_epihunter.eu_hd4",
-                    0,
-                    "^https?://(www\\.)?combell\\.com/",
-                    1,
-                    [],
-                    [
-                        {
                             "e": 775
                         }
                     ],
@@ -10303,9 +10275,9 @@
                 ],
                 [
                     1,
-                    "auto_CA_nationalarchives.gov.uk_rx0",
+                    "auto_CA_coasthotels.com_f8m",
                     0,
-                    "^https?://(www\\.)?webarchive\\.nationalarchives\\.gov\\.uk/",
+                    "^https?://(www\\.)?coasthotels\\.com/",
                     1,
                     [],
                     [
@@ -10320,26 +10292,17 @@
                     ],
                     [
                         {
-                            "wait": 500
-                        },
-                        {
                             "c": 776
                         }
                     ],
-                    [
-                        {
-                            "timeout": 1000,
-                            "check": "none",
-                            "wv": 776
-                        }
-                    ],
+                    [],
                     {}
                 ],
                 [
                     1,
-                    "auto_CA_natureconservancy.ca_3pp",
+                    "auto_CA_epihunter.eu_hd4",
                     0,
-                    "^https?://(www\\.)?natureconservancy\\.ca/",
+                    "^https?://(www\\.)?combell\\.com/",
                     1,
                     [],
                     [
@@ -10371,9 +10334,9 @@
                 ],
                 [
                     1,
-                    "auto_CA_ontariospca.ca_k32",
+                    "auto_CA_nationalarchives.gov.uk_rx0",
                     0,
-                    "^https?://(www\\.)?widget-next\\.clym-sdk\\.net/",
+                    "^https?://(www\\.)?webarchive\\.nationalarchives\\.gov\\.uk/",
                     1,
                     [],
                     [
@@ -10405,9 +10368,9 @@
                 ],
                 [
                     1,
-                    "auto_CA_phoenixnap.com_hrb",
+                    "auto_CA_natureconservancy.ca_3pp",
                     0,
-                    "^https?://(www\\.)?widget-next\\.clym-sdk\\.net/",
+                    "^https?://(www\\.)?natureconservancy\\.ca/",
                     1,
                     [],
                     [
@@ -10439,7 +10402,7 @@
                 ],
                 [
                     1,
-                    "auto_CH_phoenixnap.com_lx5",
+                    "auto_CA_ontariospca.ca_k32",
                     0,
                     "^https?://(www\\.)?widget-next\\.clym-sdk\\.net/",
                     1,
@@ -10473,9 +10436,9 @@
                 ],
                 [
                     1,
-                    "auto_CH_swisscare.com_arx",
+                    "auto_CA_phoenixnap.com_hrb",
                     0,
-                    "^https?://(www\\.)?swisscare\\.com/",
+                    "^https?://(www\\.)?widget-next\\.clym-sdk\\.net/",
                     1,
                     [],
                     [
@@ -10507,9 +10470,9 @@
                 ],
                 [
                     1,
-                    "auto_DE_alfaromeo.de_gvg_+2",
+                    "auto_CH_phoenixnap.com_lx5",
                     0,
-                    "^https?://(www\\.)?cookielaw\\.emea\\.fcagroup\\.com/|^https?://(www\\.)?cookielaw\\.emea\\.fcagroup\\.com/|^https?://(www\\.)?cookielaw\\.emea\\.fcagroup\\.com/",
+                    "^https?://(www\\.)?widget-next\\.clym-sdk\\.net/",
                     1,
                     [],
                     [
@@ -10541,9 +10504,9 @@
                 ],
                 [
                     1,
-                    "auto_DE_huss-licht-ton.de_jj0",
+                    "auto_CH_swisscare.com_arx",
                     0,
-                    "^https?://(www\\.)?huss-licht-ton\\.de/",
+                    "^https?://(www\\.)?swisscare\\.com/",
                     1,
                     [],
                     [
@@ -10575,9 +10538,9 @@
                 ],
                 [
                     1,
-                    "auto_DE_modellbau-berlinski.de_8vm",
+                    "auto_DE_alfaromeo.de_gvg_+2",
                     0,
-                    "^https?://(www\\.)?modellbau-berlinski\\.de/",
+                    "^https?://(www\\.)?cookielaw\\.emea\\.fcagroup\\.com/|^https?://(www\\.)?cookielaw\\.emea\\.fcagroup\\.com/|^https?://(www\\.)?cookielaw\\.emea\\.fcagroup\\.com/",
                     1,
                     [],
                     [
@@ -10609,9 +10572,9 @@
                 ],
                 [
                     1,
-                    "auto_DE_phoenixnap.com_xq7",
+                    "auto_DE_huss-licht-ton.de_jj0",
                     0,
-                    "^https?://(www\\.)?widget-next\\.clym-sdk\\.net/",
+                    "^https?://(www\\.)?huss-licht-ton\\.de/",
                     1,
                     [],
                     [
@@ -10643,9 +10606,9 @@
                 ],
                 [
                     1,
-                    "auto_FR_fiat.fr_3fh",
+                    "auto_DE_modellbau-berlinski.de_8vm",
                     0,
-                    "^https?://(www\\.)?cookielaw\\.emea\\.fcagroup\\.com/",
+                    "^https?://(www\\.)?modellbau-berlinski\\.de/",
                     1,
                     [],
                     [
@@ -10677,43 +10640,9 @@
                 ],
                 [
                     1,
-                    "auto_FR_stellantis.com_67q",
+                    "auto_DE_phoenixnap.com_xq7",
                     0,
-                    "^https?://(www\\.)?cookielaw\\.emea\\.fcagroup\\.com/",
-                    1,
-                    [],
-                    [
-                        {
-                            "e": 786
-                        }
-                    ],
-                    [
-                        {
-                            "v": 786
-                        }
-                    ],
-                    [
-                        {
-                            "wait": 500
-                        },
-                        {
-                            "c": 786
-                        }
-                    ],
-                    [
-                        {
-                            "timeout": 1000,
-                            "check": "none",
-                            "wv": 786
-                        }
-                    ],
-                    {}
-                ],
-                [
-                    1,
-                    "auto_GB_dropbox.com_0_+1",
-                    0,
-                    "^https?://(www\\.)?dropbox\\.com/|^https?://(www\\.)?dropbox\\.com/",
+                    "^https?://(www\\.)?widget-next\\.clym-sdk\\.net/",
                     1,
                     [],
                     [
@@ -10728,17 +10657,26 @@
                     ],
                     [
                         {
+                            "wait": 500
+                        },
+                        {
                             "c": 787
                         }
                     ],
-                    [],
+                    [
+                        {
+                            "timeout": 1000,
+                            "check": "none",
+                            "wv": 787
+                        }
+                    ],
                     {}
                 ],
                 [
                     1,
-                    "auto_GB_investing.thisismoney.co.uk_0",
+                    "auto_FR_fiat.fr_3fh",
                     0,
-                    "^https?://(www\\.)?thisismoney\\.co\\.uk/",
+                    "^https?://(www\\.)?cookielaw\\.emea\\.fcagroup\\.com/",
                     1,
                     [],
                     [
@@ -10753,17 +10691,60 @@
                     ],
                     [
                         {
+                            "wait": 500
+                        },
+                        {
                             "c": 788
                         }
                     ],
-                    [],
+                    [
+                        {
+                            "timeout": 1000,
+                            "check": "none",
+                            "wv": 788
+                        }
+                    ],
                     {}
                 ],
                 [
                     1,
-                    "auto_GB_village-hotels.co.uk_hsa",
+                    "auto_FR_stellantis.com_67q",
                     0,
-                    "^https?://(www\\.)?village-hotels\\.co\\.uk/",
+                    "^https?://(www\\.)?cookielaw\\.emea\\.fcagroup\\.com/",
+                    1,
+                    [],
+                    [
+                        {
+                            "e": 788
+                        }
+                    ],
+                    [
+                        {
+                            "v": 788
+                        }
+                    ],
+                    [
+                        {
+                            "wait": 500
+                        },
+                        {
+                            "c": 788
+                        }
+                    ],
+                    [
+                        {
+                            "timeout": 1000,
+                            "check": "none",
+                            "wv": 788
+                        }
+                    ],
+                    {}
+                ],
+                [
+                    1,
+                    "auto_GB_dropbox.com_0_+1",
+                    0,
+                    "^https?://(www\\.)?dropbox\\.com/|^https?://(www\\.)?dropbox\\.com/",
                     1,
                     [],
                     [
@@ -10778,60 +10759,17 @@
                     ],
                     [
                         {
-                            "wait": 500
-                        },
-                        {
                             "c": 789
                         }
                     ],
-                    [
-                        {
-                            "timeout": 1000,
-                            "check": "none",
-                            "wv": 789
-                        }
-                    ],
-                    {}
-                ],
-                [
-                    1,
-                    "auto_NL_fiat.nl_trv_+1",
-                    0,
-                    "^https?://(www\\.)?cookielaw\\.emea\\.fcagroup\\.com/|^https?://(www\\.)?cookielaw\\.emea\\.fcagroup\\.com/",
-                    1,
                     [],
-                    [
-                        {
-                            "e": 786
-                        }
-                    ],
-                    [
-                        {
-                            "v": 786
-                        }
-                    ],
-                    [
-                        {
-                            "wait": 500
-                        },
-                        {
-                            "c": 786
-                        }
-                    ],
-                    [
-                        {
-                            "timeout": 1000,
-                            "check": "none",
-                            "wv": 786
-                        }
-                    ],
                     {}
                 ],
                 [
                     1,
-                    "auto_NL_flitsmeister.nl_ws8",
+                    "auto_GB_investing.thisismoney.co.uk_0",
                     0,
-                    "^https?://(www\\.)?cookies\\.flitsmeister\\.com/",
+                    "^https?://(www\\.)?thisismoney\\.co\\.uk/",
                     1,
                     [],
                     [
@@ -10846,26 +10784,17 @@
                     ],
                     [
                         {
-                            "wait": 500
-                        },
-                        {
                             "c": 790
                         }
                     ],
-                    [
-                        {
-                            "timeout": 1000,
-                            "check": "none",
-                            "wv": 790
-                        }
-                    ],
+                    [],
                     {}
                 ],
                 [
                     1,
-                    "auto_NL_interpolis.nl_jk9",
+                    "auto_GB_village-hotels.co.uk_hsa",
                     0,
-                    "^https?://(www\\.)?interpolis\\.nl/",
+                    "^https?://(www\\.)?village-hotels\\.co\\.uk/",
                     1,
                     [],
                     [
@@ -10897,9 +10826,43 @@
                 ],
                 [
                     1,
-                    "auto_US_dropbox.com_0_+1",
+                    "auto_NL_fiat.nl_trv_+1",
                     0,
-                    "^https?://(www\\.)?dropbox\\.com/|^https?://(www\\.)?dropbox\\.com/",
+                    "^https?://(www\\.)?cookielaw\\.emea\\.fcagroup\\.com/|^https?://(www\\.)?cookielaw\\.emea\\.fcagroup\\.com/",
+                    1,
+                    [],
+                    [
+                        {
+                            "e": 788
+                        }
+                    ],
+                    [
+                        {
+                            "v": 788
+                        }
+                    ],
+                    [
+                        {
+                            "wait": 500
+                        },
+                        {
+                            "c": 788
+                        }
+                    ],
+                    [
+                        {
+                            "timeout": 1000,
+                            "check": "none",
+                            "wv": 788
+                        }
+                    ],
+                    {}
+                ],
+                [
+                    1,
+                    "auto_NL_flitsmeister.nl_ws8",
+                    0,
+                    "^https?://(www\\.)?cookies\\.flitsmeister\\.com/",
                     1,
                     [],
                     [
@@ -10914,8 +10877,76 @@
                     ],
                     [
                         {
-                            "text": "Decline",
+                            "wait": 500
+                        },
+                        {
                             "c": 792
+                        }
+                    ],
+                    [
+                        {
+                            "timeout": 1000,
+                            "check": "none",
+                            "wv": 792
+                        }
+                    ],
+                    {}
+                ],
+                [
+                    1,
+                    "auto_NL_interpolis.nl_jk9",
+                    0,
+                    "^https?://(www\\.)?interpolis\\.nl/",
+                    1,
+                    [],
+                    [
+                        {
+                            "e": 793
+                        }
+                    ],
+                    [
+                        {
+                            "v": 793
+                        }
+                    ],
+                    [
+                        {
+                            "wait": 500
+                        },
+                        {
+                            "c": 793
+                        }
+                    ],
+                    [
+                        {
+                            "timeout": 1000,
+                            "check": "none",
+                            "wv": 793
+                        }
+                    ],
+                    {}
+                ],
+                [
+                    1,
+                    "auto_US_dropbox.com_0_+1",
+                    0,
+                    "^https?://(www\\.)?dropbox\\.com/|^https?://(www\\.)?dropbox\\.com/",
+                    1,
+                    [],
+                    [
+                        {
+                            "e": 794
+                        }
+                    ],
+                    [
+                        {
+                            "v": 794
+                        }
+                    ],
+                    [
+                        {
+                            "text": "Decline",
+                            "c": 794
                         }
                     ],
                     [],
@@ -10930,25 +10961,25 @@
                     [],
                     [
                         {
-                            "e": 793
+                            "e": 795
                         }
                     ],
                     [
                         {
-                            "v": 793
+                            "v": 795
                         }
                     ],
                     [
                         {
-                            "k": 794
+                            "k": 796
                         },
                         {
                             "all": true,
                             "optional": true,
-                            "k": 795
+                            "k": 797
                         },
                         {
-                            "k": 796
+                            "k": 798
                         }
                     ],
                     [
@@ -10967,49 +10998,49 @@
                     "^https://cmp-consent-tool\\.privacymanager\\.io/",
                     1,
                     [
-                        797,
-                        798
+                        799,
+                        800
                     ],
                     [
                         {
-                            "e": 799
+                            "e": 801
                         }
                     ],
                     [
                         {
-                            "v": 799
+                            "v": 801
                         }
                     ],
                     [
                         {
                             "if": {
-                                "e": 800
+                                "e": 802
                             },
                             "then": [
                                 {
-                                    "k": 800
+                                    "k": 802
                                 },
                                 {
-                                    "c": 801
+                                    "c": 803
                                 }
                             ],
                             "else": [
                                 {
-                                    "c": 802
+                                    "c": 804
                                 },
                                 {
-                                    "w": 803
+                                    "w": 805
                                 },
                                 {
-                                    "w": 804
+                                    "w": 806
                                 },
                                 {
                                     "all": true,
                                     "optional": true,
-                                    "k": 805
+                                    "k": 807
                                 },
                                 {
-                                    "k": 804
+                                    "k": 806
                                 }
                             ]
                         }
@@ -11026,20 +11057,20 @@
                     [],
                     [
                         {
-                            "e": 806
+                            "e": 808
                         },
                         {
-                            "e": 807
+                            "e": 809
                         }
                     ],
                     [
                         {
-                            "v": 807
+                            "v": 809
                         }
                     ],
                     [
                         {
-                            "c": 807
+                            "c": 809
                         }
                     ],
                     [],
@@ -12643,12 +12674,12 @@
                     [],
                     [
                         {
-                            "e": 809
+                            "e": 1530
                         }
                     ],
                     [
                         {
-                            "v": 809
+                            "v": 1530
                         }
                     ],
                     [
@@ -12656,14 +12687,14 @@
                             "wait": 500
                         },
                         {
-                            "c": 809
+                            "c": 1530
                         }
                     ],
                     [
                         {
                             "timeout": 1000,
                             "check": "none",
-                            "wv": 809
+                            "wv": 1530
                         }
                     ],
                     {}
@@ -12813,12 +12844,12 @@
                     [],
                     [
                         {
-                            "e": 808
+                            "e": 1531
                         }
                     ],
                     [
                         {
-                            "v": 808
+                            "v": 1531
                         }
                     ],
                     [
@@ -12826,14 +12857,14 @@
                             "wait": 500
                         },
                         {
-                            "c": 808
+                            "c": 1531
                         }
                     ],
                     [
                         {
                             "timeout": 1000,
                             "check": "none",
-                            "wv": 808
+                            "wv": 1531
                         }
                     ],
                     {}
@@ -19220,12 +19251,12 @@
                     [],
                     [
                         {
-                            "e": 809
+                            "e": 1530
                         }
                     ],
                     [
                         {
-                            "v": 809
+                            "v": 1530
                         }
                     ],
                     [
@@ -19233,14 +19264,14 @@
                             "wait": 500
                         },
                         {
-                            "c": 809
+                            "c": 1530
                         }
                     ],
                     [
                         {
                             "timeout": 1000,
                             "check": "none",
-                            "wv": 809
+                            "wv": 1530
                         }
                     ],
                     {}
@@ -20376,12 +20407,12 @@
                     [],
                     [
                         {
-                            "e": 809
+                            "e": 1530
                         }
                     ],
                     [
                         {
-                            "v": 809
+                            "v": 1530
                         }
                     ],
                     [
@@ -20389,14 +20420,14 @@
                             "wait": 500
                         },
                         {
-                            "c": 809
+                            "c": 1530
                         }
                     ],
                     [
                         {
                             "timeout": 1000,
                             "check": "none",
-                            "wv": 809
+                            "wv": 1530
                         }
                     ],
                     {}
@@ -22436,12 +22467,12 @@
                     [],
                     [
                         {
-                            "e": 809
+                            "e": 1530
                         }
                     ],
                     [
                         {
-                            "v": 809
+                            "v": 1530
                         }
                     ],
                     [
@@ -22449,14 +22480,14 @@
                             "wait": 500
                         },
                         {
-                            "c": 809
+                            "c": 1530
                         }
                     ],
                     [
                         {
                             "timeout": 1000,
                             "check": "none",
-                            "wv": 809
+                            "wv": 1530
                         }
                     ],
                     {}
@@ -24169,12 +24200,12 @@
                     [],
                     [
                         {
-                            "e": 809
+                            "e": 1530
                         }
                     ],
                     [
                         {
-                            "v": 809
+                            "v": 1530
                         }
                     ],
                     [
@@ -24182,14 +24213,14 @@
                             "wait": 500
                         },
                         {
-                            "c": 809
+                            "c": 1530
                         }
                     ],
                     [
                         {
                             "timeout": 1000,
                             "check": "none",
-                            "wv": 809
+                            "wv": 1530
                         }
                     ],
                     {}
@@ -25726,12 +25757,12 @@
                     [],
                     [
                         {
-                            "e": 809
+                            "e": 1530
                         }
                     ],
                     [
                         {
-                            "v": 809
+                            "v": 1530
                         }
                     ],
                     [
@@ -25739,14 +25770,14 @@
                             "wait": 500
                         },
                         {
-                            "c": 809
+                            "c": 1530
                         }
                     ],
                     [
                         {
                             "timeout": 1000,
                             "check": "none",
-                            "wv": 809
+                            "wv": 1530
                         }
                     ],
                     {}
@@ -28053,6 +28084,33 @@
                 ],
                 [
                     1,
+                    "pornhub-compact-cookie-banner",
+                    0,
+                    "^https://(www\\.)?pornhub\\.com/",
+                    22,
+                    [
+                        1532
+                    ],
+                    [
+                        {
+                            "e": 1533
+                        }
+                    ],
+                    [
+                        {
+                            "v": 1533
+                        }
+                    ],
+                    [
+                        {
+                            "k": 1533
+                        }
+                    ],
+                    [],
+                    {}
+                ],
+                [
+                    1,
                     "pornhub.com",
                     0,
                     "^https://(www\\.)?pornhub\\.com/",
@@ -29487,18 +29545,18 @@
             "index": {
                 "genericRuleRange": [
                     0,
-                    194
+                    195
                 ],
                 "frameRuleRange": [
-                    192,
-                    219
+                    193,
+                    220
                 ],
                 "specificRuleRange": [
-                    194,
-                    780
+                    195,
+                    782
                 ],
-                "genericStringEnd": 773,
-                "frameStringEnd": 808
+                "genericStringEnd": 775,
+                "frameStringEnd": 810
             }
         }
     }


### PR DESCRIPTION
Asana Task/Github Issue: https://app.asana.com/1/137249556945/project/1201844467387842/task/1216841975425026

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Data-only ruleset refresh in a single JSON feature file; no application logic changes, with typical risk limited to mis-targeted dismiss clicks on affected sites.
> 
> **Overview**
> Bumps the **autoconsent** rules in `features/autoconsent.json` to **v16.15.0**, extending cookie-banner detection and dismiss behavior.
> 
> Adds generic selectors for **cookieinfo** (`.cookieinfo`, `.cookieinfo-close`) and a compact **Pornhub** banner (`#cookieBanner.cbShort`, `.cbCloseButton`), plus new site rules **`cookieinfo`** and **`pornhub-compact-cookie-banner`**. Two long **csm-wrapper** / **cookie-consent-modal** selectors are moved within the selector list rather than removed.
> 
> The bulk of the diff reindexes shared string and rule IDs (e.g. `773`→`775`, several auto-rules now use `1530`/`1531`) and updates the rules **`index`** ranges (`genericRuleRange`, `frameRuleRange`, `specificRuleRange`, `genericStringEnd`, `frameStringEnd`) so existing auto-generated site rules keep pointing at the right elements.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dbdcba058d4244db1aff081d1d6c133c05db3dc1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->