### PR TITLE
Set contextualSuggestedPrompts to enabled

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -446,8 +446,8 @@
                     "minSupportedVersion": "7.216.0"
                 },
                 "contextualSuggestedPrompts": {
-                    "state": "internal",
-                    "minSupportedVersion": "7.231.0"
+                    "state": "enabled",
+                    "minSupportedVersion": "7.232.0"
                 }
             },
             "settings": {


### PR DESCRIPTION
**Asana Task/Github Issue:**https://app.asana.com/1/137249556945/project/1210947754188321/task/1215959396625893?focus=true

## Description
<!-- 
  Please delete either or both process sections below.
-->
Enables feature flag

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [x] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single feature-flag flip in ios-override.json with no secrets or unrelated config changes.
> 
> **Overview**
> Updates the iOS privacy configuration override for **`contextualSuggestedPrompts`** under **`aiChat`**: **`state`** moves from **`internal`** to **`enabled`**, and **`minSupportedVersion`** bumps from **7.231.0** to **7.232.0**.
> 
> This ships contextual suggested prompts in Duck.ai to production iOS clients on supported app versions rather than limiting them to internal builds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 76a8804e93b865bbef855047fd24bddd4068f192. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->