### PR TITLE
Add more Facebook SDK Tracker Allowlist entries

### DIFF
--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -2469,7 +2469,17 @@
                             "nglish.com",
                             "looping.app",
                             "playhousehold.com",
-                            "cidercasino.com"
+                            "cidercasino.com",
+                            "jackpota.com",
+                            "wattpad.com",
+                            "classmates.com",
+                            "deliveroo.co.uk",
+                            "sweetsweeps.com",
+                            "studysmarter.de",
+                            "huuugecasino.com",
+                            "governmentjobs.com",
+                            "kixeye.com",
+                            "word-champs.com"
                         ],
                         "reason": [
                             "bandsintown.com - Ticket page renders blank. With this exception the page redirects to ticketspice.com.",
@@ -2511,7 +2521,17 @@
                             "nglish.com - https://github.com/duckduckgo/privacy-configuration/pull/5652",
                             "looping.app - https://github.com/duckduckgo/privacy-configuration/pull/5652",
                             "playhousehold.com - https://github.com/duckduckgo/privacy-configuration/pull/5652",
-                            "cidercasino.com - https://github.com/duckduckgo/privacy-configuration/pull/5652"
+                            "cidercasino.com - https://github.com/duckduckgo/privacy-configuration/pull/5652",
+                            "jackpota.com - https://github.com/duckduckgo/privacy-configuration/pull/5654",
+                            "wattpad.com - https://github.com/duckduckgo/privacy-configuration/pull/5654",
+                            "classmates.com - https://github.com/duckduckgo/privacy-configuration/pull/5654",
+                            "deliveroo.co.uk - https://github.com/duckduckgo/privacy-configuration/pull/5654",
+                            "sweetsweeps.com - https://github.com/duckduckgo/privacy-configuration/pull/5654",
+                            "studysmarter.de - https://github.com/duckduckgo/privacy-configuration/pull/5654",
+                            "huuugecasino.com - https://github.com/duckduckgo/privacy-configuration/pull/5654",
+                            "governmentjobs.com - https://github.com/duckduckgo/privacy-configuration/pull/5654",
+                            "kixeye.com - https://github.com/duckduckgo/privacy-configuration/pull/5654",
+                            "word-champs.com - https://github.com/duckduckgo/privacy-configuration/pull/5654"
                         ]
                     },
                     {
@@ -2547,13 +2567,15 @@
                             "nordicwellness.se",
                             "playwsop.com",
                             "varaaheti.fi",
-                            "bandsintown.com"
+                            "bandsintown.com",
+                            "saucey.com"
                         ],
                         "reason": [
                             "nordicwellness.se - https://github.com/duckduckgo/privacy-configuration/issues/1453",
                             "playwsop.com - https://github.com/duckduckgo/privacy-configuration/pull/5604",
                             "varaaheti.fi - https://github.com/duckduckgo/privacy-configuration/pull/5614",
-                            "bandsintown.com - https://github.com/duckduckgo/privacy-configuration/pull/5652"
+                            "bandsintown.com - https://github.com/duckduckgo/privacy-configuration/pull/5652",
+                            "saucey.com - https://github.com/duckduckgo/privacy-configuration/pull/5654"
                         ]
                     },
                     {


### PR DESCRIPTION
Since we have started blocking the Facebook SDK more often, there have been more
cases of website breakage (e.g. broken "Login with Facebook" buttons for web
games), let's add some more Tracker Allowlist entries to mitigate cases that
users are reporting.

**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/task/1216208388522818?focus=true