### PR TITLE
[FEAT][Rebrand] Add newTabPageRebranding feature flag for macOS and Windows

### DIFF
--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -2417,6 +2417,10 @@
                 "onboardingRebranding": {
                     "state": "enabled",
                     "minSupportedVersion": "1.192.0"
+                },
+                "newTabPageRebranding": {
+                    "state": "enabled",
+                    "minSupportedVersion": "1.192.0"
                 }
             }
         },

--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -4753,6 +4753,9 @@
                 "autoconsentStats": {
                     "state": "enabled",
                     "minSupportedVersion": "0.143.3"
+                },
+                "newTabPageRebranding": {
+                    "state": "internal"
                 }
             },
             "minSupportedVersion": "0.100.0"


### PR DESCRIPTION
## Summary

- **macOS**: adds `newTabPageRebranding` under `macOSBrowserConfig.features` → `state: enabled`, `minSupportedVersion: 1.192.0`
- **Windows**: adds `newTabPageRebranding` under `htmlNewTabPage.features` → `state: internal` (no version gating, DDG employees only)

## Notes

Windows starts as `internal` since Jonathan L's build is still in progress. Once it ships, a follow-up PR will bump it to `enabled` with the appropriate `minSupportedVersion`.

## Test plan

- [ ] macOS: NTP rebrand renders correctly on 1.192.0+
- [ ] Windows: NTP rebrand visible for internal users, hidden for everyone else