### PR TITLE
Windows: add secureStorageDapper flags, preview-only subfeatures

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -6146,6 +6146,28 @@
         "architectureX86Deprecation": {
             "state": "internal",
             "exceptions": []
+        },
+        "secureStorageDapper": {
+            "state": "enabled",
+            "minSupportedVersion": "0.170.0",
+            "exceptions": [],
+            "features": {
+                "bookmarks": {
+                    "state": "preview"
+                },
+                "brokenSites": {
+                    "state": "preview"
+                },
+                "promoHistory": {
+                    "state": "preview"
+                },
+                "remoteMessages": {
+                    "state": "preview"
+                },
+                "vault": {
+                    "state": "preview"
+                }
+            }
         }
     },
     "unprotectedTemporary": []


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/72649045549333/task/1215838942577432?focus=true

## Description
Feature flags for EF to Dapper migration.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only change to Windows feature overrides; no runtime code or schema changes in this diff.
> 
> **Overview**
> Adds a new **`secureStorageDapper`** entry to the Windows privacy-configuration override so the EF→Dapper secure-storage rollout can be controlled remotely.
> 
> The parent flag is **enabled** with **`minSupportedVersion`: `0.170.0`**. Nested capabilities **`bookmarks`**, **`brokenSites`**, **`promoHistory`**, **`remoteMessages`**, and **`vault`** are each set to **`preview`**, so only preview builds get the Dapper path until those subflags are raised.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e19e0b9453d5d707d03fb18a672f83367683018d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->