### PR TITLE
TEST ONLY: probe autofill siteSpecificFixes auto-approval

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -1653,6 +1653,21 @@
                                         }
                                     }
                                 ]
+                            },
+                            {
+                                "condition": [
+                                    { "domain": "example.com" }
+                                ],
+                                "patchSettings": [
+                                    {
+                                        "path": "/inputTypeSettings/-",
+                                        "op": "add",
+                                        "value": {
+                                            "selector": "input#ddg-auto-approval-probe",
+                                            "type": "unknown"
+                                        }
+                                    }
+                                ]
                             }
                         ]
                     }


### PR DESCRIPTION
Adds an inert example.com inputTypeSettings entry so the auto-approval bot can be exercised end to end against the allowlist branch. Do not merge.

**Asana Task/Github Issue:**

## Description
<!-- 
  Please delete either or both process sections below.
-->

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only config on example.com with an unknown input type; no intended production autofill behavior change if not merged.
> 
> **Overview**
> **Test-only change — do not merge** (per PR description).
> 
> Adds a new **example.com** conditional patch under iOS autofill `siteSpecificFixes` that appends an `inputTypeSettings` rule for `input#ddg-auto-approval-probe` with type `unknown`. This is an inert probe entry intended to exercise the **auto-approval** bot end-to-end on the allowlist branch, not a real site fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 773efbfaca1413c4fd886846fb828a46ebd1cb8a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->