### PR TITLE
Android: Enable contextualNativeInput feature

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -719,6 +719,10 @@
                 "nativeInputNavBar": {
                     "state": "enabled",
                     "minSupportedVersion": 52890000
+                },
+                "contextualNativeInput": {
+                    "state": "enabled",
+                    "minSupportedVersion": 52920000
                 }
             }
         },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/task/1216989781514309?focus=true

## Description
Enabled Contextual Native Input to users starting at 5.292.0

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ x] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Ships a new Duck.ai UI/input behavior to all eligible Android users via remote config; impact is product-facing rather than security-critical, but regressions would affect contextual chat at scale.
> 
> **Overview**
> Turns on the **`contextualNativeInput`** sub-feature under **`aiChat`** in the Android privacy override so Duck.ai can use the native input path in contextual (page-aware) chat.
> 
> The flag is **`enabled`** with **`minSupportedVersion`** **52920000** (app **5.292.0**). There is no staged rollout in this change—only clients at or above that version receive it once config is deployed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 931494bb4e4cfcef858f1c99ee8d0e851fae4aad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->