### PR TITLE
Rollout ntpAsDefaultAfterIdleReturn to 10%

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -1989,6 +1989,17 @@
                         "defaultIdleThresholdSeconds": "1800"
                     }
                 },
+                "ntpAsDefaultAfterIdleReturn": {
+                    "state": "enabled",
+                    "minSupportedVersion": 52890000,
+                    "rollout": {
+                        "steps": [
+                            {
+                                "percent": 10
+                            }
+                        ]
+                    }
+                },
                 "pdfViewer": {
                     "state": "enabled",
                     "minSupportedVersion": 52790000


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/task/1216914308986177?focus=true

## Description
Roll out the Escape Hatch (Default = NTP after 30 mins of inactivity) to all existing users with an accompanying RMF message. 

This PR Enables `ntpAsDefaultAfterIdleReturn` feature flag for 10% of users on 5.289.0+.
This begins the gradual rollout of "New Tab Page as the default after idle” paired with `showNTPAfterIdleReturn` (already at 100% from 5.278.0), it makes the full after-idle NTP behaviour live for 10% of eligible users.
### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [x] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [x] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [x] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default tab behavior after idle for 10% of eligible Android users, which can affect retention and support but is a limited, flag-gated rollout.
> 
> **Overview**
> Adds the **`ntpAsDefaultAfterIdleReturn`** remote feature under **`androidBrowserConfig`** for Android **5.289.0+** (`minSupportedVersion`: 52890000), enabled with a **10%** rollout step.
> 
> This turns on the “escape hatch” so the **New Tab Page is the default after returning from ~30 minutes of idle**, alongside the already-shipped **`showNTPAfterIdleReturn`** (5.278.0+, 1800s threshold). Only config rollout changes—no app code in this PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b979b7c68d0885bc245a2e6ecceba84ab6ca16e3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->