### PR TITLE
Disable sending incident crash reports for FaultedException

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -5273,7 +5273,7 @@
                     "state": "enabled"
                 },
                 "sendIncidentCrashReports": {
-                    "state": "enabled",
+                    "state": "disabled",
                     "settings": {
                         "ExceptionTypes": [
                             "FaultedException"


### PR DESCRIPTION
Asana Task/Github Issue: https://app.asana.com/1/137249556945/task/1216783909912517?focus=true

Reverts duckduckgo/privacy-configuration#5665