### PR TITLE
Add addToDockAndWidgetExperimentJul25 experiment to the android config

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -5141,7 +5141,7 @@
             "features": {
                 "addToDockAndWidgetExperimentJul25": {
                     "state": "enabled",
-                    "minSupportedVersion": 52930000,
+                    "minSupportedVersion": 52920000,
                     "cohorts": [
                         {
                             "name": "control",

--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -5134,6 +5134,34 @@
                     }
                 }
             }
+        },
+        "onboardingPrompts": {
+            "state": "enabled",
+            "exceptions": [],
+            "features": {
+                "addToDockAndWidgetExperimentJul25": {
+                    "state": "enabled",
+                    "minSupportedVersion": 52930000,
+                    "cohorts": [
+                        {
+                            "name": "control",
+                            "weight": 1
+                        },
+                        {
+                            "name": "treatmentDockOnly",
+                            "weight": 1
+                        },
+                        {
+                            "name": "treatmentWidgetOnly",
+                            "weight": 1
+                        },
+                        {
+                            "name": "treatmentDockAndWidget",
+                            "weight": 1
+                        }
+                    ]
+                }
+            }
         }
     },
     "unprotectedTemporary": [],


### PR DESCRIPTION
**Asana Task/Github Issue:**https://app.asana.com/1/137249556945/project/1211724162604201/task/1216232144477362?focus=true

## Description
Adds the onboardingPrompts feature with the addToDockAndWidgetExperimentJul25 sub-feature to the Android override. 

Four evenly-weighted cohorts: control, treatmentDockOnly, treatmentWidgetOnly, treatmentDockAndWidget. Enabled from Android 5.292.0 (minSupportedVersion 52920000).

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [x] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only addition following existing onboarding experiment patterns; affects which onboarding UI Android shows, not security or data handling. Note the PR checklist still has schema validation unchecked.
> 
> **Overview**
> Adds a new **`onboardingPrompts`** feature to the Android override with sub-feature **`addToDockAndWidgetExperimentJul25`**, enabling an A/B experiment for add-to-dock and home-screen widget prompts during onboarding.
> 
> The experiment is **enabled** for app builds **≥ 5.292.0** (`minSupportedVersion` **52920000**), with **four equal-weight cohorts**: `control`, `treatmentDockOnly`, `treatmentWidgetOnly`, and `treatmentDockAndWidget`. There is **no rollout ladder** in this change—eligible clients get cohort assignment under the enabled flag.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 62518b8aaac5a68a7862d3b6177cb025d4578f34. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->