### PR TITLE
Enables autoplayPolicy at 5p

### DIFF
--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -2667,7 +2667,8 @@
                     "state": "enabled"
                 },
                 "autoplayPolicy": {
-                    "state": "internal",
+                    "state": "enabled",
+                    "minSupportedVersion": "1.204.0",
                     "settings": {
                         "domainsAllowList": [
                             "youtube.com",
@@ -2675,6 +2676,13 @@
                             "hulu.com",
                             "vimeo.com",
                             "primevideo.com"
+                        ]
+                    },
+                    "rollout": {
+                        "steps": [
+                            {
+                                "percent": 5
+                            }
                         ]
                     }
                 },


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/1211150618152277/task/1214035129057129?focus=true

## Description
This PR rolls out the macOS autoplayPolicy at 5% of our users base.
Thanks a lot, in advance!

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Autoplay policy changes can alter media playback on high-traffic streaming sites, though scope is limited by the domain allowlist and a 5% rollout.
> 
> **Overview**
> **macOS remote config** moves `macOSBrowserConfig.autoplayPolicy` from **internal** to **enabled**, gated by `minSupportedVersion` **1.204.0** and a **5%** rollout step.
> 
> The existing `domainsAllowList` (YouTube, Netflix, Hulu, Vimeo, Prime Video) is unchanged; only rollout visibility and audience expand.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a9af0758c2431ce4e30cf0f2e6fdbc229482d8d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->