### PR TITLE
Add aiChat.chromeMenuButton

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -1463,6 +1463,9 @@
                 "ntpSuggestionsDeletion": {
                     "state": "enabled",
                     "minSupportedVersion": "0.168.0"
+                },
+                "chromeMenuButton": {
+                    "state": "internal"
                 }
             },
             "minSupportedVersion": "0.100.0",


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1210407179200832/task/1216849573849491?focus=true

## Description
Add aiChat.chromeMenuButton

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single JSON flag addition with internal rollout state; no runtime code or shared defaults changed in this diff.
> 
> **Overview**
> Adds a new **`aiChat.chromeMenuButton`** sub-feature to the Windows privacy configuration override, gated with **`state: "internal"`** so only internal builds can surface Duck AI from the Chrome-style menu until it is promoted.
> 
> This is a config-only change under the existing `aiChat` feature block in `windows-override.json`; no URLs, version floors, or other aiChat flags are modified.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b0d7bac586f87313f99989afedfed10f5331c3c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->