### PR TITLE
Rollout nativeInputSearchOnly feature to 10 percent

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -5273,6 +5273,7 @@
         },
         "nativeInputOmnibar": {
             "state": "enabled",
+            "exceptions": [],
             "minSupportedVersion": 52920000,
             "features": {
                 "nativeInputSearchOnly": {

--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -5270,6 +5270,23 @@
                     ]
                 }
             }
+        },
+        "nativeInputOmnibar": {
+            "state": "enabled",
+            "minSupportedVersion": 52920000,
+            "features": {
+                "nativeInputSearchOnly": {
+                    "state": "enabled",
+                    "minSupportedVersion": 52920000,
+                    "rollout": {
+                        "steps": [
+                            {
+                                "percent": 10
+                            }
+                        ]
+                    }
+                }
+            }
         }
     },
     "unprotectedTemporary": [],


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/72649045549333/task/1217529315790176?focus=true

## Description
Rolling out the `nativeInputSearchOnly` feature flag to 10% in version 5.292.0

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [x] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [x] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only Android feature flag rollout at 10%; limited blast radius and reversible via remote config.
> 
> **Overview**
> Adds a new Android remote-config feature **`nativeInputOmnibar`** with sub-feature **`nativeInputSearchOnly`**, gated to app version **5.292.0** (`minSupportedVersion` 52920000).
> 
> The sub-feature is **enabled** with a **10%** incremental rollout step, so a slice of eligible Android users will get the search-only native omnibar input behavior without a full release flip.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b3fee244110f3f54ef9ebd2950b032f151f50729. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->