### PR TITLE
Enable websitePermissionsV2 for Windows

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -6183,11 +6183,12 @@
             "exceptions": []
         },
         "websitePermissions": {
-            "state": "internal",
+            "state": "enabled",
             "exceptions": [],
             "features": {
                 "websitePermissionsV2": {
-                    "state": "internal"
+                    "state": "enabled",
+                    "minSupportedVersion": "0.171.0"
                 }
             }
         },


### PR DESCRIPTION
**Asana Task/Github Issue:**

## Description
<!-- 
  Please delete either or both process sections below.
-->

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Privacy-configuration override only; no application code changes. Risk is limited to Windows clients below 0.171.0 not getting V2 until they update.
> 
> **Overview**
> Rolls out **website permissions** on Windows by changing `websitePermissions` from `internal` to **enabled** in `windows-override.json`.
> 
> The nested **websitePermissionsV2** sub-feature is also moved from `internal` to **enabled**, with **`minSupportedVersion`: `0.171.0`** so only builds at or above that version receive the V2 behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 84e3904db6d619de782eb8dce717deae8331c11a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->