### PR TITLE
Add html load exception for yahoo

### DIFF
--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -3282,14 +3282,12 @@
                         "domains": [
                             "scribd.com",
                             "notebookcheck.net",
-                            "notebookcheck.com",
-                            "yahoo.com"
+                            "notebookcheck.com"
                         ],
                         "reason": [
                             "https://github.com/duckduckgo/privacy-configuration/pull/5314",
                             "notebookcheck.net - https://github.com/duckduckgo/privacy-configuration/pull/5090",
-                            "notebookcheck.com - https://github.com/duckduckgo/privacy-configuration/pull/5129",
-                            "yahoo.com - https://github.com/duckduckgo/privacy-configuration/pull/5796"
+                            "notebookcheck.com - https://github.com/duckduckgo/privacy-configuration/pull/5129"
                         ]
                     },
                     {
@@ -3297,27 +3295,30 @@
                         "domains": [
                             "scribd.com",
                             "notebookcheck.net",
-                            "notebookcheck.com",
-                            "yahoo.com"
+                            "notebookcheck.com"
                         ],
                         "reason": [
                             "https://github.com/duckduckgo/privacy-configuration/pull/5314",
                             "notebookcheck.net - https://github.com/duckduckgo/privacy-configuration/pull/5090",
-                            "notebookcheck.com - https://github.com/duckduckgo/privacy-configuration/pull/5129",
-                            "yahoo.com - https://github.com/duckduckgo/privacy-configuration/pull/5796"
+                            "notebookcheck.com - https://github.com/duckduckgo/privacy-configuration/pull/5129"
                         ]
+                    },
+                    {
+                        "rule": "html-load.com/script",
+                        "domains": [
+                            "<all>"
+                        ],
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5796"
                     },
                     {
                         "rule": "html-load.com",
                         "domains": [
                             "notebookcheck.net",
-                            "notebookcheck.com",
-                            "yahoo.com"
+                            "notebookcheck.com"
                         ],
                         "reason": [
                             "notebookcheck.net - https://github.com/duckduckgo/privacy-configuration/pull/5090",
-                            "notebookcheck.com - https://github.com/duckduckgo/privacy-configuration/pull/5129",
-                            "yahoo.com - https://github.com/duckduckgo/privacy-configuration/pull/5796"
+                            "notebookcheck.com - https://github.com/duckduckgo/privacy-configuration/pull/5129"
                         ]
                     }
                 ]

--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -3282,12 +3282,14 @@
                         "domains": [
                             "scribd.com",
                             "notebookcheck.net",
-                            "notebookcheck.com"
+                            "notebookcheck.com",
+                            "yahoo.com"
                         ],
                         "reason": [
                             "https://github.com/duckduckgo/privacy-configuration/pull/5314",
                             "notebookcheck.net - https://github.com/duckduckgo/privacy-configuration/pull/5090",
-                            "notebookcheck.com - https://github.com/duckduckgo/privacy-configuration/pull/5129"
+                            "notebookcheck.com - https://github.com/duckduckgo/privacy-configuration/pull/5129",
+                            "yahoo.com - https://github.com/duckduckgo/privacy-configuration/pull/5796"
                         ]
                     },
                     {
@@ -3295,23 +3297,27 @@
                         "domains": [
                             "scribd.com",
                             "notebookcheck.net",
-                            "notebookcheck.com"
+                            "notebookcheck.com",
+                            "yahoo.com"
                         ],
                         "reason": [
                             "https://github.com/duckduckgo/privacy-configuration/pull/5314",
                             "notebookcheck.net - https://github.com/duckduckgo/privacy-configuration/pull/5090",
-                            "notebookcheck.com - https://github.com/duckduckgo/privacy-configuration/pull/5129"
+                            "notebookcheck.com - https://github.com/duckduckgo/privacy-configuration/pull/5129",
+                            "yahoo.com - https://github.com/duckduckgo/privacy-configuration/pull/5796"
                         ]
                     },
                     {
                         "rule": "html-load.com",
                         "domains": [
                             "notebookcheck.net",
-                            "notebookcheck.com"
+                            "notebookcheck.com",
+                            "yahoo.com"
                         ],
                         "reason": [
                             "notebookcheck.net - https://github.com/duckduckgo/privacy-configuration/pull/5090",
-                            "notebookcheck.com - https://github.com/duckduckgo/privacy-configuration/pull/5129"
+                            "notebookcheck.com - https://github.com/duckduckgo/privacy-configuration/pull/5129",
+                            "yahoo.com - https://github.com/duckduckgo/privacy-configuration/pull/5796"
                         ]
                     }
                 ]

--- a/features/web-detection.json
+++ b/features/web-detection.json
@@ -21,7 +21,7 @@
                             },
                             {
                                 "pattern": [
-                                    "^allow ads$"
+                                    "^\\s*allow ads\\s*$"
                                 ],
                                 "selector": "button"
                             }

--- a/features/web-detection.json
+++ b/features/web-detection.json
@@ -9,15 +9,23 @@
             "adwalls": {
                 "generic_en": {
                     "match": {
-                        "text": {
-                            "pattern": [
-                                "ad ?block(er)? detected",
-                                "adjust(ing)?( your)? ad blocking settings",
-                                "(turn(ing)? off|disable|disabling|deactivate)( your| my)? ad ?block(er)?",
-                                "your ad ?blocker is on",
-                                "you('re| are| may be) using an ad blocker"
-                            ]
-                        }
+                        "text": [
+                            {
+                                "pattern": [
+                                    "ad ?block(er)? detected",
+                                    "adjust(ing)?( your)? ad blocking settings",
+                                    "(turn(ing)? off|disable|disabling|deactivate)( your| my)? ad ?block(er)?",
+                                    "your ad ?blocker is on",
+                                    "you('re| are| may be) using an ad blocker"
+                                ]
+                            },
+                            {
+                                "pattern": [
+                                    "^allow ads$"
+                                ],
+                                "selector": "button"
+                            }
+                        ]
                     }
                 },
                 "generic_de": {


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1200277586140538/task/1217669390919015?focus=true

## Description
<!-- 
  Please delete either or both process sections below.
-->

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a tracker allowlist exception for html-load.com/script on all sites, which can reduce blocking coverage. Adwall detection remains disabled and is a smaller config-only change.
> 
> **Overview**
> Unblocks `html-load.com/script` on **all sites** via the tracker allowlist (existing `html-load.com` exceptions stay limited to notebookcheck).
> 
> Also updates English adwall detection: `text` is now a list of matchers, and a new rule matches buttons whose text is exactly “allow ads”. The feature remains `disabled`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa8e5d8a558836b690c2481a80829d94bf2da2d9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->