### PR TITLE
Rollout ntpAsDefaultAfterIdleReturn to 25%

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -2014,6 +2014,9 @@
                         "steps": [
                             {
                                 "percent": 10
+                            },
+                            {
+                                "percent": 25
                             }
                         ]
                     }


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1212810093780571/task/1216914308986178?focus=true

## Description
Rollout ntpAsDefaultAfterIdleReturn for 25% of users on 5.289.0+

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [x] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only rollout percentage change for an existing enabled feature; no new logic or broader flag changes beyond audience size.
> 
> **Overview**
> Expands the Android privacy-config rollout for **`ntpAsDefaultAfterIdleReturn`** by adding a second rollout step at **25%**, after the existing **10%** step. **`minSupportedVersion`** remains **52890000** (5.289.0+).
> 
> This is a staged rollout increase only; no other feature flags or settings in this PR are changed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b1e011f7069a16263b7f401fa0366ec047ad87a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->