### PR TITLE
Add more Facebook SDK Tracker Allowlist entries

### DIFF
--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -2463,7 +2463,13 @@
                             "mapotic.com",
                             "vipspades.com",
                             "goldmachine.com",
-                            "vipgames.com"
+                            "vipgames.com",
+                            "babawildslots.com",
+                            "hititrich.com",
+                            "nglish.com",
+                            "looping.app",
+                            "playhousehold.com",
+                            "cidercasino.com"
                         ],
                         "reason": [
                             "bandsintown.com - Ticket page renders blank. With this exception the page redirects to ticketspice.com.",
@@ -2499,7 +2505,22 @@
                             "mapotic.com - https://github.com/duckduckgo/privacy-configuration/pull/5614",
                             "vipspades.com - https://github.com/duckduckgo/privacy-configuration/pull/5614",
                             "goldmachine.com - https://github.com/duckduckgo/privacy-configuration/pull/5614",
-                            "vipgames.com - https://github.com/duckduckgo/privacy-configuration/pull/5614"
+                            "vipgames.com - https://github.com/duckduckgo/privacy-configuration/pull/5614",
+                            "babawildslots.com - https://github.com/duckduckgo/privacy-configuration/pull/5652",
+                            "hititrich.com - https://github.com/duckduckgo/privacy-configuration/pull/5652",
+                            "nglish.com - https://github.com/duckduckgo/privacy-configuration/pull/5652",
+                            "looping.app - https://github.com/duckduckgo/privacy-configuration/pull/5652",
+                            "playhousehold.com - https://github.com/duckduckgo/privacy-configuration/pull/5652",
+                            "cidercasino.com - https://github.com/duckduckgo/privacy-configuration/pull/5652"
+                        ]
+                    },
+                    {
+                        "rule": "connect.facebook.net/es_LA/sdk.js",
+                        "domains": [
+                            "pizzaraul.com"
+                        ],
+                        "reason": [
+                            "pizzaraul.com - https://github.com/duckduckgo/privacy-configuration/pull/5652"
                         ]
                     },
                     {
@@ -2525,12 +2546,14 @@
                         "domains": [
                             "nordicwellness.se",
                             "playwsop.com",
-                            "varaaheti.fi"
+                            "varaaheti.fi",
+                            "bandsintown.com"
                         ],
                         "reason": [
                             "nordicwellness.se - https://github.com/duckduckgo/privacy-configuration/issues/1453",
                             "playwsop.com - https://github.com/duckduckgo/privacy-configuration/pull/5604",
-                            "varaaheti.fi - https://github.com/duckduckgo/privacy-configuration/pull/5614"
+                            "varaaheti.fi - https://github.com/duckduckgo/privacy-configuration/pull/5614",
+                            "bandsintown.com - https://github.com/duckduckgo/privacy-configuration/pull/5652"
                         ]
                     },
                     {


### PR DESCRIPTION
Since we have started blocking the Facebook SDK more often, there have been more
cases of website breakage (e.g. broken "Login with Facebook" buttons for web
games), let's add some more Tracker Allowlist entries to mitigate cases that
users are reporting.

**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/task/1216208388522818?focus=true