### PR TITLE
Add chromeWebStore feature flag

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -4766,6 +4766,9 @@
                 "certificateTransparency": {
                     "state": "enabled"
                 },
+                "chromeWebStore": {
+                    "state": "internal"
+                },
                 "allowRetriesForServiceWorkerTimeouts": {
                     "state": "enabled",
                     "rollout": {


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1211781871643034/task/1217618300052649?focus=true

## Description
Add chromeWebStore feature flag so that we can enable installing extensions from the store.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [X] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.




<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single JSON override with internal-only state; no schema or other platform overrides in this diff, so production users are not enabled by default.
> 
> **Overview**
> Adds a new **`chromeWebStore`** sub-feature under the Windows **`webview`** privacy config block, set to **`internal`** so Chrome Web Store extension install behavior can be gated to internal builds before wider rollout.
> 
> This is the only change in the PR: **`overrides/windows-override.json`** alongside existing webview flags such as `certificateTransparency`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d5b0118bcf566d5e6b2d5487c5d524685d679184. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->