### PR TITLE
Update autoconsent to v16.17.0

### DIFF
--- a/features/autoconsent.json
+++ b/features/autoconsent.json
@@ -2424,7 +2424,8 @@
                 "body > div:not([id]) > div#csm-wrapper > div:not([id]) > div:not([id]) > div:nth-child(2):not([id]) > button:nth-child(2):not([id])",
                 "body > aside:not([id]) > div:nth-child(2)#cookie-consent-modal > div:not([id]) > div:not([id]) > div:not([id]) > div:not([id]) > div:not([id]) > div:not([id]) > div:nth-child(2):not([id]) > button:nth-child(2):not([id])",
                 "#cookieBanner.cbShort",
-                "#cookieBanner.cbShort .cbCloseButton"
+                "#cookieBanner.cbShort .cbCloseButton",
+                "div[id='sp_message_container_1482251'],div[id='sp_message_container_1482252']"
             ],
             "r": [
                 [
@@ -10135,6 +10136,9 @@
                         }
                     ],
                     [
+                        {
+                            "wait": 500
+                        },
                         {
                             "c": 694
                         },
@@ -28874,6 +28878,43 @@
                     {}
                 ],
                 [
+                    2,
+                    "theguardian.com",
+                    1,
+                    "^https?://(\\w+\\.)?theguardian\\.com/",
+                    10,
+                    [
+                        1534
+                    ],
+                    [
+                        {
+                            "e": 1534
+                        }
+                    ],
+                    [
+                        {
+                            "v": 1534
+                        }
+                    ],
+                    [
+                        {
+                            "h": 1534
+                        },
+                        {
+                            "removeClass": "sp-message-open",
+                            "selector": "html",
+                            "optional": true
+                        }
+                    ],
+                    [
+                        {
+                            "check": "none",
+                            "v": 1534
+                        }
+                    ],
+                    {}
+                ],
+                [
                     1,
                     "theinfatuation",
                     2,
@@ -29560,7 +29601,7 @@
                 ],
                 "specificRuleRange": [
                     195,
-                    782
+                    783
                 ],
                 "genericStringEnd": 775,
                 "frameStringEnd": 810


### PR DESCRIPTION
Asana Task/Github Issue: https://app.asana.com/1/137249556945/project/1201844467387842/task/1216935945994275

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Data-only updates to third-party cookie-consent rules with no changes to extension logic or security-sensitive code paths.
> 
> **Overview**
> Bumps the bundled **autoconsent** rule set to **v16.17.0** in `features/autoconsent.json`.
> 
> Adds a generic hide selector for Sourcepoint message containers (`sp_message_container_1482251` / `1482252`). Inserts a **500ms wait** before one existing consent action step (element ref 694). Introduces a new **theguardian.com** site rule that detects and dismisses its consent UI (ref 1534), including optionally removing the `sp-message-open` class from `html`. Updates metadata so the specific-rule range count is **783**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 64b7a0dde9bf6279c303fd5053f8700be54f994e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->