### PR TITLE
Add Windows sidebarSkills feature flag

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -1372,6 +1372,9 @@
                 "sidebarSuggestedPrompts": {
                     "state": "enabled"
                 },
+                "sidebarSkills": {
+                    "state": "internal"
+                },
                 "suggestionsDeletion": {
                     "state": "enabled",
                     "minSupportedVersion": "0.167.0"


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/481882893211075/task/1217546883158685

## Description

Adds `sidebarSkills` as an `internal` sub-feature of `aiChat` in the Windows override.

The flag gates native ownership of the Duck.ai sidebar skill slate. With it on, the Windows browser loads skill definitions, resolves them against the page-type signals it already collects, and pushes the resolved slate to the Duck.ai web app on the existing page-context message. With it off, the payload carries no skills array and the web app resolves suggestions from its own catalog exactly as it does today, so the flag-off payload is byte for byte identical to current behaviour.

Internal only. The native side is not merged yet, and the flag stays internal until the skills folder has had a security triage, since it is model instruction text writable by any local process.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [x] This feature was covered by a tech design.

Notes on the unchecked boxes:

- No schema was added. This is a sub-feature under the existing `aiChat` feature and only touches `overrides/windows-override.json`.
- Not tested in browsers yet. The Windows native side is on a branch and unmerged.
- Held as a draft until the native change lands.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only addition of an internal feature flag with no enabled rollout; no auth, data, or runtime logic changes in this PR.
> 
> **Overview**
> Adds a new **`aiChat`** sub-feature **`sidebarSkills`** on Windows with **`state: internal`**, alongside existing sidebar-related flags like **`sidebarSuggestedPrompts`**.
> 
> When enabled in native builds, this flag is meant to let the Windows browser own the Duck.ai sidebar skill slate (load definitions, resolve against page context, and pass skills on the existing page-context message). With the flag off or unset, behavior stays the same as today—the web app resolves suggestions from its own catalog and the payload should match current behaviour.
> 
> No schema or other override files are changed; this is configuration-only ahead of unmerged native work, and **internal** until skills content gets a security triage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d5315af7d37e60637843d87ec80bde83f9b3bdfe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->