### PR TITLE
Enables autoplayPolicy at 10p

### DIFF
--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -2702,6 +2702,9 @@
                         "steps": [
                             {
                                 "percent": 5
+                            },
+                            {
+                                "percent": 10
                             }
                         ]
                     }


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/1211150618152277/task/1214035129057129?focus=true

## Description
This PR rolls out the macOS autoplayPolicy at 10% of our users base.
Thanks in advance!

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Autoplay policy changes can affect media playback and site behavior on major streaming domains; scope is limited by rollout percentage and an explicit domain allowlist.
> 
> **Overview**
> Advances the macOS **autoplayPolicy** rollout in `overrides/macos-override.json` by adding a second rollout step at **10%**, after the existing **5%** step.
> 
> The feature itself is unchanged: it remains enabled for app versions **≥ 1.204.0** with the same `domainsAllowList` (YouTube, Netflix, Hulu, Vimeo, Prime Video). This PR only widens who receives that browser behavior via config rollout, not the policy rules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d51c2d319e0d3d48f4a0da2791c575e6a1b40734. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->