### PR TITLE
Update content-blocker extension to 2026.8.12

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -5009,7 +5009,7 @@
             "minSupportedVersion": "0.148.0",
             "exceptions": [],
             "settings": {
-                "extensionUrl": "https://staticcdn.duckduckgo.com/extensions/content-blocker/content-blocker-extension-2026.8.5.crx"
+                "extensionUrl": "https://staticcdn.duckduckgo.com/extensions/content-blocker/content-blocker-extension-2026.8.12.crx"
             },
             "features": {
                 "onboardingEnabled": {


### PR DESCRIPTION
Update content-blocker extension to 2026.8.12.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single config URL version bump with no logic, auth, or data-handling changes.
> 
> **Overview**
> Updates the Windows `adBlockV2Extension` download URL from `content-blocker-extension-2026.8.5.crx` to `content-blocker-extension-2026.8.12.crx` in `windows-override.json`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 02b5ac48fa2cefde67fd4545c610c06a3e25cd29. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->