### PR TITLE
[Autofill] Widen icloud signin boundary

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -1402,7 +1402,6 @@
                                 ]
                             },
                             {
-                                // Selectors target the idmsa.apple.com sign-in widget, framed by icloud.com.
                                 "condition": [
                                     { "domain": "icloud.com" }
                                 ],

--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -1400,6 +1400,27 @@
                                         }
                                     }
                                 ]
+                            },
+                            {
+                                // Selectors target the idmsa.apple.com sign-in widget, framed by icloud.com.
+                                "condition": [
+                                    { "domain": "icloud.com" }
+                                ],
+                                "patchSettings": [
+                                    {
+                                        "path": "/formBoundarySelector",
+                                        "op": "replace",
+                                        "value": "#sign_in_form"
+                                    },
+                                    {
+                                        "path": "/formTypeSettings/-",
+                                        "op": "add",
+                                        "value": {
+                                            "selector": "#sign_in_form",
+                                            "type": "login"
+                                        }
+                                    }
+                                ]
                             }
                         ]
                     }

--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -1635,7 +1635,6 @@
                                 ]
                             },
                             {
-                                // Selectors target the idmsa.apple.com sign-in widget, framed by icloud.com.
                                 "condition": [
                                     { "domain": "icloud.com" }
                                 ],

--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -1633,6 +1633,27 @@
                                         }
                                     }
                                 ]
+                            },
+                            {
+                                // Selectors target the idmsa.apple.com sign-in widget, framed by icloud.com.
+                                "condition": [
+                                    { "domain": "icloud.com" }
+                                ],
+                                "patchSettings": [
+                                    {
+                                        "path": "/formBoundarySelector",
+                                        "op": "replace",
+                                        "value": "#sign_in_form"
+                                    },
+                                    {
+                                        "path": "/formTypeSettings/-",
+                                        "op": "add",
+                                        "value": {
+                                            "selector": "#sign_in_form",
+                                            "type": "login"
+                                        }
+                                    }
+                                ]
                             }
                         ]
                     }

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -1473,6 +1473,27 @@
                                         }
                                     }
                                 ]
+                            },
+                            {
+                                // Selectors target the idmsa.apple.com sign-in widget, framed by icloud.com.
+                                "condition": [
+                                    { "domain": "icloud.com" }
+                                ],
+                                "patchSettings": [
+                                    {
+                                        "path": "/formBoundarySelector",
+                                        "op": "replace",
+                                        "value": "#sign_in_form"
+                                    },
+                                    {
+                                        "path": "/formTypeSettings/-",
+                                        "op": "add",
+                                        "value": {
+                                            "selector": "#sign_in_form",
+                                            "type": "login"
+                                        }
+                                    }
+                                ]
                             }
                         ]
                     }

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -1475,7 +1475,6 @@
                                 ]
                             },
                             {
-                                // Selectors target the idmsa.apple.com sign-in widget, framed by icloud.com.
                                 "condition": [
                                     { "domain": "icloud.com" }
                                 ],

--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -2164,6 +2164,27 @@
                                         }
                                     }
                                 ]
+                            },
+                            {
+                                // Selectors target the idmsa.apple.com sign-in widget, framed by icloud.com.
+                                "condition": [
+                                    { "domain": "icloud.com" }
+                                ],
+                                "patchSettings": [
+                                    {
+                                        "path": "/formBoundarySelector",
+                                        "op": "replace",
+                                        "value": "#sign_in_form"
+                                    },
+                                    {
+                                        "path": "/formTypeSettings/-",
+                                        "op": "add",
+                                        "value": {
+                                            "selector": "#sign_in_form",
+                                            "type": "login"
+                                        }
+                                    }
+                                ]
                             }
                         ]
                     }

--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -2166,7 +2166,6 @@
                                 ]
                             },
                             {
-                                // Selectors target the idmsa.apple.com sign-in widget, framed by icloud.com.
                                 "condition": [
                                     { "domain": "icloud.com" }
                                 ],


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1200930669568058/task/1216653494807315?focus=true

## Description
Widen icloud's form boundary, which causes button to be not detected. This PR expands that boundary to include the button.

Before
<img width="1382" height="763" alt="image" src="https://github.com/user-attachments/assets/4afd4909-5214-4eb0-a37e-633e8fe294bf" />


After
<img width="659" height="570" alt="image" src="https://github.com/user-attachments/assets/e026f119-267e-4fd4-94c8-98127232fa6c" />



### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only autofill site fix for icloud.com with no auth or credential logic changes; risk is limited to autofill behavior on that domain.
> 
> **Overview**
> Adds a **site-specific autofill fix** for `icloud.com` on Android, iOS, macOS, and Windows. For that domain, autofill now uses `#sign_in_form` as the **form boundary** and registers that element as a **login** form.
> 
> This widens the detected form area so controls outside the previous boundary—especially the sign-in button—are included in autofill behavior on iCloud’s sign-in page.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd0ba22c3bff2004b67c195fa29ef0f920574608. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->