### PR TITLE
[iOS/macOS] Enable eventHub with the Windows telemetry set

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -3730,6 +3730,169 @@
         "webDetection": {
             "state": "enabled",
             "minSupportedVersion": "7.214.0"
+        },
+        "eventHub": {
+            "state": "enabled",
+            "minSupportedVersion": "7.234.0",
+            "settings": {
+                "telemetry": {
+                    "webTelemetry_youtube_adBlocker_day": {
+                        "state": "enabled",
+                        "trigger": {
+                            "period": {
+                                "days": 1
+                            }
+                        },
+                        "parameters": {
+                            "count": {
+                                "template": "counter",
+                                "source": "youtube_adBlocker",
+                                "buckets": {
+                                    "0": { "gte": 0, "lt": 1 },
+                                    "1+": { "gte": 1 }
+                                }
+                            },
+                            "loginState": {
+                                "template": "data",
+                                "source": "youtube_adBlocker",
+                                "dataKey": "loginState"
+                            }
+                        }
+                    },
+                    "webTelemetry_youtube_playabilityError_day": {
+                        "state": "enabled",
+                        "trigger": {
+                            "period": {
+                                "days": 1
+                            }
+                        },
+                        "parameters": {
+                            "count": {
+                                "template": "counter",
+                                "source": "youtube_playabilityError",
+                                "buckets": {
+                                    "0": { "gte": 0, "lt": 1 },
+                                    "1+": { "gte": 1 }
+                                }
+                            },
+                            "loginState": {
+                                "template": "data",
+                                "source": "youtube_playabilityError",
+                                "dataKey": "loginState"
+                            }
+                        }
+                    },
+                    "webTelemetry_youtube_videoAd_day": {
+                        "state": "enabled",
+                        "trigger": {
+                            "period": {
+                                "days": 1
+                            }
+                        },
+                        "parameters": {
+                            "count": {
+                                "template": "counter",
+                                "source": "youtube_videoAd",
+                                "buckets": {
+                                    "0": { "gte": 0, "lt": 1 },
+                                    "1+": { "gte": 1 }
+                                }
+                            },
+                            "loginState": {
+                                "template": "data",
+                                "source": "youtube_videoAd",
+                                "dataKey": "loginState"
+                            }
+                        }
+                    },
+                    "webTelemetry_youtube_staticAd_day": {
+                        "state": "enabled",
+                        "trigger": {
+                            "period": {
+                                "days": 1
+                            }
+                        },
+                        "parameters": {
+                            "count": {
+                                "template": "counter",
+                                "source": "youtube_staticAd",
+                                "buckets": {
+                                    "0": { "gte": 0, "lt": 1 },
+                                    "1+": { "gte": 1 }
+                                }
+                            },
+                            "loginState": {
+                                "template": "data",
+                                "source": "youtube_staticAd",
+                                "dataKey": "loginState"
+                            }
+                        }
+                    },
+                    "webTelemetry_youtube_buffering_day": {
+                        "state": "enabled",
+                        "trigger": {
+                            "period": {
+                                "days": 1
+                            }
+                        },
+                        "parameters": {
+                            "count": {
+                                "template": "counter",
+                                "source": "youtube_buffering",
+                                "buckets": {
+                                    "0": { "gte": 0, "lt": 1 },
+                                    "1+": { "gte": 1 }
+                                }
+                            },
+                            "loginState": {
+                                "template": "data",
+                                "source": "youtube_buffering",
+                                "dataKey": "loginState"
+                            }
+                        }
+                    },
+                    "webTelemetry_captcha_recaptcha": {
+                        "state": "enabled",
+                        "trigger": {
+                            "type": "immediate",
+                            "source": "captcha_recaptcha"
+                        },
+                        "parameters": {}
+                    },
+                    "webTelemetry_captcha_hcaptcha": {
+                        "state": "enabled",
+                        "trigger": {
+                            "type": "immediate",
+                            "source": "captcha_hcaptcha"
+                        },
+                        "parameters": {}
+                    },
+                    "webTelemetry_captcha_turnstile": {
+                        "state": "enabled",
+                        "trigger": {
+                            "type": "immediate",
+                            "source": "captcha_turnstile"
+                        },
+                        "parameters": {}
+                    },
+                    "webTelemetry_captcha_cloudflare": {
+                        "state": "enabled",
+                        "trigger": {
+                            "type": "immediate",
+                            "source": "captcha_cloudflare"
+                        },
+                        "parameters": {}
+                    },
+                    "webTelemetry_captcha_other": {
+                        "state": "enabled",
+                        "trigger": {
+                            "type": "immediate",
+                            "source": "captcha_other"
+                        },
+                        "parameters": {}
+                    }
+                }
+            }
         }
     },
     "unprotectedTemporary": []

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -3049,6 +3049,169 @@
         "webDetection": {
             "state": "enabled",
             "minSupportedVersion": "1.184.0"
+        },
+        "eventHub": {
+            "state": "enabled",
+            "minSupportedVersion": "1.204.0",
+            "settings": {
+                "telemetry": {
+                    "webTelemetry_youtube_adBlocker_day": {
+                        "state": "enabled",
+                        "trigger": {
+                            "period": {
+                                "days": 1
+                            }
+                        },
+                        "parameters": {
+                            "count": {
+                                "template": "counter",
+                                "source": "youtube_adBlocker",
+                                "buckets": {
+                                    "0": { "gte": 0, "lt": 1 },
+                                    "1+": { "gte": 1 }
+                                }
+                            },
+                            "loginState": {
+                                "template": "data",
+                                "source": "youtube_adBlocker",
+                                "dataKey": "loginState"
+                            }
+                        }
+                    },
+                    "webTelemetry_youtube_playabilityError_day": {
+                        "state": "enabled",
+                        "trigger": {
+                            "period": {
+                                "days": 1
+                            }
+                        },
+                        "parameters": {
+                            "count": {
+                                "template": "counter",
+                                "source": "youtube_playabilityError",
+                                "buckets": {
+                                    "0": { "gte": 0, "lt": 1 },
+                                    "1+": { "gte": 1 }
+                                }
+                            },
+                            "loginState": {
+                                "template": "data",
+                                "source": "youtube_playabilityError",
+                                "dataKey": "loginState"
+                            }
+                        }
+                    },
+                    "webTelemetry_youtube_videoAd_day": {
+                        "state": "enabled",
+                        "trigger": {
+                            "period": {
+                                "days": 1
+                            }
+                        },
+                        "parameters": {
+                            "count": {
+                                "template": "counter",
+                                "source": "youtube_videoAd",
+                                "buckets": {
+                                    "0": { "gte": 0, "lt": 1 },
+                                    "1+": { "gte": 1 }
+                                }
+                            },
+                            "loginState": {
+                                "template": "data",
+                                "source": "youtube_videoAd",
+                                "dataKey": "loginState"
+                            }
+                        }
+                    },
+                    "webTelemetry_youtube_staticAd_day": {
+                        "state": "enabled",
+                        "trigger": {
+                            "period": {
+                                "days": 1
+                            }
+                        },
+                        "parameters": {
+                            "count": {
+                                "template": "counter",
+                                "source": "youtube_staticAd",
+                                "buckets": {
+                                    "0": { "gte": 0, "lt": 1 },
+                                    "1+": { "gte": 1 }
+                                }
+                            },
+                            "loginState": {
+                                "template": "data",
+                                "source": "youtube_staticAd",
+                                "dataKey": "loginState"
+                            }
+                        }
+                    },
+                    "webTelemetry_youtube_buffering_day": {
+                        "state": "enabled",
+                        "trigger": {
+                            "period": {
+                                "days": 1
+                            }
+                        },
+                        "parameters": {
+                            "count": {
+                                "template": "counter",
+                                "source": "youtube_buffering",
+                                "buckets": {
+                                    "0": { "gte": 0, "lt": 1 },
+                                    "1+": { "gte": 1 }
+                                }
+                            },
+                            "loginState": {
+                                "template": "data",
+                                "source": "youtube_buffering",
+                                "dataKey": "loginState"
+                            }
+                        }
+                    },
+                    "webTelemetry_captcha_recaptcha": {
+                        "state": "enabled",
+                        "trigger": {
+                            "type": "immediate",
+                            "source": "captcha_recaptcha"
+                        },
+                        "parameters": {}
+                    },
+                    "webTelemetry_captcha_hcaptcha": {
+                        "state": "enabled",
+                        "trigger": {
+                            "type": "immediate",
+                            "source": "captcha_hcaptcha"
+                        },
+                        "parameters": {}
+                    },
+                    "webTelemetry_captcha_turnstile": {
+                        "state": "enabled",
+                        "trigger": {
+                            "type": "immediate",
+                            "source": "captcha_turnstile"
+                        },
+                        "parameters": {}
+                    },
+                    "webTelemetry_captcha_cloudflare": {
+                        "state": "enabled",
+                        "trigger": {
+                            "type": "immediate",
+                            "source": "captcha_cloudflare"
+                        },
+                        "parameters": {}
+                    },
+                    "webTelemetry_captcha_other": {
+                        "state": "enabled",
+                        "trigger": {
+                            "type": "immediate",
+                            "source": "captcha_other"
+                        },
+                        "parameters": {}
+                    }
+                }
+            }
         }
     },
     "unprotectedTemporary": []


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1203936086921904/task/1217277413118520

## Description

Enables `eventHub` on iOS and macOS and mirrors the 10 Windows-specific telemetry entries onto both platforms, so YouTube interference and captcha pixels are reported on Apple platforms the same way they already are on Windows:

- 5 daily YouTube pixels (`webTelemetry_youtube_{adBlocker,playabilityError,videoAd,staticAd,buffering}_day`) — `count` counter with `0`/`1+` buckets plus a `loginState` data parameter.
- 5 immediate captcha pixels (`webTelemetry_captcha_{recaptcha,hcaptcha,turnstile,cloudflare,other}`) — `trigger.type: immediate`.

The block is placed directly after `webDetection` in each override, matching the Android convention. Version gates are set to the releases due in ~2 weeks: iOS `7.234.0`, macOS `1.204.0`.

Because `eventHub.settings.telemetry` merges per key at build time (`index.js:284`), both platforms also inherit the 16 base entries from `features/event-hub.json`. Generated iOS/macOS configs now carry 26 telemetries each — an identical set to Windows.

### Feature change process:

- [x] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [x] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

Schema note: `schema/features/event-hub.ts` already covers this feature; no schema change was required.

Testing: `npm test` passes (2873 tests), `lint` / `prettier --check` / `tsc` clean. Verified the generated `v5/ios-config.json` and `v5/macos-config.json` contain the same 26 telemetry entries as `v5/windows-config.json`.

### Quality considerations

- The 5 immediate captcha pixels sit alongside the base periodic `webTelemetry_captcha_*_{day,week}` counters, so captcha encounters are double-reported. This matches existing Windows behaviour and is intentional in this PR; worth a follow-up if we'd rather keep only one.
- No exceptions or allowlists are touched, and no existing base telemetry entry is overridden — the change is purely additive.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive remote-config only; no exceptions or overrides of existing telemetry keys. Increases client telemetry volume in line with existing Windows behavior.
> 
> **Overview**
> Enables **`eventHub`** on iOS (`7.234.0`) and macOS (`1.204.0`) in `ios-override.json` and `macos-override.json`, placed after `webDetection` like Android.
> 
> Each override adds **10 telemetry definitions** matching Windows: five daily YouTube pixels (`adBlocker`, `playabilityError`, `videoAd`, `staticAd`, `buffering`) with `0`/`1+` count buckets and `loginState`, plus five **immediate** captcha pixels (`recaptcha`, `hcaptcha`, `turnstile`, `cloudflare`, `other`).
> 
> At build time, `eventHub.settings.telemetry` merges per key with `features/event-hub.json`, so Apple platforms keep the base entries and gain these platform-specific ones—aligned with Windows’ combined telemetry set.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 50beb98e2c9d84836455e83675907ba27e125da6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->