### PR TITLE
Roll out Freemium Settings entry point to 50% of iOS users

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -3249,15 +3249,7 @@
                     "state": "disabled"
                 },
                 "freemium": {
-                    "state": "enabled",
-                    "minSupportedVersion": "7.230.0",
-                    "rollout": {
-                        "steps": [
-                            {
-                                "percent": 50
-                            }
-                        ]
-                    }
+                    "state": "disabled"
                 },
                 "remoteBrokerDelivery": {
                     "state": "enabled",
@@ -3290,7 +3282,15 @@
                     }
                 },
                 "freemiumPIR": {
-                    "state": "disabled"
+                    "state": "enabled",
+                    "minSupportedVersion": "7.230.0",
+                    "rollout": {
+                        "steps": [
+                            {
+                                "percent": 50
+                            }
+                        ]
+                    }
                 },
                 "contentBlocking": {
                     "state": "enabled"

--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -3249,7 +3249,15 @@
                     "state": "disabled"
                 },
                 "freemium": {
-                    "state": "disabled"
+                    "state": "enabled",
+                    "minSupportedVersion": "7.230.0",
+                    "rollout": {
+                        "steps": [
+                            {
+                                "percent": 50
+                            }
+                        ]
+                    }
                 },
                 "remoteBrokerDelivery": {
                     "state": "enabled",


### PR DESCRIPTION
**Asana Task/Github Issue:**

## Description

Enables the `dbp` → `freemiumPIR` sub-feature in the iOS override and rolls it out to 50% of users.

- `state`: `disabled` → `enabled`
- `minSupportedVersion`: `7.230.0`
- `rollout`: single step at `50%`

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
