### PR TITLE
[FEAT][Rebrand] Add newTabPageRebranding flag for Windows (internal)

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -4873,6 +4873,9 @@
                 "autoconsentStats": {
                     "state": "enabled",
                     "minSupportedVersion": "0.143.3"
+                },
+                "newTabPageRebranding": {
+                    "state": "internal"
                 }
             },
             "minSupportedVersion": "0.100.0"


### PR DESCRIPTION
## Summary

- Adds `newTabPageRebranding` sub-feature under `htmlNewTabPage.features` for Windows
- State: `internal` (DDG employees only, no version gating)
- macOS equivalent already merged in #5515

## Notes

Starting as `internal` since Jonathan L's Windows NTP build is still in progress. Once it ships, a follow-up PR will bump to `enabled` with the appropriate `minSupportedVersion`.

## Test plan

- [ ] Verify NTP rebrand renders correctly on Windows for internal users
- [ ] Confirm flag has no effect on non-internal users

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only feature flag addition limited to internal users, with no production behavior change for regular users.
> 
> **Overview**
> Adds the **`newTabPageRebranding`** sub-feature under `htmlNewTabPage` for Windows, set to `internal` so only DDG employees can use it.
> 
> This mirrors the existing macOS flag and intentionally omits version gating until the Windows NTP rebrand ships.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c442a9a561ef996620f71d29e44eecf44cc50f53. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->