### PR TITLE
Remove autoconsent exception for paypal.com

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -811,10 +811,6 @@
                 {
                     "domain": "dresden.de",
                     "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5532"
-                },
-                {
-                    "domain": "paypal.com",
-                    "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5800"
                 }
             ],
             "features": {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1203268166580279/task/1217808331466161?focus=true

## Description

Removes the `paypal.com` autoconsent exception that was added in #5800, re-enabling cookie pop-up management (CPM) on the site. This was the only autoconsent exception for the domain, and it lived in the Android override; no other config was touched.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL: https://paypal.com
- Problems experienced: N/A — reverting a previously added exception
- Platforms affected:
  - [ ] iOS
  - [x] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked: N/A
- Feature being disabled/modified: `autoconsent` (exception removed)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5daaa138-d7ba-4b3e-9c34-e37e20b956ec?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5daaa138-d7ba-4b3e-9c34-e37e20b956ec&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

