### PR TITLE
[iOS] Rename search token experiment flag and revert TTL changes from #5706

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -3251,12 +3251,12 @@
                 "webScrollFreezeObservability": {
                     "state": "disabled"
                 },
-                "searchTokenExperiment": {
+                "searchTokenExperimentV2": {
                     "state": "enabled",
-                    "minSupportedVersion": "7.230.0",
+                    "minSupportedVersion": "7.232.0",
                     "settings": {
-                        "tokenTTLSeconds": 43200,
-                        "refreshWindowSeconds": 43020
+                        "tokenTTLSeconds": 300,
+                        "refreshWindowSeconds": 120
                     },
                     "description": "NA experiment: search token to speed up SERP by combining Index/Deep responses.",
                     "cohorts": [

--- a/schema/features/ios-browser-config.ts
+++ b/schema/features/ios-browser-config.ts
@@ -12,7 +12,7 @@ type SubFeatures<VersionType> = {
             idleThresholdSeconds: number;
         }
     >;
-    searchTokenExperiment?: SubFeature<
+    searchTokenExperimentV2?: SubFeature<
         VersionType,
         {
             // Lifetime of the search token in seconds


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1211767540372501/task/1217093200725391

## Description
This PR includes the following changes to the search token experiment config:
* Updates the experiment name to reset the experiment.
* Bumps the minimum app version.
* Resets the TTL values as the issue was confirmed to be unrelated.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only remote feature flag and experiment settings for iOS browser; no auth or data-path changes, though clients must read the new flag name to stay in the experiment.
> 
> **Overview**
> Resets the iOS **search token SERP experiment** by renaming the sub-feature from `searchTokenExperiment` to **`searchTokenExperimentV2`** in `ios-browser-config` and `overrides/ios-override.json`, so clients treat it as a fresh experiment cohort.
> 
> The override bumps **`minSupportedVersion`** from **7.230.0** to **7.232.0** and restores shorter token timing: **`tokenTTLSeconds`** **300** (was 43200) and **`refreshWindowSeconds`** **120** (was 43020), matching the revert described in the PR after unrelated issues with the longer TTL.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 76acefa5500a00ef28f0882697b301143851ea2c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->