### PR TITLE
Rollout nativeInputSearchOnly to 25%

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -5268,6 +5268,9 @@
                         "steps": [
                             {
                                 "percent": 10
+                            },
+                            {
+                                "percent": 25
                             }
                         ]
                     }


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1212810093780571/task/1217689696467716?focus=true

## Description
Rolling out the ;nativeInputSearchOnly feature flag to 25%

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [x] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [x] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only feature-flag expansion; no code or security changes, but it will enable the native search input for more Android users.
> 
> **Overview**
> Expands the Android `nativeInputSearchOnly` flag under `nativeInputOmnibar` by adding a **25%** rollout step after the existing 10% step.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 067975b80007a0646e6f7a8cb90d52be13032461. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->