### PR TITLE
Enable prompt bar on macOS 1.203.0

### DIFF
--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -428,6 +428,10 @@
                 "omnibarWebSearch": {
                     "state": "enabled",
                     "minSupportedVersion": "1.188.0"
+                },
+                "promptBar": {
+                    "state": "enabled",
+                    "minSupportedVersion": "1.203.0"
                 }
             },
             "settings": {


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/72649045549333/task/1217149067901421?focus=true

## Description
Adds the aiChat/promptBar subfeature to the macOS override, enabled from 1.203.0.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single remote-config flag addition gated by app version; no auth, data, or rollout logic changes.
> 
> **Overview**
> Turns on the **prompt bar** for DuckDuckGo macOS by adding the `promptBar` subfeature under `aiChat` in `macos-override.json`, with `state: enabled` and `minSupportedVersion: 1.203.0`.
> 
> macOS clients at **1.203.0+** will receive remote config that exposes prompt-bar behavior alongside existing aiChat subfeatures (e.g. omnibar tools, NTP chat tools).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fbc8b747f9dbfe0527ec3f2e83e9d454cce9605b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->