### PR TITLE
Roll out CTL experiment to 50%

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -314,6 +314,31 @@
                             "weight": 1
                         }
                     ]
+                },
+                "tdsNextExperiment014": {
+                    "state": "enabled",
+                    "minSupportedVersion": 52361000,
+                    "rollout": {
+                        "steps": [
+                            {
+                                "percent": 50
+                            }
+                        ]
+                    },
+                    "settings": {
+                        "controlUrl": "v5/experiments/202607fbctl02-android-tds-control.json",
+                        "treatmentUrl": "v5/experiments/202607fbctl02-android-tds-treatment.json"
+                    },
+                    "cohorts": [
+                        {
+                            "name": "control",
+                            "weight": 1
+                        },
+                        {
+                            "name": "treatment",
+                            "weight": 1
+                        }
+                    ]
                 }
             }
         },

--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -768,6 +768,30 @@
                             "weight": 1
                         }
                     ]
+                },
+                "tdsNextExperiment014": {
+                    "state": "enabled",
+                    "rollout": {
+                        "steps": [
+                            {
+                                "percent": 50
+                            }
+                        ]
+                    },
+                    "settings": {
+                        "controlUrl": "v5/experiments/202607fbctl02-ios-tds-control.json",
+                        "treatmentUrl": "v5/experiments/202607fbctl02-ios-tds-treatment.json"
+                    },
+                    "cohorts": [
+                        {
+                            "name": "control",
+                            "weight": 1
+                        },
+                        {
+                            "name": "treatment",
+                            "weight": 1
+                        }
+                    ]
                 }
             }
         },

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -692,6 +692,30 @@
                             "weight": 1
                         }
                     ]
+                },
+                "tdsNextExperiment014": {
+                    "state": "enabled",
+                    "rollout": {
+                        "steps": [
+                            {
+                                "percent": 50
+                            }
+                        ]
+                    },
+                    "settings": {
+                        "controlUrl": "v6/experiments/202607fbctl02-macos-tds-control.json",
+                        "treatmentUrl": "v6/experiments/202607fbctl02-macos-tds-treatment.json"
+                    },
+                    "cohorts": [
+                        {
+                            "name": "control",
+                            "weight": 1
+                        },
+                        {
+                            "name": "treatment",
+                            "weight": 1
+                        }
+                    ]
                 }
             }
         },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1201720254973470/task/1216849207489966?focus=true

## Description

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> 50% rollout changes which tracker blocklist (TDS) half of users receive, which can affect site breakage and privacy behavior; scope is limited to remote config overrides rather than client code.
> 
> **Overview**
> Adds **`tdsNextExperiment014`** under `blockList` in the Android, iOS, and macOS override configs, turning on the **202607fbctl02** TDS A/B experiment at a **50%** rollout with balanced control/treatment cohorts.
> 
> Each platform points **`controlUrl`** / **`treatmentUrl`** at its own experiment JSON (`v5` on Android and iOS, `v6` on macOS). Android also sets **`minSupportedVersion`** `52361000`, matching other recent TDS next experiments on that platform.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f766999537eae86db0b54cb7c8eab7ccec441dc7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->