### PR TITLE
Update autoconsent to v16.18.1

### DIFF
--- a/features/autoconsent.json
+++ b/features/autoconsent.json
@@ -1704,7 +1704,7 @@
                 "#save-all-pur",
                 "#reminder",
                 "#cookieBanner.cbShort",
-                "#cookieBanner #cookieBannerContent, #globalCookieBanner, #cookieBanner.cbShort",
+                "body > div:not([id]) > div#csm-wrapper > div:not([id]) > div:not([id]) > div:nth-child(2):not([id]) > button:nth-child(2):not([id])",
                 "body > div#app > div:nth-child(1)#__nuxt > div#__layout > div:not([id]) > div:nth-child(4):not([id]) > div:not([id]) > div:nth-child(4):not([id]) > a:nth-child(2):not([id])",
                 "body > div:not([id]) > div:nth-child(1):not([id]) > div:nth-child(1):not([id]) > button:not([id])",
                 "body > div#wrapwrap > div:nth-child(5)#website_cookies_bar > div:not([id]) > div:not([id]) > div:not([id]) > section:not([id]) > div:not([id]) > div:not([id]) > div:nth-child(2):not([id]) > a:nth-child(1)#cookie-banner-essential",
@@ -1806,10 +1806,10 @@
                 "xpath///div[contains(., \"Vill du tillåta användningen av cookies från Instagram i den här webbläsaren?\") or contains(., \"Allow the use of cookies from Instagram on this browser?\") or contains(., \"Povolit v prohlížeči použití souborů cookie z Instagramu?\") or contains(., \"Dopustiti upotrebu kolačića s Instagrama na ovom pregledniku?\") or contains(., \"Разрешить использование файлов cookie от Instagram в этом браузере?\") or contains(., \"Vuoi consentire l'uso dei cookie di Instagram su questo browser?\") or contains(., \"Povoliť používanie cookies zo služby Instagram v tomto prehliadači?\") or contains(., \"Die Verwendung von Cookies durch Instagram in diesem Browser erlauben?\") or contains(., \"Sallitaanko Instagramin evästeiden käyttö tällä selaimella?\") or contains(., \"Engedélyezed az Instagram cookie-jainak használatát ebben a böngészőben?\") or contains(., \"Het gebruik van cookies van Instagram toestaan in deze browser?\") or contains(., \"Bu tarayıcıda Instagram'dan çerez kullanımına izin verilsin mi?\") or contains(., \"Permitir o uso de cookies do Instagram neste navegador?\") or contains(., \"Permiţi folosirea modulelor cookie de la Instagram în acest browser?\") or contains(., \"Autoriser l’utilisation des cookies d’Instagram sur ce navigateur ?\") or contains(., \"¿Permitir el uso de cookies de Instagram en este navegador?\") or contains(., \"Zezwolić na użycie plików cookie z Instagramu w tej przeglądarce?\") or contains(., \"Να επιτρέπεται η χρήση cookies από τo Instagram σε αυτό το πρόγραμμα περιήγησης;\") or contains(., \"Разрешавате ли използването на бисквитки от Instagram на този браузър?\") or contains(., \"Vil du tillade brugen af cookies fra Instagram i denne browser?\") or contains(., \"Vil du tillate bruk av informasjonskapsler fra Instagram i denne nettleseren?\")]",
                 "xpath///button[contains(., 'Отклонить необязательные файлы cookie') or contains(., 'Decline optional cookies') or contains(., 'Refuser les cookies optionnels') or contains(., 'Hylkää valinnaiset evästeet') or contains(., 'Afvis valgfrie cookies') or contains(., 'Odmietnuť nepovinné cookies') or contains(., 'Απόρριψη προαιρετικών cookies') or contains(., 'Neka valfria cookies') or contains(., 'Optionale Cookies ablehnen') or contains(., 'Rifiuta cookie facoltativi') or contains(., 'Odbij neobavezne kolačiće') or contains(., 'Avvis valgfrie informasjonskapsler') or contains(., 'İsteğe bağlı çerezleri reddet') or contains(., 'Recusar cookies opcionais') or contains(., 'Optionele cookies afwijzen') or contains(., 'Rechazar cookies opcionales') or contains(., 'Odrzuć opcjonalne pliki cookie') or contains(., 'Отхвърляне на бисквитките по избор') or contains(., 'Odmítnout volitelné soubory cookie') or contains(., 'Refuză modulele cookie opţionale') or contains(., 'A nem kötelező cookie-k elutasítása')]",
                 ".pop-cookie",
-                "#cookieBanner #cookieBannerContent, #globalCookieBanner, #cookieBanner.cbShort .cbCloseButton",
+                "body > aside:not([id]) > div:nth-child(2)#cookie-consent-modal > div:not([id]) > div:not([id]) > div:not([id]) > div:not([id]) > div:not([id]) > div:not([id]) > div:nth-child(2):not([id]) > button:nth-child(2):not([id])",
                 "#cookieBanner.cbShort .cbCloseButton",
-                "cookieConsent=2",
-                "cookieBannerState",
+                "#cookieBanner #cookieBannerContent, #globalCookieBanner",
+                "[data-role=\"cookies-modal\"] [class*=container]",
                 "#gdpr-banner-container",
                 "body > div:not([id])[data-popup=\"\"][data-popup-cookies=\"\"][data-terms-cookies-popup-common=\"\"][data-popup-need-overlay=\"true\"] > div:not([id])[data-terms-cookies-popup=\"\"][data-terms-cookies-popup-common=\"\"] > div:not([id]) > div:nth-child(2):not([id]) > button:nth-child(2):not([id])[data-cookies=\"disallow_all_cookies\"]",
                 "#gdpr-banner-container #gdpr-banner [data-testid=gdpr-banner-decline-button]",
@@ -2423,10 +2423,7 @@
                 "#no-consent-popup-close-modal",
                 "[data-role=\"cookies-modal\"]",
                 "[data-role=\"cookies-modal\"] [data-opt-hydration=\"cookies-dialog-eu\"]",
-                "[data-role=\"cookies-modal\"] [class*=experimentalButtons] button:nth-of-type(2)",
-                "[data-role=\"cookies-modal\"] [class*=container]",
-                "body > div:not([id]) > div#csm-wrapper > div:not([id]) > div:not([id]) > div:nth-child(2):not([id]) > button:nth-child(2):not([id])",
-                "body > aside:not([id]) > div:nth-child(2)#cookie-consent-modal > div:not([id]) > div:not([id]) > div:not([id]) > div:not([id]) > div:not([id]) > div:not([id]) > div:nth-child(2):not([id]) > button:nth-child(2):not([id])"
+                "[data-role=\"cookies-modal\"] [class*=experimentalButtons] button:nth-of-type(2)"
             ],
             "r": [
                 [
@@ -12651,12 +12648,12 @@
                     [],
                     [
                         {
-                            "e": 1530
+                            "e": 809
                         }
                     ],
                     [
                         {
-                            "v": 1530
+                            "v": 809
                         }
                     ],
                     [
@@ -12664,14 +12661,14 @@
                             "wait": 500
                         },
                         {
-                            "c": 1530
+                            "c": 809
                         }
                     ],
                     [
                         {
                             "timeout": 1000,
                             "check": "none",
-                            "wv": 1530
+                            "wv": 809
                         }
                     ],
                     {}
@@ -12821,12 +12818,12 @@
                     [],
                     [
                         {
-                            "e": 1531
+                            "e": 911
                         }
                     ],
                     [
                         {
-                            "v": 1531
+                            "v": 911
                         }
                     ],
                     [
@@ -12834,14 +12831,14 @@
                             "wait": 500
                         },
                         {
-                            "c": 1531
+                            "c": 911
                         }
                     ],
                     [
                         {
                             "timeout": 1000,
                             "check": "none",
-                            "wv": 1531
+                            "wv": 911
                         }
                     ],
                     {}
@@ -19228,12 +19225,12 @@
                     [],
                     [
                         {
-                            "e": 1530
+                            "e": 809
                         }
                     ],
                     [
                         {
-                            "v": 1530
+                            "v": 809
                         }
                     ],
                     [
@@ -19241,14 +19238,14 @@
                             "wait": 500
                         },
                         {
-                            "c": 1530
+                            "c": 809
                         }
                     ],
                     [
                         {
                             "timeout": 1000,
                             "check": "none",
-                            "wv": 1530
+                            "wv": 809
                         }
                     ],
                     {}
@@ -20384,12 +20381,12 @@
                     [],
                     [
                         {
-                            "e": 1530
+                            "e": 809
                         }
                     ],
                     [
                         {
-                            "v": 1530
+                            "v": 809
                         }
                     ],
                     [
@@ -20397,14 +20394,14 @@
                             "wait": 500
                         },
                         {
-                            "c": 1530
+                            "c": 809
                         }
                     ],
                     [
                         {
                             "timeout": 1000,
                             "check": "none",
-                            "wv": 1530
+                            "wv": 809
                         }
                     ],
                     {}
@@ -22444,12 +22441,12 @@
                     [],
                     [
                         {
-                            "e": 1530
+                            "e": 809
                         }
                     ],
                     [
                         {
-                            "v": 1530
+                            "v": 809
                         }
                     ],
                     [
@@ -22457,14 +22454,14 @@
                             "wait": 500
                         },
                         {
-                            "c": 1530
+                            "c": 809
                         }
                     ],
                     [
                         {
                             "timeout": 1000,
                             "check": "none",
-                            "wv": 1530
+                            "wv": 809
                         }
                     ],
                     {}
@@ -24177,12 +24174,12 @@
                     [],
                     [
                         {
-                            "e": 1530
+                            "e": 809
                         }
                     ],
                     [
                         {
-                            "v": 1530
+                            "v": 809
                         }
                     ],
                     [
@@ -24190,14 +24187,14 @@
                             "wait": 500
                         },
                         {
-                            "c": 1530
+                            "c": 809
                         }
                     ],
                     [
                         {
                             "timeout": 1000,
                             "check": "none",
-                            "wv": 1530
+                            "wv": 809
                         }
                     ],
                     {}
@@ -25734,12 +25731,12 @@
                     [],
                     [
                         {
-                            "e": 1530
+                            "e": 809
                         }
                     ],
                     [
                         {
-                            "v": 1530
+                            "v": 809
                         }
                     ],
                     [
@@ -25747,14 +25744,14 @@
                             "wait": 500
                         },
                         {
-                            "c": 1530
+                            "c": 809
                         }
                     ],
                     [
                         {
                             "timeout": 1000,
                             "check": "none",
-                            "wv": 1530
+                            "wv": 809
                         }
                     ],
                     {}
@@ -28019,37 +28016,51 @@
                 ],
                 [
                     1,
+                    "pornhub-compact-cookie-banner",
+                    0,
+                    "^https://(www\\.)?pornhub\\.com/",
+                    22,
+                    [
+                        808
+                    ],
+                    [
+                        {
+                            "e": 912
+                        }
+                    ],
+                    [
+                        {
+                            "v": 912
+                        }
+                    ],
+                    [
+                        {
+                            "k": 912
+                        }
+                    ],
+                    [],
+                    {}
+                ],
+                [
+                    1,
                     "pornhub.com",
                     0,
                     "^https://(www\\.)?pornhub\\.com/",
                     22,
                     [
-                        991,
-                        808
+                        991
                     ],
                     [
                         {
-                            "check": "any",
-                            "v": 809
+                            "e": 913
                         }
                     ],
                     [
                         {
-                            "check": "any",
-                            "v": 911
+                            "v": 913
                         }
                     ],
                     [
-                        {
-                            "if": {
-                                "v": 912
-                            },
-                            "then": [
-                                {
-                                    "c": 912
-                                }
-                            ]
-                        },
                         {
                             "if": {
                                 "e": 1374
@@ -28076,18 +28087,7 @@
                             ]
                         }
                     ],
-                    [
-                        {
-                            "any": [
-                                {
-                                    "cc": 913
-                                },
-                                {
-                                    "cc": 914
-                                }
-                            ]
-                        }
-                    ],
+                    [],
                     {}
                 ],
                 [
@@ -29333,7 +29333,7 @@
                         },
                         {
                             "optional": true,
-                            "h": 1529
+                            "h": 914
                         }
                     ],
                     [],
@@ -29522,7 +29522,7 @@
                 ],
                 "specificRuleRange": [
                     193,
-                    779
+                    780
                 ],
                 "genericStringEnd": 773,
                 "frameStringEnd": 808


### PR DESCRIPTION
Asana Task/Github Issue: https://app.asana.com/1/137249556945/project/1201844467387842/task/1216982548380775

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to autoconsent CMP selector strings and rule index references; no app auth, data, or infrastructure logic is touched. Risk is mainly whether updated selectors still match live cookie UIs on affected domains.
> 
> **Overview**
> Bumps **autoconsent** rule data to **v16.18.1** in `features/autoconsent.json`, mainly retuning cookie-banner selectors and site-specific rule wiring.
> 
> The shared selector list is reshuffled: some `#cookieBanner` / CSM-wrapper / modal paths are moved or deduplicated, `[data-role="cookies-modal"]` container matching is added in one place, and a few entries (`cookieConsent=2`, `cookieBannerState`) are dropped from that list. Multiple **auto_*** site rules (Black Diamond–family sites, Chipolo, fr.xgimi/leminor, rhinoshield.fr, bk.nl, sprinklr.co, greenpan.us) now point at selector indices **809** and **911** instead of **1530** / **1531**, aligning them with the updated compact list.
> 
> **Pornhub** is split: a new `pornhub-compact-cookie-banner` rule handles the compact banner path (and remains in `disabledCMPs`), while the main `pornhub.com` rule is simplified—fewer nested visibility checks and cookie-clear steps, with references updated to **912** / **913**. The **xhamster-us** flow uses hide index **914** instead of **1529**. Rule metadata counts are bumped (`specificRuleRange` end **780**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ad273039b505f0f42d079c9fc76df8767222c796. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->