### PR TITLE
Enable iOS Starting Experience Success Rate instrumentation for internal users

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -3334,6 +3334,11 @@
                             "weight": 1
                         }
                     ]
+                },
+                "newTabPageSessionInstrumentation": {
+                    "state": "internal",
+                    "minSupportedVersion": "7.233.0",
+                    "description": "Wide event measuring Starting Experience Success Rate."
                 }
             }
         },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/72649045549333/task/1217456842764054?focus=true

## Description
Enables iOS Starting Experience Success Rate instrumentation for internal users - sending wide event.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [x] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single iOS privacy-config flag in internal state only; no user-facing behavior or rollout to production users in this diff.
> 
> **Overview**
> Adds **`newTabPageSessionInstrumentation`** under **`iOSBrowserConfig`** in `ios-override.json`, gated to **`internal`** users on iOS **7.233.0+**.
> 
> This turns on client-side **wide-event** telemetry for **Starting Experience Success Rate** on the new tab page session path, without a public rollout or cohorts in this change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 04411c3a0d955f65a5cfb9188c6796adc6cca32a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->