### PR TITLE
Enable tab label and favicon transitions for Windows

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -5383,13 +5383,13 @@
             "exceptions": []
         },
         "tabLabelTransition": {
-            "minSupportedVersion": "0.155.0",
-            "state": "preview",
+            "minSupportedVersion": "0.172.0",
+            "state": "enabled",
             "exceptions": []
         },
         "faviconTransitions": {
-            "minSupportedVersion": "0.155.0",
-            "state": "preview",
+            "minSupportedVersion": "0.173.0",
+            "state": "enabled",
             "exceptions": []
         },
         "tabNavigationHistoryRestore": {


### PR DESCRIPTION
**Asana Task/Github Issue:**

## Description
<!-- 
  Please delete either or both process sections below.
-->

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only feature flag enablement for UI transitions; no auth, security, or data-handling changes.
> 
> **Overview**
> Promotes **tab label** and **favicon** transition animations from `preview` to fully **enabled** on Windows.
> 
> Raises the minimum supported versions to `0.172.0` for `tabLabelTransition` and `0.173.0` for `faviconTransitions` in `windows-override.json`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b2a4aefad734896d5f97a9e47955c4bc6f49efe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->