### PR TITLE
Allow ketchcdn on cbsnews.com

### DIFF
--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -3475,7 +3475,8 @@
                     {
                         "rule": "global.ketchcdn.com",
                         "domains": [
-                            "cc.com"
+                            "cc.com",
+                            "cbsnews.com"
                         ],
                         "reason": "cc.com - Ketch consent management blocked breaks the site; scoped to cc.com only. https://github.com/duckduckgo/privacy-configuration/pull/5570"
                     }


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1206670747178362/task/1216778795970115?focus=true

## Description
Fixes video loading on mobile.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single scoped domain addition to an existing allowlist rule; no auth, data, or core logic changes.
> 
> **Overview**
> Adds **cbsnews.com** to the existing tracker allowlist rule for `global.ketchcdn.com` (alongside `cc.com`), so Ketch consent scripts are not blocked on CBS News.
> 
> This mirrors the prior **cc.com** breakage fix and is intended to restore **mobile video loading** when consent management was being blocked.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3fbced1d56dba4e7017c0fb7f5b01a345df1ee9f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->