### PR TITLE
Update ad-blocking extension scriptlets for v2026.8.19

### DIFF
--- a/features/ad-blocking-extension.json
+++ b/features/ad-blocking-extension.json
@@ -4,28 +4,28 @@
     },
     "exceptions": [],
     "settings": {
-        "version": "2026.8.13",
+        "version": "2026.8.19",
         "enabledByDefault": false,
         "scriptlets": {
             "scriptlets/isolated/ublock-filters.js": {
-                "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/b277ec630fc2f56021217ebbb5c4caf9b0d82fc3ede383b8c13c1f5ea5aefcc8.js",
-                "signature": "MEQCIA9hMVMX8AtpXKLfO/ppBHcf7qkERruPBLr4cDPmiamkAiB40KpM+hGXSN807vN+NXtwLf/W3hDr0/oQg1IAPtPeKA=="
+                "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/15df6ee546c967649b94ee77f80e2f5cb75926f1837ff416e3bd3d3f101e63d3.js",
+                "signature": "MEUCIQCzP9FcglkQR7oISAIbxVH5cxJ19LtKQ0rBzDygp+LOhwIgHUOZ5Zj6emf/J7PAyww+k3BLeEX5hMJXPaVQpqjYrmc="
             },
             "scriptlets/main/ublock-filters.js": {
-                "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/5e519b4f8df8a4efccbbacfae1a7e0150924a46343cf00a558648c024ba7b0fb.js",
-                "signature": "MEUCIGBGFCIQfQtTi2v6yMqcK4ky31hNNvOECTj2cUYM3Iz3AiEAwspYlBY7/+BbU8CpqhYtiKs2Cbe8QqrScXLUHQjU/Cg="
+                "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/fbf5a76ad0f0febee778c80b0b9bab89bdc7aa29907a15c13f609f5ca531ef3d.js",
+                "signature": "MEUCIFtYmCx+seXugM++ODnA/ZP+nftJPXYA9ZzUKJgWtmIUAiEAyBH0N+lZPIDT80TEQw0J+SM3hhLsBWDPDwwPRjLiUOE="
             },
             "scriptlets/main/ublock-experimental.js": {
                 "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855.js",
-                "signature": "MEQCIFPfWt4DVstVPaamhE0K+PL1sGr9nyNe94si98NBRwbJAiAbygFKLDZSrOzOYw7vCO+un4kDOK3ILr21MiD9Wz5v2g=="
+                "signature": "MEYCIQCxLdZx0wjj+Ztjhp/a9KDCL8NPhhj63haQLNkkIQ0NhwIhALKsrf/qEmJVZPITE4MooWtHNY+wYs0lBCx2H9alBoAB"
             },
             "scriptlets/isolated/ublock-experimental.js": {
                 "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855.js",
-                "signature": "MEYCIQDJarLVk+N6LQVmiWerU7LecEJmHjVlRQB7gpfjvgJB/AIhAK56lOSPYGPX/YwKJ/pqawYRvJqRzNjHYq3zEnBYwVCy"
+                "signature": "MEYCIQD2DH5zJloGVSrQXHxQvKmkVbb7xvOUjSDnoFPulcUBQwIhALzD07suanvKpaquJwaXvducCGdWkNksIytrwwS0Hxy+"
             },
             "rules/youtube.json": {
                 "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/2337db6aa7466667595226f780b6590779db3007ac0a65ef3833f89610c92824.json",
-                "signature": "MEYCIQC2z6b/8mOz1//cavIbMyOX8yYk5gnj6EvCRb9EhP3b7wIhAIgP/xUlEvb5aHNHc9mPfxVRlQ8CaZi3SGzQMf60dJBq"
+                "signature": "MEQCIGh4p2I3R+yiW7At9KUu35HPfxUFk+9fjoADolf0+0gUAiAMazeqwMbcmW9hktoT71SdBOswz7B8O1tOvKCpJ0ybKA=="
             }
         }
     }


### PR DESCRIPTION
Update ad-blocking extension scriptlets for v2026.8.19.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which signed content-blocker scriptlets clients load, so a bad URL or signature could break ad blocking on macOS/iOS until corrected.
> 
> **Overview**
> Bumps the **ad-blocking extension** remote config from `2026.8.13` to **`2026.8.19`**.
> 
> Updates CDN `url` and `signature` entries for the uBlock filter scriptlets (`scriptlets/isolated/ublock-filters.js`, `scriptlets/main/ublock-filters.js`) and refreshes signatures for the experimental scriptlet pair and `rules/youtube.json` (experimental scriptlet URLs stay on the empty-hash placeholder). Clients will fetch the new signed scriptlet bundles from staticcdn.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bfa5d230eb349d42d36a5c3f39233b9cefcb9d66. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->