### PR TITLE
macOS: Enables appRebranding Feature Flag

### DIFF
--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -2616,7 +2616,7 @@
                     "minSupportedVersion": "1.192.0"
                 },
                 "appRebranding": {
-                    "state": "enabled",
+                    "state": "internal",
                     "minSupportedVersion": "1.201.0"
                 }
             }

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -2614,6 +2614,10 @@
                 "onboardingRebranding": {
                     "state": "enabled",
                     "minSupportedVersion": "1.192.0"
+                },
+                "appRebranding": {
+                    "state": "enabled",
+                    "minSupportedVersion": "1.201.0"
                 }
             }
         },


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/1176956903599313/task/1216927785336926?focus=true

## Description
This PR enables the `.appRebranding` Feature Flag.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Remote config-only change that limits rebranding to internal builds on supported versions; no auth, data, or blocking logic changes.
> 
> **Overview**
> Adds the **`appRebranding`** sub-feature under **`macOSBrowserConfig`** in `macos-override.json`, gated to **`internal`** users and macOS app versions **≥ 1.201.0**.
> 
> This sits next to the already **`enabled`** **`onboardingRebranding`** flag and turns on broader app rebranding UI for internal testing before a public rollout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fae449ffd934e6d74add5e64c8f8539d5b6f6b1f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->