### PR TITLE
Windows: Enable saveImmediately setting

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -4571,7 +4571,7 @@
                 "enableExtraDiagnostics": true,
                 "enable401Retry": true,
                 "jwksCachingEnabled": true,
-                "saveImmediately": false
+                "saveImmediately": true
             }
         },
         "webNotifications": {


### PR DESCRIPTION
**Asana Task/Github Issue:**

## Description
Enables the `saveImmediately` setting for the Privacy Pro feature.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [x] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single boolean flip in a Windows-only privacy config override; no auth or schema changes in this diff.
> 
> **Overview**
> Turns on **`saveImmediately`** for Windows in the Privacy Pro feature block inside `overrides/windows-override.json` (changes the setting from `false` to `true` alongside existing auth/diagnostics flags).
> 
> Windows clients that read this override will persist Privacy Pro–related settings immediately instead of deferring saves.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 61808f7a4a1036382be61f07a00f8d17b2308368. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->