### PR TITLE
Re-enable address bar perf instrumentation on Windows

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -5135,16 +5135,16 @@
             }
         },
         "uiResponsiveness": {
-            "state": "disabled",
-            "minSupportedVersion": "0.158.0",
+            "state": "enabled",
+            "minSupportedVersion": "0.170.0",
             "features": {
                 "keypressToCharacterRender": {
-                    "state": "disabled",
-                    "minSupportedVersion": "0.158.0"
+                    "state": "enabled",
+                    "minSupportedVersion": "0.170.0"
                 },
                 "keypressToSuggestionRender": {
-                    "state": "disabled",
-                    "minSupportedVersion": "0.158.0"
+                    "state": "enabled",
+                    "minSupportedVersion": "0.170.0"
                 }
             }
         },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/10125252356626/task/1217068181144489?focus=true

## Description
Instrumentation has been fixed on 0.170, so reinstating this SLO.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only override toggles; no application logic changes, only re-enabling telemetry/SLO gates on supported Windows builds.
> 
> **Overview**
> Re-enables **Windows** `uiResponsiveness` performance instrumentation in `windows-override.json` after fixes landed in **0.170**.
> 
> The parent feature and both sub-features—`keypressToCharacterRender` and `keypressToSuggestionRender`—move from **disabled** to **enabled**, with `minSupportedVersion` updated from **0.158.0** to **0.170.0** so the SLO only runs on builds with corrected instrumentation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 61086c269a1f5c255fc6fd427179f05a04f907f1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->