### PR TITLE
Enable Duck.ai launcher under aiChat on Windows.

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -1468,7 +1468,7 @@
                     "state": "enabled",
                     "minSupportedVersion": "0.170.0"
                 },
-                "duckAiLauncher": {
+                "promptBar": {
                     "state": "internal"
                 }
             },

--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -1467,6 +1467,9 @@
                 "chromeMenuButton": {
                     "state": "enabled",
                     "minSupportedVersion": "0.170.0"
+                },
+                "duckAiLauncher": {
+                    "state": "enabled"
                 }
             },
             "minSupportedVersion": "0.100.0",

--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -1469,7 +1469,7 @@
                     "minSupportedVersion": "0.170.0"
                 },
                 "duckAiLauncher": {
-                    "state": "enabled"
+                    "state": "internal"
                 }
             },
             "minSupportedVersion": "0.100.0",


### PR DESCRIPTION
## Summary
Enable `aiChat/duckAiLauncher` internally on Windows


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only change that limits a UI feature to internal users on Windows; no auth, data, or core runtime logic is modified.
> 
> **Overview**
> Adds a Windows override for the **`aiChat`** feature **`promptBar`**, setting **`state`** to **`internal`** so the Duck.ai launcher / prompt bar can be exercised by internal builds before a wider rollout.
> 
> This mirrors how other Windows AI chat capabilities are gated (for example **`detachableSidebar`**), and differs from macOS where **`promptBar`** is already **`enabled`** with a **`minSupportedVersion`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d53ffbb9e9594d5a96c99e34d6b3d92464c88707. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->