### PR TITLE
Add chromeWebstorePatching feature config

### DIFF
--- a/features/chrome-webstore-patching.json
+++ b/features/chrome-webstore-patching.json
@@ -1,0 +1,8 @@
+{
+    "_meta": {
+        "description": "Patches the Chrome Web Store UI extension add button and removes Chrome browser install steering banners in DuckDuckGo browsers."
+    },
+    "state": "disabled",
+    "exceptions": [],
+    "settings": {}
+}

--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -5713,6 +5713,45 @@
                 }
             }
         },
+        "chromeWebstorePatching": {
+            "state": "internal",
+            "exceptions": [],
+            "settings": {
+                "patchWebstore": {
+                    "state": "disabled"
+                },
+                "installButtonSelectors": [
+                    {
+                        "type": "css",
+                        "value": "button[jsname=\"wQO0od\"]"
+                    },
+                    {
+                        "type": "xpath",
+                        "value": "//button[.//span[contains(text(),'Add to Chrome')] or .//span[contains(text(),'Remove from Chrome')]]"
+                    }
+                ],
+                "installButtonTextSelectors": [
+                    "span.UywwFc-vQzf8d"
+                ],
+                "promoSelectors": [],
+                "buttonCopy": {
+                    "install": "Add to DuckDuckGo",
+                    "remove": "Remove from DuckDuckGo"
+                },
+                "domains": [
+                    {
+                        "domain": "chromewebstore.google.com",
+                        "patchSettings": [
+                            {
+                                "op": "replace",
+                                "path": "/patchWebstore/state",
+                                "value": "enabled"
+                            }
+                        ]
+                    }
+                ]
+            }
+        },
         "tabPanelDeferChanges": {
             "state": "disabled",
             "exceptions": [],

--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -5747,7 +5747,7 @@
                     "install": "Add to DuckDuckGo",
                     "remove": "Remove from DuckDuckGo",
                     "unavailable": "Unsupported extension",
-                    "unavailableDescription": "This extension isn't supported. DuckDuckGo is introducing extension support, starting with password managers."
+                    "unavailableDescription": "This extension isn't supported."
                 },
                 "domains": [
                     {

--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -5746,7 +5746,7 @@
                     "install": "Add to DuckDuckGo",
                     "remove": "Remove from DuckDuckGo",
                     "unavailable": "Unsupported extension",
-                    "unavailableDescription": "This extension isn't supported. DuckDuckGo is gradually expanding extension support, starting with password managers."
+                    "unavailableDescription": "This extension isn't supported. DuckDuckGo is introducing extension support, starting with password managers."
                 },
                 "domains": [
                     {

--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -5748,12 +5748,6 @@
                         "value": "header[role=\"banner\"] aside"
                     }
                 ],
-                "buttonCopy": {
-                    "install": "Add to DuckDuckGo",
-                    "remove": "Remove from DuckDuckGo",
-                    "unavailable": "Unsupported extension",
-                    "unavailableDescription": "This extension isn't supported."
-                },
                 "domains": [
                     {
                         "domain": "chromewebstore.google.com",

--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -5732,10 +5732,6 @@
                     {
                         "type": "css",
                         "value": "button[jscontroller=\"O626Fe\"][disabled]"
-                    },
-                    {
-                        "type": "xpath",
-                        "value": "//button[.//span[contains(text(),'Add to Chrome')] or .//span[contains(text(),'Remove from Chrome')]]"
                     }
                 ],
                 "promoSelectors": [

--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -5738,9 +5738,6 @@
                         "value": "//button[.//span[contains(text(),'Add to Chrome')] or .//span[contains(text(),'Remove from Chrome')]]"
                     }
                 ],
-                "installButtonTextSelectors": [
-                    "span.UywwFc-vQzf8d"
-                ],
                 "promoSelectors": [
                     "[jsname=\"v621tc\"]",
                     "div[jscontroller=\"o2G9me\"]",

--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -5730,6 +5730,10 @@
                         "value": "button[jsname=\"ajZLRd\"]"
                     },
                     {
+                        "type": "css",
+                        "value": "button[jscontroller=\"O626Fe\"][disabled]"
+                    },
+                    {
                         "type": "xpath",
                         "value": "//button[.//span[contains(text(),'Add to Chrome')] or .//span[contains(text(),'Remove from Chrome')]]"
                     }

--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -5726,6 +5726,10 @@
                         "value": "button[jsname=\"wQO0od\"]"
                     },
                     {
+                        "type": "css",
+                        "value": "button[jsname=\"ajZLRd\"]"
+                    },
+                    {
                         "type": "xpath",
                         "value": "//button[.//span[contains(text(),'Add to Chrome')] or .//span[contains(text(),'Remove from Chrome')]]"
                     }
@@ -5733,10 +5737,16 @@
                 "installButtonTextSelectors": [
                     "span.UywwFc-vQzf8d"
                 ],
-                "promoSelectors": [],
+                "promoSelectors": [
+                    "[jsname=\"v621tc\"]",
+                    "div[jscontroller=\"o2G9me\"]",
+                    "header[role=\"banner\"] aside"
+                ],
                 "buttonCopy": {
                     "install": "Add to DuckDuckGo",
-                    "remove": "Remove from DuckDuckGo"
+                    "remove": "Remove from DuckDuckGo",
+                    "unavailable": "Unsupported extension",
+                    "unavailableDescription": "This extension isn't supported. DuckDuckGo is gradually expanding extension support, starting with password managers."
                 },
                 "domains": [
                     {

--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -5735,9 +5735,18 @@
                     }
                 ],
                 "promoSelectors": [
-                    "[jsname=\"v621tc\"]",
-                    "div[jscontroller=\"o2G9me\"]",
-                    "header[role=\"banner\"] aside"
+                    {
+                        "type": "css",
+                        "value": "[jsname=\"v621tc\"]"
+                    },
+                    {
+                        "type": "css",
+                        "value": "div[jscontroller=\"o2G9me\"]"
+                    },
+                    {
+                        "type": "css",
+                        "value": "header[role=\"banner\"] aside"
+                    }
                 ],
                 "buttonCopy": {
                     "install": "Add to DuckDuckGo",

--- a/schema/config.ts
+++ b/schema/config.ts
@@ -41,6 +41,7 @@ import { WebExtensionsConfig } from './features/web-extensions';
 import { AdBlockingExtensionConfig } from './features/ad-blocking-extension';
 import { TabSuspension } from './features/tab-suspension';
 import { ExtensionManagementFeature } from './features/extension-management';
+import { ChromeWebstorePatchingFeature } from './features/chrome-webstore-patching';
 
 export { WebCompatSettings } from './features/webcompat';
 export { DuckPlayerSettings } from './features/duckplayer';
@@ -107,6 +108,7 @@ export type ConfigV5<VersionType> = {
         tabSuspension?: TabSuspension<VersionType>;
         webExtensions?: WebExtensionsConfig<VersionType>;
         extensionManagement?: ExtensionManagementFeature<VersionType>;
+        chromeWebstorePatching?: ChromeWebstorePatchingFeature<VersionType>;
     };
     unprotectedTemporary: SiteException[];
 };

--- a/schema/features/chrome-webstore-patching.ts
+++ b/schema/features/chrome-webstore-patching.ts
@@ -15,12 +15,22 @@ export type ChromeWebstorePatchingSettings = CSSInjectFeatureSettings<{
         state: 'enabled' | 'disabled';
     };
     /**
-     * Ordered fallback list targeting the install/uninstall <button>.
-     * The first entry matching at least one element wins.
+     * Selectors targeting the install/uninstall <button>. Every entry applies
+     * together: each gets its own hide rule and the matches are unioned, so a
+     * too-broad selector hides extra buttons wherever it sits in the list.
+     *
+     * Only `css` entries are consumed today. `xpath` is accepted by the schema
+     * so it can be added without a schema change, but it is not implemented:
+     * xpath entries are dropped at runtime. The hide has to be a stylesheet
+     * rule to cover buttons the store has not rendered yet, and xpath cannot
+     * appear in a stylesheet, so it needs a separate JS-driven hide path first.
      */
     installButtonSelectors?: SelectorEntry[];
     /**
      * CSS selectors for Chrome promo banners (e.g. "Switch to Chrome") to hide.
+     * Plain strings, not SelectorEntry: promo hiding is CSS-only (the selectors
+     * go straight into the injected stylesheet, which is what hides the banner
+     * before it paints), so xpath is not representable here by design.
      */
     promoSelectors?: string[];
     /**

--- a/schema/features/chrome-webstore-patching.ts
+++ b/schema/features/chrome-webstore-patching.ts
@@ -44,17 +44,6 @@ export type ChromeWebstorePatchingSettings = CSSInjectFeatureSettings<{
      */
     promoSelectors?: CssSelectorEntry[];
     /**
-     * Replacement button copy. install/remove label the curated pill;
-     * unavailable labels the disabled pill on non-curated detail pages, with
-     * unavailableDescription as its explanatory tooltip.
-     */
-    buttonCopy?: {
-        install: string;
-        remove: string;
-        unavailable?: string;
-        unavailableDescription?: string;
-    };
-    /**
      * Max time in ms to wait for the chrome.webstorePrivate API to appear
      * before the feature stays fail-closed (buttons remain hidden).
      */

--- a/schema/features/chrome-webstore-patching.ts
+++ b/schema/features/chrome-webstore-patching.ts
@@ -29,11 +29,15 @@ export type ChromeWebstorePatchingSettings = CSSInjectFeatureSettings<{
      */
     promoSelectors?: string[];
     /**
-     * Replacement button copy for curated extensions.
+     * Replacement button copy. install/remove label the curated pill;
+     * unavailable labels the disabled pill on non-curated detail pages, with
+     * unavailableDescription as its explanatory tooltip.
      */
     buttonCopy?: {
         install: string;
         remove: string;
+        unavailable?: string;
+        unavailableDescription?: string;
     };
     /**
      * Max time in ms to wait for the chrome.webstorePrivate API to appear

--- a/schema/features/chrome-webstore-patching.ts
+++ b/schema/features/chrome-webstore-patching.ts
@@ -5,6 +5,15 @@ type SelectorEntry = {
     value: string;
 };
 
+/**
+ * Same shape as SelectorEntry, narrowed to css. Used where an xpath entry could
+ * never be consumed, so the schema does not advertise support that is absent.
+ */
+type CssSelectorEntry = {
+    type: 'css';
+    value: string;
+};
+
 export type ChromeWebstorePatchingSettings = CSSInjectFeatureSettings<{
     /**
      * Execution gate: disabled by default everywhere, flipped to enabled on
@@ -27,12 +36,13 @@ export type ChromeWebstorePatchingSettings = CSSInjectFeatureSettings<{
      */
     installButtonSelectors?: SelectorEntry[];
     /**
-     * CSS selectors for Chrome promo banners (e.g. "Switch to Chrome") to hide.
-     * Plain strings, not SelectorEntry: promo hiding is CSS-only (the selectors
-     * go straight into the injected stylesheet, which is what hides the banner
-     * before it paints), so xpath is not representable here by design.
+     * Selectors for Chrome promo banners (e.g. "Switch to Chrome") to hide.
+     * Same entry shape as installButtonSelectors, but css only: promo hiding is
+     * pure CSS (the selectors go straight into the injected stylesheet, which is
+     * what hides the banner before it paints) and there is no JS pass here for an
+     * xpath entry to feed.
      */
-    promoSelectors?: string[];
+    promoSelectors?: CssSelectorEntry[];
     /**
      * Replacement button copy. install/remove label the curated pill;
      * unavailable labels the disabled pill on non-curated detail pages, with

--- a/schema/features/chrome-webstore-patching.ts
+++ b/schema/features/chrome-webstore-patching.ts
@@ -1,0 +1,45 @@
+import { Feature, CSSInjectFeatureSettings } from '../feature';
+
+type SelectorEntry = {
+    type: 'css' | 'xpath';
+    value: string;
+};
+
+export type ChromeWebstorePatchingSettings = CSSInjectFeatureSettings<{
+    /**
+     * Execution gate: disabled by default everywhere, flipped to enabled on
+     * chromewebstore.google.com via a `domains` patch. The feature early-returns
+     * unless this is enabled, so it never runs on unintended sites.
+     */
+    patchWebstore?: {
+        state: 'enabled' | 'disabled';
+    };
+    /**
+     * Ordered fallback list targeting the install/uninstall <button>.
+     * The first entry matching at least one element wins.
+     */
+    installButtonSelectors?: SelectorEntry[];
+    /**
+     * Ordered CSS selectors, resolved relative to the matched button,
+     * targeting the inner span that holds the button's text label.
+     */
+    installButtonTextSelectors?: string[];
+    /**
+     * CSS selectors for Chrome promo banners (e.g. "Switch to Chrome") to hide.
+     */
+    promoSelectors?: string[];
+    /**
+     * Replacement button copy for curated extensions.
+     */
+    buttonCopy?: {
+        install: string;
+        remove: string;
+    };
+    /**
+     * Max time in ms to wait for the chrome.webstorePrivate API to appear
+     * before the feature stays fail-closed (buttons remain hidden).
+     */
+    apiDetectionTimeoutMs?: number;
+}>;
+
+export type ChromeWebstorePatchingFeature<VersionType> = Feature<ChromeWebstorePatchingSettings, VersionType>;

--- a/schema/features/chrome-webstore-patching.ts
+++ b/schema/features/chrome-webstore-patching.ts
@@ -20,11 +20,6 @@ export type ChromeWebstorePatchingSettings = CSSInjectFeatureSettings<{
      */
     installButtonSelectors?: SelectorEntry[];
     /**
-     * Ordered CSS selectors, resolved relative to the matched button,
-     * targeting the inner span that holds the button's text label.
-     */
-    installButtonTextSelectors?: string[];
-    /**
      * CSS selectors for Chrome promo banners (e.g. "Switch to Chrome") to hide.
      */
     promoSelectors?: string[];


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1208671677432066/task/1216307850019524

## Description

Adds the `chromeWebstorePatching` feature config for the new C-S-S feature that patches the Chrome Web Store UI in the Windows browser (companion PR: duckduckgo/content-scope-scripts#2991):

- DDG-branded install/remove button for curated extensions (curated IDs are read from the existing `extensionManagement.curatedExtensions` catalog — not duplicated here)
- Disabled "Unsupported extension" pill on non-curated extension detail pages
- Hides "Switch to Chrome" promo banners

Structure per config review with Shane: all selector/copy values are top-level `settings` defaults; a single `domains` patch scoped to `chromewebstore.google.com` flips the `patchWebstore` `{state}` gate, and the feature early-returns unless it is enabled — the feature cannot act on any other site. Base feature ships `disabled`; the Windows override enables it at `internal` only.

Selectors were verified against the live store on a Windows DDG browser (Add button `jsname=wQO0od`, Remove button `jsname=ajZLRd`, promo hooks `jsname=v621tc` / `jscontroller=o2G9me`) and are remote-config so store markup changes are hotfixable without a client release.

### Feature change process:

- [x] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

Do not merge before the content-scope-scripts PR is approved (older clients ignore the unknown feature; new clients no-op on empty settings, so ordering is safe either way — this is process convention).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only change scoped to an internal Windows feature gate and CWS domain; no auth or data-path changes, though bad selectors could affect Web Store UI for internal users.
> 
> **Overview**
> Introduces **`chromeWebstorePatching`** remote config for the content-scope-scripts Chrome Web Store patch (DDG install/remove UI, hide promos, etc.). The base feature ships **disabled** with empty settings; a new TypeScript schema defines **`patchWebstore`** as the site gate, **`installButtonSelectors`** / **`promoSelectors`** (CSS, remote-updatable), and optional **`apiDetectionTimeoutMs`**, wired into the main config type.
> 
> On **Windows**, the override turns the feature **`internal`** and fills default CWS CSS selectors plus a **`domains`** patch on `chromewebstore.google.com` that sets **`patchWebstore.state`** to **enabled**, so injection only runs on the store.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b804556919829a953ec3fe6d9597756186dc1f44. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->