### PR TITLE
cookiePopUpPreferenceSetting: Enable for 10% on 5.290.0

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -818,6 +818,17 @@
                 "heuristicAction": {
                     "state": "enabled",
                     "minSupportedVersion": 52841000
+                },
+                "cookiePopUpPreferenceSetting": {
+                    "state": "enabled",
+                    "minSupportedVersion": 52900000,
+                    "rollout": {
+                        "steps": [
+                            {
+                                "percent": 10
+                            }
+                        ]
+                    }
                 }
             }
         },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/72649045549333/task/1213990702372115?focus=true

## Description
Enables the new CPM settings menu on Android (10% rollout), and switches them to the ‘tier1’ heuristic mode (clicking ‘ok’ buttons).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Remote feature-flag rollout only; no application code changes and limited blast radius at 10%.
> 
> **Overview**
> Adds **`cookiePopUpPreferenceSetting`** under **`autoconsent`** in `android-override.json`, turning on the CPM-related cookie popup preference UI for Android clients on app version **5.29.0+** (`minSupportedVersion`: `52900000`) with a **10%** rollout step.
> 
> This sits alongside the already-enabled **`heuristicAction`** flag in the same `autoconsent.features` block; this PR only introduces the new preference-setting feature gate and rollout, not other autoconsent behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 64fbfded16516f49b59138bf7bd28fce73656414. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->