### PR TITLE
Fix rejection wall on doublelist.com

### DIFF
--- a/features/autoconsent.json
+++ b/features/autoconsent.json
@@ -878,6 +878,10 @@
         {
             "domain": "michaels.com",
             "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5542"
+        },
+        {
+            "domain": "doublelist.com",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5685"
         }
     ],
     "settings": {


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/1206670747178362/task/1216882341901231?focus=true

## Description
### Site breakage mitigation process:
#### Brief explanation
- Reported URL: https://doublelist.com/city/inland_empire/
- Problems experienced: A rejection notice (blockwall) for not accepting the site’s terms, caused by cookie popup management (CPM).
- Platforms affected:
  - [x] iOS
  - [x] Android
  - [x] Windows
  - [x] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked: N/A
- Feature being disabled/modified: Cookie Popup Management (CPM)
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-domain autoconsent exception with no auth, data, or broad feature changes; same pattern as existing breakage mitigations.
> 
> **Overview**
> Adds **doublelist.com** to the autoconsent **exceptions** list so cookie popup management (CPM) no longer runs on that site.
> 
> This addresses a **rejection / blockwall** on doublelist.com where automatic CMP handling was treated as not accepting the site’s terms. The change is scoped to a single domain entry (linked to privacy-configuration PR 5685). Also normalizes the file’s trailing newline at EOF.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 35a652032f9802989f1e41c804250bb92da64ab4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->