### PR TITLE
Enable MSIX logs for in-progress update crash (15616).

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -5242,10 +5242,10 @@
                     "state": "enabled"
                 },
                 "reportMsixLogs": {
-                    "state": "disabled",
+                    "state": "enabled",
                     "settings": {
                         "ErrorCodes": [
-                            -2147009284
+                            15616
                         ],
                         "AllowList": [
                             "ya2fgkz3nks94",
@@ -5256,7 +5256,10 @@
                         "DenyList": [],
                         "LogLevelExceptions": [
                             1,
-                            2
+                            2,
+                            3,
+                            4,
+                            5
                         ]
                     }
                 },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1201522530643637/task/1216851160954963

## Description
<!-- 
  Please delete either or both process sections below.
-->

### Feature change process:

- [x] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [x] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [x] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only telemetry toggle for Windows extended crash reporting; no runtime code or security paths changed.
> 
> **Overview**
> Turns on **MSIX log reporting** under `extendedCrashReporting.reportMsixLogs` in `windows-override.json` and targets error code **15616** (in-progress update crash) instead of the previous code **-2147009284**.
> 
> **LogLevelExceptions** is expanded from levels 1–2 to **1–5** so more MSIX log severities are included when that crash is reported. Allow/deny package lists are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 408515eb190f93a887bd47562a88be0487fa0bd2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->