### PR TITLE
Enable showAdBlockingOmnibarAnimation in 5.291.0

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -59,6 +59,10 @@
                 "adBlockingUXImprovements": {
                     "state": "enabled",
                     "minSupportedVersion": 52890000
+                },
+                "showAdBlockingOmnibarAnimation": {
+                    "state": "enabled",
+                    "minSupportedVersion": 52910000
                 }
             },
             "minSupportedVersion": 52840000


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1212227266948491/task/1216708066070917

## Description
Enable showAdBlockingOmnibarAnimation in 5.291.0
 
### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [x] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [x] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single Android remote-config flag addition with version gating only; no auth, data, or blocking logic changes in this repo.
> 
> **Overview**
> Turns on the **`showAdBlockingOmnibarAnimation`** sub-feature under **`adBlockingExtension`** in the Android privacy config override.
> 
> The flag is set to **enabled** with **`minSupportedVersion`: `52910000`** (app **5.291.0**), so only that build and newer will show the ad-blocking omnibar animation. No rollout percentages or cohorts are added—behavior matches other simple version-gated flags like **`adBlockingUXImprovements`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e9641f56ec5c418625282e63f295337abf452160. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->