### PR TITLE
iOS: Enable monthlyFreeTrialExperiment round 2 

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -2860,7 +2860,7 @@
                     "minSupportedVersion": "7.157.0"
                 },
                 "monthlyFreeTrialExperiment": {
-                    "state": "disabled",
+                    "state": "enabled",
                     "targets": [
                         {
                             "localeCountry": "US"
@@ -2869,14 +2869,22 @@
                     "cohorts": [
                         {
                             "name": "control",
-                            "weight": 1
+                            "weight": 0
                         },
                         {
                             "name": "treatment",
+                            "weight": 0
+                        },
+                        {
+                            "name": "control2",
+                            "weight": 1
+                        },
+                        {
+                            "name": "treatment2",
                             "weight": 1
                         }
                     ],
-                    "minSupportedVersion": "7.231.0"
+                    "minSupportedVersion": "7.233.0"
                 },
                 "privacyProOnboardingCTAMarch25": {
                     "state": "enabled",

--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -2860,6 +2860,25 @@
                     "minSupportedVersion": "7.157.0"
                 },
                 "monthlyFreeTrialExperiment": {
+                    "state": "disabled",
+                    "targets": [
+                        {
+                            "localeCountry": "US"
+                        }
+                    ],
+                    "cohorts": [
+                        {
+                            "name": "control",
+                            "weight": 1
+                        },
+                        {
+                            "name": "treatment",
+                            "weight": 1
+                        }
+                    ],
+                    "minSupportedVersion": "7.231.0"
+                },
+                "monthlyFreeTrialExperiment2": {
                     "state": "enabled",
                     "targets": [
                         {
@@ -2869,18 +2888,10 @@
                     "cohorts": [
                         {
                             "name": "control",
-                            "weight": 0
-                        },
-                        {
-                            "name": "treatment",
-                            "weight": 0
-                        },
-                        {
-                            "name": "control2",
                             "weight": 1
                         },
                         {
-                            "name": "treatment2",
+                            "name": "treatment",
                             "weight": 1
                         }
                     ],


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1202926619714575/task/1217396175171502

## Description

Config companion to [apple-browsers#6296](https://github.com/duckduckgo/apple-browsers/pull/6296), which replaces the stopped `monthlyFreeTrialExperiment` with a new subfeature so the second run's data stays separate from the first.

Changes in `overrides/ios-override.json`, under `privacyPro`:

- Added `monthlyFreeTrialExperiment2`:
  - `state`: `enabled`
  - `targets`: `localeCountry: US` (same gating as the first run)
  - `cohorts`: `control` and `treatment`, both at weight `1` (the app reuses the same cohort names; only the subfeature and the purchase URL parameter — now `experiment_mobileannualtrials2_ios` — change)
  - `minSupportedVersion`: `7.233.0`
- `monthlyFreeTrialExperiment` is left untouched (still `disabled`). The app no longer reads it; it can be removed in a follow-up once nothing references it.

### Feature change process:

- [x] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)