### PR TITLE
Disable custom UA string on chatgpt.com for macOS

### DIFF
--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -1813,6 +1813,10 @@
                     {
                         "domain": "nationalmssociety.org",
                         "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1963"
+                    },
+                    {
+                        "domain": "chatgpt.com",
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5749"
                     }
                 ]
             }

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -1816,7 +1816,7 @@
                     },
                     {
                         "domain": "chatgpt.com",
-                        "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5749"
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5808"
                     }
                 ]
             }

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -1799,6 +1799,10 @@
                     {
                         "domain": "deezer.com",
                         "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5749"
+                    },
+                    {
+                        "domain": "chatgpt.com",
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5808"
                     }
                 ],
                 "webViewDefault": [
@@ -1813,10 +1817,6 @@
                     {
                         "domain": "nationalmssociety.org",
                         "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1963"
-                    },
-                    {
-                        "domain": "chatgpt.com",
-                        "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5808"
                     }
                 ]
             }

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -1746,7 +1746,7 @@
                     },
                     {
                         "domain": "app.lyssna.com",
-                        "reason": "Unsupported browser message"
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/pull/2859"
                     },
                     {
                         "domain": "ihg.com",


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/1206670747178362/task/1217746001899952?focus=true

## Description
### Site breakage mitigation process:
#### Brief explanation
- Reported URL: https://chatgpt.com
- Problems experienced:  The ➕ sign and "ChatGPT" placeholder are not displayed, there's no flashing "caret" cursor in the textbox. When you type, nothing appears on the screen but if you press Enter, the typed text is sent as a prompt.
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [x] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked: N/A
- Feature being disabled/modified: Custom user agent string. The `defaultSites` list should be enough for this.
- [ ] This change is a speculative mitigation to fix reported breakage.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only site exception for user-agent spoofing on macOS; no auth, data, or core logic changes.
> 
> **Overview**
> Adds `chatgpt.com` to the macOS `customUserAgent` `defaultSites` list so the site no longer gets DuckDuckGo’s custom user-agent. That mitigates reported ChatGPT input breakage (missing placeholder/caret and typed text not showing until Enter).
> 
> Also updates the `app.lyssna.com` exception reason to the related PR URL.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ceba39a2cf425ebb602eb5239a8b8d355a79c82c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->