### PR TITLE
Android: Update eme allowlist and add drmPolicy flag

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -382,7 +382,8 @@
                 "centralPolicy": {
                     "state": "disabled"
                 }
-            }
+            },
+            "exceptions": []
         },
         "eme": {
             "state": "enabled",

--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -376,124 +376,316 @@
         "contentBlocking": {
             "exceptions": []
         },
+        "drmPolicy": {
+            "state": "disabled",
+            "features": {
+                "centralPolicy": {
+                    "state": "disabled"
+                }
+            }
+        },
         "eme": {
             "state": "enabled",
             "exceptions": [
                 {
-                    "domain": "amazon.com",
-                    "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1162"
+                    "domain": "pornhub.com"
                 },
                 {
-                    "domain": "cnn.com",
-                    "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1220"
+                    "domain": "xvideos.com"
                 },
                 {
-                    "domain": "foxnews.com",
-                    "reason": "https://github.com/duckduckgo/privacy-configuration/issues/984"
+                    "domain": "youtube.com"
                 },
                 {
-                    "domain": "open.spotify.com",
-                    "reason": "Site displays a 'Playback disabled' notice on some media, preventing listening."
+                    "domain": "xhamster.com"
                 },
                 {
-                    "domain": "plex.tv",
-                    "reason": "https://github.com/duckduckgo/privacy-configuration/issues/684"
+                    "domain": "reddit.com"
                 },
                 {
-                    "domain": "primevideo.com",
-                    "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1162"
+                    "domain": "facebook.com"
                 },
                 {
-                    "domain": "rte.ie",
-                    "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1217"
+                    "domain": "xnxx.com"
                 },
                 {
-                    "domain": "showtime.com",
-                    "reason": "https://github.com/duckduckgo/privacy-configuration/issues/867"
+                    "domain": "instagram.com"
                 },
                 {
-                    "domain": "peacocktv.com",
-                    "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1356"
+                    "domain": "fandom.com"
                 },
                 {
-                    "domain": "disneyplus.com",
-                    "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1363"
+                    "domain": "erome.com"
                 },
                 {
-                    "domain": "hulu.com",
-                    "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1363"
+                    "domain": "amazon.com"
                 },
                 {
-                    "domain": "plus.espn.com",
-                    "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1363"
+                    "domain": "imdb.com"
                 },
                 {
-                    "domain": "netflix.com",
-                    "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1363"
+                    "domain": "viralxxxporn.com"
                 },
                 {
-                    "domain": "paramountplus.com",
-                    "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1363"
+                    "domain": "eporner.com"
                 },
                 {
-                    "domain": "tv.apple.com",
-                    "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1363"
+                    "domain": "x.com"
                 },
                 {
-                    "domain": "curiositystream.com",
-                    "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1363"
+                    "domain": "linkedin.com"
                 },
                 {
-                    "domain": "starz.com",
-                    "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1363"
+                    "domain": "rule34.xxx"
                 },
                 {
-                    "domain": "dazn.com",
-                    "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1363"
+                    "domain": "yahoo.com"
                 },
                 {
-                    "domain": "crunchyroll.com",
-                    "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1363"
+                    "domain": "bbc.com"
                 },
                 {
-                    "domain": "funimation.com",
-                    "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1363"
+                    "domain": "tubesafari.com"
                 },
                 {
-                    "domain": "mubi.com",
-                    "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1363"
+                    "domain": "t.me"
                 },
                 {
-                    "domain": "crave.ca",
-                    "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1363"
+                    "domain": "yandex.com"
                 },
                 {
-                    "domain": "britbox.com",
-                    "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1363"
+                    "domain": "bbc.co.uk"
                 },
                 {
-                    "domain": "dailywire.com",
-                    "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1363"
+                    "domain": "scrolller.com"
                 },
                 {
-                    "domain": "fubo.tv",
-                    "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1363"
+                    "domain": "rule34video.com"
                 },
                 {
-                    "domain": "acorn.tv",
-                    "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1363"
+                    "domain": "xhamster.desi"
                 },
                 {
-                    "domain": "shudder.com",
-                    "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1363"
+                    "domain": "aznude.com"
                 },
                 {
-                    "domain": "music.amazon.com",
-                    "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1363"
+                    "domain": "wikihow.com"
                 },
                 {
-                    "domain": "youtube.com",
-                    "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1363"
+                    "domain": "nudevista.com"
+                },
+                {
+                    "domain": "tiktok.com"
+                },
+                {
+                    "domain": "foxnews.com"
+                },
+                {
+                    "domain": "xhamster19.com"
+                },
+                {
+                    "domain": "nytimes.com"
+                },
+                {
+                    "domain": "youporn.com"
+                },
+                {
+                    "domain": "thisvid.com"
+                },
+                {
+                    "domain": "mypikpak.com"
+                },
+                {
+                    "domain": "archive.org"
+                },
+                {
+                    "domain": "chaturbate.com"
+                },
+                {
+                    "domain": "luxuretv.com"
+                },
+                {
+                    "domain": "allrecipes.com"
+                },
+                {
+                    "domain": "accuweather.com"
+                },
+                {
+                    "domain": "webmd.com"
+                },
+                {
+                    "domain": "amazon.de"
+                },
+                {
+                    "domain": "notfans.com"
+                },
+                {
+                    "domain": "pornhub.org"
+                },
+                {
+                    "domain": "spankbang.com"
+                },
+                {
+                    "domain": "msn.com"
+                },
+                {
+                    "domain": "amazon.co.uk"
+                },
+                {
+                    "domain": "erothots.co"
+                },
+                {
+                    "domain": "steamcommunity.com"
+                },
+                {
+                    "domain": "fapello.com"
+                },
+                {
+                    "domain": "alohatube.com"
+                },
+                {
+                    "domain": "leakgallery.com"
+                },
+                {
+                    "domain": "cumguru.com"
+                },
+                {
+                    "domain": "dailymail.com"
+                },
+                {
+                    "domain": "fapopedia.net"
+                },
+                {
+                    "domain": "stripchat.com"
+                },
+                {
+                    "domain": "thothub.to"
+                },
+                {
+                    "domain": "pinterest.com"
+                },
+                {
+                    "domain": "hanime.tv"
+                },
+                {
+                    "domain": "theguardian.com"
+                },
+                {
+                    "domain": "porntrex.com"
+                },
+                {
+                    "domain": "tnaflix.com"
+                },
+                {
+                    "domain": "telegram.im"
+                },
+                {
+                    "domain": "scribd.com"
+                },
+                {
+                    "domain": "people.com"
+                },
+                {
+                    "domain": "tagesschau.de"
+                },
+                {
+                    "domain": "spotify.com"
+                },
+                {
+                    "domain": "play.google.com"
+                },
+                {
+                    "domain": "easyliveauction.com"
+                },
+                {
+                    "domain": "xfinity.com"
+                },
+                {
+                    "domain": "bitchute.com"
+                },
+                {
+                    "domain": "onlyfans.com"
+                },
+                {
+                    "domain": "xhamsterlive.com"
+                },
+                {
+                    "domain": "newsmax.com"
+                },
+                {
+                    "domain": "n-tv.de"
+                },
+                {
+                    "domain": "peacocktv.com"
+                },
+                {
+                    "domain": "sportschau.de"
+                },
+                {
+                    "domain": "cnn.com"
+                },
+                {
+                    "domain": "xgroovy.com"
+                },
+                {
+                    "domain": "espn.com"
+                },
+                {
+                    "domain": "iporntv.net"
+                },
+                {
+                    "domain": "youjizz.com"
+                },
+                {
+                    "domain": "rule34.gg"
+                },
+                {
+                    "domain": "pussyspace.com"
+                },
+                {
+                    "domain": "pornone.com"
+                },
+                {
+                    "domain": "redtube.com"
+                },
+                {
+                    "domain": "trannyclips.com"
+                },
+                {
+                    "domain": "xhamster3.com"
+                },
+                {
+                    "domain": "tubepornstars.com"
+                },
+                {
+                    "domain": "netflix.com"
+                },
+                {
+                    "domain": "tubepleasure.com"
+                },
+                {
+                    "domain": "cums.net"
+                },
+                {
+                    "domain": "vk.com"
+                },
+                {
+                    "domain": "porzo.com"
+                },
+                {
+                    "domain": "dailymotion.com"
+                },
+                {
+                    "domain": "missav.live"
+                },
+                {
+                    "domain": "goldtits.com"
+                },
+                {
+                    "domain": "heavy-r.com"
+                },
+                {
+                    "domain": "gaymaletube.com"
                 }
             ]
         },

--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -378,6 +378,7 @@
         },
         "drmPolicy": {
             "state": "disabled",
+            "minSupportedVersion": 52950000,
             "features": {
                 "centralPolicy": {
                     "state": "disabled"


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1207418217763355/task/1213825322108469?focus=true

## Description

This PR adds:
- A new `eme` domain allow-list for the auto-approval of DRM requests
- A new FF for the DRM policy feature rollout

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [x] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Large changes to which sites get automatic EME/DRM approval affect playback and protected content across many domains; mis-inclusions or omissions can cause widespread breakage or broader DRM exposure than intended.
> 
> **Overview**
> **Android remote config** adds a **`drmPolicy`** feature block (disabled, `minSupportedVersion` **52950000**) with nested **`centralPolicy`** also disabled, preparing a future DRM policy rollout without turning it on yet.
> 
> The **`eme`** feature stays enabled but its **`exceptions`** list is **replaced wholesale**: the previous smaller set of streaming/news sites with per-entry **`reason`** strings becomes a **much larger domain-only allowlist** (hundreds of high-traffic sites, including many adult domains). Overlap remains for some names (e.g. `youtube.com`, `netflix.com`, `amazon.com`, `cnn.com`, `foxnews.com`, `peacocktv.com`), but the curation model shifts from issue-linked breakage fixes to bulk auto-approval targets for DRM/EME requests on Android.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 78417e84fd86ef3519a305dffa85826b3aa9788a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->