### PR TITLE
Revert macOS UA override for chatgpt.com

### DIFF
--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -1799,10 +1799,6 @@
                     {
                         "domain": "deezer.com",
                         "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5749"
-                    },
-                    {
-                        "domain": "chatgpt.com",
-                        "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5808"
                     }
                 ],
                 "webViewDefault": [
@@ -1817,6 +1813,10 @@
                     {
                         "domain": "nationalmssociety.org",
                         "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1963"
+                    },
+                    {
+                        "domain": "chatgpt.com",
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5808"
                     }
                 ]
             }

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -1813,10 +1813,6 @@
                     {
                         "domain": "nationalmssociety.org",
                         "reason": "https://github.com/duckduckgo/privacy-configuration/issues/1963"
-                    },
-                    {
-                        "domain": "chatgpt.com",
-                        "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5808"
                     }
                 ]
             }


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/1205996472045435/task/1217746001899952?focus=true

## Description
### Site breakage mitigation process:
#### Brief explanation
- Reported URL: https://chatgpt.com
- Problems experienced: Reverting override because it seems UA string is not the cause.
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [x] macOS
  - [ ] Extensions
- Tracker(s) being unblocked: N/A
- Feature being disabled/modified: UA string
- [ ] This change is a speculative mitigation to fix reported breakage.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-domain macOS privacy-config revert with no auth or data changes; main effect is restored default UA on chatgpt.com, which may re-expose any original site issue if the root cause was misidentified.
> 
> **Overview**
> **Reverts the macOS site-specific user-agent mitigation for `chatgpt.com`** by deleting its entry from `customUserAgent.settings.defaultSites` in `overrides/macos-override.json`.
> 
> That list (with `defaultPolicy: "brand"`) had applied the standard “present as Safari / drop DuckDuckGo UA branding” workaround added in PR #5808. The change is scoped to **macOS only**; other platforms are untouched.
> 
> After this ships, DuckDuckGo Browser on macOS will use the normal custom user-agent behavior on `https://chatgpt.com` again, on the basis that the reported breakage was **not** caused by the UA string.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff4b5ecb338a915c22ad60ab3542944a3a2e2912. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->