### PR TITLE
Remove Guardian autoconsent exception

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -976,10 +976,6 @@
                     "reason": "https://github.com/duckduckgo/privacy-configuration/pull/4648"
                 },
                 {
-                    "domain": "theguardian.com",
-                    "reason": "https://github.com/duckduckgo/privacy-configuration/pull/4985"
-                },
-                {
                     "domain": "mumsnet.com",
                     "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5119"
                 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1203268166580279/task/1217450724898837?focus=true

## Description
Removes the iOS autoconsent exception for `theguardian.com`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fa0278d2-f36b-4ee4-9671-bd79d7a5a0a2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fa0278d2-f36b-4ee4-9671-bd79d7a5a0a2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

