### PR TITLE
Remove singleTabFireDialog feature flag

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -1961,29 +1961,6 @@
                         "defaultIdleThresholdSeconds": "1800"
                     }
                 },
-                "singleTabFireDialog": {
-                    "state": "enabled",
-                    "minSupportedVersion": 52742000,
-                    "rollout": {
-                        "steps": [
-                            {
-                                "percent": 5
-                            },
-                            {
-                                "percent": 10
-                            },
-                            {
-                                "percent": 25
-                            },
-                            {
-                                "percent": 50
-                            },
-                            {
-                                "percent": 100
-                            }
-                        ]
-                    }
-                },
                 "pdfViewer": {
                     "state": "enabled",
                     "minSupportedVersion": 52790000


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1207418217763355/task/1213953948418615?focus=true

## Description
Removes the old `singleTabFireDialog`, which is being removed from the codebase.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [x] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.
