### PR TITLE
fiix browser not recognised on deezer-com

### DIFF
--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -1746,6 +1746,10 @@
                     {
                         "domain": "hulu.com",
                         "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5327"
+                    },
+                    {
+                        "domain": "deezer.com",
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5749"
                     }
                 ],
                 "webViewDefault": [


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1206670747178362/task/1217316794793519?focus=true

## Description


### Site breakage mitigation process:
#### Brief explanation
- Reported URL: https://www.deezer.com/fr/artist/2090121
- Problems experienced: browser not being recognised
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ x] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked: 
- Feature being disabled/modified: custom user agent
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-domain macOS override in privacy configuration; no auth or data-path changes.
> 
> **Overview**
> Adds **`deezer.com`** to the macOS **`customUserAgent`** `defaultSites` list so Deezer receives the browser’s brand-based user agent instead of the default DuckDuckGo string.
> 
> This addresses reported breakage on macOS where Deezer did not recognize the browser (e.g. artist pages). The change follows the same pattern as other streaming/media sites already on the list (e.g. `hulu.com`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe065ed6c8a4809cb28c6f2ed5d454e109d3ff7a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->