### PR TITLE
Enable aiChat nativePromptEditing on Android for 5.294.0+

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -675,6 +675,10 @@
                     "state": "enabled",
                     "minSupportedVersion": 52860000
                 },
+                "nativePromptEditing": {
+                    "state": "enabled",
+                    "minSupportedVersion": 52940000
+                },
                 "nativeInputField": {
                     "state": "enabled",
                     "minSupportedVersion": 52840000,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/72649045549333/task/1217549511628462?focus=true

## Description

Enable the `nativePromptEditing` sub-feature under `aiChat` on Android for app version `52940000` (5.294.0) and above.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [x] This feature was covered by a tech design.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8d299aee-a82f-4195-ad0b-e6ab56abaa2f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8d299aee-a82f-4195-ad0b-e6ab56abaa2f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

