### PR TITLE
Add macOS onboarding subscription upsell experiment (50/50)

### DIFF
--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -2488,6 +2488,20 @@
                             "localeCountry": "US"
                         }
                     ]
+                },
+                "onboardingSubscriptionUpsellExperiment": {
+                    "state": "enabled",
+                    "minSupportedVersion": "1.203.0",
+                    "cohorts": [
+                        {
+                            "name": "control",
+                            "weight": 1
+                        },
+                        {
+                            "name": "treatment",
+                            "weight": 1
+                        }
+                    ]
                 }
             }
         },

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -2491,7 +2491,7 @@
                 },
                 "onboardingSubscriptionUpsellExperiment": {
                     "state": "enabled",
-                    "minSupportedVersion": "1.203.0",
+                    "minSupportedVersion": "1.204.0",
                     "cohorts": [
                         {
                             "name": "control",


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/72649045549333/task/1217261325073144

## Description

Adds the `onboardingSubscriptionUpsellExperiment` subfeature under `privacyPro` in the macOS override, supporting duckduckgo/apple-browsers#6243

> [!IMPORTANT]
> Draft — do not merge until duckduckgo/apple-browsers#6243 has landed and shipped in 1.203.0.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only change that gates an onboarding upsell experiment; no auth or payment logic in this repo, though it affects subscription messaging for eligible macOS users once the client ships.
> 
> **Overview**
> Adds remote config for a **macOS Privacy Pro onboarding subscription upsell experiment** by introducing `onboardingSubscriptionUpsellExperiment` under `privacyPro` in `macos-override.json`.
> 
> The flag is **enabled** with **`minSupportedVersion` `1.204.0`** and a **50/50 split** between **`control`** and **`treatment`** cohorts (equal weights). This wires server-side config for client work in duckduckgo/apple-browsers#6243; the PR description notes it should not ship until that client change is in **1.203.0**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e5481c7a2b90b74b32e88edac97123732f60c7a2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->