### PR TITLE
Update content-blocker extension to 2026.7.29

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -4998,7 +4998,7 @@
             "minSupportedVersion": "0.148.0",
             "exceptions": [],
             "settings": {
-                "extensionUrl": "https://staticcdn.duckduckgo.com/extensions/content-blocker/content-blocker-extension-2026.7.24.crx"
+                "extensionUrl": "https://staticcdn.duckduckgo.com/extensions/content-blocker/content-blocker-extension-2026.7.29.crx"
             },
             "features": {
                 "onboardingEnabled": {


### PR DESCRIPTION
Update content-blocker extension to 2026.7.29.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single CDN URL bump in a Windows override; no logic or security surface changes.
> 
> **Overview**
> Updates the Windows `adBlockV2Extension` **extensionUrl** in `overrides/windows-override.json` from `content-blocker-extension-2026.7.24.crx` to **`content-blocker-extension-2026.7.29.crx`**. No other feature flags or settings in that block change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6df25b3924ab046805ec9d4224dfae7fa206b2e3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->