### PR TITLE
Cleanup unneeded mitigations

### DIFF
--- a/features/autoconsent.json
+++ b/features/autoconsent.json
@@ -48,10 +48,6 @@
             "reason": "https://github.com/duckduckgo/privacy-configuration/pull/3924"
         },
         {
-            "domain": "events.com",
-            "reason": "https://github.com/duckduckgo/privacy-configuration/pull/3172"
-        },
-        {
             "domain": "geo.fr",
             "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2476"
         },
@@ -614,10 +610,6 @@
         {
             "domain": "wheeloffortune.com",
             "reason": "https://github.com/duckduckgo/privacy-configuration/pull/3776"
-        },
-        {
-            "domain": "paypal.com",
-            "reason": "https://github.com/duckduckgo/privacy-configuration/pull/3826"
         },
         {
             "domain": "snyk.io",


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/task/1212717515965366?focus=true
https://app.asana.com/1/137249556945/task/1212716627842631?focus=true

## Description
Mitigations no longer needed on paypal.com and events.com

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only cleanup with a small user-visible effect: cookie consent handling on paypal.com and events.com may change if the old mitigations were still doing something meaningful.
> 
> **Overview**
> Removes two **autoconsent exception/mitigation** entries from `features/autoconsent.json` for **`events.com`** and **`paypal.com`**, on the basis that those site-specific workarounds are no longer needed.
> 
> No other feature files change in this diff; autoconsent behavior on those domains will follow the default rules again instead of the prior exceptions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 70dea849130e08747af3f6861151d4c9abf7429d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->