### PR TITLE
Removed stretched image fix for thewhitecompany.com

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -4068,21 +4068,6 @@
                 ]
             },
             {
-                "domain": "thewhitecompany.com",
-                "rules": [
-                    {
-                        "selector": ".image-swiper__vertical-image .responsive-image__image",
-                        "type": "modify-style",
-                        "values": [
-                            {
-                                "property": "height",
-                                "value": "auto"
-                            }
-                        ]
-                    }
-                ]
-            },
-            {
                 "domain": "thewindowsclub.com",
                 "rules": [
                     {


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/1206670747178362/task/1216789106339066?focus=true

## Description
### Site breakage mitigation process:
#### Brief explanation
- Reported URL: https://www.thewhitecompany.com/uk/Linen-Scoop-Neck-Elasticated-Cuff-Jumpsuit/p/A18688
- Problems experienced: Stretched/squashed images on thewhitecompany.com – reverting #5680
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [x] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked: N/A
- Feature being disabled/modified: Element hiding
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-domain config removal with no auth or data changes; only restores default styling behavior on one retailer site.
> 
> **Overview**
> Reverts a prior site-specific **element hiding** rule for **thewhitecompany.com** by deleting the entire domain entry from `element-hiding.json`.
> 
> That rule used `modify-style` to set `height: auto` on `.image-swiper__vertical-image .responsive-image__image`, which was meant to fix stretched product images but is being rolled back because it caused squashed/stretched imagery on product pages (e.g. UK product URLs).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd253cd1ea2762baf568ffc5e5abb67080b2b705. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->