### PR TITLE
Enables videoAutoplay on macOS

### DIFF
--- a/features/web-telemetry.json
+++ b/features/web-telemetry.json
@@ -3,6 +3,7 @@
     "exceptions": [],
     "settings": {
         "videoPlayback": "disabled",
+        "videoAutoplay": "disabled",
         "urlChanged": "disabled"
     }
 }

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -179,6 +179,7 @@
             "exceptions": [],
             "settings": {
                 "videoPlayback": "enabled",
+                "videoAutoplay": "enabled",
                 "urlChanged": "enabled"
             }
         },


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/1211150618152277/task/1217376780027472?focus=true

## Description
This PR enables Video Autoplay on macOS

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 4ccc1880213aebc43a7823ae4dc496bad9b4184f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->