### PR TITLE
Hide browser extension links for capitaloneshopping.com

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -1142,6 +1142,23 @@
                 ]
             },
             {
+                "domain": "capitaloneshopping.com",
+                "rules": [
+                    {
+                        "selector": "[class*='_install-shopping-cta_']",
+                        "type": "hide"
+                    },
+                    {
+                        "selector": ".extension-modal",
+                        "type": "hide"
+                    },
+                    {
+                        "selector": ".install-banner",
+                        "type": "hide"
+                    }
+                ]
+            },
+            {
                 "domain": "carandclassic.com",
                 "rules": [
                     {


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/1206670747178362/task/1216744719688129?focus=true

## Description
### Site breakage mitigation process:
#### Brief explanation
- Reported URL: https://capitaloneshopping.com and https://capitaloneshopping.com/capitalone
- Problems experienced: Links shown for the browser extension, which we don’t support so therefore unusable and confusing for users. Need to use `hide` because the elements contain text.
- Platforms affected:
  - [x] iOS
  - [x] Android
  - [x] Windows
  - [x] MacOS
  - [x] Extensions
- Tracker(s) being unblocked: N/A
- Feature being disabled/modified: Element hiding
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-domain privacy config addition with no auth, data, or core logic changes; minor risk if selectors are overly broad.
> 
> **Overview**
> Adds **site-specific element hiding** for `capitaloneshopping.com` so users no longer see browser-extension install prompts (CTAs, modals, banners) that are not supported in DuckDuckGo’s browser.
> 
> Three new rules in `element-hiding.json` use **`hide`** (not `hide-empty`) because those nodes include visible text. Selectors target install-shopping CTA class patterns, `.extension-modal`, and `.install-banner`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ab4ff424a4bca8dc3ca090a25abbdd459901cfcd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->