### PR TITLE
Disable adwall detection on homedepot

### DIFF
--- a/features/web-detection.json
+++ b/features/web-detection.json
@@ -288,27 +288,10 @@
                 ]
             },
             {
-                "condition": [
-                    {
-                        "injectName": "android",
-                        "minSupportedVersion": 52720000,
-                        "domain": "homedepot.com"
-                    },
-                    {
-                        "injectName": "windows",
-                        "minSupportedVersion": "0.162.0",
-                        "domain": "homedepot.com"
-                    }
-                ],
-                "patchSettings": [
-                    { "op": "remove", "path": "/detectors/adwalls/generic_en/triggers/auto" },
-                    { "op": "remove", "path": "/detectors/adwalls/generic_de/triggers/auto" },
-                    { "op": "remove", "path": "/detectors/adwalls/generic_es/triggers/auto" },
-                    { "op": "remove", "path": "/detectors/adwalls/generic_it/triggers/auto" },
-                    { "op": "remove", "path": "/detectors/adwalls/generic_nl/triggers/auto" },
-                    { "op": "remove", "path": "/detectors/adwalls/generic_se/triggers/auto" },
-                    { "op": "remove", "path": "/detectors/adwalls/admiral/triggers/auto" }
-                ]
+                "condition": {
+                    "domain": "homedepot.com"
+                },
+                "patchSettings": [{ "op": "remove", "path": "/detectors/adwalls" }]
             }
         ]
     }

--- a/features/web-detection.json
+++ b/features/web-detection.json
@@ -291,7 +291,9 @@
                 "condition": {
                     "domain": "homedepot.com"
                 },
-                "patchSettings": [{ "op": "replace", "path": "/detectors/adwalls", "value": {} }]
+                "patchSettings": [
+                    { "op": "replace", "path": "/detectors/adwalls", "value": {} }
+                ]
             }
         ]
     }

--- a/features/web-detection.json
+++ b/features/web-detection.json
@@ -291,7 +291,7 @@
                 "condition": {
                     "domain": "homedepot.com"
                 },
-                "patchSettings": [{ "op": "remove", "path": "/detectors/adwalls" }]
+                "patchSettings": [{ "op": "replace", "path": "/detectors/adwalls", "value": {} }]
             }
         ]
     }

--- a/features/web-detection.json
+++ b/features/web-detection.json
@@ -286,6 +286,29 @@
                         "value": { "fireEvent": { "state": "enabled", "type": "admiralAdwall" } }
                     }
                 ]
+            },
+            {
+                "condition": [
+                    {
+                        "injectName": "android",
+                        "minSupportedVersion": 52720000,
+                        "domain": "homedepot.com"
+                    },
+                    {
+                        "injectName": "windows",
+                        "minSupportedVersion": "0.162.0",
+                        "domain": "homedepot.com"
+                    }
+                ],
+                "patchSettings": [
+                    { "op": "remove", "path": "/detectors/adwalls/generic_en/triggers/auto" },
+                    { "op": "remove", "path": "/detectors/adwalls/generic_de/triggers/auto" },
+                    { "op": "remove", "path": "/detectors/adwalls/generic_es/triggers/auto" },
+                    { "op": "remove", "path": "/detectors/adwalls/generic_it/triggers/auto" },
+                    { "op": "remove", "path": "/detectors/adwalls/generic_nl/triggers/auto" },
+                    { "op": "remove", "path": "/detectors/adwalls/generic_se/triggers/auto" },
+                    { "op": "remove", "path": "/detectors/adwalls/admiral/triggers/auto" }
+                ]
             }
         ]
     }


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1215563955516274/task/1216961635866799?focus=true

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-domain feature-flag style change in remote config; no auth or data paths affected.
> 
> **Overview**
> Adds a **domain-scoped exception** for `homedepot.com` in `web-detection` so adwall detection does not run on that site.
> 
> When the condition matches, a `conditionalChanges` entry **replaces** `/detectors/adwalls` with `{}`, clearing all adwall detectors (generic language matchers and Admiral) for Home Depot only. Other domains keep the existing adwall configuration and triggers/actions from the version-gated patches above.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1369c270d4040976eda282884e2f2f3d434f906e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->