### PR TITLE
macOS: Enable onboardingChromeExtension experiment

### DIFF
--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -2624,6 +2624,20 @@
                 "appRebranding": {
                     "state": "internal",
                     "minSupportedVersion": "1.201.0"
+                },
+                "onboardingChromeExtension": {
+                    "state": "enabled",
+                    "minSupportedVersion": "1.202.0",
+                    "cohorts": [
+                        {
+                            "name": "control",
+                            "weight": 1
+                        },
+                        {
+                            "name": "treatment",
+                            "weight": 1
+                        }
+                    ]
                 }
             }
         },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1209825025475019/task/1216006558410864?focus=true

## Description

Enables the `onboardingChromeExtension` experiment in macOS 1.202.0.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only change gating a new onboarding experiment; no application logic in this repo.
> 
> **Overview**
> Adds macOS override config to turn on the **`onboardingChromeExtension`** experiment under **`macOSBrowserConfig`** for app versions **1.202.0+**.
> 
> The feature is **`enabled`** with equal-weight **`control`** and **`treatment`** cohorts, so eligible users are split for an A/B test of onboarding that promotes the Chrome extension.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8c1dd0e8fbefed17d241c1a6dbb57aa29eb0290a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->