### PR TITLE
Add duckPlayer bufferingFeedback setting, enabled on Android

### DIFF
--- a/features/duck-player.json
+++ b/features/duck-player.json
@@ -73,6 +73,9 @@
                 },
                 "bufferingFeedback": {
                     "state": "disabled"
+                },
+                "fullscreenGuard": {
+                    "state": "disabled"
                 }
             },
             "serpProxy": {

--- a/features/duck-player.json
+++ b/features/duck-player.json
@@ -70,6 +70,9 @@
                 },
                 "videoDrawer": {
                     "state": "disabled"
+                },
+                "bufferingFeedback": {
+                    "state": "disabled"
                 }
             },
             "serpProxy": {

--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -2215,6 +2215,9 @@
                             "state": "enabled",
                             "spinnerTimeoutMs": 45000,
                             "spinnerDelayMs": 500
+                        },
+                        "fullscreenGuard": {
+                            "state": "enabled"
                         }
                     },
                     "serpProxy": {

--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -2210,6 +2210,11 @@
                         },
                         "videoDrawer": {
                             "state": "disabled"
+                        },
+                        "bufferingFeedback": {
+                            "state": "enabled",
+                            "giveUpMs": 45000,
+                            "spinnerDelayMs": 500
                         }
                     },
                     "serpProxy": {

--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -2213,7 +2213,7 @@
                         },
                         "bufferingFeedback": {
                             "state": "enabled",
-                            "giveUpMs": 45000,
+                            "spinnerTimeoutMs": 45000,
                             "spinnerDelayMs": 500
                         }
                     },

--- a/schema/features/duckplayer.ts
+++ b/schema/features/duckplayer.ts
@@ -4,7 +4,7 @@ type StateObject = {
     state: FeatureState;
 };
 type BufferingFeedbackObject = StateObject & {
-    giveUpMs?: number;
+    spinnerTimeoutMs?: number;
     spinnerDelayMs?: number;
 };
 export type DuckPlayerSettings = CSSInjectFeatureSettings<{

--- a/schema/features/duckplayer.ts
+++ b/schema/features/duckplayer.ts
@@ -34,6 +34,7 @@ export type DuckPlayerSettings = CSSInjectFeatureSettings<{
             videoOverlays: StateObject;
             videoDrawer?: StateObject;
             bufferingFeedback?: BufferingFeedbackObject;
+            fullscreenGuard?: StateObject;
         };
         serpProxy: StateObject;
     };

--- a/schema/features/duckplayer.ts
+++ b/schema/features/duckplayer.ts
@@ -3,6 +3,10 @@ import { Feature, CSSInjectFeatureSettings, FeatureState } from '../feature';
 type StateObject = {
     state: FeatureState;
 };
+type BufferingFeedbackObject = StateObject & {
+    giveUpMs?: number;
+    spinnerDelayMs?: number;
+};
 export type DuckPlayerSettings = CSSInjectFeatureSettings<{
     tryDuckPlayerLink: string;
     duckPlayerDisabledHelpPageLink: string | null;
@@ -29,6 +33,7 @@ export type DuckPlayerSettings = CSSInjectFeatureSettings<{
             clickInterception: StateObject;
             videoOverlays: StateObject;
             videoDrawer?: StateObject;
+            bufferingFeedback?: BufferingFeedbackObject;
         };
         serpProxy: StateObject;
     };


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1163321984198618/task/1215899251052616?focus=true

## Description

Introduces two Duck Player settings:

1. `bufferingFeedback` When enabled, shows the video poster frame and a loading spinner when video playback is delayed due to ad-blocking. Settings:
    - `state: 'enabled'|'disabled'` (default disabled)
    - `spinnerDelayMs: number` (default undefined) Grace period before showing the spinner in case a video starts playing immediately | 
    - `spinnerTimeoutMs: number` (default undefined) Time to wait for video playback before bailing out

3. `fullscreenGuard` When enabled, prevents YouTube from going into fullscreen mode while the Duck Player overlay is visible. Settings:
    - `state: 'enabled'|'disabled'` (default disabled)

Testing instruction and binaries:

https://app.asana.com/1/137249556945/project/488551667048375/task/1216958181818132?focus=true

Related PRs:
1. https://github.com/duckduckgo/content-scope-scripts/pull/2915
4. https://github.com/duckduckgo/Android/pull/9344

### Feature change process:

- [x] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [x] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config and TypeScript schema only; defaults stay disabled outside the Android override, with no auth or data-handling changes.
> 
> **Overview**
> Adds **two optional Duck Player YouTube overlay settings** to the privacy config schema and base feature JSON, with Android-specific overrides turning them on.
> 
> **`bufferingFeedback`** and **`fullscreenGuard`** are declared on `overlays.youtube` in `schema/features/duckplayer.ts`. `bufferingFeedback` can include optional `spinnerDelayMs` and `spinnerTimeoutMs` for poster/spinner UX during ad-block–related playback delays.
> 
> In **`features/duck-player.json`**, both settings default to **`disabled`**. The **`android-override.json`** Duck Player block enables **`bufferingFeedback`** with `spinnerDelayMs: 500` and `spinnerTimeoutMs: 45000`, and enables **`fullscreenGuard`** to block YouTube fullscreen while the overlay is visible.
> 
> Implementation behavior lives in related **content-scope-scripts** and **Android** changes; this PR only ships config and schema.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 39614eea56ef2fd1c9e03c68d5db94f415e24911. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->