### PR TITLE
Update content-blocker extension to 2026.8.19

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -5013,7 +5013,7 @@
             "minSupportedVersion": "0.148.0",
             "exceptions": [],
             "settings": {
-                "extensionUrl": "https://staticcdn.duckduckgo.com/extensions/content-blocker/content-blocker-extension-2026.8.13.crx"
+                "extensionUrl": "https://staticcdn.duckduckgo.com/extensions/content-blocker/content-blocker-extension-2026.8.19.crx"
             },
             "features": {
                 "onboardingEnabled": {


### PR DESCRIPTION
Update content-blocker extension to 2026.8.19.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single URL version bump in remote config; low risk unless the new CRX build is faulty, which is outside this diff.
> 
> **Overview**
> Updates the Windows feature override for **adBlockV2Extension** so clients download the newer content-blocker CRX (`2026.8.19` instead of `2026.8.13`). No other override fields (`minSupportedVersion`, feature flags, or exceptions) change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 40f87c1b290915e89ea2ce6d0b807221e12f84cd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->