### PR TITLE
Update ad-blocking extension scriptlets for v2026.8.25

### DIFF
--- a/features/ad-blocking-extension.json
+++ b/features/ad-blocking-extension.json
@@ -4,28 +4,28 @@
     },
     "exceptions": [],
     "settings": {
-        "version": "2026.8.20",
+        "version": "2026.8.25",
         "enabledByDefault": false,
         "scriptlets": {
             "scriptlets/isolated/ublock-filters.js": {
                 "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/99ecade91c2ac5bfc11707f75cf9c0d56ae365d87b1b062c57935852372cb473.js",
-                "signature": "MEUCIALEZThRK76E81j3tlY/EZVteGV2dl1eT1HZMXdp/E8sAiEAzQolGCE8XWVR8senQIT/4wBE42FRtdjzkJ4uqsAjoko="
+                "signature": "MEQCIERaLIcV4JsFgx2MSaHZZ+xo7Uu8oyL9IYRpOzjaxy2HAiBo8DC3ACmEHLH1dJtltLucdtWGLSN2QUx8yY5NWTlmTA=="
             },
             "scriptlets/main/ublock-filters.js": {
                 "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/fbf5a76ad0f0febee778c80b0b9bab89bdc7aa29907a15c13f609f5ca531ef3d.js",
-                "signature": "MEUCIQD2SIYoeMI1ojtxxCALD7Fop89pfpq+fx6hJnym2gFmqwIgPBkbgdLrpFbD5am9icKFbFY1pF8Ft+xaY+gnzqxVtXA="
+                "signature": "MEYCIQCKW5ckTYhP3xGQkbjOqASSL3ILggNDcRJFEI7a2roVTgIhAM0kYwkNbzygu5sOoZlUBPUstY8WZaTMmSCkENzYnWbc"
             },
             "scriptlets/main/ublock-experimental.js": {
                 "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855.js",
-                "signature": "MEUCID+szntDl56/AjE+gossNixSauM9KOZGMMaexAnzktQtAiEAvBMy4nH1GJlZBS0oQQHvGzS/yhMT7vr1fmZVFe6xmHM="
+                "signature": "MEYCIQCfSCze1e9WO82o8YmHC+uqqO2NI7t3e1JrYHe80uktggIhAOMv5350c37COLnCyzGGRxFNc9CVSk1kFRbV1datvNAG"
             },
             "scriptlets/isolated/ublock-experimental.js": {
                 "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855.js",
-                "signature": "MEQCIF0h9eonAoJbXxmyfx9O3FUeEmcTZfvsf/Gf83z0P9ECAiBp6l7YuvJVYI4t2+Tm0QczprgL1BntyWC+UsC1VCmVXQ=="
+                "signature": "MEYCIQCF3z9XyFjA7AcmuTwmwPdn2hw/sCjKNBRABrYF+mQ4WgIhAImDuZu7w+dV+iFj+azv3GR53Z7wqa1BqONPtC70Q1EE"
             },
             "rules/youtube.json": {
                 "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/2337db6aa7466667595226f780b6590779db3007ac0a65ef3833f89610c92824.json",
-                "signature": "MEYCIQDVeM9xiCGu7IdvLFf++j11IRr3QHxg5ODb5P0gUwfRKAIhAK/vfWj1u6d1iYIDsCeb2ddiliJz6bItpZsuK6j6e3bB"
+                "signature": "MEQCIAlLYeKb0ec9ueF7KeS3PmWxtORI6di2UTKiMqmjpjrSAiBbKQ7vqxvCa/vvngowX/1+SlpxAwzKYddeO+TcvwI4kg=="
             }
         }
     }


### PR DESCRIPTION
Update ad-blocking extension scriptlets for v2026.8.25.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Routine signed scriptlet metadata update with no rollout or feature-state changes; wrong signatures would fail client verification rather than silently loading bad content.
> 
> **Overview**
> Bumps the macOS/iOS **ad blocking extension** remote config from **2026.8.20** to **2026.8.25** in `features/ad-blocking-extension.json`.
> 
> The change refreshes **ECDSA signatures** for five scriptlet/rule entries (`ublock-filters` main/isolated, `ublock-experimental` main/isolated, and `rules/youtube.json`) while keeping the existing static CDN **URLs** unchanged. Clients use version plus signatures to pick up verified content-blocker assets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2818cd4482e1f3f01314ce360663cbde807aacb0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->