### PR TITLE
Update ad-blocking extension scriptlets for v2026.8.12

### DIFF
--- a/features/ad-blocking-extension.json
+++ b/features/ad-blocking-extension.json
@@ -4,28 +4,28 @@
     },
     "exceptions": [],
     "settings": {
-        "version": "2026.8.5",
+        "version": "2026.8.12",
         "enabledByDefault": false,
         "scriptlets": {
             "scriptlets/isolated/ublock-filters.js": {
-                "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/bdd3e75623825bafd976f497c4bd70a9189daa6f511de6b44d3fd783a487d600.js",
-                "signature": "MEUCIQDMGyLIx8hsLaRgTvti00Zoi3c44ddDpIHMfv657BBlXQIgSZ+NiAD02ljDNk2YR0CQy1oq2d90twmRfaNCMeX+fFY="
+                "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/b277ec630fc2f56021217ebbb5c4caf9b0d82fc3ede383b8c13c1f5ea5aefcc8.js",
+                "signature": "MEYCIQCO63C+4WTtBO7WWcUgjFtka3nwom//grRn4n+UoNL2PQIhALaePDY61l4NVQYGlftMT9h9ElmOzHdjn7m+8YfTCLbn"
             },
             "scriptlets/main/ublock-filters.js": {
-                "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/dc71af3824020d822518c4aba1144a916494902a46e79ede2bb781afc699c68b.js",
-                "signature": "MEUCIQDB4YQhs03h9Ypj/rveBy0KfqS7RuH9wNEbLjY2KgW/zQIgZoNySJvJzGUjoY3wMeFFKEFE1CKoptU1f3BnMG4vw9o="
+                "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/89a10d331cc172d6b01da80770d0fb640cd1ebef3b9e270f97456235744aa3c7.js",
+                "signature": "MEUCIQCspGQMf4GVRRQXOto5KIFfhMeQqz71na8k5SjUcMyGIgIgAaj2TIOlaRSiIRIijo2010xwCNTVmLk55mCZHNfC3HY="
             },
             "scriptlets/main/ublock-experimental.js": {
                 "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855.js",
-                "signature": "MEYCIQCGl6JVL0rvo1otKr6QgBrvCsjzUatnzkfTIEWWpCMp9wIhAOnqOaTdX+9dEGKZZf5jYX6lwhxYZDM6DfcDiuC0sCja"
+                "signature": "MEUCIQDw6BFbXSYgOsUVj9Ax6v9dkMMg8G03XjaokDZJIaLV4wIgUzA76MiixVhI51iweYjl1+/XO2mMmbX8gToBuKMQcBA="
             },
             "scriptlets/isolated/ublock-experimental.js": {
                 "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855.js",
-                "signature": "MEYCIQCSOln+we7EZDZOn9FzKMRU4IuY/JUsxRUQM2ltUMyZJAIhAOqrzvLPdsohzzeMtHkBmzHkSU01Tm8NIXr6I4ds81yo"
+                "signature": "MEUCIQC0ONKwH9LqHzZWjjyGDjo1LJqaTxj567OJjoT1rs+u0QIgbU0Gw5/yK7ffVelTA9mftywmmyWucAdguD8AaTZpaMo="
             },
             "rules/youtube.json": {
                 "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/2337db6aa7466667595226f780b6590779db3007ac0a65ef3833f89610c92824.json",
-                "signature": "MEUCIQD3DZvt2gZJL9Cqq8BXbzp1x8PVtRsYJcxi8Ft9O378FgIgMy7l4cr4vd/bdWnTwHnchBU/ZZIlM6ndb2OH3LlRHgw="
+                "signature": "MEYCIQC2jgjmB1JAEpCf50hGc/0Tr9kXCv8yPwp1wszXV5rwlgIhAPxc7EXa6D7wwL1MtQzoZrODsx9iyLjkS+jkwu3W5dbg"
             }
         }
     }


### PR DESCRIPTION
Update ad-blocking extension scriptlets for v2026.8.12.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates remotely loaded, signed content-blocker scriptlets that run in page context; integrity is preserved via new signatures, but incorrect assets could affect browsing/ad blocking.
> 
> **Overview**
> Bumps the macOS/iOS **ad-blocking extension** config from `2026.8.5` to `2026.8.12`.
> 
> Updates CDN URLs and signatures for the `ublock-filters` scriptlets (main and isolated). Also refreshes signatures for the experimental scriptlets and `youtube.json` rules (URLs unchanged for those).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 69b14da6af7e7fef08dba51c58fb9aad32d640ee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->