### PR TITLE
Add architectureX86Deprecation flag

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -6193,6 +6193,10 @@
                     "state": "enabled"
                 }
             }
+        },
+        "windowsX86Deprecation": {
+            "state": "internal",
+            "exceptions": []
         }
     },
     "unprotectedTemporary": []

--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -6194,7 +6194,7 @@
                 }
             }
         },
-        "windowsX86Deprecation": {
+        "architectureX86Deprecation": {
             "state": "internal",
             "exceptions": []
         }


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1210407179200832/task/1214377688148630?focus=true

## Description
Add windowsX86Deprecation flag

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only addition of an internal feature flag with no enabled-by-default behavior or logic changes in this repo.
> 
> **Overview**
> Adds a new Windows privacy-configuration feature entry **`architectureX86Deprecation`** in `overrides/windows-override.json`, set to **`internal`** with an empty **`exceptions`** list, alongside existing top-level features such as **`wpf`**.
> 
> This wires the flag into the Windows override bundle so the DuckDuckGo Windows client can read it from remote config (aligned with the PR’s **windowsX86Deprecation** work) before broader rollout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e2324256d5e305b346ce6242b6d8ce0af385f636. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->