### PR TITLE
[Android] Enable the flags - optimizeContentScopeInjection, optimizeContentScopeMessaging, cacheContentScopeExperiments

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -3487,6 +3487,15 @@
             "features": {
                 "useNewWebCompatApis": {
                     "state": "disabled"
+                },
+                "optimizeContentScopeInjection": {
+                    "state": "enabled"
+                },
+                "optimizeContentScopeMessaging": {
+                    "state": "enabled"
+                },
+                "cacheContentScopeExperiments": {
+                    "state": "enabled"
                 }
             },
             "exceptions": []

--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -3489,12 +3489,15 @@
                     "state": "disabled"
                 },
                 "optimizeContentScopeInjection": {
+                    "minSupportedVersion": 52920000,
                     "state": "enabled"
                 },
                 "optimizeContentScopeMessaging": {
+                    "minSupportedVersion": 52920000,
                     "state": "enabled"
                 },
                 "cacheContentScopeExperiments": {
+                    "minSupportedVersion": 52920000,
                     "state": "enabled"
                 }
             },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/72649045549333/task/1217249931938296?focus=true

## Description
<!-- 
  Please delete either or both process sections below.
-->

This PR enables the 3 flags below for Android, under `clientContentFeatures`:
- `optimizeContentScopeInjection`
- `optimizeContentScopeMessaging`
- `cacheContentScopeExperiments`

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [x] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how content-scope protections run on Android WebViews for app version 52920000+, which can affect page compatibility and privacy behavior site-wide.
> 
> **Overview**
> Turns on three **Android** sub-features under `clientContentFeatures` in `android-override.json`, each gated at **`minSupportedVersion` 52920000**:
> 
> - **`optimizeContentScopeInjection`**
> - **`optimizeContentScopeMessaging`**
> - **`cacheContentScopeExperiments`**
> 
> Only clients at or above that build version receive these optimizations for content-scope script injection, messaging, and experiment caching.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5470e9427977095fee696a645c00e8cbbbe16097. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->