### PR TITLE
Hide adblock wall on memorabletv.com

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -2790,6 +2790,22 @@
                 ]
             },
             {
+                "domain": "memorabletv.com",
+                "rules": [
+                    {
+                        "type": "disable-default"
+                    },
+                    {
+                        "selector": ".advert-wrap",
+                        "type": "hide-empty"
+                    },
+                    {
+                        "selector": ".adsbygoogle",
+                        "type": "hide-empty"
+                    }
+                ]
+            },
+            {
                 "domain": "merriam-webster.com",
                 "rules": [
                     {


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/1205996472045435/task/1216898695683386?focus=true

## Description
### Site breakage mitigation process:
#### Brief explanation
- Reported URL: https://www.memorabletv.com/news/great-british-bake-off-returns-this-autumn-nigella-lawson/
- Problems experienced: Undismissable adblock wall.
- Platforms affected:
  - [x] iOS
  - [x] Android
  - [x] Windows
  - [x] MacOS
  - [x] Extensions
- Tracker(s) being unblocked: N/A
- Feature being disabled/modified: Element hiding
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-domain privacy config change with no auth or data handling; follows established disable-default + targeted hide-empty mitigations.
> 
> **Overview**
> Adds a **memorabletv.com** domain block in `element-hiding.json` so users can read articles without an undismissable adblock wall.
> 
> The entry uses **`disable-default`** to turn off the global element-hiding rules on that site (same pattern as other breakage fixes), then applies only **`hide-empty`** on `.advert-wrap` and `.adsbygoogle` so ad slots are collapsed without triggering the site’s anti-adblock overlay.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 05337b47a4ba9ae60de81c067e42dfecca41c05e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->