### PR TITLE
Android: Rollout Fire Mode to 10% of users

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -5002,6 +5002,24 @@
                     ]
                 }
             }
+        },
+        "fireMode": {
+            "state": "enabled",
+            "minSupportedVersion": 52890000,
+            "exceptions": [],
+            "features": {
+                "fireTabs": {
+                    "state": "enabled",
+                    "minSupportedVersion": 52890000,
+                    "rollout": {
+                        "steps": [
+                            {
+                                "percent": 10
+                            }
+                        ]
+                    }
+                }
+            }
         }
     },
     "unprotectedTemporary": [],


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1207418217763355/task/1216728189441214?focus=true

## Description

Rolls out the Fire Mode feature to 10% of users running version 5.289.0 or higher.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [x] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Remote feature rollout affects tab/browser UX for a subset of production Android users; scope is limited to config and a single 10% step.
> 
> **Overview**
> Adds a new **`fireMode`** feature block to the Android privacy override so clients on **5.289.0+** (`minSupportedVersion`: 52890000) can receive Fire Mode configuration remotely.
> 
> The only sub-feature enabled in this change is **`fireTabs`**, with a **10%** rollout step—matching the intent to expose Fire Mode tabs to a small initial cohort rather than all eligible users.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 64e80a09ba19abd927ab277ce1037d940b0e5c02. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->