### PR TITLE
Remove selectors causing freeze on reddit.com

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -3563,7 +3563,7 @@
                         "type": "hide"
                     },
                     {
-                        "selector": "shreddit-experience-tree[active-experiences*=\"app_selector\"], .XPromoBlockingModal, .XPromoInFeed, .xPromoAppStoreFooter, #configured-xpromo-blocking_xpromo_nsfw_blocking, #configured-xpromo-unrated_block, #xpromo-bottom-sheet[aria-label*=\"See Reddit in...\"], #xpromo-bottom-sheet[aria-label*=\"See this post in...\"], #app-upsell-blocking-bottom-sheet-seo, #app-upsell-blocking-bottom-sheet-direct, .AppSelectorModal__body, .XPromoBottomBar, [bundlename=\"bottom_bar_xpromo\"], [data-testid=\"bottom-sheet-upsell-wrapper\"], [slot=\"use-app\"], bottom-bar[app-link-params], xpromo-app-selector, .mobile-web-redirect-bar, .upsell_banner",
+                        "selector": "shreddit-experience-tree[active-experiences*=\"app_selector\"], .XPromoBlockingModal, .XPromoInFeed, .xPromoAppStoreFooter, #configured-xpromo-blocking_xpromo_nsfw_blocking, #configured-xpromo-unrated_block, #xpromo-bottom-sheet[aria-label*=\"See Reddit in...\"], #xpromo-bottom-sheet[aria-label*=\"See this post in...\"], .AppSelectorModal__body, .XPromoBottomBar, [bundlename=\"bottom_bar_xpromo\"], [data-testid=\"bottom-sheet-upsell-wrapper\"], [slot=\"use-app\"], bottom-bar[app-link-params], xpromo-app-selector, .mobile-web-redirect-bar, .upsell_banner",
                         "type": "hide"
                     }
                 ]


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/1200277586140538/task/1217081867741669?focus=true

## Description
### Site breakage mitigation process:
#### Brief explanation
- Reported URL: https://www.reddit.com
- Problems experienced: Reports of the page freezing while scrolling. Caused by hiding the non-dismissable “Open in app” popup message, so removing the offending selectors.
- Platforms affected:
  - [x] iOS
  - [x] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-domain config tweak with a clear breakage fix; tradeoff is those upsell sheets may show again on mobile Reddit.
> 
> **Overview**
> **Fixes Reddit mobile scroll freezes** by trimming three element-hiding selectors on `reddit.com` that targeted app upsell bottom sheets (`#app-upsell-blocking-bottom-sheet-seo`, `#app-upsell-blocking-bottom-sheet-direct`, `#direct-app-upsell-blocking-bottom-sheet`).
> 
> Hiding those non-dismissable “Open in app” UI was reported to lock up the page while scrolling on iOS and Android. Other xpromo / app-selector hides for Reddit stay in place.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 541a394f387ef40eff680adb073c249f4bd1173e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->