### PR TITLE
Enable setTabTitleEarly for Windows

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -4811,7 +4811,8 @@
                     "settings": { "attemptCount": 5 }
                 },
                 "setTabTitleEarly": {
-                    "state": "internal"
+                    "state": "enabled",
+                    "minSupportedVersion": "0.170.0"
                 }
             },
             "exceptions": []


### PR DESCRIPTION
Set minSupportedVersion to 0.170.0 so the webview subfeature ships with the next Windows release.

**Asana Task/Github Issue:**

## Description
<!-- 
  Please delete either or both process sections below.
-->

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Configuration-only change gating an existing webview subfeature; no application code modified.
> 
> **Overview**
> The Windows override promotes **`setTabTitleEarly`** from **`internal`** to **`enabled`**, with **`minSupportedVersion`** set to **`0.170.0`** so the webview subfeature rolls out with the next Windows browser release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 27d5f9af286b9ce937efa6b7e99e76bcf81f951b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->