### PR TITLE
iOS: Enable subscriptionPromoForExistingUsers

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -3030,7 +3030,7 @@
                 },
                 "subscriptionPromoForExistingUsers": {
                     "state": "enabled",
-                    "minSupportedVersion": "7.234.0"
+                    "minSupportedVersion": "7.235.0"
                 }
             }
         },

--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -3027,6 +3027,10 @@
                 "allowProTierPurchase": {
                     "state": "enabled",
                     "minSupportedVersion": "7.210.0"
+                },
+                "subscriptionPromoForExistingUsers": {
+                    "state": "enabled",
+                    "minSupportedVersion": "7.234.0"
                 }
             }
         },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/72649045549333/task/1216597258137324

## Description

Enables the `subscriptionPromoForExistingUsers` subfeature under `privacyPro` in the iOS override. This activates the subscription promo half-sheet for existing users who completed onboarding but never saw a subscription offer (complements the reinstaller path, which is enabled by default in the app).

Changes in `overrides/ios-override.json`, under `privacyPro`:

- Added `subscriptionPromoForExistingUsers`:
  - `state`: `enabled`
  - `minSupportedVersion`: `7.234.0`

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single iOS remote-config toggle with a version gate; no app logic or schema changes in this repo.
> 
> **Overview**
> Turns on the **`privacyPro.subscriptionPromoForExistingUsers`** subfeature in `overrides/ios-override.json` for iOS (`state`: **enabled**, `minSupportedVersion`: **7.235.0**).
> 
> That config flag lets the app show the subscription promo half-sheet to **existing users** who finished onboarding but never saw a subscription offer, alongside the reinstaller promo path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1bbedbde54f94fd8f08b2a64a67283045f091cd3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->