### PR TITLE
Prevent adblock wall on reviewjournal.com

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -5008,6 +5008,22 @@
                         "type": "disable-default"
                     }
                 ]
+            },
+            {
+                "domain": "reviewjournal.com",
+                "rules": [
+                    {
+                        "type": "disable-default"
+                    },
+                    {
+                        "selector": "[id*='google_ads_iframe']",
+                        "type": "hide"
+                    },
+                    {
+                        "selector": ".rj-lazy-ad",
+                        "type": "hide-empty"
+                    }
+                ]
             }
         ]
     }


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1206670747178362/task/1216849697058039?focus=true

## Description
Adblocker wall on reviewjournal.com. Triggered by a honeypot element that element-hiding was hiding.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-domain privacy config change with a well-established disable-default plus targeted-hide pattern; no auth or core app logic.
> 
> **Overview**
> Adds **reviewjournal.com** to `element-hiding.json` so the site’s adblock detection no longer fires when global element-hiding rules hide a honeypot element.
> 
> On this domain, **default** element-hiding rules are turned off (`disable-default`), then ads are handled with two site-specific rules: hide `[id*='google_ads_iframe']` and `hide-empty` on `.rj-lazy-ad`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f945e566d89669bdda6ab45f4ab566015205389e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->