### PR TITLE
Enable promo presentation coordination for internal iOS users

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -1736,6 +1736,15 @@
         "remoteMessaging": {
             "state": "enabled"
         },
+        "promoQueue": {
+            "state": "enabled",
+            "features": {
+                "promoPresentationCoordination": {
+                    "state": "internal",
+                    "minSupportedVersion": "7.235.0"
+                }
+            }
+        },
         "customUserAgent": {
             "state": "enabled",
             "settings": {


### PR DESCRIPTION
**Asana Task/Github Issue:**

https://app.asana.com/1/137249556945/project/1209527836175384/task/1217795760596570

## Description

Enables `promoPresentationCoordination` under `promoQueue` for internal users running iOS app version 7.235.0 or later. Non-internal users remain unaffected.

This change uses the platform-neutral subfeature key expected by the renamed iOS client.

Tech design: https://app.asana.com/1/137249556945/project/1208671677432066/task/1216624996708289?focus=true

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [x] This feature was covered by a tech design.

## Validation

- `npm run build`
- `npm run unit-tests` — 3,188 passing
- `npx eslint overrides/ios-override.json`
- `npx prettier overrides/ios-override.json --check`
- `npm run tsc`