### PR TITLE
iOS: Bump min app version for search token experiment

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -3399,7 +3399,7 @@
                 },
                 "searchTokenExperimentV2": {
                     "state": "enabled",
-                    "minSupportedVersion": "7.232.0",
+                    "minSupportedVersion": "7.233.0",
                     "settings": {
                         "tokenTTLSeconds": 300,
                         "refreshWindowSeconds": 120


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/task/1217641494300395

## Description
Bumps the minimum app version for the search token experiment. 7.233 has new pixels, and we want all data flowing to the BE to come from clients with client-side pixels to have accurate dashboards.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 113ac8f370eb5a56811d25d627ffb500b3cdcb0f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->