### PR TITLE
Site breakage: Expand html-load mitigation on yahoo.com to avoid adwall and looping issue on iOS

### DIFF
--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -3320,7 +3320,7 @@
                         "reason": [
                             "notebookcheck.net - https://github.com/duckduckgo/privacy-configuration/pull/5090",
                             "notebookcheck.com - https://github.com/duckduckgo/privacy-configuration/pull/5129",
-                            "yahoo.com - "https://github.com/duckduckgo/privacy-configuration/pull/5796"
+                            "yahoo.com - https://github.com/duckduckgo/privacy-configuration/pull/5796"
                         ]
                     }
                 ]

--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -3311,16 +3311,21 @@
                         "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5796"
                     },
                     {
+                        "rule": "html-load.com/player",
+                        "domains": [
+                            "<all>"
+                        ],
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5824"
+                    },
+                    {
                         "rule": "html-load.com",
                         "domains": [
                             "notebookcheck.net",
-                            "notebookcheck.com",
-                            "yahoo.com"
+                            "notebookcheck.com"
                         ],
                         "reason": [
                             "notebookcheck.net - https://github.com/duckduckgo/privacy-configuration/pull/5090",
-                            "notebookcheck.com - https://github.com/duckduckgo/privacy-configuration/pull/5129",
-                            "yahoo.com - https://github.com/duckduckgo/privacy-configuration/pull/5796"
+                            "notebookcheck.com - https://github.com/duckduckgo/privacy-configuration/pull/5129"
                         ]
                     }
                 ]

--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -3314,11 +3314,13 @@
                         "rule": "html-load.com",
                         "domains": [
                             "notebookcheck.net",
-                            "notebookcheck.com"
+                            "notebookcheck.com",
+                            "yahoo.com"
                         ],
                         "reason": [
                             "notebookcheck.net - https://github.com/duckduckgo/privacy-configuration/pull/5090",
-                            "notebookcheck.com - https://github.com/duckduckgo/privacy-configuration/pull/5129"
+                            "notebookcheck.com - https://github.com/duckduckgo/privacy-configuration/pull/5129",
+                            "yahoo.com - "https://github.com/duckduckgo/privacy-configuration/pull/5796"
                         ]
                     }
                 ]


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1206670747178362/task/1217669390919015?focus=true

## Description
Mitigates adwall and looping issue on yahoo.com and sports.yahoo.com.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL: yahoo.com
- Problems experienced: adwall
- Platforms affected:
  - [x] iOS
  - [x] Android
  - [x] Windows
  - [x] MacOS
  - [x] Extensions
- Tracker(s) being unblocked: html-load.com
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Globally allowlisting another html-load.com path reduces tracker blocking on every site; intentional for breakage but widens third-party load beyond the prior script-only mitigation.
> 
> **Overview**
> Adds a **tracker allowlist** rule for **`html-load.com/player`** with **`&lt;all&gt;`** domains, matching the existing global mitigation for **`html-load.com/script`**.
> 
> This lets **`html-load.com`** player URLs load on sites where blocking them caused an **adwall** and **looping** (reported on **yahoo.com** / **sports.yahoo.com**, especially **iOS** and **macOS**). Only this path is expanded; other **`html-load.com`** rules (e.g. notebookcheck-specific entries) are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 34f2badfc6ff29296446bb42f1e86c855ede34c2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->