### PR TITLE
Hide pornhub post-cookie notice

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -5059,6 +5059,15 @@
                         "type": "hide-empty"
                     }
                 ]
+            },
+            {
+                "domain": "pornhub.com",
+                "rules": [
+                    {
+                        "selector": "#cookieBanner.cbShort",
+                        "type": "hide"
+                    }
+                ]
             }
         ]
     }


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1201844467387842/task/1216910384468772?focus=true

## Description
Pornhub shows a notice suggesting that the user should go back and “accept all cookies” after our cookie pop-up management automatically rejects them. We can add a element hiding rule to hide this.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-site element-hiding rule with a narrow selector; no auth, data, or shared infrastructure changes.
> 
> **Overview**
> Adds a **pornhub.com** domain rule in `element-hiding.json` that hides `#cookieBanner.cbShort` after DuckDuckGo’s cookie management rejects cookies on the site.
> 
> Pornhub surfaces a short banner nudging users to go back and accept all cookies when the initial consent flow is auto-rejected; this rule removes that follow-up UI without changing autoconsent behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 400d3ca44132a3bf7ffe176aa646389e82ba9dc3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->