### PR TITLE
Update content-blocker extension to 2026.8.13

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -5009,7 +5009,7 @@
             "minSupportedVersion": "0.148.0",
             "exceptions": [],
             "settings": {
-                "extensionUrl": "https://staticcdn.duckduckgo.com/extensions/content-blocker/content-blocker-extension-2026.8.5.crx"
+                "extensionUrl": "https://staticcdn.duckduckgo.com/extensions/content-blocker/content-blocker-extension-2026.8.13.crx"
             },
             "features": {
                 "onboardingEnabled": {


### PR DESCRIPTION
Update content-blocker extension to 2026.8.13.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single URL bump in a Windows config override; no auth or data-path changes, but it affects which extension build Windows users receive.
> 
> **Overview**
> Bumps the Windows **adBlockV2Extension** CDN URL in `overrides/windows-override.json` from `content-blocker-extension-2026.8.5.crx` to **2026.8.13**. No feature flags, `minSupportedVersion`, or other override fields change—only where Windows clients download the v2 content-blocker extension.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ad97119580778ee36075f863f74f28f0eeb5b656. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->