### PR TITLE
fix(pir): enable the macOS WebView user agent

### DIFF
--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -601,7 +601,7 @@
                     "minSupportedVersion": "1.171.0"
                 },
                 "webViewUserAgent": {
-                    "state": "disabled",
+                    "state": "enabled",
                     "minSupportedVersion": "1.182.0"
                 },
                 "optOutRetryError96Hours": {


### PR DESCRIPTION
### Summary

Asana: https://app.asana.com/1/137249556945/project/1215419848050295/task/1217730613780235?focus=true

During the hack phase I thought we did not need this flag. I think cached state or the app using the wrong flag setting affected that result. When I repeated the same Apple test with the flag explicitly off and on, the off state returned `Rate Limit Exceeded` and the on state loaded `Search Results`.

## Test plan

* [ ] Load this PR's macOS preview config in an app at version `1.182.0` or newer, then confirm `dbpWebViewUserAgent` is on.
* [ ] Run PropertyRecord Scan for the approved Daniel Silva profile, then confirm Search Results load instead of `Rate Limit Exceeded`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single remote-config flag flip for PIR WebView user-agent on macOS; no code or auth changes.
> 
> **Overview**
> Turns on the `dbp` `webViewUserAgent` flag in `macos-override.json` (min version `1.182.0`). This is meant to stop PropertyRecord scans from hitting `Rate Limit Exceeded` so search results load.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c294d31354471458991ab6862eff79938ba9dc37. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->