### PR TITLE
Enable updatedModelPicker FF for internal users

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -407,6 +407,10 @@
                         ]
                     }
                 },
+                "updatedModelPicker": {
+                    "state": "internal",
+                    "minSupportedVersion": "7.234.0"
+                },
                 "contextualUnifiedToggleInput": {
                     "state": "enabled",
                     "description": "Contextual Unified Toggle Input (UTI) for Duck.ai",


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1210947754188321/task/1217159579063399?focus=true

## Description
<!-- 
  Please delete either or both process sections below.
-->

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [x] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single remote-config override with internal-only scope; no app code or broad user rollout.
> 
> **Overview**
> Adds the **`updatedModelPicker`** sub-feature under **`aiChat`** in `ios-override.json`, gated to **internal** users on iOS **7.234.0+**.
> 
> This turns on the new Duck.ai model picker UI for dogfooding only; there is no public rollout or cohort config in this change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a32a580dedfc38e64c78b8925edc70ffb71b4e39. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->