### PR TITLE
Fix endless reloads on homedepot.com on macOS and iOS

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -2453,7 +2453,8 @@
                                     "petsuppliesplus.com",
                                     "myenneagramtest.org",
                                     "arcteryx.com",
-                                    "topsecretrecipes.com"
+                                    "topsecretrecipes.com",
+                                    "homedepot.com"
                                 ],
                                 "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5632"
                             }

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -2149,7 +2149,8 @@
                                     "petsuppliesplus.com",
                                     "myenneagramtest.org",
                                     "arcteryx.com",
-                                    "topsecretrecipes.com"
+                                    "topsecretrecipes.com",
+                                    "homedepot.com"
                                 ],
                                 "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5637"
                             }


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/1206670747178362/task/1216745443087938?focus=true

## Description
### Site breakage mitigation process:
#### Brief explanation
- Reported URL: homedepot.com
- Problems experienced: Infinite reload loop on iOS and macOS – a continuation of #5632 and #5637 
- Platforms affected:
  - [x] iOS
  - [ ] Android
  - [ ] Windows
  - [x] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked: `www.google.com/measurement/1p-conversion`
- Feature being disabled/modified: N/A
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-domain tracker allowlist entry in platform overrides; no auth or core logic changes.
> 
> **Overview**
> Adds **`homedepot.com`** to the tracker allowlist for **`www.google.com/measurement/1p-conversion`** in **`ios-override.json`** and **`macos-override.json`**, alongside the same domain list used in related fixes (#5632 / #5637).
> 
> This lets that Google measurement request load on Home Depot instead of being blocked, which was causing an **infinite reload loop** on iOS and macOS.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c2c6652b97423cbe3f1673135b40c5794bab959. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->