### PR TITLE
Enable sending incident crash reports for FaultedException

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -5273,7 +5273,7 @@
                     "state": "enabled"
                 },
                 "sendIncidentCrashReports": {
-                    "state": "disabled",
+                    "state": "enabled",
                     "settings": {
                         "ExceptionTypes": [
                             "FaultedException"


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/task/1216783909912517?focus=true

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single Windows privacy-configuration flag flip with exception type already constrained to FaultedException; no application code changes.
> 
> **Overview**
> Turns on the Windows remote feature **`sendIncidentCrashReports`** in `overrides/windows-override.json`, changing **`state`** from **`disabled`** to **`enabled`**.
> 
> Reporting is scoped via existing **`settings.ExceptionTypes`** to **`FaultedException`** only, so incident crash reports for that exception type can be sent (e.g. to Sentry) on Windows without widening other exception reporting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8133d126f45ccfc4e5746283c974be90a3af5b75. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->