### PR TITLE
Enable storage partitioning on Stable with rollout at 5%

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -2571,7 +2571,7 @@
             }
         },
         "storagePartitioning": {
-            "state": "preview",
+            "state": "enabled",
             "minSupportedVersion": "0.169.0",
             "rollout": {
                 "steps": [

--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -2572,6 +2572,14 @@
         },
         "storagePartitioning": {
             "state": "preview",
+            "minSupportedVersion": "0.169.0",
+            "rollout": {
+                "steps": [
+                    {
+                        "percent": 5.0
+                    }
+                ]
+            },
             "exceptions": []
         },
         "customUserAgent": {


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/task/1216570285754757?focus=true

## Description

Proceed past Preview and enable the storagePartitioning feature in Stable, starting at 5%.
Next step in plan outlined in https://app.asana.com/1/137249556945/task/1216445202121081?focus=true

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Override-only feature-flag rollout; no application code changes.
> 
> **Overview**
> **Windows Stable** moves `storagePartitioning` from **preview** to **enabled** in `overrides/windows-override.json`, with **`minSupportedVersion` `0.169.0`** and a **5%** rollout step. Exceptions stay empty.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e8c2ddc55ff270a344b16d6ad7e6d0b6293e03f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->