### PR TITLE
iOS: Update config for inactivityNotification

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -3092,8 +3092,8 @@
                     "state": "disabled"
                 },
                 "inactivityNotification": {
-                    "state": "disabled",
-                    "minSupportedVersion": "7.233.0",
+                    "state": "enabled",
+                    "minSupportedVersion": "7.234.0",
                     "description": "Local inactivity provisional notifications delivered to Notification Center.",
                     "settings": {
                         "daysInactive": 7,

--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -3093,13 +3093,11 @@
                 },
                 "inactivityNotification": {
                     "state": "disabled",
-                    "minSupportedVersion": "7.187.0",
+                    "minSupportedVersion": "7.233.0",
                     "description": "Local inactivity provisional notifications delivered to Notification Center.",
-                    "targets": [
-                        { "localeLanguage": "en", "localeCountry": "US" }
-                    ],
                     "settings": {
-                        "daysInactive": "7"
+                        "daysInactive": 7,
+                        "maxInteractions": 4
                     }
                 },
                 "customization": {

--- a/schema/features/ios-browser-config.ts
+++ b/schema/features/ios-browser-config.ts
@@ -21,6 +21,15 @@ type SubFeatures<VersionType> = {
             refreshWindowSeconds: number;
         }
     >;
+    inactivityNotification?: SubFeature<
+        VersionType,
+        {
+            // Number of days of inactivity before a notification is delivered
+            daysInactive: number;
+            // Maximum number of notification interactions before delivery stops
+            maxInteractions: number;
+        }
+    >;
 };
 
 export type IOSBrowserConfig<VersionType> = Feature<


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/task/1217155088944611

## Description

Updates the config for inactivityNotification to coordinate with app changes that can be tested in https://github.com/duckduckgo/apple-browsers/pull/6208.

Feature is also enabled in iOS version with related changes (ship review completed).

### Feature change process:

- [x] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [x] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Schema and override JSON only; no runtime logic here. Risk is mainly if `state: enabled` ships before the matching app release, which could expose incomplete notification behavior on supported builds.
> 
> **Overview**
> Aligns iOS remote config and TypeScript schema for **inactivityNotification** with upcoming app behavior (companion `apple-browsers` PR).
> 
> Under `iOSBrowserConfig`, the subfeature is set to **enabled** with `minSupportedVersion` **7.234.0** (was disabled at 7.187.0). Locale **en-US targets** are removed so eligibility is no longer restricted in config. Settings now use numeric `daysInactive: 7` (was string `"7"`) and add **`maxInteractions: 4`** to cap how many times users can engage before notifications stop.
> 
> `schema/features/ios-browser-config.ts` adds an **`inactivityNotification`** `SubFeature` definition validating those two numeric settings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 80646d59e9b1904954c9acd5b8dfe93021ca48db. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->