### PR TITLE
Add eventHub feature to iOS and macOS overrides

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -3708,6 +3708,10 @@
         "webDetection": {
             "state": "enabled",
             "minSupportedVersion": "7.214.0"
+        },
+        "eventHub": {
+            "state": "enabled",
+            "minSupportedVersion": "7.900.0"
         }
     },
     "unprotectedTemporary": []

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -3059,6 +3059,10 @@
         "webDetection": {
             "state": "enabled",
             "minSupportedVersion": "1.184.0"
+        },
+        "eventHub": {
+            "state": "enabled",
+            "minSupportedVersion": "1.900.0"
         }
     },
     "unprotectedTemporary": []


### PR DESCRIPTION



**Asana Task/Github Issue:**

## Description
<!-- 
  Please delete either or both process sections below.
-->
minSupportedVersion is a placeholder (7.900.0 iOS / 1.900.0 macOS) to be replaced with the real shipping version by the Apple team.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.
