### PR TITLE
hide ad walls on yakimaherald

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -5040,6 +5040,25 @@
                         "type": "hide-empty"
                     }
                 ]
+            },
+            {
+                "domain": [
+                    "yakimaherald.com",
+                    "union-bulletin.com"
+                ],
+                "rules": [
+                    {
+                        "type": "disable-default"
+                    },
+                    {
+                        "selector": "[id*='google_ads_iframe']",
+                        "type": "hide"
+                    },
+                    {
+                        "selector": ".tnt-ads",
+                        "type": "hide-empty"
+                    }
+                ]
             }
         ]
     }


### PR DESCRIPTION

**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/11472677167855/task/1216801663106834

## Description
<!-- 
  Please delete either or both process sections below.
-->
Hides adwalls on yakimaherald and union-bulletin

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only change to element-hiding rules for two domains; no auth, data, or runtime code changes.
> 
> **Overview**
> Adds **site-specific element-hiding** for `yakimaherald.com` and `union-bulletin.com` so ad-wall placeholders are removed when ads are blocked.
> 
> The new block **turns off default hiding rules** on those domains, then **hides Google ad iframes** and **empties `.tnt-ads`** containers—matching the pattern used for similar news sites (e.g. reviewjournal).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 372bc4c159ee7af89b344e9224fcba8be6e47a68. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->