### PR TITLE
Roll out captcha detectors to 50%

### DIFF
--- a/features/web-detection.json
+++ b/features/web-detection.json
@@ -90,6 +90,7 @@
             },
             "captcha": {
                 "recaptcha": {
+                    "state": "disabled",
                     "match": {
                         "element": {
                             "selector": [
@@ -97,11 +98,12 @@
                                 "iframe[src*='recaptcha']",
                                 "iframe[title*='recaptcha' i]"
                             ],
-                            "visibility": "visible"
+                            "visibility": "content"
                         }
                     }
                 },
                 "hcaptcha": {
+                    "state": "disabled",
                     "match": {
                         "element": {
                             "selector": [
@@ -109,22 +111,25 @@
                                 "iframe[src*='hcaptcha.com']",
                                 "iframe[title*='hcaptcha' i]"
                             ],
-                            "visibility": "visible"
+                            "visibility": "content"
                         }
                     }
                 },
                 "turnstile": {
+                    "state": "disabled",
                     "match": {
                         "element": {
                             "selector": [
                                 ".cf-turnstile:not(#turnstile-wrapper)",
-                                ".cf-turnstile:not(#turnstile-wrapper) iframe"
+                                ".cf-turnstile:not(#turnstile-wrapper) iframe",
+                                "iframe[src*='challenges.cloudflare.com/turnstile']"
                             ],
-                            "visibility": "visible"
+                            "visibility": "content"
                         }
                     }
                 },
                 "cloudflare": {
+                    "state": "disabled",
                     "match": {
                         "element": {
                             "selector": [
@@ -135,8 +140,117 @@
                                 "#cf-challenge-running",
                                 "#challenge-stage"
                             ],
-                            "visibility": "visible"
+                            "visibility": "content"
                         }
+                    }
+                },
+                "datadome": {
+                    "state": "disabled",
+                    "match": {
+                        "element": {
+                            "selector": [
+                                "iframe[src*='captcha-delivery.com']",
+                                "iframe[title*='datadome' i]"
+                            ],
+                            "visibility": "content"
+                        }
+                    }
+                },
+                "imperva": {
+                    "state": "disabled",
+                    "match": {
+                        "any": [
+                            {
+                                "text": {
+                                    "selector": [
+                                        "title",
+                                        "body"
+                                    ],
+                                    "pattern": [
+                                        "Pardon Our Interruption",
+                                        "protected and accelerated by Imperva",
+                                        "Additional security check is required"
+                                    ]
+                                }
+                            },
+                            {
+                                "element": {
+                                    "selector": [
+                                        "iframe[src*='_Incapsula_Resource']"
+                                    ],
+                                    "visibility": "content"
+                                }
+                            }
+                        ]
+                    }
+                },
+                "arkose": {
+                    "state": "disabled",
+                    "match": {
+                        "element": {
+                            "selector": [
+                                "iframe[src*='arkoselabs.com']",
+                                "iframe[src*='funcaptcha.com']",
+                                "#FunCaptcha-Token",
+                                "[data-pkey]"
+                            ],
+                            "visibility": "content"
+                        }
+                    }
+                },
+                "geetest": {
+                    "state": "disabled",
+                    "match": {
+                        "element": {
+                            "selector": [
+                                "iframe[src*='geetest.com']",
+                                ".geetest_box",
+                                ".geetest_captcha",
+                                "[class*='geetest_']"
+                            ],
+                            "visibility": "content"
+                        }
+                    }
+                },
+                "awswaf": {
+                    "state": "disabled",
+                    "match": {
+                        "element": {
+                            "selector": [
+                                "iframe[src*='captcha.awswaf.com']",
+                                "iframe[src*='token.awswaf.com']"
+                            ],
+                            "visibility": "content"
+                        }
+                    }
+                },
+                "perimeterx": {
+                    "state": "disabled",
+                    "match": {
+                        "any": [
+                            {
+                                "element": {
+                                    "selector": [
+                                        "#px-captcha",
+                                        "iframe[src*='px-cdn.net']",
+                                        "iframe[src*='px-cloud.net']"
+                                    ],
+                                    "visibility": "content"
+                                }
+                            },
+                            {
+                                "text": {
+                                    "selector": [
+                                        "title",
+                                        "body"
+                                    ],
+                                    "pattern": [
+                                        "Access to this page has been denied",
+                                        "we believe you are using automation tools"
+                                    ]
+                                }
+                            }
+                        ]
                     }
                 },
                 "other": {
@@ -284,6 +398,373 @@
                         "op": "add",
                         "path": "/detectors/adwalls/admiral/actions",
                         "value": { "fireEvent": { "state": "enabled", "type": "admiralAdwall" } }
+                    }
+                ]
+            },
+            {
+                "condition": [
+                    {
+                        "experiment": {
+                            "experimentName": "contentScopeExperiment5",
+                            "cohort": "treatment"
+                        },
+                        "injectName": "android"
+                    },
+                    {
+                        "experiment": {
+                            "experimentName": "contentScopeExperiment5",
+                            "cohort": "treatment"
+                        },
+                        "injectName": "apple-isolated"
+                    }
+                ],
+                "patchSettings": [
+                    {
+                        "op": "replace",
+                        "path": "/detectors/captcha/recaptcha/state",
+                        "value": "enabled"
+                    },
+                    {
+                        "op": "replace",
+                        "path": "/detectors/captcha/hcaptcha/state",
+                        "value": "enabled"
+                    },
+                    {
+                        "op": "replace",
+                        "path": "/detectors/captcha/turnstile/state",
+                        "value": "enabled"
+                    },
+                    {
+                        "op": "replace",
+                        "path": "/detectors/captcha/cloudflare/state",
+                        "value": "enabled"
+                    },
+                    {
+                        "op": "replace",
+                        "path": "/detectors/captcha/datadome/state",
+                        "value": "enabled"
+                    },
+                    {
+                        "op": "replace",
+                        "path": "/detectors/captcha/imperva/state",
+                        "value": "enabled"
+                    },
+                    {
+                        "op": "replace",
+                        "path": "/detectors/captcha/arkose/state",
+                        "value": "enabled"
+                    },
+                    {
+                        "op": "replace",
+                        "path": "/detectors/captcha/geetest/state",
+                        "value": "enabled"
+                    },
+                    {
+                        "op": "replace",
+                        "path": "/detectors/captcha/awswaf/state",
+                        "value": "enabled"
+                    },
+                    {
+                        "op": "replace",
+                        "path": "/detectors/captcha/perimeterx/state",
+                        "value": "enabled"
+                    },
+                    {
+                        "op": "add",
+                        "path": "/detectors/captcha/recaptcha/triggers",
+                        "value": {
+                            "auto": {
+                                "state": "enabled",
+                                "when": {
+                                    "intervalMs": [
+                                        2000,
+                                        5000,
+                                        10000,
+                                        20000
+                                    ]
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "op": "add",
+                        "path": "/detectors/captcha/recaptcha/actions",
+                        "value": {
+                            "fireEvent": {
+                                "state": "enabled",
+                                "type": "captcha_recaptcha"
+                            }
+                        }
+                    },
+                    {
+                        "op": "add",
+                        "path": "/detectors/captcha/hcaptcha/triggers",
+                        "value": {
+                            "auto": {
+                                "state": "enabled",
+                                "when": {
+                                    "intervalMs": [
+                                        2000,
+                                        5000,
+                                        10000,
+                                        20000
+                                    ]
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "op": "add",
+                        "path": "/detectors/captcha/hcaptcha/actions",
+                        "value": {
+                            "fireEvent": {
+                                "state": "enabled",
+                                "type": "captcha_hcaptcha"
+                            }
+                        }
+                    },
+                    {
+                        "op": "add",
+                        "path": "/detectors/captcha/turnstile/triggers",
+                        "value": {
+                            "auto": {
+                                "state": "enabled",
+                                "when": {
+                                    "intervalMs": [
+                                        2000,
+                                        5000,
+                                        10000,
+                                        20000
+                                    ]
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "op": "add",
+                        "path": "/detectors/captcha/turnstile/actions",
+                        "value": {
+                            "fireEvent": {
+                                "state": "enabled",
+                                "type": "captcha_turnstile"
+                            }
+                        }
+                    },
+                    {
+                        "op": "add",
+                        "path": "/detectors/captcha/cloudflare/triggers",
+                        "value": {
+                            "auto": {
+                                "state": "enabled",
+                                "when": {
+                                    "intervalMs": [
+                                        2000,
+                                        5000,
+                                        10000,
+                                        20000
+                                    ]
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "op": "add",
+                        "path": "/detectors/captcha/cloudflare/actions",
+                        "value": {
+                            "fireEvent": {
+                                "state": "enabled",
+                                "type": "captcha_cloudflare"
+                            }
+                        }
+                    },
+                    {
+                        "op": "add",
+                        "path": "/detectors/captcha/datadome/triggers",
+                        "value": {
+                            "auto": {
+                                "state": "enabled",
+                                "when": {
+                                    "intervalMs": [
+                                        2000,
+                                        5000,
+                                        10000,
+                                        20000
+                                    ]
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "op": "add",
+                        "path": "/detectors/captcha/datadome/actions",
+                        "value": {
+                            "fireEvent": {
+                                "state": "enabled",
+                                "type": "captcha_datadome"
+                            }
+                        }
+                    },
+                    {
+                        "op": "add",
+                        "path": "/detectors/captcha/imperva/triggers",
+                        "value": {
+                            "auto": {
+                                "state": "enabled",
+                                "when": {
+                                    "intervalMs": [
+                                        2000,
+                                        5000,
+                                        10000,
+                                        20000
+                                    ]
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "op": "add",
+                        "path": "/detectors/captcha/imperva/actions",
+                        "value": {
+                            "fireEvent": {
+                                "state": "enabled",
+                                "type": "captcha_imperva"
+                            }
+                        }
+                    },
+                    {
+                        "op": "add",
+                        "path": "/detectors/captcha/arkose/triggers",
+                        "value": {
+                            "auto": {
+                                "state": "enabled",
+                                "when": {
+                                    "intervalMs": [
+                                        2000,
+                                        5000,
+                                        10000,
+                                        20000
+                                    ]
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "op": "add",
+                        "path": "/detectors/captcha/arkose/actions",
+                        "value": {
+                            "fireEvent": {
+                                "state": "enabled",
+                                "type": "captcha_arkose"
+                            }
+                        }
+                    },
+                    {
+                        "op": "add",
+                        "path": "/detectors/captcha/geetest/triggers",
+                        "value": {
+                            "auto": {
+                                "state": "enabled",
+                                "when": {
+                                    "intervalMs": [
+                                        2000,
+                                        5000,
+                                        10000,
+                                        20000
+                                    ]
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "op": "add",
+                        "path": "/detectors/captcha/geetest/actions",
+                        "value": {
+                            "fireEvent": {
+                                "state": "enabled",
+                                "type": "captcha_geetest"
+                            }
+                        }
+                    },
+                    {
+                        "op": "add",
+                        "path": "/detectors/captcha/awswaf/triggers",
+                        "value": {
+                            "auto": {
+                                "state": "enabled",
+                                "when": {
+                                    "intervalMs": [
+                                        2000,
+                                        5000,
+                                        10000,
+                                        20000
+                                    ]
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "op": "add",
+                        "path": "/detectors/captcha/awswaf/actions",
+                        "value": {
+                            "fireEvent": {
+                                "state": "enabled",
+                                "type": "captcha_awswaf"
+                            }
+                        }
+                    },
+                    {
+                        "op": "add",
+                        "path": "/detectors/captcha/perimeterx/triggers",
+                        "value": {
+                            "auto": {
+                                "state": "enabled",
+                                "when": {
+                                    "intervalMs": [
+                                        2000,
+                                        5000,
+                                        10000,
+                                        20000
+                                    ]
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "op": "add",
+                        "path": "/detectors/captcha/perimeterx/actions",
+                        "value": {
+                            "fireEvent": {
+                                "state": "enabled",
+                                "type": "captcha_perimeterx"
+                            }
+                        }
+                    },
+                    {
+                        "op": "add",
+                        "path": "/detectors/captcha/other/triggers",
+                        "value": {
+                            "auto": {
+                                "state": "enabled",
+                                "when": {
+                                    "intervalMs": [
+                                        2000,
+                                        5000,
+                                        10000,
+                                        20000
+                                    ]
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "op": "add",
+                        "path": "/detectors/captcha/other/actions",
+                        "value": {
+                            "fireEvent": {
+                                "state": "enabled",
+                                "type": "captcha_other"
+                            }
+                        }
                     }
                 ]
             },

--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -4675,6 +4675,28 @@
                             "weight": 1
                         }
                     ]
+                },
+                "contentScopeExperiment5": {
+                    "state": "enabled",
+                    "minSupportedVersion": 52900000,
+                    "description": "Captcha detection: auto-run + fireEvent for the captcha detectors",
+                    "rollout": {
+                        "steps": [
+                            {
+                                "percent": 50
+                            }
+                        ]
+                    },
+                    "cohorts": [
+                        {
+                            "name": "control",
+                            "weight": 1
+                        },
+                        {
+                            "name": "treatment",
+                            "weight": 1
+                        }
+                    ]
                 }
             }
         },

--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -928,6 +928,28 @@
                             "weight": 1
                         }
                     ]
+                },
+                "contentScopeExperiment5": {
+                    "state": "enabled",
+                    "minSupportedVersion": "7.231.0",
+                    "description": "Captcha detection: auto-run + fireEvent for the captcha detectors",
+                    "rollout": {
+                        "steps": [
+                            {
+                                "percent": 50
+                            }
+                        ]
+                    },
+                    "cohorts": [
+                        {
+                            "name": "control",
+                            "weight": 1
+                        },
+                        {
+                            "name": "treatment",
+                            "weight": 1
+                        }
+                    ]
                 }
             }
         },

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -171,6 +171,28 @@
                             "weight": 1
                         }
                     ]
+                },
+                "contentScopeExperiment5": {
+                    "state": "enabled",
+                    "minSupportedVersion": "1.201.0",
+                    "description": "Captcha detection: auto-run + fireEvent for the captcha detectors",
+                    "rollout": {
+                        "steps": [
+                            {
+                                "percent": 50
+                            }
+                        ]
+                    },
+                    "cohorts": [
+                        {
+                            "name": "control",
+                            "weight": 1
+                        },
+                        {
+                            "name": "treatment",
+                            "weight": 1
+                        }
+                    ]
                 }
             }
         },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1215218660135895/task/1216542212155680?focus=true

## Description

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> A 50% experiment turns on periodic DOM/text checks and telemetry on real browsing sessions; mis-detection or overhead could affect treatment users but remains cohort-gated and config-only.
> 
> **Overview**
> Rolls out **captcha detection** to half of eligible Android and Apple-isolated clients under **`contentScopeExperiment5`**, with control/treatment cohorts and platform-specific minimum app versions in Android, iOS, and macOS overrides.
> 
> **`web-detection.json`** expands captcha coverage: existing providers default to **`state: disabled`** and use **`visibility: content`** instead of `visible`; Turnstile gains an extra iframe selector. New disabled-by-default matchers are added for **DataDome, Imperva, Arkose, GeeTest, AWS WAF, and PerimeterX** (element and/or text patterns).
> 
> For **treatment** users on Android and `apple-isolated`, a new conditional patch **enables** reCAPTCHA, hCaptcha, Turnstile, Cloudflare, and the new providers plus **`captcha/other`**, and wires **auto polling** (2–20s) with **`fireEvent`** telemetry types such as `captcha_recaptcha` and `captcha_datadome`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c40fc10a9380f92289b62b2cbda608bf430bd0f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->