### PR TITLE
Disable captcha detector experiment

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -4677,7 +4677,7 @@
                     ]
                 },
                 "contentScopeExperiment5": {
-                    "state": "enabled",
+                    "state": "disabled",
                     "minSupportedVersion": 52900000,
                     "description": "Captcha detection: auto-run + fireEvent for the captcha detectors",
                     "rollout": {

--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -930,7 +930,7 @@
                     ]
                 },
                 "contentScopeExperiment5": {
-                    "state": "enabled",
+                    "state": "disabled",
                     "minSupportedVersion": "7.231.0",
                     "description": "Captcha detection: auto-run + fireEvent for the captcha detectors",
                     "rollout": {

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -173,7 +173,7 @@
                     ]
                 },
                 "contentScopeExperiment5": {
-                    "state": "enabled",
+                    "state": "disabled",
                     "minSupportedVersion": "1.201.0",
                     "description": "Captcha detection: auto-run + fireEvent for the captcha detectors",
                     "rollout": {


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1215218660135895/task/1217408393396335?focus=true

## Description

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Simple experiment flag flip from enabled to disabled in config overrides; no code or security-sensitive logic changes.
> 
> **Overview**
> Disables the **`contentScopeExperiment5`** captcha detection experiment (auto-run + fireEvent) on Android, iOS, and macOS by setting its state from `enabled` to `disabled` in the platform override configs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b1fcd7811948d929d4e12c49cab6e566f2a31290. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->