### PR TITLE
Add xpath chunking config

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,8 @@
         "prettier": "3.8.4",
         "prettier-plugin-multiline-arrays": "^4.1.7",
         "ts-json-schema-generator": "^2.9.0",
-        "typescript": "^6.0.3"
+        "typescript": "^6.0.3",
+        "xpath": "^0.0.34"
       }
     },
     "node_modules/@augment-vir/assert": {
@@ -4045,6 +4046,16 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/xpath": {
+      "version": "0.0.34",
+      "resolved": "https://registry.npmjs.org/xpath/-/xpath-0.0.34.tgz",
+      "integrity": "sha512-FxF6+rkr1rNSQrhUNYrAFJpRXNzlDoMxeXN5qI84939ylEv3qqPFKa85Oxr6tDaJKqwW6KKyo2v26TSv3k6LeA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.0"
+      }
+    },
     "node_modules/y18n": {
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
@@ -6732,6 +6743,12 @@
           }
         }
       }
+    },
+    "xpath": {
+      "version": "0.0.34",
+      "resolved": "https://registry.npmjs.org/xpath/-/xpath-0.0.34.tgz",
+      "integrity": "sha512-FxF6+rkr1rNSQrhUNYrAFJpRXNzlDoMxeXN5qI84939ylEv3qqPFKa85Oxr6tDaJKqwW6KKyo2v26TSv3k6LeA==",
+      "dev": true
     },
     "y18n": {
       "version": "5.0.8",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "prettier": "3.8.4",
     "prettier-plugin-multiline-arrays": "^4.1.7",
     "ts-json-schema-generator": "^2.9.0",
-    "typescript": "^6.0.3"
+    "typescript": "^6.0.3",
+    "xpath": "^0.0.34"
   },
   "dependencies": {
     "eslint-plugin-json": "^4.0.1",

--- a/schema/features/web-detection.ts
+++ b/schema/features/web-detection.ts
@@ -35,11 +35,34 @@ type ConditionOperator = 'any' | 'all' | 'none';
 
 type ConditionNode<Final> = Final | { [K in ConditionOperator]?: ConditionBranch<Final> };
 
+/**
+ * Tuning for `xpath` text matching, which scans selected text in chunks rather than
+ * concatenating it in full so that a large page is not held in memory at once.
+ *
+ * Both values are counted in characters. Omit them unless a detector needs tuning.
+ *
+ * Has no effect on `selector`, which always reads text in one go.
+ */
+type XPathConfig = {
+    /**
+     * Characters matched at a time. 0 turns chunking off, matching the whole
+     * selected text in one go.
+     */
+    chunkSize?: number;
+    /**
+     * Characters carried over between chunks, which sets the longest match that can
+     * span a chunk boundary and still be found. Raise this if a detector's phrases
+     * are long enough to be split.
+     */
+    chunkTail?: number;
+};
+
 export type ConditionTypes = {
     text: {
         pattern: MaybeArray<string>;
         selector?: MaybeArray<string>;
         xpath?: MaybeArray<string>;
+        xpathConfig?: XPathConfig;
     };
     element: {
         selector: MaybeArray<string>;

--- a/tests/web-detection-tests.js
+++ b/tests/web-detection-tests.js
@@ -1,5 +1,6 @@
 import { expect } from 'chai';
 import fs from 'fs';
+import xpath from 'xpath';
 import platforms from '../platforms.js';
 
 const OPERATOR_KEYS = [

--- a/tests/web-detection-tests.js
+++ b/tests/web-detection-tests.js
@@ -55,6 +55,133 @@ function assertConditionNode(node, path) {
     }
 }
 
+/** Floor for a non-zero chunkSize. Smaller chunks multiply regex tests for little gain. */
+const MIN_CHUNK_SIZE = 1024;
+
+/**
+ * Upper bound on chunkTail as a fraction of chunkSize. A tail is re-scanned by the
+ * following test, so this caps the scanning overhead a config can impose at 1.25x.
+ */
+const MAX_TAIL_RATIO = 4;
+
+/**
+ * Assert an `xpathConfig` block holds sensible values.
+ *
+ * Clients use these values as configured, so this is the only place they are
+ * checked - a bad value fails the build here naming the detector.
+ *
+ * The chunkSize/chunkTail ratio is only checked when both are present in the same
+ * block. Judging a lone chunkTail would mean hardcoding the client's default
+ * chunkSize here, which would silently go stale if that default ever changed.
+ *
+ * @param {Record<string, unknown>} xpathConfig
+ * @param {string} path - used in error messages
+ */
+function assertXPathConfig(xpathConfig, path) {
+    const { chunkSize, chunkTail } = xpathConfig;
+
+    for (const [
+        key,
+        value,
+    ] of Object.entries({ chunkSize, chunkTail })) {
+        if (value === undefined) continue;
+        expect(
+            Number.isInteger(value) && Number(value) >= 0,
+            `${path}/${key}: expected a non-negative integer, got ${JSON.stringify(value)}`,
+        ).to.equal(true);
+    }
+
+    if (chunkSize !== undefined) {
+        expect(
+            chunkSize === 0 || Number(chunkSize) >= MIN_CHUNK_SIZE,
+            `${path}/chunkSize: expected 0 (chunking disabled) or at least ${MIN_CHUNK_SIZE}, got ${chunkSize}`,
+        ).to.equal(true);
+    }
+
+    // A chunkSize of 0 disables chunking, leaving the tail unused
+    if (chunkTail === undefined || chunkSize === undefined || chunkSize === 0) return;
+    const maxTail = Number(chunkSize) / MAX_TAIL_RATIO;
+    expect(
+        Number(chunkTail) <= maxTail,
+        `${path}/chunkTail: expected at most chunkSize / ${MAX_TAIL_RATIO} (${maxTail}), got ${chunkTail}`,
+    ).to.equal(true);
+}
+
+/**
+ * Invoke `cb` for every leaf of a `text` condition branch, descending through
+ * operator blocks and arrays.
+ *
+ * @param {unknown} node
+ * @param {string} path
+ * @param {(condition: Record<string, any>, path: string) => void} cb
+ */
+function forEachTextLeaf(node, path, cb) {
+    if (Array.isArray(node)) {
+        node.forEach((n, i) => forEachTextLeaf(n, `${path}[${i}]`, cb));
+        return;
+    }
+    if (node === null || typeof node !== 'object') return;
+
+    const opKeys = OPERATOR_KEYS.filter((k) => k in node);
+    if (opKeys.length > 0) {
+        for (const op of opKeys) {
+            forEachTextLeaf(node[op], `${path}.${op}`, cb);
+        }
+        return;
+    }
+    cb(node, path);
+}
+
+/**
+ * Invoke `cb` for every `text` leaf condition reachable from a match tree.
+ *
+ * @param {unknown} node
+ * @param {string} path
+ * @param {(condition: Record<string, any>, path: string) => void} cb
+ */
+function forEachTextCondition(node, path, cb) {
+    if (Array.isArray(node)) {
+        node.forEach((n, i) => forEachTextCondition(n, `${path}[${i}]`, cb));
+        return;
+    }
+    if (node === null || typeof node !== 'object') return;
+
+    for (const op of OPERATOR_KEYS) {
+        if (op in node) forEachTextCondition(node[op], `${path}.${op}`, cb);
+    }
+    if ('text' in node) forEachTextLeaf(node.text, `${path}.text`, cb);
+}
+
+/** Patch paths that land on an `xpathConfig` block or one of its values. */
+const XPATH_CONFIG_PATCH_PATH = /\/xpathConfig(?:\/(chunkSize|chunkTail))?$/;
+
+/**
+ * Validate a patch operation targeting `xpathConfig`.
+ *
+ * Patches are applied client-side, so a value set only by a patch never appears as a
+ * literal in the generated config and would otherwise go unchecked.
+ *
+ * @param {Record<string, any>} operation
+ * @param {string} path
+ */
+function assertXPathConfigPatch(operation, path) {
+    const match = XPATH_CONFIG_PATCH_PATH.exec(operation.path ?? '');
+    if (!match || operation.op === 'remove') return;
+
+    const key = match[1];
+    if (key === undefined) {
+        expect(
+            operation.value !== null && typeof operation.value === 'object' && !Array.isArray(operation.value),
+            `${path}: patch of ${operation.path} expected an object value, got ${JSON.stringify(operation.value)}`,
+        ).to.equal(true);
+        assertXPathConfig(operation.value, `${path} ${operation.path}`);
+        return;
+    }
+
+    // Only one value is being set, so it is checked in isolation
+    assertXPathConfig({ [key]: operation.value }, `${path} ${operation.path}`);
+}
+
 const platformOutput = platforms.map((item) => item.replace('browsers/', 'extension-'));
 
 const latestConfigs = platformOutput.map((plat) => {
@@ -162,6 +289,170 @@ describe('webDetection config tests', () => {
                     }
                 });
             });
+        });
+    });
+
+    describe('xpathConfig validation', () => {
+        forEachWebDetectionConfig(({ configName, webDetection, detectors }) => {
+            describe(configName, () => {
+                for (const [
+                    groupName,
+                    group,
+                ] of Object.entries(detectors)) {
+                    for (const [
+                        detectorId,
+                        detector,
+                    ] of Object.entries(group)) {
+                        it(`${groupName}.${detectorId} xpathConfig values are within sensible bounds`, () => {
+                            forEachTextCondition(detector.match, `detectors.${groupName}.${detectorId}.match`, (condition, path) => {
+                                if (condition.xpathConfig !== undefined) {
+                                    assertXPathConfig(condition.xpathConfig, `${path}/xpathConfig`);
+                                }
+                            });
+                        });
+                    }
+                }
+
+                it('xpathConfig patch operations are within sensible bounds', () => {
+                    const settings = /** @type {Record<string, any>} */ (webDetection.settings);
+                    for (const [
+                        index,
+                        entry,
+                    ] of (settings.domains ?? []).entries()) {
+                        for (const operation of entry.patchSettings ?? []) {
+                            assertXPathConfigPatch(operation, `domains[${index}] (${entry.domain})`);
+                        }
+                    }
+                    for (const [
+                        index,
+                        entry,
+                    ] of (settings.conditionalChanges ?? []).entries()) {
+                        for (const operation of entry.patchSettings ?? []) {
+                            assertXPathConfigPatch(operation, `conditionalChanges[${index}]`);
+                        }
+                    }
+                });
+            });
+        });
+    });
+
+    describe('forEachTextCondition (self-test)', () => {
+        /**
+         * @param {unknown} match
+         * @returns {string[]}
+         */
+        function collect(match) {
+            /** @type {string[]} */
+            const found = [];
+            forEachTextCondition(match, '$', (condition) => found.push(String(condition.pattern)));
+            return found;
+        }
+
+        it('reaches a plain text leaf', () => {
+            expect(collect({ text: { pattern: 'a' } })).to.deep.equal([
+                'a',
+            ]);
+        });
+
+        it('reaches leaves through operator blocks at both levels', () => {
+            const match = {
+                all: [
+                    {
+                        text: {
+                            any: [
+                                { pattern: 'a' },
+                                { pattern: 'b' },
+                            ],
+                        },
+                    },
+                    {
+                        text: {
+                            none: [
+                                { pattern: 'c' },
+                            ],
+                        },
+                    },
+                ],
+            };
+            expect(collect(match)).to.deep.equal([
+                'a',
+                'b',
+                'c',
+            ]);
+        });
+
+        it('reaches leaves through arrays', () => {
+            const match = [
+                {
+                    text: [
+                        { pattern: 'a' },
+                        { pattern: 'b' },
+                    ],
+                },
+                { element: { selector: '.x' } },
+            ];
+            expect(collect(match)).to.deep.equal([
+                'a',
+                'b',
+            ]);
+        });
+
+        it('ignores element conditions', () => {
+            expect(collect({ element: { selector: '.x' } })).to.deep.equal([]);
+        });
+
+        it('finds the text conditions in the real configs (sanity)', () => {
+            /** @type {string[]} */
+            const found = [];
+            forEachWebDetectionConfig(({ detectors }) => {
+                for (const group of Object.values(detectors)) {
+                    for (const detector of Object.values(group)) {
+                        forEachTextCondition(detector.match, '$', (condition) => found.push(String(condition.pattern)));
+                    }
+                }
+            });
+            expect(found.length).to.be.greaterThan(0);
+        });
+    });
+
+    describe('xpathConfig validation (self-test)', () => {
+        /**
+         * @param {Record<string, unknown>} xpathConfig
+         */
+        const check = (xpathConfig) => () => assertXPathConfig(xpathConfig, '$');
+
+        it('accepts an in-bounds config', () => {
+            expect(check({ chunkSize: 8192, chunkTail: 512 })).to.not.throw();
+        });
+
+        it('accepts chunkSize 0, which disables chunking', () => {
+            expect(check({ chunkSize: 0 })).to.not.throw();
+            // The tail is unused once chunking is off, so the ratio does not apply
+            expect(check({ chunkSize: 0, chunkTail: 99999 })).to.not.throw();
+        });
+
+        it('accepts chunkTail 0', () => {
+            expect(check({ chunkSize: 8192, chunkTail: 0 })).to.not.throw();
+        });
+
+        it('rejects non-integer and negative values', () => {
+            expect(check({ chunkSize: 8192.5 })).to.throw();
+            expect(check({ chunkSize: -1 })).to.throw();
+            expect(check({ chunkTail: '512' })).to.throw();
+        });
+
+        it('rejects a non-zero chunkSize below the floor', () => {
+            expect(check({ chunkSize: 32 })).to.throw();
+        });
+
+        it('rejects a chunkTail above a quarter of chunkSize', () => {
+            expect(check({ chunkSize: 8192, chunkTail: 2049 })).to.throw();
+            expect(check({ chunkSize: 8192, chunkTail: 2048 })).to.not.throw();
+        });
+
+        it('checks a lone chunkTail in isolation, since the ratio needs a chunkSize', () => {
+            expect(check({ chunkTail: 99999 })).to.not.throw();
+            expect(check({ chunkTail: -1 })).to.throw();
         });
     });
 

--- a/tests/web-detection-tests.js
+++ b/tests/web-detection-tests.js
@@ -108,6 +108,85 @@ function assertXPathConfig(xpathConfig, path) {
 }
 
 /**
+ * Assert an XPath expression parses under the XPath 1.0 grammar.
+ *
+ * Only the grammar is checked. An expression that parses may still select nothing on
+ * a real page, and browser engines may disagree at the edges of the spec.
+ *
+ * @param {unknown} expression
+ * @param {string} path - used in error messages
+ */
+function assertValidXPath(expression, path) {
+    expect(typeof expression, `${path}: expected a string, got ${JSON.stringify(expression)}`).to.equal('string');
+    try {
+        xpath.parse(/** @type {string} */ (expression));
+    } catch (error) {
+        expect.fail(`${path}: ${JSON.stringify(expression)} is not a valid XPath expression - ${error.message}`);
+    }
+}
+
+/**
+ * Compile a pattern source, throwing on a syntax error.
+ *
+ * @param {string} source
+ * @returns {RegExp}
+ */
+function compilePattern(source) {
+    return new RegExp(source, 'i');
+}
+
+/**
+ * Assert every entry of a `pattern` value is a regular expression in its own right.
+ *
+ * Syntax is all that is checked, and only against this Node version.
+ *
+ * @param {unknown} pattern - a single pattern or an array of them
+ * @param {string} path - used in error messages
+ */
+function assertValidPattern(pattern, path) {
+    const patterns = Array.isArray(pattern)
+        ? pattern
+        : [
+              pattern,
+          ];
+    for (const [
+        index,
+        entry,
+    ] of patterns.entries()) {
+        expect(typeof entry, `${path}[${index}]: expected a string, got ${JSON.stringify(entry)}`).to.equal('string');
+        try {
+            compilePattern(entry);
+        } catch (error) {
+            expect.fail(`${path}[${index}]: ${JSON.stringify(entry)} is not a valid regular expression - ${error.message}`);
+        }
+    }
+}
+
+/**
+ * Assert the expressions of a single `text` leaf condition.
+ *
+ * @param {Record<string, any>} condition
+ * @param {string} path - used in error messages
+ */
+function assertTextConditionExpressions(condition, path) {
+    if (condition.pattern !== undefined) {
+        assertValidPattern(condition.pattern, `${path}/pattern`);
+    }
+    const expressions = Array.isArray(condition.xpath)
+        ? condition.xpath
+        : [
+              condition.xpath,
+          ];
+    for (const [
+        index,
+        expression,
+    ] of expressions.entries()) {
+        if (expression === undefined) continue;
+        assertValidXPath(expression, `${path}/xpath[${index}]`);
+    }
+}
+
+/**
  * Invoke `cb` for every leaf of a `text` condition branch, descending through
  * operator blocks and arrays.
  *
@@ -182,6 +261,44 @@ function assertXPathConfigPatch(operation, path) {
     assertXPathConfig({ [key]: operation.value }, `${path} ${operation.path}`);
 }
 
+/** Patch paths that land on an `xpath` value, or on one entry of an `xpath` array. */
+const XPATH_PATCH_PATH = /\/xpath(?:\/\d+)?$/;
+
+/** Patch paths that land on a `pattern` value, or on one entry of a `pattern` array. */
+const PATTERN_PATCH_PATH = /\/pattern(?:\/\d+)?$/;
+
+/**
+ * Validate a patch operation targeting an `xpath` or `pattern` value.
+ *
+ * Patches are applied client-side, so a value set only by a patch never appears as a
+ * literal in the generated config and would otherwise go unchecked.
+ *
+ * @param {Record<string, any>} operation
+ * @param {string} path - used in error messages
+ */
+function assertExpressionPatch(operation, path) {
+    const operationPath = operation.path ?? '';
+    if (operation.op === 'remove') return;
+
+    if (XPATH_PATCH_PATH.test(operationPath)) {
+        const values = Array.isArray(operation.value)
+            ? operation.value
+            : [
+                  operation.value,
+              ];
+        for (const [
+            index,
+            expression,
+        ] of values.entries()) {
+            assertValidXPath(expression, `${path} ${operationPath}[${index}]`);
+        }
+    }
+
+    if (PATTERN_PATCH_PATH.test(operationPath)) {
+        assertValidPattern(operation.value, `${path} ${operationPath}`);
+    }
+}
+
 const platformOutput = platforms.map((item) => item.replace('browsers/', 'extension-'));
 
 const latestConfigs = platformOutput.map((plat) => {
@@ -190,6 +307,33 @@ const latestConfigs = platformOutput.map((plat) => {
         body: JSON.parse(fs.readFileSync(`./generated/v5/${plat}-config.json`)),
     };
 });
+
+/**
+ * Invoke `cb` for every patch operation the feature can apply, from either the
+ * per-domain or the conditional lists.
+ *
+ * @param {import('../schema/features/web-detection').WebDetectionFeature<number>} webDetection
+ * @param {(operation: Record<string, any>, path: string) => void} cb
+ */
+function forEachPatchOperation(webDetection, cb) {
+    const settings = /** @type {Record<string, any>} */ (webDetection.settings);
+    for (const [
+        index,
+        entry,
+    ] of (settings.domains ?? []).entries()) {
+        for (const operation of entry.patchSettings ?? []) {
+            cb(operation, `domains[${index}] (${entry.domain})`);
+        }
+    }
+    for (const [
+        index,
+        entry,
+    ] of (settings.conditionalChanges ?? []).entries()) {
+        for (const operation of entry.patchSettings ?? []) {
+            cb(operation, `conditionalChanges[${index}]`);
+        }
+    }
+}
 
 /**
  * Iterate every generated config that has a webDetection feature with detectors.
@@ -314,23 +458,35 @@ describe('webDetection config tests', () => {
                 }
 
                 it('xpathConfig patch operations are within sensible bounds', () => {
-                    const settings = /** @type {Record<string, any>} */ (webDetection.settings);
+                    forEachPatchOperation(webDetection, assertXPathConfigPatch);
+                });
+            });
+        });
+    });
+
+    describe('expression validation', () => {
+        forEachWebDetectionConfig(({ configName, webDetection, detectors }) => {
+            describe(configName, () => {
+                for (const [
+                    groupName,
+                    group,
+                ] of Object.entries(detectors)) {
                     for (const [
-                        index,
-                        entry,
-                    ] of (settings.domains ?? []).entries()) {
-                        for (const operation of entry.patchSettings ?? []) {
-                            assertXPathConfigPatch(operation, `domains[${index}] (${entry.domain})`);
-                        }
+                        detectorId,
+                        detector,
+                    ] of Object.entries(group)) {
+                        it(`${groupName}.${detectorId} xpath and pattern values are well formed`, () => {
+                            forEachTextCondition(
+                                detector.match,
+                                `detectors.${groupName}.${detectorId}.match`,
+                                assertTextConditionExpressions,
+                            );
+                        });
                     }
-                    for (const [
-                        index,
-                        entry,
-                    ] of (settings.conditionalChanges ?? []).entries()) {
-                        for (const operation of entry.patchSettings ?? []) {
-                            assertXPathConfigPatch(operation, `conditionalChanges[${index}]`);
-                        }
-                    }
+                }
+
+                it('xpath and pattern patch operations are well formed', () => {
+                    forEachPatchOperation(webDetection, assertExpressionPatch);
                 });
             });
         });
@@ -453,6 +609,127 @@ describe('webDetection config tests', () => {
         it('checks a lone chunkTail in isolation, since the ratio needs a chunkSize', () => {
             expect(check({ chunkTail: 99999 })).to.not.throw();
             expect(check({ chunkTail: -1 })).to.throw();
+        });
+    });
+
+    describe('expression validation (self-test)', () => {
+        /** @param {unknown} expression */
+        const checkXPath = (expression) => () => assertValidXPath(expression, '$');
+
+        /** @param {unknown} pattern */
+        const checkPattern = (pattern) => () => assertValidPattern(pattern, '$');
+
+        it('accepts XPath expressions of the shape detectors use', () => {
+            expect(checkXPath('//div//text()')).to.not.throw();
+            expect(checkXPath('//*[@class="banner"]//text()')).to.not.throw();
+            expect(checkXPath('//div[contains(@id, "consent")]')).to.not.throw();
+        });
+
+        it('rejects malformed XPath expressions', () => {
+            expect(checkXPath('//div[')).to.throw();
+            expect(checkXPath('//div[@class="a"')).to.throw();
+            expect(checkXPath('')).to.throw();
+        });
+
+        it('rejects a non-string XPath expression', () => {
+            expect(checkXPath(42)).to.throw();
+            expect(checkXPath(null)).to.throw();
+        });
+
+        it('accepts a single pattern and an array of them', () => {
+            expect(checkPattern('foo')).to.not.throw();
+            expect(
+                checkPattern([
+                    'foo',
+                    'bar(baz)?',
+                ]),
+            ).to.not.throw();
+        });
+
+        it('rejects a malformed pattern', () => {
+            expect(checkPattern('foo(')).to.throw();
+            expect(checkPattern('[a-')).to.throw();
+        });
+
+        it('rejects entries that are only valid as a pair', () => {
+            expect(
+                checkPattern([
+                    'a(',
+                    'b)',
+                ]),
+            ).to.throw();
+        });
+
+        it('rejects a non-string pattern entry', () => {
+            expect(
+                checkPattern([
+                    'foo',
+                    7,
+                ]),
+            ).to.throw();
+        });
+
+        it('checks both keys of a text leaf', () => {
+            expect(() => assertTextConditionExpressions({ pattern: 'foo', xpath: '//div//text()' }, '$')).to.not.throw();
+            expect(() => assertTextConditionExpressions({ pattern: 'foo(', xpath: '//div//text()' }, '$')).to.throw();
+            expect(() => assertTextConditionExpressions({ pattern: 'foo', xpath: '//div[' }, '$')).to.throw();
+            expect(() => assertTextConditionExpressions({ pattern: 'foo' }, '$')).to.not.throw();
+        });
+
+        it('checks every entry of an xpath array', () => {
+            expect(() =>
+                assertTextConditionExpressions(
+                    {
+                        pattern: 'foo',
+                        xpath: [
+                            '//div//text()',
+                            '//span[',
+                        ],
+                    },
+                    '$',
+                ),
+            ).to.throw();
+        });
+    });
+
+    describe('expression patch validation (self-test)', () => {
+        /** @param {Record<string, any>} operation */
+        const check = (operation) => () => assertExpressionPatch(operation, '$');
+
+        it('checks a patched xpath value', () => {
+            expect(check({ op: 'replace', path: '/detectors/g/d/match/text/xpath', value: '//div//text()' })).to.not.throw();
+            expect(check({ op: 'replace', path: '/detectors/g/d/match/text/xpath', value: '//div[' })).to.throw();
+        });
+
+        it('checks every entry of a patched xpath array', () => {
+            expect(
+                check({
+                    op: 'replace',
+                    path: '/detectors/g/d/match/text/xpath',
+                    value: [
+                        '//div//text()',
+                        '//span[',
+                    ],
+                }),
+            ).to.throw();
+        });
+
+        it('checks a patched single xpath array entry', () => {
+            expect(check({ op: 'replace', path: '/detectors/g/d/match/text/xpath/1', value: '//div[' })).to.throw();
+        });
+
+        it('checks a patched pattern value', () => {
+            expect(check({ op: 'add', path: '/detectors/g/d/match/text/pattern', value: 'foo' })).to.not.throw();
+            expect(check({ op: 'add', path: '/detectors/g/d/match/text/pattern', value: 'foo(' })).to.throw();
+        });
+
+        it('ignores removals and unrelated paths', () => {
+            expect(check({ op: 'remove', path: '/detectors/g/d/match/text/xpath' })).to.not.throw();
+            expect(check({ op: 'replace', path: '/detectors/g/d/state', value: 'disabled' })).to.not.throw();
+        });
+
+        it('does not mistake xpathConfig for an xpath value', () => {
+            expect(check({ op: 'replace', path: '/detectors/g/d/match/text/xpathConfig', value: { chunkSize: 8192 } })).to.not.throw();
         });
     });
 


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/72649045549333/task/1217111223619806?focus=true

## Description
<!-- 
  Please delete either or both process sections below.
-->

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Schema and test-only validation for new optional config fields; no changes to generated detector behavior unless configs later adopt xpathConfig.
> 
> **Overview**
> Adds optional **`xpathConfig`** on web-detection **text** match conditions so clients can tune XPath text scanning via **`chunkSize`** (disable with `0` or set a minimum chunk) and **`chunkTail`** (overlap across chunks for long phrases). **`selector`**-based text matching is unchanged.
> 
> The TypeScript schema documents **`XPathConfig`** and wires it into **`ConditionTypes.text`**. Dev dependency **`xpath`** is added so tests can parse XPath 1.0 expressions.
> 
> **`web-detection-tests.js`** now walks all generated configs (and domain/conditional **patch** operations) to enforce sensible **`xpathConfig`** bounds, valid **`xpath`** and **`pattern`** syntax, including values introduced only through patches.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 390484ba4572d963f06029c0f894e2b29e1bd2a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->