### PR TITLE
Configure iOS text selection

### DIFF
--- a/features/text-selection.json
+++ b/features/text-selection.json
@@ -1,0 +1,7 @@
+{
+    "_meta": {
+        "description": "Tracks the frame containing selected text for native text-selection actions."
+    },
+    "state": "disabled",
+    "exceptions": []
+}

--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -448,6 +448,10 @@
                 "contextualSuggestedPrompts": {
                     "state": "enabled",
                     "minSupportedVersion": "7.232.0"
+                },
+                "textActions": {
+                    "state": "enabled",
+                    "minSupportedVersion": "7.235.0"
                 }
             },
             "settings": {
@@ -3777,7 +3781,7 @@
         },
         "textSelection": {
             "state": "enabled",
-            "minSupportedVersion": "7.234.0"
+            "minSupportedVersion": "7.235.0"
         },
         "forceDarkModeOnWebsites": {
             "state": "enabled",

--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -3775,6 +3775,10 @@
         "contextMenu": {
             "state": "disabled"
         },
+        "textSelection": {
+            "state": "enabled",
+            "minSupportedVersion": "7.234.0"
+        },
         "forceDarkModeOnWebsites": {
             "state": "enabled",
             "minSupportedVersion": "7.210.0",


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/72649045549333/task/1217482331118256

## Description

Adds remote configuration for the text-selection support introduced by [Content Scope Scripts 16.10.0](https://github.com/duckduckgo/content-scope-scripts/releases/tag/16.10.0) and [apple-browsers#6292](https://github.com/duckduckgo/apple-browsers/pull/6292).

- Adds the `textSelection` C-S-S feature with a disabled base state and exceptions support.
- Enables C-S-S `textSelection` and native `aiChat.textActions` on iOS from `7.235.0`.
- Keeps macOS `textSelection` disabled through the inherited base state because macOS loads the shared Apple isolated bundle but has no native `textSelection` handler.

`7.234.0` is the current internal iOS train. Apple changes merged now first enter the next internal train, `7.235.0`, so both gates begin there. Older iOS versions remain disabled through `minSupportedVersion`.

### Validation

- `npm install` with Node 20
- `npm run test` — 3,125 passing, including build, unit tests, lint, and TypeScript checks
- Generated v3, v4, and v5 configurations inspected:
  - iOS: `textSelection` and `aiChat.textActions` enabled from `7.235.0`
  - macOS: `textSelection` disabled and `aiChat.textActions` absent

A dedicated schema was not added because both entries use the existing generic feature and subfeature schema; the generated configurations passed schema validation in `npm run test`.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [x] This feature was covered by a tech design.