### PR TITLE
Disable captcha detector visibility cohort

### DIFF
--- a/features/web-detection.json
+++ b/features/web-detection.json
@@ -405,29 +405,15 @@
                 "condition": [
                     {
                         "experiment": {
-                            "experimentName": "contentScopeExperiment6",
-                            "cohort": "treatmentCon"
+                            "experimentName": "contentScopeExperiment7",
+                            "cohort": "treatment"
                         },
                         "injectName": "android"
                     },
                     {
                         "experiment": {
-                            "experimentName": "contentScopeExperiment6",
-                            "cohort": "treatmentCon"
-                        },
-                        "injectName": "apple-isolated"
-                    },
-                    {
-                        "experiment": {
-                            "experimentName": "contentScopeExperiment6",
-                            "cohort": "treatmentVis"
-                        },
-                        "injectName": "android"
-                    },
-                    {
-                        "experiment": {
-                            "experimentName": "contentScopeExperiment6",
-                            "cohort": "treatmentVis"
+                            "experimentName": "contentScopeExperiment7",
+                            "cohort": "treatment"
                         },
                         "injectName": "apple-isolated"
                     }
@@ -658,27 +644,7 @@
                                 }
                             }
                         }
-                    }
-                ]
-            },
-            {
-                "condition": [
-                    {
-                        "experiment": {
-                            "experimentName": "contentScopeExperiment6",
-                            "cohort": "treatmentCon"
-                        },
-                        "injectName": "android"
                     },
-                    {
-                        "experiment": {
-                            "experimentName": "contentScopeExperiment6",
-                            "cohort": "treatmentCon"
-                        },
-                        "injectName": "apple-isolated"
-                    }
-                ],
-                "patchSettings": [
                     {
                         "op": "add",
                         "path": "/detectors/captcha/recaptcha/actions",
@@ -733,131 +699,6 @@
                         "op": "add",
                         "path": "/detectors/captcha/other/actions",
                         "value": { "fireEvent": { "state": "enabled", "type": "captcha_other_t_con" } }
-                    }
-                ]
-            },
-            {
-                "condition": [
-                    {
-                        "experiment": {
-                            "experimentName": "contentScopeExperiment6",
-                            "cohort": "treatmentVis"
-                        },
-                        "injectName": "android"
-                    },
-                    {
-                        "experiment": {
-                            "experimentName": "contentScopeExperiment6",
-                            "cohort": "treatmentVis"
-                        },
-                        "injectName": "apple-isolated"
-                    }
-                ],
-                "patchSettings": [
-                    {
-                        "op": "replace",
-                        "path": "/detectors/captcha/recaptcha/match/element/visibility",
-                        "value": "visible"
-                    },
-                    {
-                        "op": "replace",
-                        "path": "/detectors/captcha/hcaptcha/match/element/visibility",
-                        "value": "visible"
-                    },
-                    {
-                        "op": "replace",
-                        "path": "/detectors/captcha/turnstile/match/element/visibility",
-                        "value": "visible"
-                    },
-                    {
-                        "op": "replace",
-                        "path": "/detectors/captcha/cloudflare/match/element/visibility",
-                        "value": "visible"
-                    },
-                    {
-                        "op": "replace",
-                        "path": "/detectors/captcha/datadome/match/element/visibility",
-                        "value": "visible"
-                    },
-                    {
-                        "op": "replace",
-                        "path": "/detectors/captcha/imperva/match/any/1/element/visibility",
-                        "value": "visible"
-                    },
-                    {
-                        "op": "replace",
-                        "path": "/detectors/captcha/arkose/match/element/visibility",
-                        "value": "visible"
-                    },
-                    {
-                        "op": "replace",
-                        "path": "/detectors/captcha/geetest/match/element/visibility",
-                        "value": "visible"
-                    },
-                    {
-                        "op": "replace",
-                        "path": "/detectors/captcha/awswaf/match/element/visibility",
-                        "value": "visible"
-                    },
-                    {
-                        "op": "replace",
-                        "path": "/detectors/captcha/perimeterx/match/any/0/element/visibility",
-                        "value": "visible"
-                    },
-                    {
-                        "op": "add",
-                        "path": "/detectors/captcha/recaptcha/actions",
-                        "value": { "fireEvent": { "state": "enabled", "type": "captcha_recaptcha_t_vis" } }
-                    },
-                    {
-                        "op": "add",
-                        "path": "/detectors/captcha/hcaptcha/actions",
-                        "value": { "fireEvent": { "state": "enabled", "type": "captcha_hcaptcha_t_vis" } }
-                    },
-                    {
-                        "op": "add",
-                        "path": "/detectors/captcha/turnstile/actions",
-                        "value": { "fireEvent": { "state": "enabled", "type": "captcha_turnstile_t_vis" } }
-                    },
-                    {
-                        "op": "add",
-                        "path": "/detectors/captcha/cloudflare/actions",
-                        "value": { "fireEvent": { "state": "enabled", "type": "captcha_cloudflare_t_vis" } }
-                    },
-                    {
-                        "op": "add",
-                        "path": "/detectors/captcha/datadome/actions",
-                        "value": { "fireEvent": { "state": "enabled", "type": "captcha_datadome_t_vis" } }
-                    },
-                    {
-                        "op": "add",
-                        "path": "/detectors/captcha/imperva/actions",
-                        "value": { "fireEvent": { "state": "enabled", "type": "captcha_imperva_t_vis" } }
-                    },
-                    {
-                        "op": "add",
-                        "path": "/detectors/captcha/arkose/actions",
-                        "value": { "fireEvent": { "state": "enabled", "type": "captcha_arkose_t_vis" } }
-                    },
-                    {
-                        "op": "add",
-                        "path": "/detectors/captcha/geetest/actions",
-                        "value": { "fireEvent": { "state": "enabled", "type": "captcha_geetest_t_vis" } }
-                    },
-                    {
-                        "op": "add",
-                        "path": "/detectors/captcha/awswaf/actions",
-                        "value": { "fireEvent": { "state": "enabled", "type": "captcha_awswaf_t_vis" } }
-                    },
-                    {
-                        "op": "add",
-                        "path": "/detectors/captcha/perimeterx/actions",
-                        "value": { "fireEvent": { "state": "enabled", "type": "captcha_perimeterx_t_vis" } }
-                    },
-                    {
-                        "op": "add",
-                        "path": "/detectors/captcha/other/actions",
-                        "value": { "fireEvent": { "state": "enabled", "type": "captcha_other_t_vis" } }
                     }
                 ]
             },

--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -4718,7 +4718,7 @@
                     ]
                 },
                 "contentScopeExperiment6": {
-                    "state": "enabled",
+                    "state": "disabled",
                     "minSupportedVersion": 52900000,
                     "description": "Captcha detection: auto-run + fireEvent for the captcha detectors, comparing 'content' vs 'visible' element visibility",
                     "rollout": {
@@ -4739,6 +4739,28 @@
                         },
                         {
                             "name": "treatmentVis",
+                            "weight": 1
+                        }
+                    ]
+                },
+                "contentScopeExperiment7": {
+                    "state": "enabled",
+                    "minSupportedVersion": 52900000,
+                    "description": "Captcha detection: auto-run + fireEvent for the captcha detectors, using 'content' element visibility",
+                    "rollout": {
+                        "steps": [
+                            {
+                                "percent": 50
+                            }
+                        ]
+                    },
+                    "cohorts": [
+                        {
+                            "name": "control",
+                            "weight": 1
+                        },
+                        {
+                            "name": "treatment",
                             "weight": 1
                         }
                     ]

--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -952,7 +952,7 @@
                     ]
                 },
                 "contentScopeExperiment6": {
-                    "state": "enabled",
+                    "state": "disabled",
                     "minSupportedVersion": "7.231.0",
                     "description": "Captcha detection: auto-run + fireEvent for the captcha detectors, comparing 'content' vs 'visible' element visibility",
                     "rollout": {
@@ -973,6 +973,28 @@
                         },
                         {
                             "name": "treatmentVis",
+                            "weight": 1
+                        }
+                    ]
+                },
+                "contentScopeExperiment7": {
+                    "state": "enabled",
+                    "minSupportedVersion": "7.231.0",
+                    "description": "Captcha detection: auto-run + fireEvent for the captcha detectors, using 'content' element visibility",
+                    "rollout": {
+                        "steps": [
+                            {
+                                "percent": 50
+                            }
+                        ]
+                    },
+                    "cohorts": [
+                        {
+                            "name": "control",
+                            "weight": 1
+                        },
+                        {
+                            "name": "treatment",
                             "weight": 1
                         }
                     ]

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -195,7 +195,7 @@
                     ]
                 },
                 "contentScopeExperiment6": {
-                    "state": "enabled",
+                    "state": "disabled",
                     "minSupportedVersion": "1.201.0",
                     "description": "Captcha detection: auto-run + fireEvent for the captcha detectors, comparing 'content' vs 'visible' element visibility",
                     "rollout": {
@@ -216,6 +216,28 @@
                         },
                         {
                             "name": "treatmentVis",
+                            "weight": 1
+                        }
+                    ]
+                },
+                "contentScopeExperiment7": {
+                    "state": "enabled",
+                    "minSupportedVersion": "1.201.0",
+                    "description": "Captcha detection: auto-run + fireEvent for the captcha detectors, using 'content' element visibility",
+                    "rollout": {
+                        "steps": [
+                            {
+                                "percent": 50
+                            }
+                        ]
+                    },
+                    "cohorts": [
+                        {
+                            "name": "control",
+                            "weight": 1
+                        },
+                        {
+                            "name": "treatment",
                             "weight": 1
                         }
                     ]


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1215218660135895/task/1217408393396335?focus=true

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes live experiment assignment and captcha telemetry for a subset of users; no auth or data-model changes, but rollout affects in-browser detection behavior.
> 
> **Overview**
> **Turns off** the `contentScopeExperiment6` captcha A/B test (content vs **visible** element visibility) on Android, iOS, and macOS overrides and **starts** `contentScopeExperiment7` at **50%** rollout with only **control** and **treatment** cohorts.
> 
> In `web-detection.json`, captcha detector patches (enable detectors, auto triggers, `fireEvent` actions) now apply under **experiment7 / treatment** for `android` and `apple-isolated`. The separate **treatmentVis** conditional block and duplicate **treatmentCon** experiment blocks are **removed**, so the visibility cohort and its `*_t_vis` event types are no longer configured.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1414374a83cc3e1cac92296907c086058e387728. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->