### PR TITLE
Fix squashed images on thewhitecompany.com

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -4068,6 +4068,21 @@
                 ]
             },
             {
+                "domain": "thewhitecompany.com",
+                "rules": [
+                    {
+                        "selector": ".image-swiper__vertical-image .responsive-image__image",
+      					"type": "modify-style",
+      					"values": [
+                            {
+                                "property": "height",
+                                "value": "auto"
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
                 "domain": "thewindowsclub.com",
                 "rules": [
                     {

--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -4072,8 +4072,8 @@
                 "rules": [
                     {
                         "selector": ".image-swiper__vertical-image .responsive-image__image",
-      					"type": "modify-style",
-      					"values": [
+                        "type": "modify-style",
+                        "values": [
                             {
                                 "property": "height",
                                 "value": "auto"


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/1206670747178362/task/1216789106339066?focus=true

## Description
### Site breakage mitigation process:
#### Brief explanation
- Reported URL: https://www.thewhitecompany.com/uk/Linen-Scoop-Neck-Elasticated-Cuff-Jumpsuit/p/A18688
- Problems experienced: Images appear horizontally squashed on older macOS versions, e.g. macOS 14. A [known Webkit bug](https://bugs.webkit.org/show_bug.cgi?id=293644) but this mitigation works around it.
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [x] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked: N/A
- Feature being disabled/modified: Element hiding
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-domain cosmetic CSS override with no auth, data, or global rule changes.
> 
> **Overview**
> Adds a **site-specific element-hiding rule** for `thewhitecompany.com` that applies `modify-style` with `height: auto` to `.image-swiper__vertical-image .responsive-image__image`, addressing horizontally squashed product gallery images on older macOS (WebKit bug workaround).
> 
> No default ad-hiding rules change; only this domain entry is new in `features/element-hiding.json`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bfee86ee3ca662c4d8efbb25c076533eb092c511. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->