### PR TITLE
Enable Windows promptBar from 0.171.0.

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -1469,7 +1469,8 @@
                     "minSupportedVersion": "0.170.0"
                 },
                 "promptBar": {
-                    "state": "internal"
+                    "state": "enabled",
+                    "minSupportedVersion": "0.171.0"
                 }
             },
             "minSupportedVersion": "0.100.0",


### PR DESCRIPTION
## Summary
- Enable `aiChat.promptBar` on Windows
- Gate it behind `minSupportedVersion: "0.171.0"`


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single feature-flag entry in Windows overrides; no application logic or security paths changed.
> 
> **Overview**
> Rolls out the **aiChat `promptBar`** feature on Windows by changing `promptBar.state` from `internal` to `enabled` in `windows-override.json`, with **`minSupportedVersion: "0.171.0"`** so only builds at or above that version receive the flag.
> 
> Older Windows clients keep the prior behavior (no general rollout via this config path).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c48faf42db2ae6c7186bc27e1f7a4340e2864386. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->