### PR TITLE
Update content-blocker extension to 2026.8.25

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -5036,7 +5036,7 @@
             "minSupportedVersion": "0.148.0",
             "exceptions": [],
             "settings": {
-                "extensionUrl": "https://staticcdn.duckduckgo.com/extensions/content-blocker/content-blocker-extension-2026.8.20.crx"
+                "extensionUrl": "https://staticcdn.duckduckgo.com/extensions/content-blocker/content-blocker-extension-2026.8.25.crx"
             },
             "features": {
                 "onboardingEnabled": {


### PR DESCRIPTION
Update content-blocker extension to 2026.8.25.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single config URL bump for the Windows content-blocker extension with no logic or security-path changes.
> 
> **Overview**
> Updates the Windows override for **`adBlockV2Extension`** so **`extensionUrl`** points to **`content-blocker-extension-2026.8.25.crx`** instead of **`2026.8.20`**. The feature remains enabled with the same **`minSupportedVersion`** (`0.148.0`) and settings; only the packaged extension artifact version changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 69c8be76a43e9b91c3b0b14aee84b2f0990c6ded. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->