### PR TITLE
Enable unified menu button in 0.170

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -1465,7 +1465,8 @@
                     "minSupportedVersion": "0.168.0"
                 },
                 "chromeMenuButton": {
-                    "state": "internal"
+                    "state": "enabled",
+                    "minSupportedVersion": "0.170.0"
                 }
             },
             "minSupportedVersion": "0.100.0",


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1210407179200832/task/1216849573849491?focus=true

## Description
Enable unified menu button in 0.170

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single feature-flag rollout in remote config with a version gate; no application logic changes in this repo.
> 
> **Overview**
> The Windows override turns on the **`chromeMenuButton`** (unified menu button) feature for clients on **0.170.0** and above by setting `state` to `enabled` and adding `minSupportedVersion: "0.170.0"`, replacing the previous **`internal`**-only rollout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 21f8cd7ab397c8f0b71bdcb5cf8883e0cdad776f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->