### PR TITLE
Add extensionManagement learnMoreUrl settings for the Windows extensions page

### DIFF
--- a/features/extension-management.json
+++ b/features/extension-management.json
@@ -7,7 +7,9 @@
     "settings": {
         "hiddenExtensionIds": [],
         "disabledExtensionIds": [],
-        "specialBehavior": {}
+        "specialBehavior": {},
+        "learnMoreUrl": "https://duckduckgo.com/duckduckgo-help-pages",
+        "learnMoreUrlRemoteDisable": "https://duckduckgo.com/duckduckgo-help-pages"
     },
     "features": {
         "curatedExtensions": {

--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -5674,7 +5674,9 @@
                     "hdokiejnpimakedhajhdlcegeplioahd": {
                         "overridesInternalAutofill": true
                     }
-                }
+                },
+                "learnMoreUrl": "https://duckduckgo.com/duckduckgo-help-pages",
+                "learnMoreUrlRemoteDisable": "https://duckduckgo.com/duckduckgo-help-pages"
             },
             "features": {
                 "curatedExtensions": {

--- a/schema/features/extension-management.ts
+++ b/schema/features/extension-management.ts
@@ -10,6 +10,10 @@ type ExtensionManagementSettings = {
     hiddenExtensionIds: string[];
     disabledExtensionIds: string[];
     specialBehavior: Record<string, ExtensionSpecialBehavior>;
+    // Help-page URL for the page-header "Learn more" link on the extensions settings screen.
+    learnMoreUrl?: string;
+    // Help-page URL for the "Learn more" link on a remotely-disabled extension's notice.
+    learnMoreUrlRemoteDisable?: string;
 };
 
 // One entry in the curated extensions catalog


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/72649045549333/task/1216298013853987?focus=true

## Description

Adds two remote-config settings to the `extensionManagement` feature so the Windows browser's two
Extensions-settings "Learn more" links can be driven from config instead of a hard-coded URL:

- `learnMoreUrl` — the page-header/description "Learn more" link.
- `learnMoreUrlRemoteDisable` — the "Learn more" link on a remotely-disabled extension's notice.

Both are optional strings and default to `https://duckduckgo.com/duckduckgo-help-pages`. The browser also falls
back to that URL when the config value is absent or malformed, so shipping is safe if a value is ever missing.
Only the Windows browser consumes these today; the values are set in the base feature and the Windows override,
and the settings type is added to the schema.

Changes:
- `schema/features/extension-management.ts` — two optional `string` fields on `ExtensionManagementSettings`.
- `features/extension-management.json` — default URLs in the base `settings`.
- `overrides/windows-override.json` — Windows `settings` values.

### Feature change process:

- [x] I have added a schema to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

> Draft: pairs with the Windows browser change that reads these settings (not yet merged). The placeholder help
> URL should be replaced with the final extensions help page before this is marked ready.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Remote-config-only additions with optional fields and static help URLs; no auth, data, or runtime logic in this repo.
> 
> **Overview**
> Adds two optional **`extensionManagement`** settings so the Windows browser can point Extensions-settings **Learn more** links at help URLs from remote config instead of hard-coded values.
> 
> **`learnMoreUrl`** drives the page-header/description link; **`learnMoreUrlRemoteDisable`** drives the link on a remotely-disabled extension notice. Both are optional strings on **`ExtensionManagementSettings`** in the schema, default to `https://duckduckgo.com/duckduckgo-help-pages` in **`features/extension-management.json`**, and are repeated in **`overrides/windows-override.json`** for Windows. Consumption is in a paired Windows browser change not in this repo.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 20144add06b63620f8cdac9cd2e1ab7245d31e32. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->