### PR TITLE
Update content-blocker extension to 2026.7.24

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -4992,7 +4992,7 @@
             "minSupportedVersion": "0.148.0",
             "exceptions": [],
             "settings": {
-                "extensionUrl": "https://staticcdn.duckduckgo.com/extensions/content-blocker/content-blocker-extension-2026.7.20.crx"
+                "extensionUrl": "https://staticcdn.duckduckgo.com/extensions/content-blocker/content-blocker-extension-2026.7.24.crx"
             },
             "features": {
                 "onboardingEnabled": {


### PR DESCRIPTION
Update content-blocker extension to 2026.7.24.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single CDN URL bump in Windows overrides; behavior depends on the shipped extension but no app logic changes here.
> 
> **Overview**
> Updates the Windows remote config for **adBlockV2Extension** so clients download the newer content-blocker CRX (`content-blocker-extension-2026.7.24.crx` instead of `2026.7.20.crx`). No other flags, version gates, or feature toggles change in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b96903dda0b0416fde9d5f786db9b28ab5c1b97. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->