### PR TITLE
Update autoconsent to v16.18.0

### DIFF
--- a/features/autoconsent.json
+++ b/features/autoconsent.json
@@ -1099,7 +1099,7 @@
                 ".cc-type-info[aria-describedby=\"cookieconsent:desc\"] .cc-compliance .cc-btn",
                 ".cc-deny",
                 "[aria-describedby=\"cookieconsent:desc\"]",
-                "[aria-describedby=\"cookieconsent:desc\"] .cc-type-opt-both",
+                ".brlbs-btn-save,#CookieBoxSaveButton",
                 "[aria-describedby=\"cookieconsent:desc\"].cc-type-opt-out",
                 ".cmp-pref-link",
                 ".cmp-body [id*=rejectAll]",
@@ -1201,9 +1201,9 @@
                 "div[class^=\"cookies-banner-module_\"]",
                 ".cookie-banner.show .cookie-banner__content-all-btn",
                 ".cookie-banner__content-essential-btn",
-                "*[data-testid='dl-cookieBanner']",
-                "[data-testid='dl-cookieBanner']",
-                "button[data-testid='cookie-banner-strict-accept-selected']",
+                ".brlbs-cmpnt-close-button[data-borlabs-cookie-actions=\"close-button\"]",
+                ".cookieinfo",
+                ".cookieinfo-close",
                 "div[class^=\"cookies-banner-module_cookie-banner_\"]",
                 "div[class^=\"cookies-banner-module_small-cookie-banner_\"]",
                 "#tarteaucitronRoot",
@@ -1668,8 +1668,6 @@
                 "datagrail_consent",
                 ".disclaimer-opened #disclaimer-cookies",
                 "#disclaimer-reject_cookies",
-                ".cookieinfo",
-                ".cookieinfo-close",
                 "body > div#root > div#ccpa-iframe-theme-provider[data-testid=\"ccpa-iframe-theme-provider\"] > div#ccpa-iframe[data-testid=\"ccpa-iframe\"] > div#ccpa_consent_banner[data-testid=\"ccpa_consent_banner\"] > div:not([id]) > div:nth-child(3):not([id]) > span:not([id]) > span:not([id]) > div:nth-child(2):not([id]) > span:nth-child(1):not([id]) > button#decline_cookies_button[data-testid=\"decline_cookies_button\"]",
                 "body:not([id]) > div#banner-0 > div:nth-child(1)#grouped-pageload-Banner > div:not([id]) > div:not([id]) > div:not([id]) > div:nth-child(3):not([id]) > button:nth-child(2):not([id])",
                 "body > div#iubenda-cs-banner > div:not([id]) > div:not([id]) > div:not([id]) > div:nth-child(5):not([id]) > div:nth-child(2):not([id]) > button:nth-child(1):not([id])",
@@ -1705,6 +1703,8 @@
                 "span[role=checkbox][aria-checked=true]",
                 "#save-all-pur",
                 "#reminder",
+                "#cookieBanner.cbShort",
+                "#cookieBanner #cookieBannerContent, #globalCookieBanner, #cookieBanner.cbShort",
                 "body > div#app > div:nth-child(1)#__nuxt > div#__layout > div:not([id]) > div:nth-child(4):not([id]) > div:not([id]) > div:nth-child(4):not([id]) > a:nth-child(2):not([id])",
                 "body > div:not([id]) > div:nth-child(1):not([id]) > div:nth-child(1):not([id]) > button:not([id])",
                 "body > div#wrapwrap > div:nth-child(5)#website_cookies_bar > div:not([id]) > div:not([id]) > div:not([id]) > section:not([id]) > div:not([id]) > div:not([id]) > div:nth-child(2):not([id]) > a:nth-child(1)#cookie-banner-essential",
@@ -1806,10 +1806,10 @@
                 "xpath///div[contains(., \"Vill du tillåta användningen av cookies från Instagram i den här webbläsaren?\") or contains(., \"Allow the use of cookies from Instagram on this browser?\") or contains(., \"Povolit v prohlížeči použití souborů cookie z Instagramu?\") or contains(., \"Dopustiti upotrebu kolačića s Instagrama na ovom pregledniku?\") or contains(., \"Разрешить использование файлов cookie от Instagram в этом браузере?\") or contains(., \"Vuoi consentire l'uso dei cookie di Instagram su questo browser?\") or contains(., \"Povoliť používanie cookies zo služby Instagram v tomto prehliadači?\") or contains(., \"Die Verwendung von Cookies durch Instagram in diesem Browser erlauben?\") or contains(., \"Sallitaanko Instagramin evästeiden käyttö tällä selaimella?\") or contains(., \"Engedélyezed az Instagram cookie-jainak használatát ebben a böngészőben?\") or contains(., \"Het gebruik van cookies van Instagram toestaan in deze browser?\") or contains(., \"Bu tarayıcıda Instagram'dan çerez kullanımına izin verilsin mi?\") or contains(., \"Permitir o uso de cookies do Instagram neste navegador?\") or contains(., \"Permiţi folosirea modulelor cookie de la Instagram în acest browser?\") or contains(., \"Autoriser l’utilisation des cookies d’Instagram sur ce navigateur ?\") or contains(., \"¿Permitir el uso de cookies de Instagram en este navegador?\") or contains(., \"Zezwolić na użycie plików cookie z Instagramu w tej przeglądarce?\") or contains(., \"Να επιτρέπεται η χρήση cookies από τo Instagram σε αυτό το πρόγραμμα περιήγησης;\") or contains(., \"Разрешавате ли използването на бисквитки от Instagram на този браузър?\") or contains(., \"Vil du tillade brugen af cookies fra Instagram i denne browser?\") or contains(., \"Vil du tillate bruk av informasjonskapsler fra Instagram i denne nettleseren?\")]",
                 "xpath///button[contains(., 'Отклонить необязательные файлы cookie') or contains(., 'Decline optional cookies') or contains(., 'Refuser les cookies optionnels') or contains(., 'Hylkää valinnaiset evästeet') or contains(., 'Afvis valgfrie cookies') or contains(., 'Odmietnuť nepovinné cookies') or contains(., 'Απόρριψη προαιρετικών cookies') or contains(., 'Neka valfria cookies') or contains(., 'Optionale Cookies ablehnen') or contains(., 'Rifiuta cookie facoltativi') or contains(., 'Odbij neobavezne kolačiće') or contains(., 'Avvis valgfrie informasjonskapsler') or contains(., 'İsteğe bağlı çerezleri reddet') or contains(., 'Recusar cookies opcionais') or contains(., 'Optionele cookies afwijzen') or contains(., 'Rechazar cookies opcionales') or contains(., 'Odrzuć opcjonalne pliki cookie') or contains(., 'Отхвърляне на бисквитките по избор') or contains(., 'Odmítnout volitelné soubory cookie') or contains(., 'Refuză modulele cookie opţionale') or contains(., 'A nem kötelező cookie-k elutasítása')]",
                 ".pop-cookie",
-                ".miniConsent,#PrivacyPolicyBanner",
-                "#PrivacyPolicyBanner",
-                "#cookie-settings",
-                "#reject-all-cookies",
+                "#cookieBanner #cookieBannerContent, #globalCookieBanner, #cookieBanner.cbShort .cbCloseButton",
+                "#cookieBanner.cbShort .cbCloseButton",
+                "cookieConsent=2",
+                "cookieBannerState",
                 "#gdpr-banner-container",
                 "body > div:not([id])[data-popup=\"\"][data-popup-cookies=\"\"][data-terms-cookies-popup-common=\"\"][data-popup-need-overlay=\"true\"] > div:not([id])[data-terms-cookies-popup=\"\"][data-terms-cookies-popup-common=\"\"] > div:not([id]) > div:nth-child(2):not([id]) > button:nth-child(2):not([id])[data-cookies=\"disallow_all_cookies\"]",
                 "#gdpr-banner-container #gdpr-banner [data-testid=gdpr-banner-decline-button]",
@@ -2268,7 +2268,7 @@
                 "#cookie-consent-banner button[aria-label=\"Reject non-essential cookies and continue.\"]",
                 "body > div:not([id]) > div:nth-child(2):not([id]) > div:nth-child(2):not([id]) > button:nth-child(2):not([id])",
                 "body > div:not([id]) > div:nth-child(2):not([id]) > div:not([id]) > div:nth-child(2):not([id]) > div:nth-child(2):not([id]) > button:nth-child(2):not([id])",
-                "#cookieBanner #cookieBannerContent, #globalCookieBanner",
+                "div[id='sp_message_container_1482251'],div[id='sp_message_container_1482252']",
                 "#globalCookieBanner .js-customizeGlobalCookies",
                 "#cookieBanner button.cbSecondaryCTA",
                 "#__rptl-cookiebanner #__rptl-cookiebanner-reject",
@@ -2426,10 +2426,7 @@
                 "[data-role=\"cookies-modal\"] [class*=experimentalButtons] button:nth-of-type(2)",
                 "[data-role=\"cookies-modal\"] [class*=container]",
                 "body > div:not([id]) > div#csm-wrapper > div:not([id]) > div:not([id]) > div:nth-child(2):not([id]) > button:nth-child(2):not([id])",
-                "body > aside:not([id]) > div:nth-child(2)#cookie-consent-modal > div:not([id]) > div:not([id]) > div:not([id]) > div:not([id]) > div:not([id]) > div:not([id]) > div:nth-child(2):not([id]) > button:nth-child(2):not([id])",
-                "#cookieBanner.cbShort",
-                "#cookieBanner.cbShort .cbCloseButton",
-                "div[id='sp_message_container_1482251'],div[id='sp_message_container_1482252']"
+                "body > aside:not([id]) > div:nth-child(2)#cookie-consent-modal > div:not([id]) > div:not([id]) > div:not([id]) > div:not([id]) > div:not([id]) > div:not([id]) > div:nth-child(2):not([id]) > button:nth-child(2):not([id])"
             ],
             "r": [
                 [
@@ -3271,21 +3268,52 @@
                             ],
                             "else": [
                                 {
-                                    "k": 113
-                                },
-                                {
-                                    "wv": 114
-                                },
-                                {
-                                    "all": true,
-                                    "optional": true,
-                                    "k": 115
-                                },
-                                {
-                                    "k": 116
-                                },
-                                {
-                                    "wait": 500
+                                    "if": {
+                                        "e": 204
+                                    },
+                                    "then": [
+                                        {
+                                            "k": 204
+                                        }
+                                    ],
+                                    "else": [
+                                        {
+                                            "if": {
+                                                "e": 306
+                                            },
+                                            "then": [
+                                                {
+                                                    "k": 306
+                                                }
+                                            ],
+                                            "else": [
+                                                {
+                                                    "if": {
+                                                        "e": 113
+                                                    },
+                                                    "then": [
+                                                        {
+                                                            "k": 113
+                                                        },
+                                                        {
+                                                            "wv": 114
+                                                        },
+                                                        {
+                                                            "all": true,
+                                                            "optional": true,
+                                                            "k": 115
+                                                        },
+                                                        {
+                                                            "k": 116
+                                                        },
+                                                        {
+                                                            "wait": 500
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    ]
                                 }
                             ]
                         }
@@ -3956,33 +3984,6 @@
                                     "h": 203
                                 }
                             ]
-                        }
-                    ],
-                    [],
-                    {}
-                ],
-                [
-                    1,
-                    "Complianz opt-both",
-                    2,
-                    "",
-                    22,
-                    [
-                        204
-                    ],
-                    [
-                        {
-                            "e": 204
-                        }
-                    ],
-                    [
-                        {
-                            "v": 204
-                        }
-                    ],
-                    [
-                        {
-                            "c": 202
                         }
                     ],
                     [],
@@ -4678,21 +4679,21 @@
                     "",
                     22,
                     [
-                        773
+                        307
                     ],
                     [
                         {
-                            "e": 773
+                            "e": 307
                         }
                     ],
                     [
                         {
-                            "v": 773
+                            "v": 307
                         }
                     ],
                     [
                         {
-                            "c": 774
+                            "c": 308
                         }
                     ],
                     [],
@@ -5114,45 +5115,6 @@
                             ]
                         }
                     ],
-                    {}
-                ],
-                [
-                    1,
-                    "deepl.com",
-                    2,
-                    "",
-                    22,
-                    [
-                        306
-                    ],
-                    [
-                        {
-                            "e": 307
-                        }
-                    ],
-                    [
-                        {
-                            "v": 307
-                        }
-                    ],
-                    [
-                        {
-                            "if": {
-                                "e": 308
-                            },
-                            "then": [
-                                {
-                                    "k": 308
-                                }
-                            ],
-                            "else": [
-                                {
-                                    "h": 307
-                                }
-                            ]
-                        }
-                    ],
-                    [],
                     {}
                 ],
                 [
@@ -10263,6 +10225,65 @@
                     [],
                     [
                         {
+                            "e": 773
+                        }
+                    ],
+                    [
+                        {
+                            "v": 773
+                        }
+                    ],
+                    [
+                        {
+                            "wait": 500
+                        },
+                        {
+                            "c": 773
+                        }
+                    ],
+                    [
+                        {
+                            "timeout": 1000,
+                            "check": "none",
+                            "wv": 773
+                        }
+                    ],
+                    {}
+                ],
+                [
+                    1,
+                    "auto_CA_coasthotels.com_f8m",
+                    0,
+                    "^https?://(www\\.)?coasthotels\\.com/",
+                    1,
+                    [],
+                    [
+                        {
+                            "e": 774
+                        }
+                    ],
+                    [
+                        {
+                            "v": 774
+                        }
+                    ],
+                    [
+                        {
+                            "c": 774
+                        }
+                    ],
+                    [],
+                    {}
+                ],
+                [
+                    1,
+                    "auto_CA_epihunter.eu_hd4",
+                    0,
+                    "^https?://(www\\.)?combell\\.com/",
+                    1,
+                    [],
+                    [
+                        {
                             "e": 775
                         }
                     ],
@@ -10290,9 +10311,9 @@
                 ],
                 [
                     1,
-                    "auto_CA_coasthotels.com_f8m",
+                    "auto_CA_nationalarchives.gov.uk_rx0",
                     0,
-                    "^https?://(www\\.)?coasthotels\\.com/",
+                    "^https?://(www\\.)?webarchive\\.nationalarchives\\.gov\\.uk/",
                     1,
                     [],
                     [
@@ -10307,17 +10328,26 @@
                     ],
                     [
                         {
+                            "wait": 500
+                        },
+                        {
                             "c": 776
                         }
                     ],
-                    [],
+                    [
+                        {
+                            "timeout": 1000,
+                            "check": "none",
+                            "wv": 776
+                        }
+                    ],
                     {}
                 ],
                 [
                     1,
-                    "auto_CA_epihunter.eu_hd4",
+                    "auto_CA_natureconservancy.ca_3pp",
                     0,
-                    "^https?://(www\\.)?combell\\.com/",
+                    "^https?://(www\\.)?natureconservancy\\.ca/",
                     1,
                     [],
                     [
@@ -10349,9 +10379,9 @@
                 ],
                 [
                     1,
-                    "auto_CA_nationalarchives.gov.uk_rx0",
+                    "auto_CA_ontariospca.ca_k32",
                     0,
-                    "^https?://(www\\.)?webarchive\\.nationalarchives\\.gov\\.uk/",
+                    "^https?://(www\\.)?widget-next\\.clym-sdk\\.net/",
                     1,
                     [],
                     [
@@ -10383,9 +10413,9 @@
                 ],
                 [
                     1,
-                    "auto_CA_natureconservancy.ca_3pp",
+                    "auto_CA_phoenixnap.com_hrb",
                     0,
-                    "^https?://(www\\.)?natureconservancy\\.ca/",
+                    "^https?://(www\\.)?widget-next\\.clym-sdk\\.net/",
                     1,
                     [],
                     [
@@ -10417,7 +10447,7 @@
                 ],
                 [
                     1,
-                    "auto_CA_ontariospca.ca_k32",
+                    "auto_CH_phoenixnap.com_lx5",
                     0,
                     "^https?://(www\\.)?widget-next\\.clym-sdk\\.net/",
                     1,
@@ -10451,9 +10481,9 @@
                 ],
                 [
                     1,
-                    "auto_CA_phoenixnap.com_hrb",
+                    "auto_CH_swisscare.com_arx",
                     0,
-                    "^https?://(www\\.)?widget-next\\.clym-sdk\\.net/",
+                    "^https?://(www\\.)?swisscare\\.com/",
                     1,
                     [],
                     [
@@ -10485,9 +10515,9 @@
                 ],
                 [
                     1,
-                    "auto_CH_phoenixnap.com_lx5",
+                    "auto_DE_alfaromeo.de_gvg_+2",
                     0,
-                    "^https?://(www\\.)?widget-next\\.clym-sdk\\.net/",
+                    "^https?://(www\\.)?cookielaw\\.emea\\.fcagroup\\.com/|^https?://(www\\.)?cookielaw\\.emea\\.fcagroup\\.com/|^https?://(www\\.)?cookielaw\\.emea\\.fcagroup\\.com/",
                     1,
                     [],
                     [
@@ -10519,9 +10549,9 @@
                 ],
                 [
                     1,
-                    "auto_CH_swisscare.com_arx",
+                    "auto_DE_huss-licht-ton.de_jj0",
                     0,
-                    "^https?://(www\\.)?swisscare\\.com/",
+                    "^https?://(www\\.)?huss-licht-ton\\.de/",
                     1,
                     [],
                     [
@@ -10553,9 +10583,9 @@
                 ],
                 [
                     1,
-                    "auto_DE_alfaromeo.de_gvg_+2",
+                    "auto_DE_modellbau-berlinski.de_8vm",
                     0,
-                    "^https?://(www\\.)?cookielaw\\.emea\\.fcagroup\\.com/|^https?://(www\\.)?cookielaw\\.emea\\.fcagroup\\.com/|^https?://(www\\.)?cookielaw\\.emea\\.fcagroup\\.com/",
+                    "^https?://(www\\.)?modellbau-berlinski\\.de/",
                     1,
                     [],
                     [
@@ -10587,9 +10617,9 @@
                 ],
                 [
                     1,
-                    "auto_DE_huss-licht-ton.de_jj0",
+                    "auto_DE_phoenixnap.com_xq7",
                     0,
-                    "^https?://(www\\.)?huss-licht-ton\\.de/",
+                    "^https?://(www\\.)?widget-next\\.clym-sdk\\.net/",
                     1,
                     [],
                     [
@@ -10621,9 +10651,9 @@
                 ],
                 [
                     1,
-                    "auto_DE_modellbau-berlinski.de_8vm",
+                    "auto_FR_fiat.fr_3fh",
                     0,
-                    "^https?://(www\\.)?modellbau-berlinski\\.de/",
+                    "^https?://(www\\.)?cookielaw\\.emea\\.fcagroup\\.com/",
                     1,
                     [],
                     [
@@ -10655,9 +10685,43 @@
                 ],
                 [
                     1,
-                    "auto_DE_phoenixnap.com_xq7",
+                    "auto_FR_stellantis.com_67q",
                     0,
-                    "^https?://(www\\.)?widget-next\\.clym-sdk\\.net/",
+                    "^https?://(www\\.)?cookielaw\\.emea\\.fcagroup\\.com/",
+                    1,
+                    [],
+                    [
+                        {
+                            "e": 786
+                        }
+                    ],
+                    [
+                        {
+                            "v": 786
+                        }
+                    ],
+                    [
+                        {
+                            "wait": 500
+                        },
+                        {
+                            "c": 786
+                        }
+                    ],
+                    [
+                        {
+                            "timeout": 1000,
+                            "check": "none",
+                            "wv": 786
+                        }
+                    ],
+                    {}
+                ],
+                [
+                    1,
+                    "auto_GB_dropbox.com_0_+1",
+                    0,
+                    "^https?://(www\\.)?dropbox\\.com/|^https?://(www\\.)?dropbox\\.com/",
                     1,
                     [],
                     [
@@ -10672,109 +10736,7 @@
                     ],
                     [
                         {
-                            "wait": 500
-                        },
-                        {
                             "c": 787
-                        }
-                    ],
-                    [
-                        {
-                            "timeout": 1000,
-                            "check": "none",
-                            "wv": 787
-                        }
-                    ],
-                    {}
-                ],
-                [
-                    1,
-                    "auto_FR_fiat.fr_3fh",
-                    0,
-                    "^https?://(www\\.)?cookielaw\\.emea\\.fcagroup\\.com/",
-                    1,
-                    [],
-                    [
-                        {
-                            "e": 788
-                        }
-                    ],
-                    [
-                        {
-                            "v": 788
-                        }
-                    ],
-                    [
-                        {
-                            "wait": 500
-                        },
-                        {
-                            "c": 788
-                        }
-                    ],
-                    [
-                        {
-                            "timeout": 1000,
-                            "check": "none",
-                            "wv": 788
-                        }
-                    ],
-                    {}
-                ],
-                [
-                    1,
-                    "auto_FR_stellantis.com_67q",
-                    0,
-                    "^https?://(www\\.)?cookielaw\\.emea\\.fcagroup\\.com/",
-                    1,
-                    [],
-                    [
-                        {
-                            "e": 788
-                        }
-                    ],
-                    [
-                        {
-                            "v": 788
-                        }
-                    ],
-                    [
-                        {
-                            "wait": 500
-                        },
-                        {
-                            "c": 788
-                        }
-                    ],
-                    [
-                        {
-                            "timeout": 1000,
-                            "check": "none",
-                            "wv": 788
-                        }
-                    ],
-                    {}
-                ],
-                [
-                    1,
-                    "auto_GB_dropbox.com_0_+1",
-                    0,
-                    "^https?://(www\\.)?dropbox\\.com/|^https?://(www\\.)?dropbox\\.com/",
-                    1,
-                    [],
-                    [
-                        {
-                            "e": 789
-                        }
-                    ],
-                    [
-                        {
-                            "v": 789
-                        }
-                    ],
-                    [
-                        {
-                            "c": 789
                         }
                     ],
                     [],
@@ -10789,17 +10751,17 @@
                     [],
                     [
                         {
-                            "e": 790
+                            "e": 788
                         }
                     ],
                     [
                         {
-                            "v": 790
+                            "v": 788
                         }
                     ],
                     [
                         {
-                            "c": 790
+                            "c": 788
                         }
                     ],
                     [],
@@ -10810,6 +10772,108 @@
                     "auto_GB_village-hotels.co.uk_hsa",
                     0,
                     "^https?://(www\\.)?village-hotels\\.co\\.uk/",
+                    1,
+                    [],
+                    [
+                        {
+                            "e": 789
+                        }
+                    ],
+                    [
+                        {
+                            "v": 789
+                        }
+                    ],
+                    [
+                        {
+                            "wait": 500
+                        },
+                        {
+                            "c": 789
+                        }
+                    ],
+                    [
+                        {
+                            "timeout": 1000,
+                            "check": "none",
+                            "wv": 789
+                        }
+                    ],
+                    {}
+                ],
+                [
+                    1,
+                    "auto_NL_fiat.nl_trv_+1",
+                    0,
+                    "^https?://(www\\.)?cookielaw\\.emea\\.fcagroup\\.com/|^https?://(www\\.)?cookielaw\\.emea\\.fcagroup\\.com/",
+                    1,
+                    [],
+                    [
+                        {
+                            "e": 786
+                        }
+                    ],
+                    [
+                        {
+                            "v": 786
+                        }
+                    ],
+                    [
+                        {
+                            "wait": 500
+                        },
+                        {
+                            "c": 786
+                        }
+                    ],
+                    [
+                        {
+                            "timeout": 1000,
+                            "check": "none",
+                            "wv": 786
+                        }
+                    ],
+                    {}
+                ],
+                [
+                    1,
+                    "auto_NL_flitsmeister.nl_ws8",
+                    0,
+                    "^https?://(www\\.)?cookies\\.flitsmeister\\.com/",
+                    1,
+                    [],
+                    [
+                        {
+                            "e": 790
+                        }
+                    ],
+                    [
+                        {
+                            "v": 790
+                        }
+                    ],
+                    [
+                        {
+                            "wait": 500
+                        },
+                        {
+                            "c": 790
+                        }
+                    ],
+                    [
+                        {
+                            "timeout": 1000,
+                            "check": "none",
+                            "wv": 790
+                        }
+                    ],
+                    {}
+                ],
+                [
+                    1,
+                    "auto_NL_interpolis.nl_jk9",
+                    0,
+                    "^https?://(www\\.)?interpolis\\.nl/",
                     1,
                     [],
                     [
@@ -10841,43 +10905,9 @@
                 ],
                 [
                     1,
-                    "auto_NL_fiat.nl_trv_+1",
+                    "auto_US_dropbox.com_0_+1",
                     0,
-                    "^https?://(www\\.)?cookielaw\\.emea\\.fcagroup\\.com/|^https?://(www\\.)?cookielaw\\.emea\\.fcagroup\\.com/",
-                    1,
-                    [],
-                    [
-                        {
-                            "e": 788
-                        }
-                    ],
-                    [
-                        {
-                            "v": 788
-                        }
-                    ],
-                    [
-                        {
-                            "wait": 500
-                        },
-                        {
-                            "c": 788
-                        }
-                    ],
-                    [
-                        {
-                            "timeout": 1000,
-                            "check": "none",
-                            "wv": 788
-                        }
-                    ],
-                    {}
-                ],
-                [
-                    1,
-                    "auto_NL_flitsmeister.nl_ws8",
-                    0,
-                    "^https?://(www\\.)?cookies\\.flitsmeister\\.com/",
+                    "^https?://(www\\.)?dropbox\\.com/|^https?://(www\\.)?dropbox\\.com/",
                     1,
                     [],
                     [
@@ -10892,76 +10922,8 @@
                     ],
                     [
                         {
-                            "wait": 500
-                        },
-                        {
-                            "c": 792
-                        }
-                    ],
-                    [
-                        {
-                            "timeout": 1000,
-                            "check": "none",
-                            "wv": 792
-                        }
-                    ],
-                    {}
-                ],
-                [
-                    1,
-                    "auto_NL_interpolis.nl_jk9",
-                    0,
-                    "^https?://(www\\.)?interpolis\\.nl/",
-                    1,
-                    [],
-                    [
-                        {
-                            "e": 793
-                        }
-                    ],
-                    [
-                        {
-                            "v": 793
-                        }
-                    ],
-                    [
-                        {
-                            "wait": 500
-                        },
-                        {
-                            "c": 793
-                        }
-                    ],
-                    [
-                        {
-                            "timeout": 1000,
-                            "check": "none",
-                            "wv": 793
-                        }
-                    ],
-                    {}
-                ],
-                [
-                    1,
-                    "auto_US_dropbox.com_0_+1",
-                    0,
-                    "^https?://(www\\.)?dropbox\\.com/|^https?://(www\\.)?dropbox\\.com/",
-                    1,
-                    [],
-                    [
-                        {
-                            "e": 794
-                        }
-                    ],
-                    [
-                        {
-                            "v": 794
-                        }
-                    ],
-                    [
-                        {
                             "text": "Decline",
-                            "c": 794
+                            "c": 792
                         }
                     ],
                     [],
@@ -10976,25 +10938,25 @@
                     [],
                     [
                         {
-                            "e": 795
+                            "e": 793
                         }
                     ],
                     [
                         {
-                            "v": 795
+                            "v": 793
                         }
                     ],
                     [
                         {
-                            "k": 796
+                            "k": 794
                         },
                         {
                             "all": true,
                             "optional": true,
-                            "k": 797
+                            "k": 795
                         },
                         {
-                            "k": 798
+                            "k": 796
                         }
                     ],
                     [
@@ -11013,49 +10975,49 @@
                     "^https://cmp-consent-tool\\.privacymanager\\.io/",
                     1,
                     [
-                        799,
-                        800
+                        797,
+                        798
                     ],
                     [
                         {
-                            "e": 801
+                            "e": 799
                         }
                     ],
                     [
                         {
-                            "v": 801
+                            "v": 799
                         }
                     ],
                     [
                         {
                             "if": {
-                                "e": 802
+                                "e": 800
                             },
                             "then": [
                                 {
-                                    "k": 802
+                                    "k": 800
                                 },
                                 {
-                                    "c": 803
+                                    "c": 801
                                 }
                             ],
                             "else": [
                                 {
-                                    "c": 804
+                                    "c": 802
                                 },
                                 {
-                                    "w": 805
+                                    "w": 803
                                 },
                                 {
-                                    "w": 806
+                                    "w": 804
                                 },
                                 {
                                     "all": true,
                                     "optional": true,
-                                    "k": 807
+                                    "k": 805
                                 },
                                 {
-                                    "k": 806
+                                    "k": 804
                                 }
                             ]
                         }
@@ -11072,20 +11034,20 @@
                     [],
                     [
                         {
-                            "e": 808
+                            "e": 806
                         },
                         {
-                            "e": 809
+                            "e": 807
                         }
                     ],
                     [
                         {
-                            "v": 809
+                            "v": 807
                         }
                     ],
                     [
                         {
-                            "c": 809
+                            "c": 807
                         }
                     ],
                     [],
@@ -27316,48 +27278,6 @@
                 ],
                 [
                     1,
-                    "jdsports",
-                    2,
-                    "^https://(www|m)\\.jdsports\\.",
-                    22,
-                    [
-                        911
-                    ],
-                    [
-                        {
-                            "e": 911
-                        }
-                    ],
-                    [
-                        {
-                            "v": 911
-                        }
-                    ],
-                    [
-                        {
-                            "if": {
-                                "e": 912
-                            },
-                            "then": [
-                                {
-                                    "h": 912
-                                }
-                            ],
-                            "else": [
-                                {
-                                    "c": 913
-                                },
-                                {
-                                    "c": 914
-                                }
-                            ]
-                        }
-                    ],
-                    [],
-                    {}
-                ],
-                [
-                    1,
                     "justgiving.com",
                     2,
                     "^https://(?:[a-z0-9-]+\\.)?justgiving\\.com/",
@@ -28099,51 +28019,37 @@
                 ],
                 [
                     1,
-                    "pornhub-compact-cookie-banner",
-                    0,
-                    "^https://(www\\.)?pornhub\\.com/",
-                    22,
-                    [
-                        1532
-                    ],
-                    [
-                        {
-                            "e": 1533
-                        }
-                    ],
-                    [
-                        {
-                            "v": 1533
-                        }
-                    ],
-                    [
-                        {
-                            "k": 1533
-                        }
-                    ],
-                    [],
-                    {}
-                ],
-                [
-                    1,
                     "pornhub.com",
                     0,
                     "^https://(www\\.)?pornhub\\.com/",
                     22,
                     [
-                        991
+                        991,
+                        808
                     ],
                     [
                         {
-                            "e": 1373
+                            "check": "any",
+                            "v": 809
                         }
                     ],
                     [
                         {
-                            "v": 1373
+                            "check": "any",
+                            "v": 911
                         }
                     ],
                     [
+                        {
+                            "if": {
+                                "v": 912
+                            },
+                            "then": [
+                                {
+                                    "c": 912
+                                }
+                            ]
+                        },
                         {
                             "if": {
                                 "e": 1374
@@ -28170,7 +28076,18 @@
                             ]
                         }
                     ],
-                    [],
+                    [
+                        {
+                            "any": [
+                                {
+                                    "cc": 913
+                                },
+                                {
+                                    "cc": 914
+                                }
+                            ]
+                        }
+                    ],
                     {}
                 ],
                 [
@@ -28888,21 +28805,21 @@
                     "^https?://(\\w+\\.)?theguardian\\.com/",
                     10,
                     [
-                        1534
+                        1373
                     ],
                     [
                         {
-                            "e": 1534
+                            "e": 1373
                         }
                     ],
                     [
                         {
-                            "v": 1534
+                            "v": 1373
                         }
                     ],
                     [
                         {
-                            "h": 1534
+                            "h": 1373
                         },
                         {
                             "removeClass": "sp-message-open",
@@ -28913,7 +28830,7 @@
                     [
                         {
                             "check": "none",
-                            "v": 1534
+                            "v": 1373
                         }
                     ],
                     {}
@@ -29597,18 +29514,18 @@
             "index": {
                 "genericRuleRange": [
                     0,
-                    195
+                    193
                 ],
                 "frameRuleRange": [
-                    193,
-                    220
+                    191,
+                    218
                 ],
                 "specificRuleRange": [
-                    195,
-                    783
+                    193,
+                    779
                 ],
-                "genericStringEnd": 775,
-                "frameStringEnd": 810
+                "genericStringEnd": 773,
+                "frameStringEnd": 808
             }
         }
     }


### PR DESCRIPTION
Asana Task/Github Issue: https://app.asana.com/1/137249556945/project/1201844467387842/task/1216971607532376

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect automated cookie dismissal across many sites via selector and rule-flow updates; mis-targeted clicks are possible if upstream rules are wrong, but scope matches a routine autoconsent vendor sync.
> 
> **Overview**
> Bumps **`features/autoconsent.json`** to autoconsent **v16.18.0**, refreshing cookie-banner selectors and rule wiring rather than changing extension logic elsewhere.
> 
> **Rule consolidation:** Standalone entries for **Complianz opt-both**, **deepl.com**, **jdsports**, and **pornhub-compact-cookie-banner** are removed. Their behavior is folded into other rules—Borlabs now branches through Complianz opt-both and deepl before the generic flow—and **pornhub.com** uses broader detection plus optional compact-banner clicks.
> 
> **Selectors:** Borlabs save/close controls, **cookieinfo**, and several **cookieBanner** / privacy-banner patterns are added or relocated in the shared selector list; some Deepl `data-testid` entries are dropped in favor of Borlabs/cookieinfo targets.
> 
> **Indexing:** Internal rule and string indices are renumbered (e.g. **cookieinfo** 773→307, many **auto_*** site rules −2), and the rules **index** block reflects fewer generic rules (195→193) and adjusted string ends.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 36e31fca3beb96adc5af1094d95cc6871aa770b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->