### PR TITLE
macOS: Enables appRebranding at 5p

### DIFF
--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -2679,8 +2679,15 @@
                     "minSupportedVersion": "1.192.0"
                 },
                 "appRebranding": {
-                    "state": "internal",
-                    "minSupportedVersion": "1.201.0"
+                    "state": "enabled",
+                    "minSupportedVersion": "1.203.0",
+                    "rollout": {
+                        "steps": [
+                            {
+                                "percent": 5
+                            }
+                        ]
+                    }
                 },
                 "onboardingChromeExtension": {
                     "state": "enabled",


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/1176956903599313/task/1215941849226485?focus=true

## Description
This PR rolls out the macOS App Rebranding at 5% of our users base.
Thanks a lot, in advance!


### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only change in a privacy override file; limited 5% rollout with a higher minimum app version reduces blast radius.
> 
> **Overview**
> Updates the macOS remote config for **`appRebranding`** under `macOSBrowserConfig` so the rebranded app UI can reach a small slice of production users instead of staying internal-only.
> 
> **`state`** moves from `internal` to `enabled`, **`minSupportedVersion`** bumps from `1.201.0` to `1.203.0`, and a **`rollout`** block is added with a single step at **5%** of the user base.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9961cbc2455b2804cb2180c45a936a0011eb4693. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->