### PR TITLE
Allow auto-approval of autofill siteSpecificFixes

### DIFF
--- a/.github/scripts/json-diff-directories.js
+++ b/.github/scripts/json-diff-directories.js
@@ -307,7 +307,10 @@ function displayApprovalStatus(dir1Files, dir2Files, isOpen) {
                     continue;
                 }
 
-                const analysis = analyzePatchesForApproval(patches);
+                const analysis = analyzePatchesForApproval(patches, {
+                    baseConfig: patchedJson1,
+                    updatedConfig: patchedJson2,
+                });
                 const summary = generateChangeSummary(patches);
 
                 fileAnalysis[filePath] = {
@@ -315,6 +318,7 @@ function displayApprovalStatus(dir1Files, dir2Files, isOpen) {
                     message: analysis.shouldApprove ? '✅ Auto-approved' : '❌ Manual review required',
                     patches,
                     disallowedPatches: analysis.disallowedPatches || [],
+                    siteSpecificFixesReasons: analysis.siteSpecificFixesReasons || [],
                     summary,
                     approvalAnalysis: analysis,
                 };
@@ -371,8 +375,15 @@ function displayApprovalStatus(dir1Files, dir2Files, isOpen) {
     // Manual review files
     if (groupedFiles.manual_review.length > 0) {
         outString += '\n## ❌ Manual Review Required\n';
-        groupedFiles.manual_review.forEach(({ filePath, disallowedPatches, summary }) => {
+        groupedFiles.manual_review.forEach(({ filePath, disallowedPatches, siteSpecificFixesReasons, summary }) => {
             outString += `- **${filePath}** (${summary.total} total changes)\n`;
+
+            if (siteSpecificFixesReasons?.length > 0) {
+                outString += '  **Autofill site-specific fixes needing review:**\n';
+                siteSpecificFixesReasons.forEach((reason) => {
+                    outString += `  - ${reason}\n`;
+                });
+            }
 
             if (disallowedPatches.length > 0) {
                 outString += '  **Disallowed paths that require review:**\n';

--- a/automation-utils.js
+++ b/automation-utils.js
@@ -57,6 +57,13 @@ export const AUTO_APPROVABLE_FEATURES = {
     '/features/mediaPlaybackRequiresUserGesture': [
         '/exceptions',
     ],
+    // Nested CSS-inject subfeature. Only site-scoped patches are auto-approved;
+    // global defaults (formBoundarySelector, formTypeSettings, etc.) and
+    // subfeature state/rollout still require review.
+    '/features/autofill/features/siteSpecificFixes': [
+        '/settings/conditionalChanges',
+        '/settings/domains',
+    ],
 };
 
 /**

--- a/automation-utils.js
+++ b/automation-utils.js
@@ -1,6 +1,9 @@
 import fs from 'fs';
 import path from 'path';
 import { immutableJSONPatch } from 'immutable-json-patch';
+import pkg from 'fast-json-patch';
+
+const { compare } = pkg;
 
 /**
  * Auto-approvable features configuration
@@ -56,13 +59,6 @@ export const AUTO_APPROVABLE_FEATURES = {
     ],
     '/features/mediaPlaybackRequiresUserGesture': [
         '/exceptions',
-    ],
-    // Nested CSS-inject subfeature. Only site-scoped patches are auto-approved;
-    // global defaults (formBoundarySelector, formTypeSettings, etc.) and
-    // subfeature state/rollout still require review.
-    '/features/autofill/features/siteSpecificFixes': [
-        '/settings/conditionalChanges',
-        '/settings/domains',
     ],
 };
 
@@ -165,11 +161,308 @@ export function isAllowedChangesOnly(patches) {
 }
 
 /**
+ * Path of the autofill siteSpecificFixes subfeature within a generated config.
+ *
+ * This subfeature is not listed in AUTO_APPROVABLE_FEATURES because a path
+ * allowlist cannot express what makes one of its changes safe. Its entries hold
+ * arbitrary JSON patch operations that are only applied at runtime, so the path
+ * of the change says nothing about its effect. It is evaluated by
+ * evaluateSiteSpecificFixesChange instead.
+ */
+export const SITE_SPECIFIC_FIXES_PATH = '/features/autofill/features/siteSpecificFixes';
+
+/**
+ * Settings keys a site-scoped autofill fix is allowed to affect.
+ */
+export const SITE_SPECIFIC_FIXES_ALLOWED_KEYS = [
+    'formBoundarySelector',
+    'formTypeSettings',
+    'inputTypeSettings',
+    'failsafeSettings',
+];
+
+/**
+ * Condition keys that keep a conditionalChanges entry scoped to named domains.
+ * Anything else (urlPattern, experiment, internal, preview, ...) can widen the
+ * change beyond the sites listed in the PR, so it is left for a human.
+ */
+const DOMAIN_SCOPED_CONDITION_KEYS = [
+    'domain',
+];
+
+/**
+ * Patch operations a site fix may use. `move` and `copy` read from elsewhere in
+ * the settings and `test` is inert, so they are left for a human.
+ */
+const SUPPORTED_PATCH_OPS = [
+    'add',
+    'replace',
+    'remove',
+];
+
+function stableStringify(value) {
+    if (Array.isArray(value)) {
+        return `[${value.map(stableStringify).join(',')}]`;
+    }
+    if (value && typeof value === 'object') {
+        return `{${Object.keys(value)
+            .sort()
+            .map((key) => `"${key}":${stableStringify(value[key])}`)
+            .join(',')}}`;
+    }
+    return JSON.stringify(value);
+}
+
+function getSiteSpecificFixesSettings(config) {
+    return config?.features?.autofill?.features?.siteSpecificFixes?.settings;
+}
+
+/**
+ * Returns the settings a conditionalChanges entry is patched against, i.e. the
+ * subfeature defaults without the conditional entries themselves.
+ */
+function getBaselineSettings(settings) {
+    const baseline = { ...settings };
+    delete baseline.conditionalChanges;
+    return baseline;
+}
+
+/**
+ * Extracts the domains a condition is scoped to, or null when the condition can
+ * match sites that are not named in it.
+ * @param {Object|Array} condition - A conditionalChanges condition block or array of blocks
+ * @returns {string[]|null} The domains matched, or null when not domain-scoped
+ */
+export function getScopedDomains(condition) {
+    const blocks = Array.isArray(condition)
+        ? condition
+        : [
+              condition,
+          ];
+    if (blocks.length === 0) {
+        return null;
+    }
+
+    const domains = [];
+    for (const block of blocks) {
+        if (!block || typeof block !== 'object' || Array.isArray(block)) {
+            return null;
+        }
+        const keys = Object.keys(block);
+        if (keys.length === 0 || !keys.every((key) => DOMAIN_SCOPED_CONDITION_KEYS.includes(key))) {
+            return null;
+        }
+        const blockDomains = Array.isArray(block.domain)
+            ? block.domain
+            : [
+                  block.domain,
+              ];
+        if (!blockDomains.length || !blockDomains.every((domain) => typeof domain === 'string' && domain.length > 0)) {
+            return null;
+        }
+        domains.push(...blockDomains);
+    }
+
+    return domains;
+}
+
+/**
+ * Checks the shape of a conditionalChanges entry's operations.
+ *
+ * immutable-json-patch is permissive: replacing a path that does not exist, or
+ * removing a key that is absent, silently succeeds. Applying a patch therefore
+ * cannot be the only check, or a fix that quietly does nothing would look the
+ * same as one that works.
+ *
+ * @param {Array} patchSettings - The operations from a conditionalChanges entry
+ * @returns {string[]} Problems found, empty when the operations look sound
+ */
+export function validatePatchOperations(patchSettings) {
+    if (!Array.isArray(patchSettings) || patchSettings.length === 0) {
+        return [
+            'has no patchSettings operations',
+        ];
+    }
+
+    const problems = [];
+    for (const operation of patchSettings) {
+        if (!operation || typeof operation !== 'object' || Array.isArray(operation)) {
+            problems.push('has an operation that is not an object');
+            continue;
+        }
+        if (!SUPPORTED_PATCH_OPS.includes(operation.op)) {
+            problems.push(`uses the unsupported op \`${operation.op}\``);
+            continue;
+        }
+        if (typeof operation.path !== 'string' || operation.path === '' || operation.path === '/') {
+            problems.push('replaces the entire settings object');
+            continue;
+        }
+        const touchedKey = operation.path.split('/')[1];
+        if (!SITE_SPECIFIC_FIXES_ALLOWED_KEYS.includes(touchedKey)) {
+            problems.push(`writes \`${operation.path}\`, which is outside the site-fix settings`);
+        }
+    }
+
+    return problems;
+}
+
+/**
+ * Applies a conditionalChanges entry's patchSettings, reporting failures rather
+ * than throwing so malformed patches can be surfaced as review reasons.
+ */
+function applyPatchSettings(settings, patchSettings) {
+    if (!Array.isArray(patchSettings)) {
+        return { ok: false, error: 'patchSettings is not an array' };
+    }
+    try {
+        return { ok: true, settings: immutableJSONPatch(settings, patchSettings) };
+    } catch (error) {
+        return { ok: false, error: error.message };
+    }
+}
+
+/**
+ * Builds the settings each domain actually ends up with, by applying every
+ * conditionalChanges entry that targets it in order. Entries that are not
+ * domain-scoped are applied to every domain, since they can match anywhere.
+ */
+function computeEffectiveSettingsByDomain(settings) {
+    const baseline = getBaselineSettings(settings);
+    const entries = Array.isArray(settings?.conditionalChanges) ? settings.conditionalChanges : [];
+
+    const domains = new Set();
+    for (const entry of entries) {
+        for (const domain of getScopedDomains(entry?.condition) || []) {
+            domains.add(domain);
+        }
+    }
+
+    const byDomain = {};
+    const failures = [];
+
+    for (const domain of domains) {
+        let effective = baseline;
+        for (const entry of entries) {
+            const scopedDomains = getScopedDomains(entry?.condition);
+            const applies = scopedDomains === null || scopedDomains.includes(domain);
+            if (!applies || !entry?.patchSettings) {
+                continue;
+            }
+            const result = applyPatchSettings(effective, entry.patchSettings);
+            if (!result.ok) {
+                failures.push(`patch for \`${domain}\` failed to apply: ${result.error}`);
+                break;
+            }
+            effective = result.settings;
+        }
+        byDomain[domain] = effective;
+    }
+
+    return { baseline, byDomain, failures };
+}
+
+/**
+ * Decides whether autofill siteSpecificFixes changes are safe to auto-approve.
+ *
+ * Rather than trusting the shape of the diff, this applies the conditional
+ * patches and inspects what they actually do: the subfeature defaults must be
+ * untouched, every new or edited entry must be scoped to named domains and
+ * apply cleanly, and the resulting per-domain settings may only differ in the
+ * site-fix keys.
+ *
+ * @param {Object} baseConfig - The generated config before the change
+ * @param {Object} updatedConfig - The generated config after the change
+ * @returns {Object} Result with approval status and the reasons review is needed
+ */
+export function evaluateSiteSpecificFixesChange(baseConfig, updatedConfig) {
+    const baseSettings = getSiteSpecificFixesSettings(baseConfig);
+    const updatedSettings = getSiteSpecificFixesSettings(updatedConfig);
+
+    if (!baseSettings || !updatedSettings) {
+        return {
+            approved: false,
+            reasons: [
+                'siteSpecificFixes settings could not be read from both configs',
+            ],
+        };
+    }
+
+    const reasons = [];
+
+    // The defaults apply to every site, so any change to them needs a human.
+    const baselineChanges = compare(getBaselineSettings(baseSettings), getBaselineSettings(updatedSettings));
+    if (baselineChanges.length > 0) {
+        reasons.push(`siteSpecificFixes defaults changed: ${baselineChanges.map((change) => `\`${change.path || '/'}\``).join(', ')}`);
+    }
+
+    // Only entries the PR introduces or edits are held to the scoping rules;
+    // entries already on the base branch were reviewed when they landed.
+    const baseEntries = Array.isArray(baseSettings.conditionalChanges) ? baseSettings.conditionalChanges : [];
+    const updatedEntries = Array.isArray(updatedSettings.conditionalChanges) ? updatedSettings.conditionalChanges : [];
+    const baseEntryHashes = new Set(baseEntries.map(stableStringify));
+
+    const updatedBaseline = getBaselineSettings(updatedSettings);
+    for (const entry of updatedEntries) {
+        if (baseEntryHashes.has(stableStringify(entry))) {
+            continue;
+        }
+        const scopedDomains = getScopedDomains(entry?.condition);
+        if (scopedDomains === null) {
+            reasons.push(`new conditionalChanges entry is not scoped to specific domains: \`${stableStringify(entry?.condition)}\``);
+            continue;
+        }
+
+        const label = scopedDomains.join(', ');
+        const problems = validatePatchOperations(entry?.patchSettings);
+        if (problems.length > 0) {
+            reasons.push(...problems.map((problem) => `new conditionalChanges entry for \`${label}\` ${problem}`));
+            continue;
+        }
+
+        const result = applyPatchSettings(updatedBaseline, entry.patchSettings);
+        if (!result.ok) {
+            reasons.push(`new conditionalChanges entry for \`${label}\` is malformed: ${result.error}`);
+            continue;
+        }
+        if (compare(updatedBaseline, result.settings).length === 0) {
+            reasons.push(`new conditionalChanges entry for \`${label}\` does not change anything, so the fix would be inert`);
+        }
+    }
+
+    // Compare what each domain actually resolves to before and after.
+    const baseEffective = computeEffectiveSettingsByDomain(baseSettings);
+    const updatedEffective = computeEffectiveSettingsByDomain(updatedSettings);
+    reasons.push(...baseEffective.failures, ...updatedEffective.failures);
+
+    const allDomains = new Set([
+        ...Object.keys(baseEffective.byDomain),
+        ...Object.keys(updatedEffective.byDomain),
+    ]);
+
+    for (const domain of allDomains) {
+        const before = baseEffective.byDomain[domain] ?? baseEffective.baseline;
+        const after = updatedEffective.byDomain[domain] ?? updatedEffective.baseline;
+        for (const change of compare(before, after)) {
+            const touchedKey = change.path.split('/')[1];
+            if (!SITE_SPECIFIC_FIXES_ALLOWED_KEYS.includes(touchedKey)) {
+                reasons.push(`change for \`${domain}\` affects \`${change.path || '/'}\`, which is outside the site-fix settings`);
+            }
+        }
+    }
+
+    return { approved: reasons.length === 0, reasons };
+}
+
+/**
  * Analyzes patches to determine if they should be auto-approved
  * @param {Array} patches - Array of JSON patches from fast-json-patch
+ * @param {Object} [context] - The generated configs the patches were derived from
+ * @param {Object} [context.baseConfig] - The config before the change
+ * @param {Object} [context.updatedConfig] - The config after the change
  * @returns {Object} Analysis result with approval status and reasoning
  */
-export function analyzePatchesForApproval(patches) {
+export function analyzePatchesForApproval(patches, context = {}) {
     if (patches.length === 0) {
         return {
             shouldApprove: false,
@@ -177,8 +470,22 @@ export function analyzePatchesForApproval(patches) {
         };
     }
 
+    const siteSpecificFixesPatches = patches.filter((patch) => patch.path.startsWith(SITE_SPECIFIC_FIXES_PATH));
+    const remainingPatches = patches.filter((patch) => !patch.path.startsWith(SITE_SPECIFIC_FIXES_PATH));
+
+    let siteSpecificFixesReasons = [];
+    if (siteSpecificFixesPatches.length > 0) {
+        if (!context.baseConfig || !context.updatedConfig) {
+            siteSpecificFixesReasons = [
+                'siteSpecificFixes changes cannot be evaluated without both configs',
+            ];
+        } else {
+            siteSpecificFixesReasons = evaluateSiteSpecificFixesChange(context.baseConfig, context.updatedConfig).reasons;
+        }
+    }
+
     // Check if changes are only to auto-approvable allowed paths
-    if (isAllowedChangesOnly(patches)) {
+    if (isAllowedChangesOnly(remainingPatches) && siteSpecificFixesReasons.length === 0) {
         return {
             shouldApprove: true,
             reason: 'Auto-approved: Changes only to auto-approvable feature domains/exceptions',
@@ -187,12 +494,15 @@ export function analyzePatchesForApproval(patches) {
 
     // Check if any changes are outside allowed paths
     const disallowedPatches = [];
-    for (const patch of patches) {
+    for (const patch of remainingPatches) {
         const featurePath = AUTO_APPROVABLE_FEATURE_PATHS.find((feature) => patch.path.startsWith(feature));
         const isDisallowed = featurePath ? !isPathAllowedForFeature(patch.path, featurePath) : true;
         if (isDisallowed) {
             disallowedPatches.push(patch);
         }
+    }
+    if (siteSpecificFixesReasons.length > 0) {
+        disallowedPatches.push(...siteSpecificFixesPatches);
     }
 
     // This case covers changes to non-auto-approvable features
@@ -200,6 +510,7 @@ export function analyzePatchesForApproval(patches) {
         shouldApprove: false,
         reason: 'Manual review required: Changes to disallowed paths',
         disallowedPatches,
+        siteSpecificFixesReasons,
     };
 }
 

--- a/tests/test-auto-approval.js
+++ b/tests/test-auto-approval.js
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import { analyzePatchesForApproval, generateChangeSummary } from '../automation-utils.js';
+import { analyzePatchesForApproval, evaluateSiteSpecificFixesChange, generateChangeSummary } from '../automation-utils.js';
 
 describe('Auto-approval logic tests', () => {
     const testCases = [
@@ -87,74 +87,6 @@ describe('Auto-approval logic tests', () => {
             expected: false,
         },
         {
-            name: 'Autofill siteSpecificFixes conditionalChanges - should approve',
-            patches: [
-                {
-                    op: 'add',
-                    path: '/features/autofill/features/siteSpecificFixes/settings/conditionalChanges/28/condition',
-                    value: [
-                        { domain: 'icloud.com' },
-                    ],
-                },
-                {
-                    op: 'add',
-                    path: '/features/autofill/features/siteSpecificFixes/settings/conditionalChanges/28/patchSettings',
-                    value: [
-                        { path: '/formBoundarySelector', op: 'replace', value: '#sign_in_form' },
-                        {
-                            path: '/formTypeSettings/-',
-                            op: 'add',
-                            value: { selector: '#sign_in_form', type: 'login' },
-                        },
-                    ],
-                },
-            ],
-            expected: true,
-        },
-        {
-            name: 'Autofill siteSpecificFixes domains - should approve',
-            patches: [
-                {
-                    op: 'add',
-                    path: '/features/autofill/features/siteSpecificFixes/settings/domains/0',
-                    value: { domain: 'example.com', patchSettings: [] },
-                },
-            ],
-            expected: true,
-        },
-        {
-            name: 'Autofill siteSpecificFixes global settings - should NOT approve',
-            patches: [
-                {
-                    op: 'replace',
-                    path: '/features/autofill/features/siteSpecificFixes/settings/formBoundarySelector',
-                    value: '#sign_in_form',
-                },
-            ],
-            expected: false,
-        },
-        {
-            name: 'Autofill siteSpecificFixes mixed with global settings - should NOT approve',
-            patches: [
-                {
-                    op: 'add',
-                    path: '/features/autofill/features/siteSpecificFixes/settings/conditionalChanges/0',
-                    value: {
-                        condition: [
-                            { domain: 'icloud.com' },
-                        ],
-                        patchSettings: [],
-                    },
-                },
-                {
-                    op: 'replace',
-                    path: '/features/autofill/features/siteSpecificFixes/settings/failsafeSettings/maxFormsPerPage',
-                    value: 1,
-                },
-            ],
-            expected: false,
-        },
-        {
             name: 'Autofill parent feature exceptions - should NOT approve',
             patches: [
                 {
@@ -172,6 +104,19 @@ describe('Auto-approval logic tests', () => {
                     op: 'replace',
                     path: '/features/autofill/features/autofillOSPasskeys/state',
                     value: 'enabled',
+                },
+            ],
+            expected: false,
+        },
+        {
+            name: 'Autofill siteSpecificFixes without config context - should NOT approve',
+            patches: [
+                {
+                    op: 'add',
+                    path: '/features/autofill/features/siteSpecificFixes/settings/conditionalChanges/1/condition',
+                    value: [
+                        { domain: 'icloud.com' },
+                    ],
                 },
             ],
             expected: false,
@@ -227,18 +172,11 @@ describe('Auto-approvable features structure tests', () => {
         expect(summary.otherChanges).to.equal(0);
     });
 
-    it('should approve autofill siteSpecificFixes conditionalChanges like icloud.com form-boundary PRs', () => {
+    it('should not approve autofill siteSpecificFixes changes without the configs to evaluate', () => {
         const siteSpecificFixesPatches = [
             {
                 op: 'add',
-                path: '/features/autofill/features/siteSpecificFixes/settings/conditionalChanges/28/condition',
-                value: [
-                    { domain: 'icloud.com' },
-                ],
-            },
-            {
-                op: 'add',
-                path: '/features/autofill/features/siteSpecificFixes/settings/conditionalChanges/28/patchSettings',
+                path: '/features/autofill/features/siteSpecificFixes/settings/conditionalChanges/1/patchSettings',
                 value: [
                     { path: '/formBoundarySelector', op: 'replace', value: '#sign_in_form' },
                 ],
@@ -246,28 +184,10 @@ describe('Auto-approvable features structure tests', () => {
         ];
 
         const result = analyzePatchesForApproval(siteSpecificFixesPatches);
-        const summary = generateChangeSummary(siteSpecificFixesPatches);
-
-        expect(result.shouldApprove).to.equal(true);
-        expect(result.reason).to.include('Auto-approved');
-        expect(summary.autoApprovableChanges).to.equal(2);
-        expect(summary.otherChanges).to.equal(0);
-    });
-
-    it('should not approve autofill siteSpecificFixes global default setting changes', () => {
-        const globalSettingsPatches = [
-            {
-                op: 'replace',
-                path: '/features/autofill/features/siteSpecificFixes/settings/formTypeSettings/0',
-                value: { selector: 'form', type: 'login' },
-            },
-        ];
-
-        const result = analyzePatchesForApproval(globalSettingsPatches);
 
         expect(result.shouldApprove).to.equal(false);
-        expect(result.reason).to.include('Manual review required');
-        expect(result.disallowedPatches).to.have.length(1);
+        expect(result.siteSpecificFixesReasons).to.have.length(1);
+        expect(result.siteSpecificFixesReasons[0]).to.include('without both configs');
     });
 
     it('should not approve element hiding rules changes', () => {
@@ -416,5 +336,326 @@ describe('generateChangeSummary specific tests', () => {
         expect(summary.otherChanges).to.equal(0);
         expect(Object.keys(summary.byOperation)).to.have.length(0);
         expect(Object.keys(summary.byPath)).to.have.length(0);
+    });
+});
+
+describe('Autofill siteSpecificFixes approval tests', () => {
+    /**
+     * Builds a generated config containing only the autofill siteSpecificFixes
+     * subfeature, which is all evaluateSiteSpecificFixesChange reads.
+     */
+    function configWithEntries(conditionalChanges, overrides = {}) {
+        return {
+            features: {
+                autofill: {
+                    state: 'enabled',
+                    features: {
+                        siteSpecificFixes: {
+                            state: 'enabled',
+                            settings: {
+                                formBoundarySelector: '',
+                                formTypeSettings: [
+                                    { selector: '#existing-form', type: 'login' },
+                                ],
+                                inputTypeSettings: [],
+                                failsafeSettings: { maxInputsPerPage: 100 },
+                                conditionalChanges,
+                                ...overrides,
+                            },
+                        },
+                    },
+                },
+            },
+        };
+    }
+
+    const existingEntry = {
+        condition: [
+            { domain: 'fedex.com' },
+        ],
+        patchSettings: [
+            {
+                path: '/inputTypeSettings/-',
+                op: 'add',
+                value: { selector: 'input#password', type: 'credentials.password.current' },
+            },
+        ],
+    };
+
+    const base = configWithEntries([
+        existingEntry,
+    ]);
+
+    it('approves a domain-scoped fix like the icloud.com form-boundary change', () => {
+        const updated = configWithEntries([
+            existingEntry,
+            {
+                condition: [
+                    { domain: 'icloud.com' },
+                ],
+                patchSettings: [
+                    { path: '/formBoundarySelector', op: 'replace', value: '#sign_in_form' },
+                    {
+                        path: '/formTypeSettings/-',
+                        op: 'add',
+                        value: { selector: '#sign_in_form', type: 'login' },
+                    },
+                ],
+            },
+        ]);
+
+        const result = evaluateSiteSpecificFixesChange(base, updated);
+
+        expect(result.reasons).to.deep.equal([]);
+        expect(result.approved).to.equal(true);
+    });
+
+    it('approves editing an existing site fix in place', () => {
+        const updated = configWithEntries([
+            {
+                ...existingEntry,
+                patchSettings: [
+                    {
+                        path: '/inputTypeSettings/-',
+                        op: 'add',
+                        value: { selector: 'input#pass', type: 'credentials.password.current' },
+                    },
+                ],
+            },
+        ]);
+
+        const result = evaluateSiteSpecificFixesChange(base, updated);
+
+        expect(result.approved).to.equal(true);
+    });
+
+    it('approves removing a site fix', () => {
+        const result = evaluateSiteSpecificFixesChange(base, configWithEntries([]));
+
+        expect(result.approved).to.equal(true);
+    });
+
+    it('rejects a wildcard urlPattern condition that escapes domain scoping', () => {
+        const updated = configWithEntries([
+            existingEntry,
+            {
+                condition: [
+                    { urlPattern: '*' },
+                ],
+                patchSettings: [
+                    { path: '/formBoundarySelector', op: 'replace', value: 'body' },
+                ],
+            },
+        ]);
+
+        const result = evaluateSiteSpecificFixesChange(base, updated);
+
+        expect(result.approved).to.equal(false);
+        expect(result.reasons.join(' ')).to.include('not scoped to specific domains');
+    });
+
+    it('rejects a root replace that rewrites the whole settings object', () => {
+        const updated = configWithEntries([
+            existingEntry,
+            {
+                condition: [
+                    { domain: 'example.com' },
+                ],
+                patchSettings: [
+                    {
+                        path: '',
+                        op: 'replace',
+                        value: { formBoundarySelector: 'body', formTypeSettings: [], inputTypeSettings: [] },
+                    },
+                ],
+            },
+        ]);
+
+        const result = evaluateSiteSpecificFixesChange(base, updated);
+
+        expect(result.approved).to.equal(false);
+        expect(result.reasons.join(' ')).to.include('entire settings object');
+    });
+
+    it('rejects an experiment-gated condition', () => {
+        const updated = configWithEntries([
+            existingEntry,
+            {
+                condition: [
+                    { experiment: { experimentName: 'autofillTest', cohort: 'treatment' } },
+                ],
+                patchSettings: [
+                    { path: '/formBoundarySelector', op: 'replace', value: 'form' },
+                ],
+            },
+        ]);
+
+        const result = evaluateSiteSpecificFixesChange(base, updated);
+
+        expect(result.approved).to.equal(false);
+        expect(result.reasons.join(' ')).to.include('not scoped to specific domains');
+    });
+
+    it('rejects a condition that mixes a domain with a broader matcher', () => {
+        const updated = configWithEntries([
+            existingEntry,
+            {
+                condition: [
+                    { domain: 'example.com', urlPattern: '/login' },
+                ],
+                patchSettings: [
+                    { path: '/formBoundarySelector', op: 'replace', value: 'form' },
+                ],
+            },
+        ]);
+
+        const result = evaluateSiteSpecificFixesChange(base, updated);
+
+        expect(result.approved).to.equal(false);
+        expect(result.reasons.join(' ')).to.include('not scoped to specific domains');
+    });
+
+    it('rejects a patch that silently does nothing instead of failing', () => {
+        const updated = configWithEntries([
+            existingEntry,
+            {
+                condition: [
+                    { domain: 'example.com' },
+                ],
+                // immutable-json-patch no-ops rather than throwing on this path.
+                patchSettings: [
+                    { path: '/failsafeSettings/missing/nested', op: 'replace', value: 5 },
+                ],
+            },
+        ]);
+
+        const result = evaluateSiteSpecificFixesChange(base, updated);
+
+        expect(result.approved).to.equal(false);
+        expect(result.reasons.join(' ')).to.include('inert');
+    });
+
+    it('rejects an entry with no patchSettings', () => {
+        const updated = configWithEntries([
+            existingEntry,
+            {
+                condition: [
+                    { domain: 'example.com' },
+                ],
+            },
+        ]);
+
+        const result = evaluateSiteSpecificFixesChange(base, updated);
+
+        expect(result.approved).to.equal(false);
+        expect(result.reasons.join(' ')).to.include('no patchSettings operations');
+    });
+
+    it('rejects move and copy operations', () => {
+        const updated = configWithEntries([
+            existingEntry,
+            {
+                condition: [
+                    { domain: 'example.com' },
+                ],
+                patchSettings: [
+                    { path: '/inputTypeSettings/0', op: 'move', from: '/formTypeSettings/0' },
+                ],
+            },
+        ]);
+
+        const result = evaluateSiteSpecificFixesChange(base, updated);
+
+        expect(result.approved).to.equal(false);
+        expect(result.reasons.join(' ')).to.include('unsupported op');
+    });
+
+    it('rejects a patch that writes a key outside the site-fix settings', () => {
+        const updated = configWithEntries([
+            existingEntry,
+            {
+                condition: [
+                    { domain: 'example.com' },
+                ],
+                patchSettings: [
+                    { path: '/someOtherSetting', op: 'add', value: true },
+                ],
+            },
+        ]);
+
+        const result = evaluateSiteSpecificFixesChange(base, updated);
+
+        expect(result.approved).to.equal(false);
+        expect(result.reasons.join(' ')).to.include('outside the site-fix settings');
+    });
+
+    it('rejects a change to the subfeature defaults that applies to every site', () => {
+        const updated = configWithEntries(
+            [
+                existingEntry,
+            ],
+            { formBoundarySelector: 'body' },
+        );
+
+        const result = evaluateSiteSpecificFixesChange(base, updated);
+
+        expect(result.approved).to.equal(false);
+        expect(result.reasons.join(' ')).to.include('defaults changed');
+    });
+
+    it('rejects an empty condition array that matches everything', () => {
+        const updated = configWithEntries([
+            existingEntry,
+            {
+                condition: [],
+                patchSettings: [
+                    { path: '/formBoundarySelector', op: 'replace', value: 'body' },
+                ],
+            },
+        ]);
+
+        const result = evaluateSiteSpecificFixesChange(base, updated);
+
+        expect(result.approved).to.equal(false);
+        expect(result.reasons.join(' ')).to.include('not scoped to specific domains');
+    });
+
+    it('is reachable through analyzePatchesForApproval when configs are supplied', () => {
+        const updated = configWithEntries([
+            existingEntry,
+            {
+                condition: [
+                    { domain: 'icloud.com' },
+                ],
+                patchSettings: [
+                    { path: '/formBoundarySelector', op: 'replace', value: '#sign_in_form' },
+                ],
+            },
+        ]);
+        const patches = [
+            {
+                op: 'add',
+                path: '/features/autofill/features/siteSpecificFixes/settings/conditionalChanges/1',
+                value: updated.features.autofill.features.siteSpecificFixes.settings.conditionalChanges[1],
+            },
+        ];
+
+        const approved = analyzePatchesForApproval(patches, { baseConfig: base, updatedConfig: updated });
+        expect(approved.shouldApprove).to.equal(true);
+
+        const hostile = configWithEntries([
+            existingEntry,
+            {
+                condition: [
+                    { urlPattern: '*' },
+                ],
+                patchSettings: [
+                    { path: '/formBoundarySelector', op: 'replace', value: 'body' },
+                ],
+            },
+        ]);
+        const rejected = analyzePatchesForApproval(patches, { baseConfig: base, updatedConfig: hostile });
+        expect(rejected.shouldApprove).to.equal(false);
+        expect(rejected.disallowedPatches).to.have.length(1);
     });
 });

--- a/tests/test-auto-approval.js
+++ b/tests/test-auto-approval.js
@@ -86,6 +86,96 @@ describe('Auto-approval logic tests', () => {
             ],
             expected: false,
         },
+        {
+            name: 'Autofill siteSpecificFixes conditionalChanges - should approve',
+            patches: [
+                {
+                    op: 'add',
+                    path: '/features/autofill/features/siteSpecificFixes/settings/conditionalChanges/28/condition',
+                    value: [
+                        { domain: 'icloud.com' },
+                    ],
+                },
+                {
+                    op: 'add',
+                    path: '/features/autofill/features/siteSpecificFixes/settings/conditionalChanges/28/patchSettings',
+                    value: [
+                        { path: '/formBoundarySelector', op: 'replace', value: '#sign_in_form' },
+                        {
+                            path: '/formTypeSettings/-',
+                            op: 'add',
+                            value: { selector: '#sign_in_form', type: 'login' },
+                        },
+                    ],
+                },
+            ],
+            expected: true,
+        },
+        {
+            name: 'Autofill siteSpecificFixes domains - should approve',
+            patches: [
+                {
+                    op: 'add',
+                    path: '/features/autofill/features/siteSpecificFixes/settings/domains/0',
+                    value: { domain: 'example.com', patchSettings: [] },
+                },
+            ],
+            expected: true,
+        },
+        {
+            name: 'Autofill siteSpecificFixes global settings - should NOT approve',
+            patches: [
+                {
+                    op: 'replace',
+                    path: '/features/autofill/features/siteSpecificFixes/settings/formBoundarySelector',
+                    value: '#sign_in_form',
+                },
+            ],
+            expected: false,
+        },
+        {
+            name: 'Autofill siteSpecificFixes mixed with global settings - should NOT approve',
+            patches: [
+                {
+                    op: 'add',
+                    path: '/features/autofill/features/siteSpecificFixes/settings/conditionalChanges/0',
+                    value: {
+                        condition: [
+                            { domain: 'icloud.com' },
+                        ],
+                        patchSettings: [],
+                    },
+                },
+                {
+                    op: 'replace',
+                    path: '/features/autofill/features/siteSpecificFixes/settings/failsafeSettings/maxFormsPerPage',
+                    value: 1,
+                },
+            ],
+            expected: false,
+        },
+        {
+            name: 'Autofill parent feature exceptions - should NOT approve',
+            patches: [
+                {
+                    op: 'add',
+                    path: '/features/autofill/exceptions/0',
+                    value: { domain: 'example.com', reason: 'testing' },
+                },
+            ],
+            expected: false,
+        },
+        {
+            name: 'Autofill other subfeature changes - should NOT approve',
+            patches: [
+                {
+                    op: 'replace',
+                    path: '/features/autofill/features/autofillOSPasskeys/state',
+                    value: 'enabled',
+                },
+            ],
+            expected: false,
+        },
     ];
 
     testCases.forEach((testCase) => {
@@ -135,6 +225,49 @@ describe('Auto-approvable features structure tests', () => {
         expect(result.reason).to.include('Auto-approved');
         expect(summary.autoApprovableChanges).to.equal(1);
         expect(summary.otherChanges).to.equal(0);
+    });
+
+    it('should approve autofill siteSpecificFixes conditionalChanges like icloud.com form-boundary PRs', () => {
+        const siteSpecificFixesPatches = [
+            {
+                op: 'add',
+                path: '/features/autofill/features/siteSpecificFixes/settings/conditionalChanges/28/condition',
+                value: [
+                    { domain: 'icloud.com' },
+                ],
+            },
+            {
+                op: 'add',
+                path: '/features/autofill/features/siteSpecificFixes/settings/conditionalChanges/28/patchSettings',
+                value: [
+                    { path: '/formBoundarySelector', op: 'replace', value: '#sign_in_form' },
+                ],
+            },
+        ];
+
+        const result = analyzePatchesForApproval(siteSpecificFixesPatches);
+        const summary = generateChangeSummary(siteSpecificFixesPatches);
+
+        expect(result.shouldApprove).to.equal(true);
+        expect(result.reason).to.include('Auto-approved');
+        expect(summary.autoApprovableChanges).to.equal(2);
+        expect(summary.otherChanges).to.equal(0);
+    });
+
+    it('should not approve autofill siteSpecificFixes global default setting changes', () => {
+        const globalSettingsPatches = [
+            {
+                op: 'replace',
+                path: '/features/autofill/features/siteSpecificFixes/settings/formTypeSettings/0',
+                value: { selector: 'form', type: 'login' },
+            },
+        ];
+
+        const result = analyzePatchesForApproval(globalSettingsPatches);
+
+        expect(result.shouldApprove).to.equal(false);
+        expect(result.reason).to.include('Manual review required');
+        expect(result.disallowedPatches).to.have.length(1);
     });
 
     it('should not approve element hiding rules changes', () => {


### PR DESCRIPTION
Extend AUTO_APPROVABLE_FEATURES so domain-scoped siteSpecificFixes patches (conditionalChanges and domains) can be auto-approved, matching PRs like icloud.com form-boundary fixes. Global defaults, other autofill subfeatures, and parent-feature exceptions still require review.

**Asana Task/Github Issue:**

## Description
<!-- 
  Please delete either or both process sections below.
-->

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CI auto-approval policy for autofill config; incorrect rules could auto-merge risky site-wide or malformed fixes, though scope is limited to automation tooling and heavily tested.
> 
> **Overview**
> Adds **semantic auto-approval** for autofill `siteSpecificFixes` changes instead of extending the path allowlist, since `conditionalChanges` patches can’t be judged safely from diff paths alone.
> 
> `analyzePatchesForApproval` now accepts optional **before/after generated configs**. Patches under `siteSpecificFixes` are evaluated via `evaluateSiteSpecificFixesChange`, which simulates per-domain effective settings and only approves when defaults stay unchanged, new/edited entries are **domain-only** conditions, operations are limited to add/replace/remove on allowed keys (`formBoundarySelector`, `formTypeSettings`, etc.), and patches actually apply (not inert no-ops). Other autofill paths (parent exceptions, other subfeatures) still require manual review.
> 
> The JSON diff GitHub script passes patched configs into analysis and prints **site-specific fix review reasons** when manual review is required. Tests cover approve/reject cases and integration through `analyzePatchesForApproval`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 611d5edb0d4da008e17a4e9efb34ecc25c274049. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->