### PR TITLE
Enable promoPresentationCoordination for internal iOS users

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -1736,6 +1736,15 @@
         "remoteMessaging": {
             "state": "enabled"
         },
+        "promoQueue": {
+            "state": "enabled",
+            "features": {
+                "promoPresentationCoordination": {
+                    "state": "internal",
+                    "minSupportedVersion": "7.235.0"
+                }
+            }
+        },
         "customUserAgent": {
             "state": "enabled",
             "settings": {

--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -1736,15 +1736,6 @@
         "remoteMessaging": {
             "state": "enabled"
         },
-        "promoQueue": {
-            "state": "enabled",
-            "features": {
-                "promoPresentationCoordination": {
-                    "state": "internal",
-                    "minSupportedVersion": "7.235.0"
-                }
-            }
-        },
         "customUserAgent": {
             "state": "enabled",
             "settings": {
@@ -3454,6 +3445,10 @@
                             "weight": 1
                         }
                     ]
+                },
+                "promoPresentationCoordination": {
+                    "state": "internal",
+                    "minSupportedVersion": "7.235.0"
                 }
             }
         },


### PR DESCRIPTION
**Asana Task/Github Issue:**

https://app.asana.com/1/137249556945/project/1209527836175384/task/1217795760596570

## Description

Enables `promoPresentationCoordination` under `iOSBrowserConfig` for internal users running iOS app version 7.235.0 or later. Non-internal users remain unaffected.

Tech design: https://app.asana.com/1/137249556945/project/1208671677432066/task/1216624996708289?focus=true

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [x] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [x] This feature was covered by a tech design.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal-only feature flag in `ios-override.json` with a version gate; production users are unaffected until state changes.
> 
> **Overview**
> Turns on **`promoPresentationCoordination`** in the iOS override (`iOSBrowserConfig`) with **`state: internal`** and **`minSupportedVersion: 7.235.0`**, so only internal builds on that app version or newer receive coordinated promo presentation behavior.
> 
> General iOS users stay on the prior config until this is rolled out beyond internal. The change is a single remote-config flag addition with no rollout percentages or cohorts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 45a44fbc2463b8aff2f0dc72555ab898e1365437. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
