### PR TITLE
Update content-blocker extension to 2026.8.20

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -5013,7 +5013,7 @@
             "minSupportedVersion": "0.148.0",
             "exceptions": [],
             "settings": {
-                "extensionUrl": "https://staticcdn.duckduckgo.com/extensions/content-blocker/content-blocker-extension-2026.8.19.crx"
+                "extensionUrl": "https://staticcdn.duckduckgo.com/extensions/content-blocker/content-blocker-extension-2026.8.20.crx"
             },
             "features": {
                 "onboardingEnabled": {


### PR DESCRIPTION
Update content-blocker extension to 2026.8.20.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single remote-config URL version bump with no logic or security-control changes.
> 
> **Overview**
> Points the Windows `adBlockV2Extension` remote config at the 2026.8.20 content-blocker CRX instead of 2026.8.19.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7700555139e23c5272aaa2706dcc57313de2e4f1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->