### PR TITLE
Enabling multi-tab attachment internally

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -1451,10 +1451,13 @@
                     "minSupportedVersion": "0.158.0"
                 },
                 "sidebarAttachMoreTabs": {
-                    "state": "disabled"
+                    "state": "internal"
                 },
                 "omnibarAttachMoreTabs": {
-                    "state": "disabled"
+                    "state": "internal"
+                },
+                "ntpAttachMoreTabs": {
+                    "state": "internal"
                 },
                 "onboardingToggleAffectsNtpAndDdg": {
                     "state": "enabled",


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/72649045549333/task/1217272906895725?focus=true

## Description

Enabling multi-tab attachment internally on all surfaces: Address Bar, New Tab Page, and AI Chat Sidebar.


### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [X] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [X] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Windows-only config gating to internal users; no public rollout or client logic changes in this diff.
> 
> **Overview**
> On **Windows only**, this turns on multi-tab attachment for Duck AI in **internal** mode on three surfaces: **AI Chat sidebar** (`sidebarAttachMoreTabs`), **address bar / omnibar** (`omnibarAttachMoreTabs`), and **New Tab Page** (`ntpAttachMoreTabs`).
> 
> `sidebarAttachMoreTabs` and `omnibarAttachMoreTabs` move from **disabled** to **internal**; **ntpAttachMoreTabs** is added with **internal** in the `aiChat` override block.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d8cdbebc9202ce5dbe0177a3492999ca7a434918. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->