### PR TITLE
Update ad-blocking extension scriptlets for v2026.8.20

### DIFF
--- a/features/ad-blocking-extension.json
+++ b/features/ad-blocking-extension.json
@@ -4,28 +4,28 @@
     },
     "exceptions": [],
     "settings": {
-        "version": "2026.8.19",
+        "version": "2026.8.20",
         "enabledByDefault": false,
         "scriptlets": {
             "scriptlets/isolated/ublock-filters.js": {
-                "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/15df6ee546c967649b94ee77f80e2f5cb75926f1837ff416e3bd3d3f101e63d3.js",
-                "signature": "MEUCIQCzP9FcglkQR7oISAIbxVH5cxJ19LtKQ0rBzDygp+LOhwIgHUOZ5Zj6emf/J7PAyww+k3BLeEX5hMJXPaVQpqjYrmc="
+                "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/99ecade91c2ac5bfc11707f75cf9c0d56ae365d87b1b062c57935852372cb473.js",
+                "signature": "MEUCIALEZThRK76E81j3tlY/EZVteGV2dl1eT1HZMXdp/E8sAiEAzQolGCE8XWVR8senQIT/4wBE42FRtdjzkJ4uqsAjoko="
             },
             "scriptlets/main/ublock-filters.js": {
                 "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/fbf5a76ad0f0febee778c80b0b9bab89bdc7aa29907a15c13f609f5ca531ef3d.js",
-                "signature": "MEUCIFtYmCx+seXugM++ODnA/ZP+nftJPXYA9ZzUKJgWtmIUAiEAyBH0N+lZPIDT80TEQw0J+SM3hhLsBWDPDwwPRjLiUOE="
+                "signature": "MEUCIQD2SIYoeMI1ojtxxCALD7Fop89pfpq+fx6hJnym2gFmqwIgPBkbgdLrpFbD5am9icKFbFY1pF8Ft+xaY+gnzqxVtXA="
             },
             "scriptlets/main/ublock-experimental.js": {
                 "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855.js",
-                "signature": "MEYCIQCxLdZx0wjj+Ztjhp/a9KDCL8NPhhj63haQLNkkIQ0NhwIhALKsrf/qEmJVZPITE4MooWtHNY+wYs0lBCx2H9alBoAB"
+                "signature": "MEUCID+szntDl56/AjE+gossNixSauM9KOZGMMaexAnzktQtAiEAvBMy4nH1GJlZBS0oQQHvGzS/yhMT7vr1fmZVFe6xmHM="
             },
             "scriptlets/isolated/ublock-experimental.js": {
                 "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855.js",
-                "signature": "MEYCIQD2DH5zJloGVSrQXHxQvKmkVbb7xvOUjSDnoFPulcUBQwIhALzD07suanvKpaquJwaXvducCGdWkNksIytrwwS0Hxy+"
+                "signature": "MEQCIF0h9eonAoJbXxmyfx9O3FUeEmcTZfvsf/Gf83z0P9ECAiBp6l7YuvJVYI4t2+Tm0QczprgL1BntyWC+UsC1VCmVXQ=="
             },
             "rules/youtube.json": {
                 "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/2337db6aa7466667595226f780b6590779db3007ac0a65ef3833f89610c92824.json",
-                "signature": "MEQCIGh4p2I3R+yiW7At9KUu35HPfxUFk+9fjoADolf0+0gUAiAMazeqwMbcmW9hktoT71SdBOswz7B8O1tOvKCpJ0ybKA=="
+                "signature": "MEYCIQDVeM9xiCGu7IdvLFf++j11IRr3QHxg5ODb5P0gUwfRKAIhAK/vfWj1u6d1iYIDsCeb2ddiliJz6bItpZsuK6j6e3bB"
             }
         }
     }


### PR DESCRIPTION
Update ad-blocking extension scriptlets for v2026.8.20.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates remotely loaded, signed content-blocker scriptlets that run in the browser. Risk is limited to a routine asset/signature rotation rather than logic changes in this repo.
> 
> **Overview**
> Bumps the macOS/iOS ad-blocking extension config from `2026.8.19` to `2026.8.20`.
> 
> Updates CDN URLs and signatures for the uBlock scriptlets (notably `ublock-filters.js` isolated) and re-signs the remaining scriptlets and YouTube rules so clients fetch the new signed assets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 06203a5440ccc3f4edc0f1ab9507ea138a1f86f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->