### PR TITLE
Update ad-blocking extension scriptlets for v2026.7.29

### DIFF
--- a/features/ad-blocking-extension.json
+++ b/features/ad-blocking-extension.json
@@ -4,28 +4,28 @@
     },
     "exceptions": [],
     "settings": {
-        "version": "2026.7.24",
+        "version": "2026.7.29",
         "enabledByDefault": false,
         "scriptlets": {
             "scriptlets/isolated/ublock-filters.js": {
                 "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/ce0dd8a0e723d431647217d29073c357fb03d497187b019ba9eb422c7b2f99e1.js",
-                "signature": "MEQCIFj/kvjIAi6exzK6KJ3Z+gW1NOWOq94x6Sw72VNFyQETAiBb4xHe2dzxjQ94pSnopWsl3VY+tWDShtwlzCRblO4sJw=="
+                "signature": "MEUCIQC0noPlfy4PmqGwcweIHo+Tr527qgjCt2itjQGtNvs7OAIgMk6ljpEJu6ZIykaGhJOfj43Z/IaWqv0we/a+w60Y0yk="
             },
             "scriptlets/main/ublock-filters.js": {
-                "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/69353f7ba5b92ece1191d198e68345849ffab9681f2ed6d37cc291fc5a96b213.js",
-                "signature": "MEUCIBRGD0wJk6MRwlt0B5FEWQdlEQfRNJ6SdL6mz/jQPPKiAiEArHTk0Fmb86pcJWtFySRyUBfaDiSo9WqDBkTBlLYVom4="
+                "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/5fb67b125f34e64c82ab721a0e1a86087db06eeb1c1e144ea47c4ce78859081f.js",
+                "signature": "MEUCIQCYraoWwdHXTwputrw/XZIab91wgaUofEfa3Y1TJDLhmgIgM49JQFW0YtEnbqUy1SIBHG8gR6VepN/onDxYecRS1hI="
             },
             "scriptlets/main/ublock-experimental.js": {
                 "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855.js",
-                "signature": "MEUCIFBiaYEjUiJUlcLPld4bnx1pdIjopONzx9uS5o7K/TfeAiEAuPpX6tMwv8Lg7p+n9/OnW+hF89aLt8Dm0IadjNe5vEY="
+                "signature": "MEUCIQDxiiUcKAyMy3VrJOQt83d1ZSPDLBoacljQhH+Zs6K4IQIgAxjzemFxl/iYQp52TnVrtJU6xjYvEbNZmFY9uH2sLu8="
             },
             "scriptlets/isolated/ublock-experimental.js": {
                 "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855.js",
-                "signature": "MEUCIB60hdLtMBQNrdeVFKzH8IAXLFwUn/4WQttkkZEiIul7AiEAjN3NWni1pk6BNqVPrTtue9hn6AQWiHghLeqnV4gdcls="
+                "signature": "MEQCIH2D3Bm4dtvVEBttWz2Uxk49dLNsAuOdEdoFuQsiAE8GAiBqfYqSqe0Apxg1sJlj0Z47Xb+QezckbfXanFyFPhxM3g=="
             },
             "rules/youtube.json": {
                 "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/2337db6aa7466667595226f780b6590779db3007ac0a65ef3833f89610c92824.json",
-                "signature": "MEUCIBWnCMgH8m1WDWFUuSkrEZfLhdFlj5gFdlv7Jg36GgloAiEAuG7YpL4OXFybh0QEk74lwoMqAZXoG8OtqpqVCvsbnSw="
+                "signature": "MEQCIGGOWi9FpSazcAHzdsG0wCfUFOY56Hg09OIYVLVng754AiAc3fYhJtpwYCVGK1Sv3MfKgrdkG+H5rhHAqPsHoOThdw=="
             }
         }
     }


### PR DESCRIPTION
Update ad-blocking extension scriptlets for v2026.7.29.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Routine signed scriptlet manifest update only; no logic or enablement changes in this repo.
> 
> **Overview**
> Bumps the ad-blocking extension feature config from **2026.7.24** to **2026.7.29**.
> 
> The **main** `ublock-filters.js` scriptlet points to a new CDN URL and signature; **isolated** `ublock-filters`, both **ublock-experimental** entries, and **rules/youtube.json** keep the same URLs but get refreshed **signatures**. No structural or policy changes (`enabledByDefault` stays false, exceptions unchanged).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dccd2d880c17c1a7e0a25cfce62ae6ec472ab145. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->