### PR TITLE
Add `performanceOptimizedPaywalls` feature flag (off by default)

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -4215,6 +4215,22 @@
                             }
                         ]
                     }
+                },
+                "performanceOptimizedPaywalls": {
+                    "state": "disabled",
+                    "settings": {
+                        "entryPoints": {
+                            "vpn": {
+                                "path": "/subscriptions/new/mobile/vpn"
+                            },
+                            "duckai": {
+                                "path": "/subscriptions/new/mobile/duckai"
+                            },
+                            "pir": {
+                                "path": "/subscriptions/new/mobile/pir"
+                            }
+                        }
+                    }
                 }
             }
         },

--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -3220,6 +3220,22 @@
                 "allowProTierPurchase": {
                     "state": "enabled",
                     "minSupportedVersion": "7.210.0"
+                },
+                "performanceOptimizedPaywalls": {
+                    "state": "disabled",
+                    "settings": {
+                        "entryPoints": {
+                            "vpn": {
+                                "path": "/subscriptions/new/mobile/vpn"
+                            },
+                            "duckai": {
+                                "path": "/subscriptions/new/mobile/duckai"
+                            },
+                            "pir": {
+                                "path": "/subscriptions/new/mobile/pir"
+                            }
+                        }
+                    }
                 }
             }
         },

--- a/schema/config.ts
+++ b/schema/config.ts
@@ -42,6 +42,7 @@ import { WebExtensionsConfig } from './features/web-extensions';
 import { AdBlockingExtensionConfig } from './features/ad-blocking-extension';
 import { TabSuspension } from './features/tab-suspension';
 import { ExtensionManagementFeature } from './features/extension-management';
+import { PrivacyProFeature } from './features/privacy-pro';
 
 export { WebCompatSettings } from './features/webcompat';
 export { DuckPlayerSettings } from './features/duckplayer';
@@ -113,6 +114,7 @@ export type ConfigV5<VersionType> = {
         tabSuspension?: TabSuspension<VersionType>;
         webExtensions?: WebExtensionsConfig<VersionType>;
         extensionManagement?: ExtensionManagementFeature<VersionType>;
+        privacyPro?: PrivacyProFeature<VersionType>;
     };
     unprotectedTemporary: SiteException[];
 };

--- a/schema/features/privacy-pro.ts
+++ b/schema/features/privacy-pro.ts
@@ -1,0 +1,19 @@
+import { Feature, SubFeature } from '../feature';
+
+type PaywallEntryPoint = {
+    path: string;
+};
+
+type PerformanceOptimizedPaywallsSettings = {
+    entryPoints?: {
+        vpn?: PaywallEntryPoint;
+        duckai?: PaywallEntryPoint;
+        pir?: PaywallEntryPoint;
+    };
+};
+
+type SubFeatures<VersionType> = {
+    performanceOptimizedPaywalls?: SubFeature<VersionType, PerformanceOptimizedPaywallsSettings>;
+};
+
+export type PrivacyProFeature<VersionType> = Feature<any, VersionType, SubFeatures<VersionType> & Record<string, SubFeature<VersionType>>>;


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1201141132935289/task/1217750626830939?focus=true

## Description
- [x] Adds a feature flag for iOS + Android to allow the use of upcoming performance optimized paywalls.
- [x] `off` by default 

### Feature change process:

- [x] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [x] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [x] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Privacy Pro paywall routing for subscription flows; impact stays low while the flag is off, but enabling it would change which paywall URLs mobile clients load.
> 
> **Overview**
> Introduces a **`performanceOptimizedPaywalls`** sub-feature under **`privacyPro`** on **iOS and Android**, default **`disabled`**, so clients can later switch to performance-oriented subscription paywalls without a config deploy for the paths.
> 
> When turned on, **`settings.entryPoints`** maps **VPN**, **Duck AI**, and **PIR** to mobile subscription URLs (`/subscriptions/new/mobile/vpn`, `duckai`, `pir`).
> 
> Adds **`schema/features/privacy-pro.ts`** and wires **`privacyPro`** into the shared config schema in **`schema/config.ts`** so overrides for this feature validate consistently.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 10d45f1ab3a5165bb773ad7861ceb2d0877aeb4f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->