### PR TITLE
[Android] Remove feature flag: webViewClipboardImage

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -4650,10 +4650,6 @@
                 }
             }
         },
-        "webViewClipboardImage": {
-            "state": "enabled",
-            "exceptions": []
-        },
         "webViewCompat": {
             "state": "disabled",
             "exceptions": [],


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1200581511062568/task/1213039097669913?focus=true

## Description
<!-- 
  Please delete either or both process sections below.
-->
Removed `webViewClipboardImage` feature flag.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [x] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only removal of a single feature flag with no other repo references; behavior depends on whether the Android app treats missing flags as off or always-on after rollout.
> 
> **Overview**
> Removes the **`webViewClipboardImage`** feature entry from the Android privacy config override (`overrides/android-override.json`). The flag was previously **enabled** with no exceptions; deleting it drops remote toggling for that capability on Android clients that read this config.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5d6f023966b476062aee3298d5b23bf77398dadc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->