### PR TITLE
Update ad-blocking extension scriptlets for v2026.8.13

### DIFF
--- a/features/ad-blocking-extension.json
+++ b/features/ad-blocking-extension.json
@@ -4,28 +4,28 @@
     },
     "exceptions": [],
     "settings": {
-        "version": "2026.8.5",
+        "version": "2026.8.13",
         "enabledByDefault": false,
         "scriptlets": {
             "scriptlets/isolated/ublock-filters.js": {
-                "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/bdd3e75623825bafd976f497c4bd70a9189daa6f511de6b44d3fd783a487d600.js",
-                "signature": "MEUCIQDMGyLIx8hsLaRgTvti00Zoi3c44ddDpIHMfv657BBlXQIgSZ+NiAD02ljDNk2YR0CQy1oq2d90twmRfaNCMeX+fFY="
+                "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/b277ec630fc2f56021217ebbb5c4caf9b0d82fc3ede383b8c13c1f5ea5aefcc8.js",
+                "signature": "MEQCIA9hMVMX8AtpXKLfO/ppBHcf7qkERruPBLr4cDPmiamkAiB40KpM+hGXSN807vN+NXtwLf/W3hDr0/oQg1IAPtPeKA=="
             },
             "scriptlets/main/ublock-filters.js": {
-                "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/dc71af3824020d822518c4aba1144a916494902a46e79ede2bb781afc699c68b.js",
-                "signature": "MEUCIQDB4YQhs03h9Ypj/rveBy0KfqS7RuH9wNEbLjY2KgW/zQIgZoNySJvJzGUjoY3wMeFFKEFE1CKoptU1f3BnMG4vw9o="
+                "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/5e519b4f8df8a4efccbbacfae1a7e0150924a46343cf00a558648c024ba7b0fb.js",
+                "signature": "MEUCIGBGFCIQfQtTi2v6yMqcK4ky31hNNvOECTj2cUYM3Iz3AiEAwspYlBY7/+BbU8CpqhYtiKs2Cbe8QqrScXLUHQjU/Cg="
             },
             "scriptlets/main/ublock-experimental.js": {
                 "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855.js",
-                "signature": "MEYCIQCGl6JVL0rvo1otKr6QgBrvCsjzUatnzkfTIEWWpCMp9wIhAOnqOaTdX+9dEGKZZf5jYX6lwhxYZDM6DfcDiuC0sCja"
+                "signature": "MEQCIFPfWt4DVstVPaamhE0K+PL1sGr9nyNe94si98NBRwbJAiAbygFKLDZSrOzOYw7vCO+un4kDOK3ILr21MiD9Wz5v2g=="
             },
             "scriptlets/isolated/ublock-experimental.js": {
                 "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855.js",
-                "signature": "MEYCIQCSOln+we7EZDZOn9FzKMRU4IuY/JUsxRUQM2ltUMyZJAIhAOqrzvLPdsohzzeMtHkBmzHkSU01Tm8NIXr6I4ds81yo"
+                "signature": "MEYCIQDJarLVk+N6LQVmiWerU7LecEJmHjVlRQB7gpfjvgJB/AIhAK56lOSPYGPX/YwKJ/pqawYRvJqRzNjHYq3zEnBYwVCy"
             },
             "rules/youtube.json": {
                 "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/2337db6aa7466667595226f780b6590779db3007ac0a65ef3833f89610c92824.json",
-                "signature": "MEUCIQD3DZvt2gZJL9Cqq8BXbzp1x8PVtRsYJcxi8Ft9O378FgIgMy7l4cr4vd/bdWnTwHnchBU/ZZIlM6ndb2OH3LlRHgw="
+                "signature": "MEYCIQC2z6b/8mOz1//cavIbMyOX8yYk5gnj6EvCRb9EhP3b7wIhAIgP/xUlEvb5aHNHc9mPfxVRlQ8CaZi3SGzQMf60dJBq"
             }
         }
     }


### PR DESCRIPTION
Update ad-blocking extension scriptlets for v2026.8.13.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes signed CDN scriptlet payloads used by content blocking on macOS/iOS; incorrect URLs or signatures could break ad blocking or block updates until fixed.
> 
> **Overview**
> Bumps the macOS/iOS ad-blocking feature config from **2026.8.5** to **2026.8.13** in `features/ad-blocking-extension.json`.
> 
> For each listed scriptlet entry, the **CDN URL** (content hash path) and **signature** are updated so clients fetch and verify the new static assets. The isolated and main **ublock-filters** bundles get new URLs; **ublock-experimental** entries keep the same empty-hash URL but new signatures; **rules/youtube.json** gets an updated signature only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f435ffd458bf090868315aff190ea0a4db816d2d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->