### PR TITLE
Enable includePageTypeSignals (Android)

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -4862,6 +4862,7 @@
             "settings": {
                 "additionalCheck": "enabled",
                 "activeCaptureOnFirstMessage": "enabled",
+                "includePageTypeSignals": "enabled",
                 "maxContentLength": 9500,
                 "mainContentSelector": "main, article, .content, .main, #content, #main",
                 "excludeSelectors": [


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1200204095367872/task/1217021536685917?focus=true

## Description

- Enables `includePageTypeSignals` in `pageContext` in order infer prompt suggestions on the contextual sheet

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [x] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single remote-config flag flip in the Android override with no rollout or exception changes; behavior is already enabled on other platforms.
> 
> **Overview**
> Turns on **`includePageTypeSignals`** under **`pageContext`** settings in `android-override.json`, matching iOS, macOS, and Windows overrides that already use this flag.
> 
> Android clients that meet **`pageContext`**’s existing `minSupportedVersion` (52680000) will now include page-type signals when capturing page context, which supports inferring prompt suggestions on the contextual Duck.ai sheet.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 072d7c1351bae24637b8a53dabea8cb7d2e55dd5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->