### PR TITLE
Element hiding: Address new app wall on Reddit.

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -3563,7 +3563,7 @@
                         "type": "hide"
                     },
                     {
-                        "selector": "shreddit-experience-tree[active-experiences*=\"app_selector\"], .XPromoBlockingModal, .XPromoInFeed, .xPromoAppStoreFooter, #configured-xpromo-blocking_xpromo_nsfw_blocking, #configured-xpromo-unrated_block, .configured-xpromo-full-screen, #xpromo-bottom-sheet[aria-label*=\"See Reddit in...\"], #xpromo-bottom-sheet[aria-label*=\"See this post in...\"], .AppSelectorModal__body, .XPromoBottomBar, [bundlename=\"bottom_bar_xpromo\"], [data-testid=\"bottom-sheet-upsell-wrapper\"], [slot=\"use-app\"], bottom-bar[app-link-params], xpromo-app-selector, .mobile-web-redirect-bar, .upsell_banner",
+                        "selector": "shreddit-experience-tree[active-experiences*=\"app_selector\"], .XPromoBlockingModal, .XPromoInFeed, .xPromoAppStoreFooter, #configured-xpromo-blocking_xpromo_nsfw_blocking, #configured-xpromo-unrated_block, .configured-xpromo-full-screen, .configured-xpromo-bottom-sheet, #xpromo-bottom-sheet[aria-label*=\"See Reddit in...\"], #xpromo-bottom-sheet[aria-label*=\"See this post in...\"], .AppSelectorModal__body, .XPromoBottomBar, [bundlename=\"bottom_bar_xpromo\"], [data-testid=\"bottom-sheet-upsell-wrapper\"], [slot=\"use-app\"], bottom-bar[app-link-params], xpromo-app-selector, .mobile-web-redirect-bar, .upsell_banner",
                         "type": "hide"
                     },
                     {

--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -3563,8 +3563,18 @@
                         "type": "hide"
                     },
                     {
-                        "selector": "shreddit-experience-tree[active-experiences*=\"app_selector\"], .XPromoBlockingModal, .XPromoInFeed, .xPromoAppStoreFooter, #configured-xpromo-blocking_xpromo_nsfw_blocking, #configured-xpromo-unrated_block, #xpromo-bottom-sheet[aria-label*=\"See Reddit in...\"], #xpromo-bottom-sheet[aria-label*=\"See this post in...\"], .AppSelectorModal__body, .XPromoBottomBar, [bundlename=\"bottom_bar_xpromo\"], [data-testid=\"bottom-sheet-upsell-wrapper\"], [slot=\"use-app\"], bottom-bar[app-link-params], xpromo-app-selector, .mobile-web-redirect-bar, .upsell_banner",
+                        "selector": "shreddit-experience-tree[active-experiences*=\"app_selector\"], .XPromoBlockingModal, .XPromoInFeed, .xPromoAppStoreFooter, #configured-xpromo-blocking_xpromo_nsfw_blocking, #configured-xpromo-unrated_block, .configured-xpromo-full-screen, #xpromo-bottom-sheet[aria-label*=\"See Reddit in...\"], #xpromo-bottom-sheet[aria-label*=\"See this post in...\"], .AppSelectorModal__body, .XPromoBottomBar, [bundlename=\"bottom_bar_xpromo\"], [data-testid=\"bottom-sheet-upsell-wrapper\"], [slot=\"use-app\"], bottom-bar[app-link-params], xpromo-app-selector, .mobile-web-redirect-bar, .upsell_banner",
                         "type": "hide"
+                    },
+                    {
+                        "selector": "html[device='mobile'] body",
+                        "type": "modify-style",
+                        "values": [
+                            {
+                                "property": "overflow-y",
+                                "value": "auto"
+                            }
+                        ]
                     }
                 ]
             },

--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -3567,7 +3567,7 @@
                         "type": "hide"
                     },
                     {
-                        "selector": "html[device='mobile'] body",
+                        "selector": "html[device='mobile'] body, html[device='tablet'] body",
                         "type": "modify-style",
                         "values": [
                             {


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1200277586140538/task/1217081867741669?focus=true

## Description
Update element hiding rule to address new app wall on reddit.com.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL: reddit.com
- Problems experienced: website blocks users from browsing in browser, forces them to install app
- Platforms affected:
  - [x] iOS
  - [x] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Site-specific element-hiding JSON only; no auth or shared runtime changes. Minor risk of over-hiding Reddit promo UI or unintended scroll behavior on mobile web.
> 
> **Overview**
> Updates **reddit.com** element-hiding rules so the new mobile **app wall / xpromo** UI is hidden and users can browse in the browser again on iOS and Android.
> 
> The existing xpromo **hide** selector gains `.configured-xpromo-full-screen` and `.configured-xpromo-bottom-sheet` so full-screen and bottom-sheet variants are covered alongside the prior blocking modals and upsells.
> 
> A new **modify-style** rule sets `overflow-y: auto` on `body` when `html` has `device='mobile'` or `device='tablet'`, undoing scroll lock that often remains after hiding the wall.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 04e2ef6f2e84dabd3d3236a8c487dc87f4d30966. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->