### PR TITLE
Enable incident crash reports for ArgumentException in Preview

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -5284,10 +5284,10 @@
                     "state": "enabled"
                 },
                 "sendIncidentCrashReports": {
-                    "state": "disabled",
+                    "state": "preview",
                     "settings": {
                         "ExceptionTypes": [
-                            "FaultedException"
+                            "ArgumentException"
                         ]
                     }
                 },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1210369001783739/task/1217360280849337?focus=true

## Description

v0.170.0 in Preview has huge CPMN (~150) for `ArgumentException`. We have only 1 report in Sentry so far. Enabling crash reports to understand if all of them has the same cause, and  get more error details.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Preview-only telemetry flag change with a single exception type; no production rollout or auth/data-path changes in this diff.
> 
> **Overview**
> Turns on **`sendIncidentCrashReports`** for the Windows override from **disabled** to **preview**, and narrows **`ExceptionTypes`** from **`FaultedException`** to **`ArgumentException`**.
> 
> This is meant to capture richer incident crash data in Preview while v0.170.0 shows high CPMN for **`ArgumentException`** with almost no Sentry signal.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f957bd4d991a4638048c60bf48a6d9d7c43d95b4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->