### PR TITLE
[iOS][Onboarding] Download Reason Experiment  feature flag and settings

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -3389,6 +3389,47 @@
                     "state": "internal",
                     "minSupportedVersion": "7.233.0",
                     "description": "Wide event measuring Starting Experience Success Rate."
+                },
+                "onboardingFlowByDownloadReasonExperiment": {
+                    "state": "enabled",
+                    "minSupportedVersion": "7.234.0",
+                    "description": "NA Experiment: tailor the onboarding flow based on the user's download reason. `settings` provides the fallback AI model list for the model-picker step when the /models API is unavailable.",
+                    "settings": {
+                        "defaultModelId": "gpt-5.4-nano",
+                        "models": [
+                            {
+                                "id": "gpt-5.4-nano",
+                                "provider": "openai",
+                                "modelShortName": "5.4-nano"
+                            },
+                            {
+                                "id": "claude-haiku-4-5",
+                                "provider": "anthropic",
+                                "modelShortName": "Haiku 4.5"
+                            },
+                            {
+                                "id": "mistral-small-2603",
+                                "provider": "mistral",
+                                "modelShortName": "Mistral"
+                            }
+                        ]
+                    },
+                    "targets": [
+                        {
+                            "localeLanguage": "en",
+                            "localeCountry": "US"
+                        }
+                    ],
+                    "cohorts": [
+                        {
+                            "name": "control",
+                            "weight": 1
+                        },
+                        {
+                            "name": "treatment",
+                            "weight": 1
+                        }
+                    ]
                 }
             }
         },

--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -3392,7 +3392,7 @@
                 },
                 "onboardingFlowByDownloadReasonExperiment": {
                     "state": "enabled",
-                    "minSupportedVersion": "7.234.0",
+                    "minSupportedVersion": "7.235.0",
                     "description": "NA Experiment: tailor the onboarding flow based on the user's download reason. `settings` provides the fallback AI model list for the model-picker step when the /models API is unavailable.",
                     "settings": {
                         "defaultModelId": "gpt-5.4-nano",

--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -3396,23 +3396,7 @@
                     "description": "NA Experiment: tailor the onboarding flow based on the user's download reason. `settings` provides the fallback AI model list for the model-picker step when the /models API is unavailable.",
                     "settings": {
                         "defaultModelId": "gpt-5.4-nano",
-                        "models": [
-                            {
-                                "id": "gpt-5.4-nano",
-                                "provider": "openai",
-                                "modelShortName": "5.4-nano"
-                            },
-                            {
-                                "id": "claude-haiku-4-5",
-                                "provider": "anthropic",
-                                "modelShortName": "Haiku 4.5"
-                            },
-                            {
-                                "id": "mistral-small-2603",
-                                "provider": "mistral",
-                                "modelShortName": "Mistral"
-                            }
-                        ]
+                        "models": "[{\"id\":\"gpt-5.4-nano\",\"provider\":\"openai\",\"modelShortName\":\"5.4-nano\"},{\"id\":\"claude-haiku-4-5\",\"provider\":\"anthropic\",\"modelShortName\":\"Haiku 4.5\"},{\"id\":\"mistral-small-2603\",\"provider\":\"mistral\",\"modelShortName\":\"Mistral\"}]"
                     },
                     "targets": [
                         {


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/task/1217523644570158

## Description
Adds a feature flag and settings for the Onboarding Download by Reason Experiment

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [x] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Remote config only; no app logic here. Experiment exposure is limited to en/US cohorts, with model IDs used only as onboarding fallback data.
> 
> **Overview**
> Adds **`onboardingFlowByDownloadReasonExperiment`** under **`iOSBrowserConfig`** in `overrides/ios-override.json` for iOS **7.235.0+**.
> 
> The flag is **enabled** for **en/US** with **control** and **treatment** cohorts (equal weight). It is meant to vary onboarding based on download reason. **`settings`** supply a fallback model picker when `/models` fails: **`defaultModelId`** `gpt-5.4-nano` and a JSON **`models`** list (GPT 5.4-nano, Claude Haiku 4.5, Mistral Small 2603).
> 
> No other overrides or schema changes are in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 56ce7f94235677b5c6f1c963a99c396b7664fe4a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->