### PR TITLE
Rollout ad blocking by default to 10%

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -46,6 +46,9 @@
                         "steps": [
                             {
                                 "percent": 5
+                            },
+                            {
+                                "percent": 10
                             }
                         ]
                     }


### PR DESCRIPTION
**Asana Task/Github Issue:**

## Description
<!-- 
  Please delete either or both process sections below.
-->

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [x] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [x] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Expands default-on ad blocking to more Android users, which can increase site breakage risk even though the change is a small incremental config rollout.
> 
> **Overview**
> Advances the Android **ad blocking extension** rollout for **`enabledByDefault`** by appending a new rollout step at **10%**, following the existing **5%** step in `overrides/android-override.json`.
> 
> No other flags change (`minSupportedVersion` **52890000**, `adBlockingUXImprovements`, or parent `adBlockingExtension` settings stay the same).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 10a8ad8d399dcb11ce684b31ef6dd33438ef6b43. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->