### PR TITLE
Disable CPM on paypal.com on Android

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -811,6 +811,10 @@
                 {
                     "domain": "dresden.de",
                     "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5532"
+                },
+                {
+                    "domain": "paypal.com",
+                    "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5800"
                 }
             ],
             "features": {


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/1206670747178362/task/1217509939045149?focus=true

## Description
### Site breakage mitigation process:
#### Brief explanation
- Reported URL: https://www.paypal.com/
- Problems experienced: Unable to open "Manage your cookie settings” page (automatically returns to “Data & Privacy” settings page.
- Platforms affected:
  - [ ] iOS
  - [x] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked: N/A
- Feature being disabled/modified: Cookie Popup Management (CPM)
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-site privacy-feature exception; no auth, data, or architecture changes. Cookie banners on PayPal will no longer be auto-handled on Android.
> 
> **Overview**
> Adds `paypal.com` to the Android `autoconsent` exceptions so Cookie Popup Management is off on that site.
> 
> This is a breakage mitigation: CPM was sending users back from “Manage your cookie settings” to the “Data & Privacy” page. Other platforms are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a43284692289acfc17f9709d06b9389385f6df62. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->