### PR TITLE
Update ad-blocking extension scriptlets for v2026.8.5

### DIFF
--- a/features/ad-blocking-extension.json
+++ b/features/ad-blocking-extension.json
@@ -4,28 +4,28 @@
     },
     "exceptions": [],
     "settings": {
-        "version": "2026.7.29",
+        "version": "2026.8.5",
         "enabledByDefault": false,
         "scriptlets": {
             "scriptlets/isolated/ublock-filters.js": {
-                "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/ce0dd8a0e723d431647217d29073c357fb03d497187b019ba9eb422c7b2f99e1.js",
-                "signature": "MEUCIQC0noPlfy4PmqGwcweIHo+Tr527qgjCt2itjQGtNvs7OAIgMk6ljpEJu6ZIykaGhJOfj43Z/IaWqv0we/a+w60Y0yk="
+                "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/bdd3e75623825bafd976f497c4bd70a9189daa6f511de6b44d3fd783a487d600.js",
+                "signature": "MEUCIQDMGyLIx8hsLaRgTvti00Zoi3c44ddDpIHMfv657BBlXQIgSZ+NiAD02ljDNk2YR0CQy1oq2d90twmRfaNCMeX+fFY="
             },
             "scriptlets/main/ublock-filters.js": {
-                "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/5fb67b125f34e64c82ab721a0e1a86087db06eeb1c1e144ea47c4ce78859081f.js",
-                "signature": "MEUCIQCYraoWwdHXTwputrw/XZIab91wgaUofEfa3Y1TJDLhmgIgM49JQFW0YtEnbqUy1SIBHG8gR6VepN/onDxYecRS1hI="
+                "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/dc71af3824020d822518c4aba1144a916494902a46e79ede2bb781afc699c68b.js",
+                "signature": "MEUCIQDB4YQhs03h9Ypj/rveBy0KfqS7RuH9wNEbLjY2KgW/zQIgZoNySJvJzGUjoY3wMeFFKEFE1CKoptU1f3BnMG4vw9o="
             },
             "scriptlets/main/ublock-experimental.js": {
                 "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855.js",
-                "signature": "MEUCIQDxiiUcKAyMy3VrJOQt83d1ZSPDLBoacljQhH+Zs6K4IQIgAxjzemFxl/iYQp52TnVrtJU6xjYvEbNZmFY9uH2sLu8="
+                "signature": "MEYCIQCGl6JVL0rvo1otKr6QgBrvCsjzUatnzkfTIEWWpCMp9wIhAOnqOaTdX+9dEGKZZf5jYX6lwhxYZDM6DfcDiuC0sCja"
             },
             "scriptlets/isolated/ublock-experimental.js": {
                 "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855.js",
-                "signature": "MEQCIH2D3Bm4dtvVEBttWz2Uxk49dLNsAuOdEdoFuQsiAE8GAiBqfYqSqe0Apxg1sJlj0Z47Xb+QezckbfXanFyFPhxM3g=="
+                "signature": "MEYCIQCSOln+we7EZDZOn9FzKMRU4IuY/JUsxRUQM2ltUMyZJAIhAOqrzvLPdsohzzeMtHkBmzHkSU01Tm8NIXr6I4ds81yo"
             },
             "rules/youtube.json": {
                 "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/2337db6aa7466667595226f780b6590779db3007ac0a65ef3833f89610c92824.json",
-                "signature": "MEQCIGGOWi9FpSazcAHzdsG0wCfUFOY56Hg09OIYVLVng754AiAc3fYhJtpwYCVGK1Sv3MfKgrdkG+H5rhHAqPsHoOThdw=="
+                "signature": "MEUCIQD3DZvt2gZJL9Cqq8BXbzp1x8PVtRsYJcxi8Ft9O378FgIgMy7l4cr4vd/bdWnTwHnchBU/ZZIlM6ndb2OH3LlRHgw="
             }
         }
     }


### PR DESCRIPTION
Update ad-blocking extension scriptlets for v2026.8.5.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Clients will fetch new scriptlet payloads from CDN; incorrect URLs or signatures would break ad-blocking or fail verification, though this is a routine signed content rollout pattern.
> 
> **Overview**
> Bumps the ad-blocking extension feature config from **2026.7.29** to **2026.8.5** in `features/ad-blocking-extension.json`.
> 
> **Isolated and main uBlock filter scriptlets** get new static CDN asset URLs (content hashes changed) and updated ECDSA signatures. **Experimental scriptlet** entries keep the same empty-hash URL but signatures are refreshed. **YouTube rules** JSON URL is unchanged; only its signature is updated.
> 
> `enabledByDefault` and exceptions remain the same.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f11f1810e818a64088d59977ae938112f15feb02. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->