### PR TITLE
Update content-blocker extension to 2026.8.5

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -5006,7 +5006,7 @@
             "minSupportedVersion": "0.148.0",
             "exceptions": [],
             "settings": {
-                "extensionUrl": "https://staticcdn.duckduckgo.com/extensions/content-blocker/content-blocker-extension-2026.7.29.crx"
+                "extensionUrl": "https://staticcdn.duckduckgo.com/extensions/content-blocker/content-blocker-extension-2026.8.5.crx"
             },
             "features": {
                 "onboardingEnabled": {


### PR DESCRIPTION
Update content-blocker extension to 2026.8.5.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single CDN URL bump in remote config; no app logic changes, though users will receive a new extension build on update.
> 
> **Overview**
> Updates the Windows feature override for **`adBlockV2Extension`** so clients download the newer content-blocker CRX (**`2026.8.5`** instead of **`2026.7.29`**). Only **`extensionUrl`** in `overrides/windows-override.json` changes; rollout flags and **`minSupportedVersion`** stay the same.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c9c4b3a97411f6a8c084d9dba1088bfa7de158f7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->