### PR TITLE
Update ad-blocking extension scriptlets for v2026.7.24

### DIFF
--- a/features/ad-blocking-extension.json
+++ b/features/ad-blocking-extension.json
@@ -4,28 +4,28 @@
     },
     "exceptions": [],
     "settings": {
-        "version": "2026.7.20",
+        "version": "2026.7.24",
         "enabledByDefault": false,
         "scriptlets": {
             "scriptlets/isolated/ublock-filters.js": {
-                "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/56e8765a2e6bfc35594d0c83840b62ad8d4fef7388bb5aecda1fc411e7697a66.js",
-                "signature": "MEQCIErTF5jJsG/BpIixayrnsewT9PyjVob1VnpJKrvSKNjLAiAXDmhXIEt5wJp0yqfCD7k6hU7FiE0Xt0FrCz1CsLMerQ=="
+                "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/ce0dd8a0e723d431647217d29073c357fb03d497187b019ba9eb422c7b2f99e1.js",
+                "signature": "MEQCIFj/kvjIAi6exzK6KJ3Z+gW1NOWOq94x6Sw72VNFyQETAiBb4xHe2dzxjQ94pSnopWsl3VY+tWDShtwlzCRblO4sJw=="
             },
             "scriptlets/main/ublock-filters.js": {
-                "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/6b328817148ffce49c795532435d5a9f2840e5bcaf9a8c745441ffe829024308.js",
-                "signature": "MEYCIQCXEbccqDx8JS0lCBIIzxUbjZjrgDOtcnthxHyqrOcqUwIhAPkoy/scxvVsT5Ga7YntRx3oGqJVJfkQAYZ3wfLz8OU2"
+                "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/69353f7ba5b92ece1191d198e68345849ffab9681f2ed6d37cc291fc5a96b213.js",
+                "signature": "MEUCIBRGD0wJk6MRwlt0B5FEWQdlEQfRNJ6SdL6mz/jQPPKiAiEArHTk0Fmb86pcJWtFySRyUBfaDiSo9WqDBkTBlLYVom4="
             },
             "scriptlets/main/ublock-experimental.js": {
                 "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855.js",
-                "signature": "MEQCIBpiMPFCN5IHj9wTHQJZAkKD3Uf/5CdNW89WHPjYbbcTAiA9HM9n1XHJm5cur3Ok/Cam6JvsyeIObmvUd8OtvXT+4Q=="
+                "signature": "MEUCIFBiaYEjUiJUlcLPld4bnx1pdIjopONzx9uS5o7K/TfeAiEAuPpX6tMwv8Lg7p+n9/OnW+hF89aLt8Dm0IadjNe5vEY="
             },
             "scriptlets/isolated/ublock-experimental.js": {
                 "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855.js",
-                "signature": "MEYCIQDpPjyDrXDC1nCQ/biYX3S5Yw6qMpK2Iuthw3wCU5nHsQIhANEYKwVcIC+ASJJ3pWPYhyjY4AJmyuiQt1731Ze2XS06"
+                "signature": "MEUCIB60hdLtMBQNrdeVFKzH8IAXLFwUn/4WQttkkZEiIul7AiEAjN3NWni1pk6BNqVPrTtue9hn6AQWiHghLeqnV4gdcls="
             },
             "rules/youtube.json": {
                 "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/2337db6aa7466667595226f780b6590779db3007ac0a65ef3833f89610c92824.json",
-                "signature": "MEUCIQD/PNv9mjxwXkF8w/1WGptt76YcOOB46HmCNzm1iJkiBgIgUIlZ7OsI9iMsvhsRB2h5spKAYZYcU2E4vrFkI8cVJW4="
+                "signature": "MEUCIBWnCMgH8m1WDWFUuSkrEZfLhdFlj5gFdlv7Jg36GgloAiEAuG7YpL4OXFybh0QEk74lwoMqAZXoG8OtqpqVCvsbnSw="
             }
         }
     }


### PR DESCRIPTION
Update ad-blocking extension scriptlets for v2026.7.24.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which signed scriptlets clients download for content blocking; bad URLs or signatures could break ad blocking or block updates until fixed.
> 
> **Overview**
> Bumps the macOS/iOS ad-blocking extension config from **2026.7.20** to **2026.7.24** in `features/ad-blocking-extension.json`.
> 
> **`scriptlets/isolated/ublock-filters.js`** and **`scriptlets/main/ublock-filters.js`** now point at new CDN scriptlet URLs with updated integrity **signatures**. The **ublock-experimental** scriptlet entries keep the same URLs but get refreshed **signatures**; **`rules/youtube.json`** keeps its URL and only its **signature** changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 82bd9a9de0036e290d232726cd95c0a9db9d3b03. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->