### PR TITLE
Raise Windows cookiePopupOptInDialog min version to 0.171.0.

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -2207,7 +2207,7 @@
                 },
                 "cookiePopupOptInDialog": {
                     "state": "enabled",
-                    "minSupportedVersion": "0.167.1",
+                    "minSupportedVersion": "0.171.0",
                     "rollout": {
                         "steps": [
                             {


### PR DESCRIPTION
## Summary
- Bump `cookiePopupOptInDialog` `minSupportedVersion` on Windows from `0.167.1` to `0.171.0`

## Test plan
- [ ] Confirm Windows preview config shows `minSupportedVersion: "0.171.0"` for `cookiePopupOptInDialog`
- [ ] Verify the dialog is available on Windows >= 0.171.0
- [ ] Verify the dialog stays off on Windows < 0.171.0

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single feature-flag version gate change with no logic, auth, or data-handling updates. Older Windows clients simply stay ineligible for the dialog.
> 
> **Overview**
> Raises the Windows `cookiePopupOptInDialog` feature flag `minSupportedVersion` from `0.167.1` to `0.171.0`. Clients below 0.171.0 will no longer receive the dialog; rollout percentages are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4812b37c3b9f3a3a1c66f202074abefe83f3d049. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->