### PR TITLE
Enable returnSessionWideEvent feature flag

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -3114,7 +3114,8 @@
         },
         "returnSessionWideEvent": {
             "state": "enabled",
-            "minSupportedVersion": 52930000
+            "minSupportedVersion": 52930000,
+            "exceptions": []
         },
         "sendFullPackageInstallSource": {
             "state": "enabled",

--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -3112,6 +3112,10 @@
             },
             "exceptions": []
         },
+        "returnSessionWideEvent": {
+            "state": "enabled",
+            "minSupportedVersion": 52930000
+        },
         "sendFullPackageInstallSource": {
             "state": "enabled",
             "settings": {


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1212810093780571/task/1217874814171892?focus=true

## Description
Enabling returnSessionWideEvent to start sending the wide event on session return

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [x] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single Android remote-config toggle for analytics/wide events only; no rollout steps or site exceptions, and behavior is gated by min app version 52930000.
> 
> **Overview**
> Turns on the **`returnSessionWideEvent`** privacy feature for Android by adding it to `android-override.json` with **`state: enabled`** and **`minSupportedVersion: 52930000`**, with no domain exceptions.
> 
> This config lets supported app builds emit a **session-wide telemetry event when the user returns to a session**, alongside existing wide-event flags such as page-load and post-idle session events.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 06d2e3a3598c4f51c2f7f39bbe10c4607600c44b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->