### PR TITLE
iOS: Disable monthlyFreeTrialExperiment

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -2838,7 +2838,7 @@
                     "minSupportedVersion": "7.157.0"
                 },
                 "monthlyFreeTrialExperiment": {
-                    "state": "enabled",
+                    "state": "disabled",
                     "targets": [
                         {
                             "localeCountry": "US"


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/72649045549333/task/1217334233390731

## Description

Turns off the iOS annual-trials experiment added in #5640 by setting the `monthlyFreeTrialExperiment` subfeature under `privacyPro.features` in `overrides/ios-override.json` to `disabled`.

- **State:** `enabled` → `disabled`
- `targets` (US), `cohorts` (`control`/`treatment`, 50/50) and `minSupportedVersion` (`7.231.0`) are left in place so the experiment can be re-enabled without re-authoring it.

Verified locally with `npm test` (build, unit tests, lint, tsc) — all green.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)