### PR TITLE
temporarily disable the new pornhub CPM rule

### DIFF
--- a/features/autoconsent.json
+++ b/features/autoconsent.json
@@ -884,7 +884,8 @@
         "disabledCMPs": [
             "healthline-media",
             "cookie-notice",
-            "notice-cookie"
+            "notice-cookie",
+            "pornhub-compact-cookie-banner"
         ],
         "filterlistExceptions": [],
         "compactRuleList": {


### PR DESCRIPTION
**Asana Task/Github Issue:** 

## Description
<!-- 
  Please delete either or both process sections below.
-->

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single config list entry that turns off one CMP rule; no auth, data, or broad autoconsent behavior changes beyond Pornhub banner auto-consent.
> 
> **Overview**
> Adds **`pornhub-compact-cookie-banner`** to **`disabledCMPs`** in `features/autoconsent.json`, so autoconsent will not apply the compact CMP rule that targets Pornhub until it is removed from that list again.
> 
> This is a temporary rollback of the new Pornhub banner handling; the rule remains in the compact rule list but is skipped at runtime like other disabled CMPs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bca6e1d5acf9ceab5784a0c482cbc514d9ace584. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->