### PR TITLE
Remove wetter.com autoconsent exception

### DIFF
--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -1575,10 +1575,6 @@
                 {
                     "domain": "vox.com",
                     "reason": "https://github.com/duckduckgo/privacy-configuration/pull/3510"
-                },
-                {
-                    "domain": "wetter.com",
-                    "reason": "https://github.com/duckduckgo/privacy-configuration/pull/3366"
                 }
             ]
         },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1203268166580279/task/1217080832840928?focus=true

## Description
Removes the autoconsent exception for wetter.com from the macOS override.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-47c2479b-0194-49f1-8824-cc3f3b7add1c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-47c2479b-0194-49f1-8824-cc3f3b7add1c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

