### PR TITLE
Disable CPM on thewhisky.pl

### DIFF
--- a/features/autoconsent.json
+++ b/features/autoconsent.json
@@ -998,6 +998,10 @@
         {
             "domain": "traxxas.com",
             "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5776"
+        },
+        {
+            "domain": "thewhisky.pl",
+            "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5806"
         }
     ],
     "settings": {


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/1204912272578138/task/1217729933405913?focus=true

## Description
### Site breakage mitigation process:
#### Brief explanation
- Reported URL: https://thewhisky.pl/297-whisky-live-warsaw
- Problems experienced: The cookie banner is set up by the website in such a way that clicking "Reject" redirects to google.com. Therefore when CPM automatically rejects cookies on the website, users get automatically redirected and can't view the website at all.
- Platforms affected:
  - [x] iOS
  - [x] Android
  - [x] Windows
  - [x] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked: N/A
- Feature being disabled/modified: Cookie Popup Management (CPM)
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only site exception for cookie consent handling; no code or security-sensitive logic changes.
> 
> **Overview**
> Disables Cookie Popup Management on `thewhisky.pl` so auto-reject no longer redirects users off the site.
> 
> The site’s reject action sends visitors to google.com; adding the domain to the autoconsent exception list avoids that breakage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9f7b7ec36d5a5eeca08a92daf8ae1d715d23e9db. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->