### PR TITLE
Adding 'simplifiedSyncSetupExperiment' disabled for Windows

### DIFF
--- a/features/sync.json
+++ b/features/sync.json
@@ -24,6 +24,9 @@
         },
         "aiChatSync": {
             "state": "disabled"
+        },
+        "simplifiedSyncSetupExperiment": {
+            "state": "disabled"
         }
     },
     "exceptions": []

--- a/features/sync.json
+++ b/features/sync.json
@@ -24,9 +24,6 @@
         },
         "aiChatSync": {
             "state": "disabled"
-        },
-        "simplifiedSyncSetupExperiment": {
-            "state": "disabled"
         }
     },
     "exceptions": []

--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -4101,6 +4101,9 @@
                 "canShowV2ConnectCode": {
                     "state": "enabled",
                     "minSupportedVersion": "0.162.0"
+                },
+                "simplifiedSyncSetupExperiment": {
+                    "state": "disabled"
                 }
             }
         },


### PR DESCRIPTION
**Asana Task/Github Issue:**

## Description
<!-- 
  Please delete either or both process sections below.
-->

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only change to a sync feature flag with no auth, data, or client logic in this repo; risk is limited to Windows sync setup UX not receiving the experiment.
> 
> **Overview**
> Adds **`simplifiedSyncSetupExperiment`** under the Windows **`sync`** overrides in `windows-override.json` with **`state: "disabled"`**, so the simplified sync setup experiment does not run on Windows clients.
> 
> This mirrors the experiment flag used on other platforms (e.g. iOS enables it with cohorts) but **explicitly keeps Windows on the control/disabled path** for that UX experiment.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 689938532c133b801510cbd0a999e8c9f39d947c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->