### PR TITLE
Revert "Enable incident crash reports for ArgumentException in Preview"

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -5284,10 +5284,10 @@
                     "state": "enabled"
                 },
                 "sendIncidentCrashReports": {
-                    "state": "preview",
+                    "state": "disabled",
                     "settings": {
                         "ExceptionTypes": [
-                            "ArgumentException"
+                            "FaultedException"
                         ]
                     }
                 },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1210369001783739/task/1217360280849337?focus=true

## Description

Reverts #5744. The `ArgumentException` issue in v0.170.0 Preview has been solved, so the automatic incident crash reports are no longer needed and should be disabled again.

In `overrides/windows-override.json`, `sendIncidentCrashReports`:
- `state`: `preview` → `disabled`
- `settings.ExceptionTypes`: `ArgumentException` → `FaultedException`

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Gom8e7FjaAhQMevJVdr9wU)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only change to a disabled feature flag; no runtime logic or security paths are modified.
> 
> **Overview**
> Reverts the temporary Windows override that turned on **incident crash reports** in Preview for `ArgumentException` after the underlying issue in v0.170.0 Preview was fixed.
> 
> In `overrides/windows-override.json`, `sendIncidentCrashReports` is set back to **disabled**, and `settings.ExceptionTypes` is restored from `ArgumentException` to `FaultedException`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ba4d351a92909cfe234931e8f581dfad9285359b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->