### PR TITLE
[iOS] Disable client-side TTL check for search-tokens

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -3252,8 +3252,8 @@
                     "state": "enabled",
                     "minSupportedVersion": "7.230.0",
                     "settings": {
-                        "tokenTTLSeconds": 300,
-                        "refreshWindowSeconds": 120
+                        "tokenTTLSeconds": 43200,
+                        "refreshWindowSeconds": 43020
                     },
                     "description": "NA experiment: search token to speed up SERP by combining Index/Deep responses.",
                     "cohorts": [


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/task/1217017771648504?focus=true

## Description

Raise the iOS searchTokenExperiment client TTL on iOSBrowserConfig:

- tokenTTLSeconds: 300 → 43200 (12h)
- refreshWindowSeconds: 120 → 43020

The 180s gap between the two is preserved. The client's refresh-ahead trigger depends only on that difference, so refresh timing is unchanged — this only extends how long a cached token stays send-eligible. state, cohorts, and everything else on the subfeature/parent are untouched.

### Why?

The backend is rejecting a large share of variant-b SERP requests as "missing token." We can't yet distinguish "client had a cached token but dropped it as expired" from "client never had a token at all." Raising the client TTL makes the client send aged tokens instead of dropping them; the backend then rejects them as "expired" rather than "missing."

So we expect the backend's "expired" count to rise and "missing" count to fall — the size of that shift tells us how much of the missing-token problem is stale-cache vs no-cache.

No user-facing impact: the backend rejects both cases identically and the SERP falls back to its normal path either way.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only numeric tweak under an existing experiment; no auth or cohort changes, and invalid tokens are still rejected server-side with the same SERP fallback.
> 
> **Overview**
> Raises **client-side** search token lifetime in `iOSBrowserConfig.searchTokenExperiment` on iOS only: `tokenTTLSeconds` goes from 300 to **43200** (12h) and `refreshWindowSeconds` from 120 to **43020**, keeping the same **180s** gap between them so proactive refresh timing is unchanged.
> 
> The intent is diagnostic: iOS clients were dropping cached tokens as expired locally, so SERP requests showed up as **missing** token on the backend. With a much longer client TTL, aged tokens are still sent and rejected as **expired** server-side instead of being withheld—helping separate stale-cache from never-had-a-token cases. Experiment **state**, cohorts, and min version are untouched; backend still rejects invalid tokens and SERP falls back the same way.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f5d17f883fb81ce02183e41a54336e3bb8fa3c1c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->