### PR TITLE
Remove aiChatSyncPromo iOS sync subfeature

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -2149,10 +2149,6 @@
                     "state": "enabled",
                     "minSupportedVersion": "7.208.2"
                 },
-                "aiChatSyncPromo": {
-                    "state": "enabled",
-                    "minSupportedVersion": "7.228.0"
-                },
                 "simplifiedSyncSetupExperiment": {
                     "state": "enabled",
                     "minSupportedVersion": "7.219.0",


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1211834678943996/task/1214965000466711

## Description

### Feature change process:

The `aiChatSyncPromo` feature flag is being deleted from the Apple client ([apple-browsers#6299](https://github.com/duckduckgo/apple-browsers/pull/6299)). The flag was enabled by default, so the Duck.ai sync promo is now permanently on. This removes the now-dead `aiChatSyncPromo` subfeature override under `sync` in `overrides/ios-override.json` so the config stops shipping the entry.

- [x] This code for the config change is ready to merge.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only cleanup of a dead feature flag override with no runtime behavior change for current clients.
> 
> **Overview**
> Removes the unused `aiChatSyncPromo` override under `sync` in `overrides/ios-override.json`.
> 
> The Apple client deleted this flag (now permanently on by default), so the config no longer needs to ship the entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 23aa4ff25ccdd1b1b50181d8b925b60f40a1a7de. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->