### PR TITLE
Disable GPC on blueair.com

### DIFF
--- a/features/gpc.json
+++ b/features/gpc.json
@@ -107,6 +107,10 @@
         {
             "domain": "michaels.com",
             "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5542"
+        },
+        {
+            "domain": "blueair.com",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5650"
         }
     ],
     "settings": {


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1206670747178362/task/1216845766246235?focus=true

## Description
Buttons non-responsive when GPC is enabled (from US IP).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-domain config exception with no logic or security changes; same low-risk pattern as existing GPC site exceptions.
> 
> **Overview**
> Adds **blueair.com** to the GPC `exceptions` list in `features/gpc.json`, so Global Privacy Control is not applied on that site.
> 
> This follows the same pattern as other site-specific GPC breaks (e.g. michaels.com, naturium.com) and is tied to [privacy-configuration#5650](https://github.com/duckduckgo/privacy-configuration/pull/5650). The goal is to fix **non-responsive buttons** when GPC is enabled from a US IP.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0569a2a23964af32845dbb8d29839e3d949bd0ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->