### PR TITLE
Update autoconsent to v16.29.0

### DIFF
--- a/features/autoconsent.json
+++ b/features/autoconsent.json
@@ -1823,6 +1823,21 @@
                 "#formContent input[type='checkbox']:checked",
                 ".cookieAction #submitCookiesBtn",
                 "type%3Dexplicit",
+                ".cookiesgdpr__base:has(.cookiesgdpr__rejectbtn)",
+                ".cookiesgdpr__base .cookiesgdpr__rejectbtn",
+                ".cookiesgdpr__base .cookiesgdpr__wrapper",
+                "\"analitica\":false",
+                "#cookieBox .block-cookie-consent",
+                "#cookieBox #consentButton.block-cookie-consent--btn",
+                "#cookieBox",
+                "#controlled_banner-cookie_consent-consent_banner",
+                "#controlled_banner-cookie_consent-privacy_setting_banner",
+                "#controlled_banner-cookie_consent-consent_banner [data-search-key-button=reject_all_text]",
+                "#controlled_submit-cookie_consent-consent_banner-privacy_setting_banner_link",
+                "#controlled_banner-cookie_consent-privacy_setting_banner [data-search-key-button=reject_all_text]",
+                "#wpconsent-root",
+                "#wpconsent-container",
+                "wpconsent_preferences=",
                 "body > div#root > div#ccpa-iframe-theme-provider[data-testid=\"ccpa-iframe-theme-provider\"] > div#ccpa-iframe[data-testid=\"ccpa-iframe\"] > div#ccpa_consent_banner[data-testid=\"ccpa_consent_banner\"] > div:not([id]) > div:nth-child(3):not([id]) > span:not([id]) > span:not([id]) > div:nth-child(2):not([id]) > span:nth-child(1):not([id]) > button#decline_cookies_button[data-testid=\"decline_cookies_button\"]",
                 "body:not([id]) > div#banner-0 > div:nth-child(1)#grouped-pageload-Banner > div:not([id]) > div:not([id]) > div:not([id]) > div:nth-child(3):not([id]) > button:nth-child(2):not([id])",
                 "body > div#iubenda-cs-banner > div:not([id]) > div:not([id]) > div:not([id]) > div:nth-child(5):not([id]) > div:nth-child(2):not([id]) > button:nth-child(1):not([id])",
@@ -1864,21 +1879,6 @@
                 "span[role=checkbox][aria-checked=true]",
                 "#save-all-pur",
                 "#reminder",
-                "[class*=CookieConsent__root___]",
-                "[class*=CookieConsent__modal___]",
-                "[class*=CookieConsent__modal___] > div > button[class*=secondary]:nth-child(2)",
-                "[data-test-id=cookies_section]",
-                ".cc-window.cc-visible",
-                ".cc-window .cc-dialog",
-                ".cc-window.cc-visible .cc-consent-require-only",
-                "dji_consentmanager",
-                "[id^=cookie-consent-banner]",
-                "#cookie-consent-denied",
-                "cookie-consent=denied",
-                "#gdpr-banner",
-                "#gdpr-banner-decline",
-                "body > div#tna-cookie-prompt-banner > div:not([id]) > div:nth-child(2):not([id]) > button:nth-child(2)#reject-cookie",
-                ".cookie-wrapper",
                 ".cookie-wrapper > .cookie-notice",
                 "#consent-modal",
                 "#privacy-settings-content",
@@ -2638,7 +2638,28 @@
                 "[data-a-target=\"consent-banner\"]",
                 "[data-a-target=\"consent-banner-accept\"]",
                 "[data-a-target=\"consent-banner\"] button:not([data-a-target])",
-                "input[type=checkbox][data-a-target=tw-checkbox]:not(:checked):not([disabled])"
+                "input[type=checkbox][data-a-target=tw-checkbox]:not(:checked):not([disabled])",
+                ".cookie-menu.js-cookie-banner",
+                ".cookie-menu.js-cookie-banner .js-cookie-banner-close",
+                "apaycnst-mktg=true",
+                "body > div#tna-cookie-prompt-banner > div:not([id]) > div:nth-child(2):not([id]) > button:nth-child(2)#reject-cookie",
+                "div[role=\"dialog\"][class*=\"CustomCookieBanner\"]",
+                "#onetrust-consent-sdk .ot-pc-refuse-all-handler",
+                ".cc-window.cc-visible",
+                ".cc-window .cc-dialog",
+                ".cc-window.cc-visible .cc-consent-require-only",
+                "dji_consentmanager",
+                "[id^=cookie-consent-banner]",
+                "#cookie-consent-denied",
+                "cookie-consent=denied",
+                "#gdpr-banner",
+                "#gdpr-banner-decline",
+                ".cookie-wrapper",
+                "[class*=CookieConsent__root___]",
+                "[class*=CookieConsent__modal___]",
+                "[class*=CookieConsent__modal___] > div > button[class*=secondary]:nth-child(2)",
+                "html.sp-message-open",
+                "[data-test-id=cookies_section]"
             ],
             "r": [
                 [
@@ -3454,6 +3475,41 @@
                         }
                     ],
                     [],
+                    {}
+                ],
+                [
+                    1,
+                    "bbva",
+                    2,
+                    "",
+                    22,
+                    [
+                        808
+                    ],
+                    [
+                        {
+                            "e": 809
+                        }
+                    ],
+                    [
+                        {
+                            "v": 809
+                        }
+                    ],
+                    [
+                        {
+                            "c": 809
+                        },
+                        {
+                            "check": "none",
+                            "wv": 810
+                        }
+                    ],
+                    [
+                        {
+                            "cc": 811
+                        }
+                    ],
                     {}
                 ],
                 [
@@ -5830,6 +5886,33 @@
                             "cc": 347
                         }
                     ],
+                    {}
+                ],
+                [
+                    1,
+                    "ecbeing",
+                    1,
+                    "",
+                    22,
+                    [
+                        812
+                    ],
+                    [
+                        {
+                            "e": 813
+                        }
+                    ],
+                    [
+                        {
+                            "v": 814
+                        }
+                    ],
+                    [
+                        {
+                            "h": 814
+                        }
+                    ],
+                    [],
                     {}
                 ],
                 [
@@ -8932,6 +9015,58 @@
                 ],
                 [
                     1,
+                    "stright",
+                    2,
+                    "",
+                    22,
+                    [
+                        815,
+                        816
+                    ],
+                    [
+                        {
+                            "e": 815
+                        }
+                    ],
+                    [
+                        {
+                            "v": 815
+                        }
+                    ],
+                    [
+                        {
+                            "if": {
+                                "v": 817
+                            },
+                            "then": [
+                                {
+                                    "c": 817
+                                }
+                            ],
+                            "else": [
+                                {
+                                    "c": 818
+                                },
+                                {
+                                    "c": 819
+                                }
+                            ]
+                        },
+                        {
+                            "check": "none",
+                            "wv": 815
+                        }
+                    ],
+                    [
+                        {
+                            "check": "none",
+                            "v": 815
+                        }
+                    ],
+                    {}
+                ],
+                [
+                    1,
                     "stripchat.com",
                     0,
                     "",
@@ -10524,6 +10659,43 @@
                 ],
                 [
                     1,
+                    "WPConsent",
+                    2,
+                    "",
+                    22,
+                    [
+                        820
+                    ],
+                    [
+                        {
+                            "e": 821
+                        }
+                    ],
+                    [
+                        {
+                            "visible": [
+                                "#wpconsent-container",
+                                "#wpconsent-banner-holder.wpconsent-banner-visible"
+                            ]
+                        }
+                    ],
+                    [
+                        {
+                            "waitForThenClick": [
+                                "#wpconsent-container",
+                                "#wpconsent-cancel-all"
+                            ]
+                        }
+                    ],
+                    [
+                        {
+                            "cc": 822
+                        }
+                    ],
+                    {}
+                ],
+                [
+                    1,
                     "xgroovy",
                     1,
                     "",
@@ -10818,532 +10990,6 @@
                     [],
                     [
                         {
-                            "e": 808
-                        }
-                    ],
-                    [
-                        {
-                            "v": 808
-                        }
-                    ],
-                    [
-                        {
-                            "wait": 500
-                        },
-                        {
-                            "c": 808
-                        }
-                    ],
-                    [
-                        {
-                            "timeout": 1000,
-                            "check": "none",
-                            "wv": 808
-                        }
-                    ],
-                    {}
-                ],
-                [
-                    1,
-                    "auto_CA_coasthotels.com_f8m",
-                    0,
-                    "^https?://(www\\.)?coasthotels\\.com/",
-                    1,
-                    [],
-                    [
-                        {
-                            "e": 809
-                        }
-                    ],
-                    [
-                        {
-                            "v": 809
-                        }
-                    ],
-                    [
-                        {
-                            "c": 809
-                        }
-                    ],
-                    [],
-                    {}
-                ],
-                [
-                    1,
-                    "auto_CA_epihunter.eu_hd4",
-                    0,
-                    "^https?://(www\\.)?combell\\.com/",
-                    1,
-                    [],
-                    [
-                        {
-                            "e": 810
-                        }
-                    ],
-                    [
-                        {
-                            "v": 810
-                        }
-                    ],
-                    [
-                        {
-                            "wait": 500
-                        },
-                        {
-                            "c": 810
-                        }
-                    ],
-                    [
-                        {
-                            "timeout": 1000,
-                            "check": "none",
-                            "wv": 810
-                        }
-                    ],
-                    {}
-                ],
-                [
-                    1,
-                    "auto_CA_nationalarchives.gov.uk_rx0",
-                    0,
-                    "^https?://(www\\.)?webarchive\\.nationalarchives\\.gov\\.uk/",
-                    1,
-                    [],
-                    [
-                        {
-                            "e": 811
-                        }
-                    ],
-                    [
-                        {
-                            "v": 811
-                        }
-                    ],
-                    [
-                        {
-                            "wait": 500
-                        },
-                        {
-                            "c": 811
-                        }
-                    ],
-                    [
-                        {
-                            "timeout": 1000,
-                            "check": "none",
-                            "wv": 811
-                        }
-                    ],
-                    {}
-                ],
-                [
-                    1,
-                    "auto_CA_natureconservancy.ca_3pp",
-                    0,
-                    "^https?://(www\\.)?natureconservancy\\.ca/",
-                    1,
-                    [],
-                    [
-                        {
-                            "e": 812
-                        }
-                    ],
-                    [
-                        {
-                            "v": 812
-                        }
-                    ],
-                    [
-                        {
-                            "wait": 500
-                        },
-                        {
-                            "c": 812
-                        }
-                    ],
-                    [
-                        {
-                            "timeout": 1000,
-                            "check": "none",
-                            "wv": 812
-                        }
-                    ],
-                    {}
-                ],
-                [
-                    1,
-                    "auto_CA_ontariospca.ca_k32",
-                    0,
-                    "^https?://(www\\.)?widget-next\\.clym-sdk\\.net/",
-                    1,
-                    [],
-                    [
-                        {
-                            "e": 813
-                        }
-                    ],
-                    [
-                        {
-                            "v": 813
-                        }
-                    ],
-                    [
-                        {
-                            "wait": 500
-                        },
-                        {
-                            "c": 813
-                        }
-                    ],
-                    [
-                        {
-                            "timeout": 1000,
-                            "check": "none",
-                            "wv": 813
-                        }
-                    ],
-                    {}
-                ],
-                [
-                    1,
-                    "auto_CA_phoenixnap.com_hrb",
-                    0,
-                    "^https?://(www\\.)?widget-next\\.clym-sdk\\.net/",
-                    1,
-                    [],
-                    [
-                        {
-                            "e": 814
-                        }
-                    ],
-                    [
-                        {
-                            "v": 814
-                        }
-                    ],
-                    [
-                        {
-                            "wait": 500
-                        },
-                        {
-                            "c": 814
-                        }
-                    ],
-                    [
-                        {
-                            "timeout": 1000,
-                            "check": "none",
-                            "wv": 814
-                        }
-                    ],
-                    {}
-                ],
-                [
-                    1,
-                    "auto_CH_phoenixnap.com_lx5",
-                    0,
-                    "^https?://(www\\.)?widget-next\\.clym-sdk\\.net/",
-                    1,
-                    [],
-                    [
-                        {
-                            "e": 815
-                        }
-                    ],
-                    [
-                        {
-                            "v": 815
-                        }
-                    ],
-                    [
-                        {
-                            "wait": 500
-                        },
-                        {
-                            "c": 815
-                        }
-                    ],
-                    [
-                        {
-                            "timeout": 1000,
-                            "check": "none",
-                            "wv": 815
-                        }
-                    ],
-                    {}
-                ],
-                [
-                    1,
-                    "auto_CH_swisscare.com_arx",
-                    0,
-                    "^https?://(www\\.)?swisscare\\.com/",
-                    1,
-                    [],
-                    [
-                        {
-                            "e": 816
-                        }
-                    ],
-                    [
-                        {
-                            "v": 816
-                        }
-                    ],
-                    [
-                        {
-                            "wait": 500
-                        },
-                        {
-                            "c": 816
-                        }
-                    ],
-                    [
-                        {
-                            "timeout": 1000,
-                            "check": "none",
-                            "wv": 816
-                        }
-                    ],
-                    {}
-                ],
-                [
-                    1,
-                    "auto_DE_alfaromeo.de_gvg_+2",
-                    0,
-                    "^https?://(www\\.)?cookielaw\\.emea\\.fcagroup\\.com/|^https?://(www\\.)?cookielaw\\.emea\\.fcagroup\\.com/|^https?://(www\\.)?cookielaw\\.emea\\.fcagroup\\.com/",
-                    1,
-                    [],
-                    [
-                        {
-                            "e": 817
-                        }
-                    ],
-                    [
-                        {
-                            "v": 817
-                        }
-                    ],
-                    [
-                        {
-                            "wait": 500
-                        },
-                        {
-                            "c": 817
-                        }
-                    ],
-                    [
-                        {
-                            "timeout": 1000,
-                            "check": "none",
-                            "wv": 817
-                        }
-                    ],
-                    {}
-                ],
-                [
-                    1,
-                    "auto_DE_huss-licht-ton.de_jj0",
-                    0,
-                    "^https?://(www\\.)?huss-licht-ton\\.de/",
-                    1,
-                    [],
-                    [
-                        {
-                            "e": 818
-                        }
-                    ],
-                    [
-                        {
-                            "v": 818
-                        }
-                    ],
-                    [
-                        {
-                            "wait": 500
-                        },
-                        {
-                            "c": 818
-                        }
-                    ],
-                    [
-                        {
-                            "timeout": 1000,
-                            "check": "none",
-                            "wv": 818
-                        }
-                    ],
-                    {}
-                ],
-                [
-                    1,
-                    "auto_DE_modellbau-berlinski.de_8vm",
-                    0,
-                    "^https?://(www\\.)?modellbau-berlinski\\.de/",
-                    1,
-                    [],
-                    [
-                        {
-                            "e": 819
-                        }
-                    ],
-                    [
-                        {
-                            "v": 819
-                        }
-                    ],
-                    [
-                        {
-                            "wait": 500
-                        },
-                        {
-                            "c": 819
-                        }
-                    ],
-                    [
-                        {
-                            "timeout": 1000,
-                            "check": "none",
-                            "wv": 819
-                        }
-                    ],
-                    {}
-                ],
-                [
-                    1,
-                    "auto_DE_phoenixnap.com_xq7",
-                    0,
-                    "^https?://(www\\.)?widget-next\\.clym-sdk\\.net/",
-                    1,
-                    [],
-                    [
-                        {
-                            "e": 820
-                        }
-                    ],
-                    [
-                        {
-                            "v": 820
-                        }
-                    ],
-                    [
-                        {
-                            "wait": 500
-                        },
-                        {
-                            "c": 820
-                        }
-                    ],
-                    [
-                        {
-                            "timeout": 1000,
-                            "check": "none",
-                            "wv": 820
-                        }
-                    ],
-                    {}
-                ],
-                [
-                    1,
-                    "auto_FR_fiat.fr_3fh",
-                    0,
-                    "^https?://(www\\.)?cookielaw\\.emea\\.fcagroup\\.com/",
-                    1,
-                    [],
-                    [
-                        {
-                            "e": 821
-                        }
-                    ],
-                    [
-                        {
-                            "v": 821
-                        }
-                    ],
-                    [
-                        {
-                            "wait": 500
-                        },
-                        {
-                            "c": 821
-                        }
-                    ],
-                    [
-                        {
-                            "timeout": 1000,
-                            "check": "none",
-                            "wv": 821
-                        }
-                    ],
-                    {}
-                ],
-                [
-                    1,
-                    "auto_FR_stellantis.com_67q",
-                    0,
-                    "^https?://(www\\.)?cookielaw\\.emea\\.fcagroup\\.com/",
-                    1,
-                    [],
-                    [
-                        {
-                            "e": 821
-                        }
-                    ],
-                    [
-                        {
-                            "v": 821
-                        }
-                    ],
-                    [
-                        {
-                            "wait": 500
-                        },
-                        {
-                            "c": 821
-                        }
-                    ],
-                    [
-                        {
-                            "timeout": 1000,
-                            "check": "none",
-                            "wv": 821
-                        }
-                    ],
-                    {}
-                ],
-                [
-                    1,
-                    "auto_GB_dropbox.com_0_+1",
-                    0,
-                    "^https?://(www\\.)?dropbox\\.com/|^https?://(www\\.)?dropbox\\.com/",
-                    1,
-                    [],
-                    [
-                        {
-                            "e": 822
-                        }
-                    ],
-                    [
-                        {
-                            "v": 822
-                        }
-                    ],
-                    [
-                        {
-                            "c": 822
-                        }
-                    ],
-                    [],
-                    {}
-                ],
-                [
-                    1,
-                    "auto_GB_investing.thisismoney.co.uk_0",
-                    0,
-                    "^https?://(www\\.)?thisismoney\\.co\\.uk/",
-                    1,
-                    [],
-                    [
-                        {
                             "e": 823
                         }
                     ],
@@ -11354,17 +11000,26 @@
                     ],
                     [
                         {
+                            "wait": 500
+                        },
+                        {
                             "c": 823
                         }
                     ],
-                    [],
+                    [
+                        {
+                            "timeout": 1000,
+                            "check": "none",
+                            "wv": 823
+                        }
+                    ],
                     {}
                 ],
                 [
                     1,
-                    "auto_GB_village-hotels.co.uk_hsa",
+                    "auto_CA_coasthotels.com_f8m",
                     0,
-                    "^https?://(www\\.)?village-hotels\\.co\\.uk/",
+                    "^https?://(www\\.)?coasthotels\\.com/",
                     1,
                     [],
                     [
@@ -11379,60 +11034,17 @@
                     ],
                     [
                         {
-                            "wait": 500
-                        },
-                        {
                             "c": 824
                         }
                     ],
-                    [
-                        {
-                            "timeout": 1000,
-                            "check": "none",
-                            "wv": 824
-                        }
-                    ],
-                    {}
-                ],
-                [
-                    1,
-                    "auto_NL_fiat.nl_trv_+1",
-                    0,
-                    "^https?://(www\\.)?cookielaw\\.emea\\.fcagroup\\.com/|^https?://(www\\.)?cookielaw\\.emea\\.fcagroup\\.com/",
-                    1,
                     [],
-                    [
-                        {
-                            "e": 821
-                        }
-                    ],
-                    [
-                        {
-                            "v": 821
-                        }
-                    ],
-                    [
-                        {
-                            "wait": 500
-                        },
-                        {
-                            "c": 821
-                        }
-                    ],
-                    [
-                        {
-                            "timeout": 1000,
-                            "check": "none",
-                            "wv": 821
-                        }
-                    ],
                     {}
                 ],
                 [
                     1,
-                    "auto_NL_flitsmeister.nl_ws8",
+                    "auto_CA_epihunter.eu_hd4",
                     0,
-                    "^https?://(www\\.)?cookies\\.flitsmeister\\.com/",
+                    "^https?://(www\\.)?combell\\.com/",
                     1,
                     [],
                     [
@@ -11464,9 +11076,9 @@
                 ],
                 [
                     1,
-                    "auto_NL_interpolis.nl_jk9",
+                    "auto_CA_nationalarchives.gov.uk_rx0",
                     0,
-                    "^https?://(www\\.)?interpolis\\.nl/",
+                    "^https?://(www\\.)?webarchive\\.nationalarchives\\.gov\\.uk/",
                     1,
                     [],
                     [
@@ -11498,9 +11110,9 @@
                 ],
                 [
                     1,
-                    "auto_US_dropbox.com_0_+1",
+                    "auto_CA_natureconservancy.ca_3pp",
                     0,
-                    "^https?://(www\\.)?dropbox\\.com/|^https?://(www\\.)?dropbox\\.com/",
+                    "^https?://(www\\.)?natureconservancy\\.ca/",
                     1,
                     [],
                     [
@@ -11515,8 +11127,568 @@
                     ],
                     [
                         {
-                            "text": "Decline",
+                            "wait": 500
+                        },
+                        {
                             "c": 827
+                        }
+                    ],
+                    [
+                        {
+                            "timeout": 1000,
+                            "check": "none",
+                            "wv": 827
+                        }
+                    ],
+                    {}
+                ],
+                [
+                    1,
+                    "auto_CA_ontariospca.ca_k32",
+                    0,
+                    "^https?://(www\\.)?widget-next\\.clym-sdk\\.net/",
+                    1,
+                    [],
+                    [
+                        {
+                            "e": 828
+                        }
+                    ],
+                    [
+                        {
+                            "v": 828
+                        }
+                    ],
+                    [
+                        {
+                            "wait": 500
+                        },
+                        {
+                            "c": 828
+                        }
+                    ],
+                    [
+                        {
+                            "timeout": 1000,
+                            "check": "none",
+                            "wv": 828
+                        }
+                    ],
+                    {}
+                ],
+                [
+                    1,
+                    "auto_CA_phoenixnap.com_hrb",
+                    0,
+                    "^https?://(www\\.)?widget-next\\.clym-sdk\\.net/",
+                    1,
+                    [],
+                    [
+                        {
+                            "e": 829
+                        }
+                    ],
+                    [
+                        {
+                            "v": 829
+                        }
+                    ],
+                    [
+                        {
+                            "wait": 500
+                        },
+                        {
+                            "c": 829
+                        }
+                    ],
+                    [
+                        {
+                            "timeout": 1000,
+                            "check": "none",
+                            "wv": 829
+                        }
+                    ],
+                    {}
+                ],
+                [
+                    1,
+                    "auto_CH_phoenixnap.com_lx5",
+                    0,
+                    "^https?://(www\\.)?widget-next\\.clym-sdk\\.net/",
+                    1,
+                    [],
+                    [
+                        {
+                            "e": 830
+                        }
+                    ],
+                    [
+                        {
+                            "v": 830
+                        }
+                    ],
+                    [
+                        {
+                            "wait": 500
+                        },
+                        {
+                            "c": 830
+                        }
+                    ],
+                    [
+                        {
+                            "timeout": 1000,
+                            "check": "none",
+                            "wv": 830
+                        }
+                    ],
+                    {}
+                ],
+                [
+                    1,
+                    "auto_CH_swisscare.com_arx",
+                    0,
+                    "^https?://(www\\.)?swisscare\\.com/",
+                    1,
+                    [],
+                    [
+                        {
+                            "e": 831
+                        }
+                    ],
+                    [
+                        {
+                            "v": 831
+                        }
+                    ],
+                    [
+                        {
+                            "wait": 500
+                        },
+                        {
+                            "c": 831
+                        }
+                    ],
+                    [
+                        {
+                            "timeout": 1000,
+                            "check": "none",
+                            "wv": 831
+                        }
+                    ],
+                    {}
+                ],
+                [
+                    1,
+                    "auto_DE_alfaromeo.de_gvg_+2",
+                    0,
+                    "^https?://(www\\.)?cookielaw\\.emea\\.fcagroup\\.com/|^https?://(www\\.)?cookielaw\\.emea\\.fcagroup\\.com/|^https?://(www\\.)?cookielaw\\.emea\\.fcagroup\\.com/",
+                    1,
+                    [],
+                    [
+                        {
+                            "e": 832
+                        }
+                    ],
+                    [
+                        {
+                            "v": 832
+                        }
+                    ],
+                    [
+                        {
+                            "wait": 500
+                        },
+                        {
+                            "c": 832
+                        }
+                    ],
+                    [
+                        {
+                            "timeout": 1000,
+                            "check": "none",
+                            "wv": 832
+                        }
+                    ],
+                    {}
+                ],
+                [
+                    1,
+                    "auto_DE_huss-licht-ton.de_jj0",
+                    0,
+                    "^https?://(www\\.)?huss-licht-ton\\.de/",
+                    1,
+                    [],
+                    [
+                        {
+                            "e": 833
+                        }
+                    ],
+                    [
+                        {
+                            "v": 833
+                        }
+                    ],
+                    [
+                        {
+                            "wait": 500
+                        },
+                        {
+                            "c": 833
+                        }
+                    ],
+                    [
+                        {
+                            "timeout": 1000,
+                            "check": "none",
+                            "wv": 833
+                        }
+                    ],
+                    {}
+                ],
+                [
+                    1,
+                    "auto_DE_modellbau-berlinski.de_8vm",
+                    0,
+                    "^https?://(www\\.)?modellbau-berlinski\\.de/",
+                    1,
+                    [],
+                    [
+                        {
+                            "e": 834
+                        }
+                    ],
+                    [
+                        {
+                            "v": 834
+                        }
+                    ],
+                    [
+                        {
+                            "wait": 500
+                        },
+                        {
+                            "c": 834
+                        }
+                    ],
+                    [
+                        {
+                            "timeout": 1000,
+                            "check": "none",
+                            "wv": 834
+                        }
+                    ],
+                    {}
+                ],
+                [
+                    1,
+                    "auto_DE_phoenixnap.com_xq7",
+                    0,
+                    "^https?://(www\\.)?widget-next\\.clym-sdk\\.net/",
+                    1,
+                    [],
+                    [
+                        {
+                            "e": 835
+                        }
+                    ],
+                    [
+                        {
+                            "v": 835
+                        }
+                    ],
+                    [
+                        {
+                            "wait": 500
+                        },
+                        {
+                            "c": 835
+                        }
+                    ],
+                    [
+                        {
+                            "timeout": 1000,
+                            "check": "none",
+                            "wv": 835
+                        }
+                    ],
+                    {}
+                ],
+                [
+                    1,
+                    "auto_FR_fiat.fr_3fh",
+                    0,
+                    "^https?://(www\\.)?cookielaw\\.emea\\.fcagroup\\.com/",
+                    1,
+                    [],
+                    [
+                        {
+                            "e": 836
+                        }
+                    ],
+                    [
+                        {
+                            "v": 836
+                        }
+                    ],
+                    [
+                        {
+                            "wait": 500
+                        },
+                        {
+                            "c": 836
+                        }
+                    ],
+                    [
+                        {
+                            "timeout": 1000,
+                            "check": "none",
+                            "wv": 836
+                        }
+                    ],
+                    {}
+                ],
+                [
+                    1,
+                    "auto_FR_stellantis.com_67q",
+                    0,
+                    "^https?://(www\\.)?cookielaw\\.emea\\.fcagroup\\.com/",
+                    1,
+                    [],
+                    [
+                        {
+                            "e": 836
+                        }
+                    ],
+                    [
+                        {
+                            "v": 836
+                        }
+                    ],
+                    [
+                        {
+                            "wait": 500
+                        },
+                        {
+                            "c": 836
+                        }
+                    ],
+                    [
+                        {
+                            "timeout": 1000,
+                            "check": "none",
+                            "wv": 836
+                        }
+                    ],
+                    {}
+                ],
+                [
+                    1,
+                    "auto_GB_dropbox.com_0_+1",
+                    0,
+                    "^https?://(www\\.)?dropbox\\.com/|^https?://(www\\.)?dropbox\\.com/",
+                    1,
+                    [],
+                    [
+                        {
+                            "e": 837
+                        }
+                    ],
+                    [
+                        {
+                            "v": 837
+                        }
+                    ],
+                    [
+                        {
+                            "c": 837
+                        }
+                    ],
+                    [],
+                    {}
+                ],
+                [
+                    1,
+                    "auto_GB_investing.thisismoney.co.uk_0",
+                    0,
+                    "^https?://(www\\.)?thisismoney\\.co\\.uk/",
+                    1,
+                    [],
+                    [
+                        {
+                            "e": 838
+                        }
+                    ],
+                    [
+                        {
+                            "v": 838
+                        }
+                    ],
+                    [
+                        {
+                            "c": 838
+                        }
+                    ],
+                    [],
+                    {}
+                ],
+                [
+                    1,
+                    "auto_GB_village-hotels.co.uk_hsa",
+                    0,
+                    "^https?://(www\\.)?village-hotels\\.co\\.uk/",
+                    1,
+                    [],
+                    [
+                        {
+                            "e": 839
+                        }
+                    ],
+                    [
+                        {
+                            "v": 839
+                        }
+                    ],
+                    [
+                        {
+                            "wait": 500
+                        },
+                        {
+                            "c": 839
+                        }
+                    ],
+                    [
+                        {
+                            "timeout": 1000,
+                            "check": "none",
+                            "wv": 839
+                        }
+                    ],
+                    {}
+                ],
+                [
+                    1,
+                    "auto_NL_fiat.nl_trv_+1",
+                    0,
+                    "^https?://(www\\.)?cookielaw\\.emea\\.fcagroup\\.com/|^https?://(www\\.)?cookielaw\\.emea\\.fcagroup\\.com/",
+                    1,
+                    [],
+                    [
+                        {
+                            "e": 836
+                        }
+                    ],
+                    [
+                        {
+                            "v": 836
+                        }
+                    ],
+                    [
+                        {
+                            "wait": 500
+                        },
+                        {
+                            "c": 836
+                        }
+                    ],
+                    [
+                        {
+                            "timeout": 1000,
+                            "check": "none",
+                            "wv": 836
+                        }
+                    ],
+                    {}
+                ],
+                [
+                    1,
+                    "auto_NL_flitsmeister.nl_ws8",
+                    0,
+                    "^https?://(www\\.)?cookies\\.flitsmeister\\.com/",
+                    1,
+                    [],
+                    [
+                        {
+                            "e": 840
+                        }
+                    ],
+                    [
+                        {
+                            "v": 840
+                        }
+                    ],
+                    [
+                        {
+                            "wait": 500
+                        },
+                        {
+                            "c": 840
+                        }
+                    ],
+                    [
+                        {
+                            "timeout": 1000,
+                            "check": "none",
+                            "wv": 840
+                        }
+                    ],
+                    {}
+                ],
+                [
+                    1,
+                    "auto_NL_interpolis.nl_jk9",
+                    0,
+                    "^https?://(www\\.)?interpolis\\.nl/",
+                    1,
+                    [],
+                    [
+                        {
+                            "e": 841
+                        }
+                    ],
+                    [
+                        {
+                            "v": 841
+                        }
+                    ],
+                    [
+                        {
+                            "wait": 500
+                        },
+                        {
+                            "c": 841
+                        }
+                    ],
+                    [
+                        {
+                            "timeout": 1000,
+                            "check": "none",
+                            "wv": 841
+                        }
+                    ],
+                    {}
+                ],
+                [
+                    1,
+                    "auto_US_dropbox.com_0_+1",
+                    0,
+                    "^https?://(www\\.)?dropbox\\.com/|^https?://(www\\.)?dropbox\\.com/",
+                    1,
+                    [],
+                    [
+                        {
+                            "e": 842
+                        }
+                    ],
+                    [
+                        {
+                            "v": 842
+                        }
+                    ],
+                    [
+                        {
+                            "text": "Decline",
+                            "c": 842
                         }
                     ],
                     [],
@@ -11531,25 +11703,25 @@
                     [],
                     [
                         {
-                            "e": 828
+                            "e": 843
                         }
                     ],
                     [
                         {
-                            "v": 828
+                            "v": 843
                         }
                     ],
                     [
                         {
-                            "k": 829
+                            "k": 844
                         },
                         {
                             "all": true,
                             "optional": true,
-                            "k": 830
+                            "k": 845
                         },
                         {
-                            "k": 831
+                            "k": 846
                         }
                     ],
                     [
@@ -11568,47 +11740,47 @@
                     "^https://plus\\.gmx\\.com/lt(?:[?#]|$)",
                     1,
                     [
-                        832
+                        847
                     ],
                     [
                         {
-                            "e": 832
+                            "e": 847
                         }
                     ],
                     [
                         {
-                            "v": 833
+                            "v": 848
                         }
                     ],
                     [
                         {
                             "if": {
-                                "e": 834
+                                "e": 849
                             },
                             "then": [
                                 {
-                                    "c": 834
+                                    "c": 849
                                 }
                             ],
                             "else": [
                                 {
                                     "if": {
-                                        "e": 835
+                                        "e": 850
                                     },
                                     "then": [
                                         {
-                                            "c": 835
+                                            "c": 850
                                         },
                                         {
-                                            "wv": 836
+                                            "wv": 851
                                         },
                                         {
-                                            "c": 836
+                                            "c": 851
                                         }
                                     ],
                                     "else": [
                                         {
-                                            "c": 836
+                                            "c": 851
                                         }
                                     ]
                                 }
@@ -11617,7 +11789,7 @@
                     ],
                     [
                         {
-                            "cc": 837
+                            "cc": 852
                         }
                     ],
                     {}
@@ -11629,49 +11801,49 @@
                     "^https://cmp-consent-tool\\.privacymanager\\.io/",
                     1,
                     [
-                        838,
-                        839
+                        853,
+                        854
                     ],
                     [
                         {
-                            "e": 840
+                            "e": 855
                         }
                     ],
                     [
                         {
-                            "v": 840
+                            "v": 855
                         }
                     ],
                     [
                         {
                             "if": {
-                                "e": 841
+                                "e": 856
                             },
                             "then": [
                                 {
-                                    "k": 841
+                                    "k": 856
                                 },
                                 {
-                                    "c": 842
+                                    "c": 857
                                 }
                             ],
                             "else": [
                                 {
-                                    "c": 843
+                                    "c": 858
                                 },
                                 {
-                                    "w": 844
+                                    "w": 859
                                 },
                                 {
-                                    "w": 845
+                                    "w": 860
                                 },
                                 {
                                     "all": true,
                                     "optional": true,
-                                    "k": 846
+                                    "k": 861
                                 },
                                 {
-                                    "k": 845
+                                    "k": 860
                                 }
                             ]
                         }
@@ -11688,20 +11860,20 @@
                     [],
                     [
                         {
-                            "e": 847
+                            "e": 862
                         },
                         {
-                            "e": 848
+                            "e": 863
                         }
                     ],
                     [
                         {
-                            "v": 848
+                            "v": 863
                         }
                     ],
                     [
                         {
-                            "c": 848
+                            "c": 863
                         }
                     ],
                     [],
@@ -12000,6 +12172,37 @@
                         }
                     ],
                     [],
+                    {}
+                ],
+                [
+                    1,
+                    "amazon-pay",
+                    2,
+                    "^https?://pay\\.amazon\\.",
+                    22,
+                    [
+                        1624
+                    ],
+                    [
+                        {
+                            "e": 1625
+                        }
+                    ],
+                    [
+                        {
+                            "v": 1624
+                        }
+                    ],
+                    [
+                        {
+                            "k": 1625
+                        }
+                    ],
+                    [
+                        {
+                            "cc": 1626
+                        }
+                    ],
                     {}
                 ],
                 [
@@ -13840,12 +14043,12 @@
                     [],
                     [
                         {
-                            "e": 862
+                            "e": 1627
                         }
                     ],
                     [
                         {
-                            "v": 862
+                            "v": 1627
                         }
                     ],
                     [
@@ -13853,14 +14056,14 @@
                             "wait": 500
                         },
                         {
-                            "c": 862
+                            "c": 1627
                         }
                     ],
                     [
                         {
                             "timeout": 1000,
                             "check": "none",
-                            "wv": 862
+                            "wv": 1627
                         }
                     ],
                     {}
@@ -27186,6 +27389,41 @@
                 ],
                 [
                     1,
+                    "deliveroo",
+                    2,
+                    "^https?://(\\w+\\.)?deliveroo\\.(co\\.uk|\\w+)/",
+                    22,
+                    [
+                        1628
+                    ],
+                    [
+                        {
+                            "e": 1628
+                        }
+                    ],
+                    [
+                        {
+                            "v": 1628
+                        }
+                    ],
+                    [
+                        {
+                            "c": 1629
+                        },
+                        {
+                            "check": "none",
+                            "wv": 1628
+                        }
+                    ],
+                    [
+                        {
+                            "cc": 1502
+                        }
+                    ],
+                    {}
+                ],
+                [
+                    1,
                     "delta.com",
                     1,
                     "^https://www\\.delta\\.com/",
@@ -27257,26 +27495,26 @@
                     "^https://(\\w+\\.)+dji\\.com/",
                     22,
                     [
-                        853
+                        1630
                     ],
                     [
                         {
-                            "e": 854
+                            "e": 1631
                         }
                     ],
                     [
                         {
-                            "e": 853
+                            "e": 1630
                         }
                     ],
                     [
                         {
-                            "c": 855
+                            "c": 1632
                         }
                     ],
                     [
                         {
-                            "cc": 856
+                            "cc": 1633
                         }
                     ],
                     {}
@@ -27288,26 +27526,26 @@
                     "^https://(www\\.)?dndbeyond\\.com/",
                     22,
                     [
-                        857
+                        1634
                     ],
                     [
                         {
-                            "e": 857
+                            "e": 1634
                         }
                     ],
                     [
                         {
-                            "v": 857
+                            "v": 1634
                         }
                     ],
                     [
                         {
-                            "c": 858
+                            "c": 1635
                         }
                     ],
                     [
                         {
-                            "cc": 859
+                            "cc": 1636
                         }
                     ],
                     {}
@@ -27319,21 +27557,38 @@
                     "^https://(www\\.)?ebay\\.([.a-z]+)/",
                     10,
                     [
-                        860
+                        1637
                     ],
                     [
                         {
-                            "e": 860
+                            "e": 1637
                         }
                     ],
                     [
                         {
-                            "v": 860
+                            "v": 1637
                         }
                     ],
                     [
                         {
-                            "c": 861
+                            "c": 1638
+                        },
+                        {
+                            "check": "none",
+                            "timeout": 2000,
+                            "optional": true,
+                            "wv": 1637
+                        },
+                        {
+                            "if": {
+                                "v": 1637
+                            },
+                            "then": [
+                                {
+                                    "timeout": 2000,
+                                    "c": 1638
+                                }
+                            ]
                         }
                     ],
                     [],
@@ -27346,7 +27601,7 @@
                     "^https://www\\.ecosia\\.org/",
                     22,
                     [
-                        863
+                        1639
                     ],
                     [
                         {
@@ -29655,21 +29910,21 @@
                     "^https://www\\.svt\\.se/",
                     22,
                     [
-                        849
+                        1640
                     ],
                     [
                         {
-                            "e": 849
+                            "e": 1640
                         }
                     ],
                     [
                         {
-                            "v": 850
+                            "v": 1641
                         }
                     ],
                     [
                         {
-                            "c": 851
+                            "c": 1642
                         }
                     ],
                     [
@@ -29780,7 +30035,7 @@
                     {}
                 ],
                 [
-                    2,
+                    3,
                     "theguardian.com",
                     1,
                     "^https?://(\\w+\\.)?theguardian\\.com/",
@@ -29795,7 +30050,14 @@
                     ],
                     [
                         {
-                            "v": 1373
+                            "any": [
+                                {
+                                    "v": 1373
+                                },
+                                {
+                                    "e": 1643
+                                }
+                            ]
                         }
                     ],
                     [
@@ -29803,9 +30065,8 @@
                             "h": 1373
                         },
                         {
-                            "removeClass": "sp-message-open",
-                            "selector": "html",
-                            "optional": true
+                            "stylesheet": "html.sp-message-open body { position: static !important; top: auto !important; width: auto !important; overflow: auto !important; }",
+                            "stylesheetId": "theguardian-scroll-unlock"
                         }
                     ],
                     [
@@ -29855,21 +30116,21 @@
                     "^https://tinyurl\\.com/",
                     22,
                     [
-                        852
+                        1644
                     ],
                     [
                         {
-                            "e": 852
+                            "e": 1644
                         }
                     ],
                     [
                         {
-                            "v": 852
+                            "v": 1644
                         }
                     ],
                     [
                         {
-                            "h": 852
+                            "h": 1644
                         }
                     ],
                     [],
@@ -30642,18 +30903,18 @@
             "index": {
                 "genericRuleRange": [
                     0,
-                    201
+                    205
                 ],
                 "frameRuleRange": [
-                    199,
-                    227
+                    203,
+                    231
                 ],
                 "specificRuleRange": [
-                    201,
-                    801
+                    205,
+                    807
                 ],
-                "genericStringEnd": 808,
-                "frameStringEnd": 849
+                "genericStringEnd": 823,
+                "frameStringEnd": 864
             }
         }
     }


### PR DESCRIPTION
Asana Task/Github Issue: https://app.asana.com/1/137249556945/project/1201844467387842/task/1217855012529607

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Data-only privacy-configuration changes for client-side cookie UI automation; incorrect rules could mis-handle banners on some sites but do not affect auth, payments, or server logic.
> 
> **Overview**
> Bumps the bundled **autoconsent** rule set in `features/autoconsent.json` to **v16.29.0**, expanding automatic cookie-banner handling across more CMP patterns and sites.
> 
> **New shared selectors and CMP rules** add coverage for cookies GDPR widgets, `#cookieBox`, controlled banner consent flows, **WPConsent** (reject via `#wpconsent-cancel-all`), **bbva**, **ecbeing**, **stright** (conditional branches), **amazon-pay**, and **deliveroo**.
> 
> **Selector lists are reorganized**: several generic patterns (OneTrust/cc-window, DJI, GDPR banner, CookieConsent modal, etc.) move between the generic and site-specific string tables, with new entries for Amazon Pay marketing cookies and Steam/Guardian-related markers.
> 
> **Site-specific tweaks** include **ebay** (optional wait and conditional re-click if the banner is still visible), **theguardian.com** (detect an alternate banner signal and unlock scrolling via an injected stylesheet instead of removing `sp-message-open` from `html`), and updated string index references across many auto-generated regional rules after the string table grew.
> 
> **Index metadata** (`genericRuleRange`, `frameRuleRange`, `specificRuleRange`, string end offsets) is adjusted to match the larger rule and string pools.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 70d252c687cc822f372ffeaf53e296c8e264f0fb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->