### PR TITLE
Disable CPM on traxxas.com

### DIFF
--- a/features/autoconsent.json
+++ b/features/autoconsent.json
@@ -874,6 +874,10 @@
         {
             "domain": "doublelist.com",
             "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5685"
+        },
+        {
+            "domain": "traxxas.com",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5776"
         }
     ],
     "settings": {


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/1206670747178362/task/1217515432191559?focus=true

## Description
### Site breakage mitigation process:
#### Brief explanation
- Reported URL: https://traxxas.com/checkout
- Problems experienced: PayPal buttons not appearing with CPM enabled.
- Platforms affected:
  - [x] iOS
  - [x] Android
  - [x] Windows
  - [x] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked: N/A
- Feature being disabled/modified: Disable CPM (Cookie Popup Management)
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-domain privacy-config exception with no auth, data, or runtime code changes.
> 
> **Overview**
> Adds **traxxas.com** to the autoconsent **exceptions** list so cookie popup management (CPM) is not applied on that domain.
> 
> This mitigates checkout breakage on `https://traxxas.com/checkout` where PayPal buttons failed to show with CPM enabled (reported on iOS, Android, Windows, and macOS).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f71b1ff13b389abb243a1327d0ccace28713dc0c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->