### PR TITLE
Fix more repeated reloads on iOS and macOS

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -2449,7 +2449,11 @@
                                     "generation.org",
                                     "poshmark.com",
                                     "partselect.com",
-                                    "golfavenue.ca"
+                                    "golfavenue.ca",
+                                    "petsuppliesplus.com",
+                                    "myenneagramtest.org",
+                                    "arcteryx.com",
+                                    "topsecretrecipes.com"
                                 ],
                                 "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5632"
                             }

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -2145,7 +2145,11 @@
                                     "generation.org",
                                     "poshmark.com",
                                     "partselect.com",
-                                    "golfavenue.ca"
+                                    "golfavenue.ca",
+                                    "petsuppliesplus.com",
+                                    "myenneagramtest.org",
+                                    "arcteryx.com",
+                                    "topsecretrecipes.com"
                                 ],
                                 "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5637"
                             }


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/1206670747178362/task/1216745443087938?focus=true

## Description
### Site breakage mitigation process:
#### Brief explanation
- Reported URLs:
  - https://www.petsuppliesplus.com/categories/dog/food/frozen-raw-refrigerated-food
  - https://myenneagramtest.org/test/
  - https://arcteryx.com/ca/en
  - https://topsecretrecipes.com/popeyes-famous-fried-chicken-copycat-recipe.html
- Problems experienced: Repeated reloads. A continuation of #5632 and #5637.
- Platforms affected:
  - [x] iOS
  - [ ] Android
  - [ ] Windows
  - [x] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked: www.google.com/measurement/1p-conversion
- Feature being disabled/modified: N/A
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow per-domain allowlist entries for a single tracker URL; no auth or global blocking changes.
> 
> **Overview**
> Adds **four domains** to the `trackerAllowlist` exception for `www.google.com/measurement/1p-conversion` in both `ios-override.json` and `macos-override.json`: `petsuppliesplus.com`, `myenneagramtest.org`, `arcteryx.com`, and `topsecretrecipes.com`.
> 
> This is the same mitigation pattern as recent PRs (#5632 / #5637): when that measurement request is blocked, affected sites can loop with **repeated reloads** on Apple platforms. Allowlisting the tracker on these hosts restores normal page behavior while leaving blocking unchanged elsewhere.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f6652222f399a78d21204a2201b5aaaa1d9aefb8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->