### PR TITLE
Update autoconsent to v16.30.0

### DIFF
--- a/features/autoconsent.json
+++ b/features/autoconsent.json
@@ -1838,6 +1838,9 @@
                 "#wpconsent-root",
                 "#wpconsent-container",
                 "wpconsent_preferences=",
+                "#r42CookieBar",
+                "#r42CookieBar .cw-deny",
+                "#r42CookieBar[open] .cw-deny",
                 "body > div#root > div#ccpa-iframe-theme-provider[data-testid=\"ccpa-iframe-theme-provider\"] > div#ccpa-iframe[data-testid=\"ccpa-iframe\"] > div#ccpa_consent_banner[data-testid=\"ccpa_consent_banner\"] > div:not([id]) > div:nth-child(3):not([id]) > span:not([id]) > span:not([id]) > div:nth-child(2):not([id]) > span:nth-child(1):not([id]) > button#decline_cookies_button[data-testid=\"decline_cookies_button\"]",
                 "body:not([id]) > div#banner-0 > div:nth-child(1)#grouped-pageload-Banner > div:not([id]) > div:not([id]) > div:not([id]) > div:nth-child(3):not([id]) > button:nth-child(2):not([id])",
                 "body > div#iubenda-cs-banner > div:not([id]) > div:not([id]) > div:not([id]) > div:nth-child(5):not([id]) > div:nth-child(2):not([id]) > button:nth-child(1):not([id])",
@@ -1879,9 +1882,6 @@
                 "span[role=checkbox][aria-checked=true]",
                 "#save-all-pur",
                 "#reminder",
-                ".cookie-wrapper > .cookie-notice",
-                "#consent-modal",
-                "#privacy-settings-content",
                 "button[type=\"submit\"]",
                 "div.one-modal__action-footer-column--secondary > a",
                 "[data-test-id=cookie-notice-reject]",
@@ -2247,7 +2247,7 @@
                 "body > div#app > div:nth-child(3):not([id]) > div:nth-child(2):not([id]) > div:nth-child(2):not([id]) > button:nth-child(2):not([id])",
                 "body > div:not([id]) > div#cookieconsent > div:nth-child(2):not([id]) > div:nth-child(3):not([id]) > div:not([id]) > button:nth-child(1)#cookie-deny",
                 "body > div#body-wrapper > section:nth-child(5):not([id]) > div:not([id]) > div:not([id]) > div:nth-child(2):not([id]) > div:not([id]) > button:nth-child(2):not([id])",
-                "body > dialog#r42CookieBar > section:nth-child(2):not([id]) > div:nth-child(3):not([id]) > button:nth-child(1):not([id])",
+                "#cookie_modal_placeholder dialog.bm-modal--cookie",
                 "body > div#modal-cookiesettings > div:not([id]) > div:not([id]) > div:nth-child(3):not([id]) > button:nth-child(2):not([id])",
                 "body > div:not([id]) > div:nth-child(3):not([id]) > div:not([id]) > button:nth-child(3):not([id])",
                 "body > div:not([id]) > div:nth-child(1)#react-content > div:nth-child(1):not([id]) > div:not([id]) > div:nth-child(3):not([id]) > div:nth-child(1):not([id]) > button:nth-child(2):not([id]) > span:not([id])",
@@ -2659,7 +2659,15 @@
                 "[class*=CookieConsent__modal___]",
                 "[class*=CookieConsent__modal___] > div > button[class*=secondary]:nth-child(2)",
                 "html.sp-message-open",
-                "[data-test-id=cookies_section]"
+                "[data-test-id=cookies_section]",
+                "Analytics_consent=2",
+                "Marketing_consent=2",
+                ".modalwindow-container.bar .modalwindow",
+                "#bibliotheek-nl-page",
+                ".modalwindow-container.bar .modalwindow button.button.primary.notok",
+                ".cookie-wrapper > .cookie-notice",
+                "#consent-modal",
+                "#privacy-settings-content"
             ],
             "r": [
                 [
@@ -8624,6 +8632,39 @@
                 ],
                 [
                     1,
+                    "r42-cookiebar",
+                    0,
+                    "",
+                    10,
+                    [
+                        823
+                    ],
+                    [
+                        {
+                            "e": 824
+                        }
+                    ],
+                    [
+                        {
+                            "v": 825
+                        }
+                    ],
+                    [
+                        {
+                            "c": 824
+                        }
+                    ],
+                    [
+                        {
+                            "timeout": 1000,
+                            "check": "none",
+                            "wv": 824
+                        }
+                    ],
+                    {}
+                ],
+                [
+                    1,
                     "real-cookie-banner",
                     0,
                     "",
@@ -10990,99 +11031,6 @@
                     [],
                     [
                         {
-                            "e": 823
-                        }
-                    ],
-                    [
-                        {
-                            "v": 823
-                        }
-                    ],
-                    [
-                        {
-                            "wait": 500
-                        },
-                        {
-                            "c": 823
-                        }
-                    ],
-                    [
-                        {
-                            "timeout": 1000,
-                            "check": "none",
-                            "wv": 823
-                        }
-                    ],
-                    {}
-                ],
-                [
-                    1,
-                    "auto_CA_coasthotels.com_f8m",
-                    0,
-                    "^https?://(www\\.)?coasthotels\\.com/",
-                    1,
-                    [],
-                    [
-                        {
-                            "e": 824
-                        }
-                    ],
-                    [
-                        {
-                            "v": 824
-                        }
-                    ],
-                    [
-                        {
-                            "c": 824
-                        }
-                    ],
-                    [],
-                    {}
-                ],
-                [
-                    1,
-                    "auto_CA_epihunter.eu_hd4",
-                    0,
-                    "^https?://(www\\.)?combell\\.com/",
-                    1,
-                    [],
-                    [
-                        {
-                            "e": 825
-                        }
-                    ],
-                    [
-                        {
-                            "v": 825
-                        }
-                    ],
-                    [
-                        {
-                            "wait": 500
-                        },
-                        {
-                            "c": 825
-                        }
-                    ],
-                    [
-                        {
-                            "timeout": 1000,
-                            "check": "none",
-                            "wv": 825
-                        }
-                    ],
-                    {}
-                ],
-                [
-                    1,
-                    "auto_CA_nationalarchives.gov.uk_rx0",
-                    0,
-                    "^https?://(www\\.)?webarchive\\.nationalarchives\\.gov\\.uk/",
-                    1,
-                    [],
-                    [
-                        {
                             "e": 826
                         }
                     ],
@@ -11110,9 +11058,9 @@
                 ],
                 [
                     1,
-                    "auto_CA_natureconservancy.ca_3pp",
+                    "auto_CA_coasthotels.com_f8m",
                     0,
-                    "^https?://(www\\.)?natureconservancy\\.ca/",
+                    "^https?://(www\\.)?coasthotels\\.com/",
                     1,
                     [],
                     [
@@ -11127,26 +11075,17 @@
                     ],
                     [
                         {
-                            "wait": 500
-                        },
-                        {
                             "c": 827
                         }
                     ],
-                    [
-                        {
-                            "timeout": 1000,
-                            "check": "none",
-                            "wv": 827
-                        }
-                    ],
+                    [],
                     {}
                 ],
                 [
                     1,
-                    "auto_CA_ontariospca.ca_k32",
+                    "auto_CA_epihunter.eu_hd4",
                     0,
-                    "^https?://(www\\.)?widget-next\\.clym-sdk\\.net/",
+                    "^https?://(www\\.)?combell\\.com/",
                     1,
                     [],
                     [
@@ -11178,9 +11117,9 @@
                 ],
                 [
                     1,
-                    "auto_CA_phoenixnap.com_hrb",
+                    "auto_CA_nationalarchives.gov.uk_rx0",
                     0,
-                    "^https?://(www\\.)?widget-next\\.clym-sdk\\.net/",
+                    "^https?://(www\\.)?webarchive\\.nationalarchives\\.gov\\.uk/",
                     1,
                     [],
                     [
@@ -11212,9 +11151,9 @@
                 ],
                 [
                     1,
-                    "auto_CH_phoenixnap.com_lx5",
+                    "auto_CA_natureconservancy.ca_3pp",
                     0,
-                    "^https?://(www\\.)?widget-next\\.clym-sdk\\.net/",
+                    "^https?://(www\\.)?natureconservancy\\.ca/",
                     1,
                     [],
                     [
@@ -11246,9 +11185,9 @@
                 ],
                 [
                     1,
-                    "auto_CH_swisscare.com_arx",
+                    "auto_CA_ontariospca.ca_k32",
                     0,
-                    "^https?://(www\\.)?swisscare\\.com/",
+                    "^https?://(www\\.)?widget-next\\.clym-sdk\\.net/",
                     1,
                     [],
                     [
@@ -11280,9 +11219,9 @@
                 ],
                 [
                     1,
-                    "auto_DE_alfaromeo.de_gvg_+2",
+                    "auto_CA_phoenixnap.com_hrb",
                     0,
-                    "^https?://(www\\.)?cookielaw\\.emea\\.fcagroup\\.com/|^https?://(www\\.)?cookielaw\\.emea\\.fcagroup\\.com/|^https?://(www\\.)?cookielaw\\.emea\\.fcagroup\\.com/",
+                    "^https?://(www\\.)?widget-next\\.clym-sdk\\.net/",
                     1,
                     [],
                     [
@@ -11314,9 +11253,9 @@
                 ],
                 [
                     1,
-                    "auto_DE_huss-licht-ton.de_jj0",
+                    "auto_CH_phoenixnap.com_lx5",
                     0,
-                    "^https?://(www\\.)?huss-licht-ton\\.de/",
+                    "^https?://(www\\.)?widget-next\\.clym-sdk\\.net/",
                     1,
                     [],
                     [
@@ -11348,9 +11287,9 @@
                 ],
                 [
                     1,
-                    "auto_DE_modellbau-berlinski.de_8vm",
+                    "auto_CH_swisscare.com_arx",
                     0,
-                    "^https?://(www\\.)?modellbau-berlinski\\.de/",
+                    "^https?://(www\\.)?swisscare\\.com/",
                     1,
                     [],
                     [
@@ -11382,9 +11321,9 @@
                 ],
                 [
                     1,
-                    "auto_DE_phoenixnap.com_xq7",
+                    "auto_DE_alfaromeo.de_gvg_+2",
                     0,
-                    "^https?://(www\\.)?widget-next\\.clym-sdk\\.net/",
+                    "^https?://(www\\.)?cookielaw\\.emea\\.fcagroup\\.com/|^https?://(www\\.)?cookielaw\\.emea\\.fcagroup\\.com/|^https?://(www\\.)?cookielaw\\.emea\\.fcagroup\\.com/",
                     1,
                     [],
                     [
@@ -11416,9 +11355,9 @@
                 ],
                 [
                     1,
-                    "auto_FR_fiat.fr_3fh",
+                    "auto_DE_huss-licht-ton.de_jj0",
                     0,
-                    "^https?://(www\\.)?cookielaw\\.emea\\.fcagroup\\.com/",
+                    "^https?://(www\\.)?huss-licht-ton\\.de/",
                     1,
                     [],
                     [
@@ -11450,43 +11389,9 @@
                 ],
                 [
                     1,
-                    "auto_FR_stellantis.com_67q",
+                    "auto_DE_modellbau-berlinski.de_8vm",
                     0,
-                    "^https?://(www\\.)?cookielaw\\.emea\\.fcagroup\\.com/",
-                    1,
-                    [],
-                    [
-                        {
-                            "e": 836
-                        }
-                    ],
-                    [
-                        {
-                            "v": 836
-                        }
-                    ],
-                    [
-                        {
-                            "wait": 500
-                        },
-                        {
-                            "c": 836
-                        }
-                    ],
-                    [
-                        {
-                            "timeout": 1000,
-                            "check": "none",
-                            "wv": 836
-                        }
-                    ],
-                    {}
-                ],
-                [
-                    1,
-                    "auto_GB_dropbox.com_0_+1",
-                    0,
-                    "^https?://(www\\.)?dropbox\\.com/|^https?://(www\\.)?dropbox\\.com/",
+                    "^https?://(www\\.)?modellbau-berlinski\\.de/",
                     1,
                     [],
                     [
@@ -11501,17 +11406,26 @@
                     ],
                     [
                         {
+                            "wait": 500
+                        },
+                        {
                             "c": 837
                         }
                     ],
-                    [],
+                    [
+                        {
+                            "timeout": 1000,
+                            "check": "none",
+                            "wv": 837
+                        }
+                    ],
                     {}
                 ],
                 [
                     1,
-                    "auto_GB_investing.thisismoney.co.uk_0",
+                    "auto_DE_phoenixnap.com_xq7",
                     0,
-                    "^https?://(www\\.)?thisismoney\\.co\\.uk/",
+                    "^https?://(www\\.)?widget-next\\.clym-sdk\\.net/",
                     1,
                     [],
                     [
@@ -11526,17 +11440,26 @@
                     ],
                     [
                         {
+                            "wait": 500
+                        },
+                        {
                             "c": 838
                         }
                     ],
-                    [],
+                    [
+                        {
+                            "timeout": 1000,
+                            "check": "none",
+                            "wv": 838
+                        }
+                    ],
                     {}
                 ],
                 [
                     1,
-                    "auto_GB_village-hotels.co.uk_hsa",
+                    "auto_FR_fiat.fr_3fh",
                     0,
-                    "^https?://(www\\.)?village-hotels\\.co\\.uk/",
+                    "^https?://(www\\.)?cookielaw\\.emea\\.fcagroup\\.com/",
                     1,
                     [],
                     [
@@ -11568,19 +11491,19 @@
                 ],
                 [
                     1,
-                    "auto_NL_fiat.nl_trv_+1",
+                    "auto_FR_stellantis.com_67q",
                     0,
-                    "^https?://(www\\.)?cookielaw\\.emea\\.fcagroup\\.com/|^https?://(www\\.)?cookielaw\\.emea\\.fcagroup\\.com/",
+                    "^https?://(www\\.)?cookielaw\\.emea\\.fcagroup\\.com/",
                     1,
                     [],
                     [
                         {
-                            "e": 836
+                            "e": 839
                         }
                     ],
                     [
                         {
-                            "v": 836
+                            "v": 839
                         }
                     ],
                     [
@@ -11588,23 +11511,23 @@
                             "wait": 500
                         },
                         {
-                            "c": 836
+                            "c": 839
                         }
                     ],
                     [
                         {
                             "timeout": 1000,
                             "check": "none",
-                            "wv": 836
+                            "wv": 839
                         }
                     ],
                     {}
                 ],
                 [
                     1,
-                    "auto_NL_flitsmeister.nl_ws8",
+                    "auto_GB_dropbox.com_0_+1",
                     0,
-                    "^https?://(www\\.)?cookies\\.flitsmeister\\.com/",
+                    "^https?://(www\\.)?dropbox\\.com/|^https?://(www\\.)?dropbox\\.com/",
                     1,
                     [],
                     [
@@ -11619,26 +11542,17 @@
                     ],
                     [
                         {
-                            "wait": 500
-                        },
-                        {
                             "c": 840
                         }
                     ],
-                    [
-                        {
-                            "timeout": 1000,
-                            "check": "none",
-                            "wv": 840
-                        }
-                    ],
+                    [],
                     {}
                 ],
                 [
                     1,
-                    "auto_NL_interpolis.nl_jk9",
+                    "auto_GB_investing.thisismoney.co.uk_0",
                     0,
-                    "^https?://(www\\.)?interpolis\\.nl/",
+                    "^https?://(www\\.)?thisismoney\\.co\\.uk/",
                     1,
                     [],
                     [
@@ -11653,26 +11567,17 @@
                     ],
                     [
                         {
-                            "wait": 500
-                        },
-                        {
                             "c": 841
                         }
                     ],
-                    [
-                        {
-                            "timeout": 1000,
-                            "check": "none",
-                            "wv": 841
-                        }
-                    ],
+                    [],
                     {}
                 ],
                 [
                     1,
-                    "auto_US_dropbox.com_0_+1",
+                    "auto_GB_village-hotels.co.uk_hsa",
                     0,
-                    "^https?://(www\\.)?dropbox\\.com/|^https?://(www\\.)?dropbox\\.com/",
+                    "^https?://(www\\.)?village-hotels\\.co\\.uk/",
                     1,
                     [],
                     [
@@ -11687,8 +11592,144 @@
                     ],
                     [
                         {
-                            "text": "Decline",
+                            "wait": 500
+                        },
+                        {
                             "c": 842
+                        }
+                    ],
+                    [
+                        {
+                            "timeout": 1000,
+                            "check": "none",
+                            "wv": 842
+                        }
+                    ],
+                    {}
+                ],
+                [
+                    1,
+                    "auto_NL_fiat.nl_trv_+1",
+                    0,
+                    "^https?://(www\\.)?cookielaw\\.emea\\.fcagroup\\.com/|^https?://(www\\.)?cookielaw\\.emea\\.fcagroup\\.com/",
+                    1,
+                    [],
+                    [
+                        {
+                            "e": 839
+                        }
+                    ],
+                    [
+                        {
+                            "v": 839
+                        }
+                    ],
+                    [
+                        {
+                            "wait": 500
+                        },
+                        {
+                            "c": 839
+                        }
+                    ],
+                    [
+                        {
+                            "timeout": 1000,
+                            "check": "none",
+                            "wv": 839
+                        }
+                    ],
+                    {}
+                ],
+                [
+                    1,
+                    "auto_NL_flitsmeister.nl_ws8",
+                    0,
+                    "^https?://(www\\.)?cookies\\.flitsmeister\\.com/",
+                    1,
+                    [],
+                    [
+                        {
+                            "e": 843
+                        }
+                    ],
+                    [
+                        {
+                            "v": 843
+                        }
+                    ],
+                    [
+                        {
+                            "wait": 500
+                        },
+                        {
+                            "c": 843
+                        }
+                    ],
+                    [
+                        {
+                            "timeout": 1000,
+                            "check": "none",
+                            "wv": 843
+                        }
+                    ],
+                    {}
+                ],
+                [
+                    1,
+                    "auto_NL_interpolis.nl_jk9",
+                    0,
+                    "^https?://(www\\.)?interpolis\\.nl/",
+                    1,
+                    [],
+                    [
+                        {
+                            "e": 844
+                        }
+                    ],
+                    [
+                        {
+                            "v": 844
+                        }
+                    ],
+                    [
+                        {
+                            "wait": 500
+                        },
+                        {
+                            "c": 844
+                        }
+                    ],
+                    [
+                        {
+                            "timeout": 1000,
+                            "check": "none",
+                            "wv": 844
+                        }
+                    ],
+                    {}
+                ],
+                [
+                    1,
+                    "auto_US_dropbox.com_0_+1",
+                    0,
+                    "^https?://(www\\.)?dropbox\\.com/|^https?://(www\\.)?dropbox\\.com/",
+                    1,
+                    [],
+                    [
+                        {
+                            "e": 845
+                        }
+                    ],
+                    [
+                        {
+                            "v": 845
+                        }
+                    ],
+                    [
+                        {
+                            "text": "Decline",
+                            "c": 845
                         }
                     ],
                     [],
@@ -11703,25 +11744,25 @@
                     [],
                     [
                         {
-                            "e": 843
+                            "e": 846
                         }
                     ],
                     [
                         {
-                            "v": 843
+                            "v": 846
                         }
                     ],
                     [
                         {
-                            "k": 844
+                            "k": 847
                         },
                         {
                             "all": true,
                             "optional": true,
-                            "k": 845
+                            "k": 848
                         },
                         {
-                            "k": 846
+                            "k": 849
                         }
                     ],
                     [
@@ -11740,47 +11781,47 @@
                     "^https://plus\\.gmx\\.com/lt(?:[?#]|$)",
                     1,
                     [
-                        847
+                        850
                     ],
                     [
                         {
-                            "e": 847
+                            "e": 850
                         }
                     ],
                     [
                         {
-                            "v": 848
+                            "v": 851
                         }
                     ],
                     [
                         {
                             "if": {
-                                "e": 849
+                                "e": 852
                             },
                             "then": [
                                 {
-                                    "c": 849
+                                    "c": 852
                                 }
                             ],
                             "else": [
                                 {
                                     "if": {
-                                        "e": 850
+                                        "e": 853
                                     },
                                     "then": [
                                         {
-                                            "c": 850
+                                            "c": 853
                                         },
                                         {
-                                            "wv": 851
+                                            "wv": 854
                                         },
                                         {
-                                            "c": 851
+                                            "c": 854
                                         }
                                     ],
                                     "else": [
                                         {
-                                            "c": 851
+                                            "c": 854
                                         }
                                     ]
                                 }
@@ -11789,7 +11830,7 @@
                     ],
                     [
                         {
-                            "cc": 852
+                            "cc": 855
                         }
                     ],
                     {}
@@ -11801,49 +11842,49 @@
                     "^https://cmp-consent-tool\\.privacymanager\\.io/",
                     1,
                     [
-                        853,
-                        854
+                        856,
+                        857
                     ],
                     [
                         {
-                            "e": 855
+                            "e": 858
                         }
                     ],
                     [
                         {
-                            "v": 855
+                            "v": 858
                         }
                     ],
                     [
                         {
                             "if": {
-                                "e": 856
+                                "e": 859
                             },
                             "then": [
                                 {
-                                    "k": 856
+                                    "k": 859
                                 },
                                 {
-                                    "c": 857
+                                    "c": 860
                                 }
                             ],
                             "else": [
                                 {
-                                    "c": 858
+                                    "c": 861
                                 },
                                 {
-                                    "w": 859
+                                    "w": 862
                                 },
                                 {
-                                    "w": 860
+                                    "w": 863
                                 },
                                 {
                                     "all": true,
                                     "optional": true,
-                                    "k": 861
+                                    "k": 864
                                 },
                                 {
-                                    "k": 860
+                                    "k": 863
                                 }
                             ]
                         }
@@ -11860,20 +11901,20 @@
                     [],
                     [
                         {
-                            "e": 862
+                            "e": 865
                         },
                         {
-                            "e": 863
+                            "e": 866
                         }
                     ],
                     [
                         {
-                            "v": 863
+                            "v": 866
                         }
                     ],
                     [
                         {
-                            "c": 863
+                            "c": 866
                         }
                     ],
                     [],
@@ -23158,40 +23199,6 @@
                 ],
                 [
                     1,
-                    "auto_NL_averoachmea.nl_fxj_+1",
-                    0,
-                    "^https?://(www\\.)?averoachmea\\.nl/|^https?://(www\\.)?centraalbeheer\\.nl/",
-                    10,
-                    [],
-                    [
-                        {
-                            "e": 1232
-                        }
-                    ],
-                    [
-                        {
-                            "v": 1232
-                        }
-                    ],
-                    [
-                        {
-                            "wait": 500
-                        },
-                        {
-                            "c": 1232
-                        }
-                    ],
-                    [
-                        {
-                            "timeout": 1000,
-                            "check": "none",
-                            "wv": 1232
-                        }
-                    ],
-                    {}
-                ],
-                [
-                    1,
                     "auto_NL_beekman.nl_f9e",
                     0,
                     "^https?://(www\\.)?beekman\\.nl/",
@@ -27090,6 +27097,43 @@
                 ],
                 [
                     1,
+                    "bankmillennium.pl",
+                    2,
+                    "^https?://(www\\.)?bankmillennium\\.pl/",
+                    22,
+                    [
+                        1232
+                    ],
+                    [
+                        {
+                            "e": 1232
+                        }
+                    ],
+                    [
+                        {
+                            "v": 1232
+                        }
+                    ],
+                    [
+                        {
+                            "waitForThenClick": [
+                                "#cookie_modal_placeholder dialog.bm-modal--cookie",
+                                "xpath///button[contains(normalize-space(.), 'Odrzu')]"
+                            ]
+                        }
+                    ],
+                    [
+                        {
+                            "cc": 1645
+                        },
+                        {
+                            "cc": 1646
+                        }
+                    ],
+                    {}
+                ],
+                [
+                    1,
                     "bbc.com",
                     2,
                     "^https://(www\\.)?bbc\\.(com|co\\.uk)",
@@ -27117,6 +27161,33 @@
                             "cc": 1545
                         }
                     ],
+                    {}
+                ],
+                [
+                    1,
+                    "bibliotheek-nl",
+                    0,
+                    "^https?://(?:www\\.)?(?:onlinebibliotheek|bibliotheek)\\.nl/",
+                    10,
+                    [
+                        1647
+                    ],
+                    [
+                        {
+                            "e": 1648
+                        }
+                    ],
+                    [
+                        {
+                            "v": 1647
+                        }
+                    ],
+                    [
+                        {
+                            "c": 1649
+                        }
+                    ],
+                    [],
                     {}
                 ],
                 [
@@ -27605,12 +27676,12 @@
                     ],
                     [
                         {
-                            "e": 864
+                            "e": 1650
                         }
                     ],
                     [
                         {
-                            "v": 864
+                            "v": 1650
                         }
                     ],
                     [
@@ -30266,16 +30337,16 @@
                     "^https://www\\.transip\\.nl/",
                     22,
                     [
-                        865
+                        1651
                     ],
                     [
                         {
                             "any": [
                                 {
-                                    "e": 865
+                                    "e": 1651
                                 },
                                 {
-                                    "e": 866
+                                    "e": 1652
                                 }
                             ]
                         }
@@ -30284,10 +30355,10 @@
                         {
                             "any": [
                                 {
-                                    "v": 865
+                                    "v": 1651
                                 },
                                 {
-                                    "v": 866
+                                    "v": 1652
                                 }
                             ]
                         }
@@ -30295,7 +30366,7 @@
                     [
                         {
                             "if": {
-                                "e": 866
+                                "e": 1652
                             },
                             "then": [
                                 {
@@ -30903,18 +30974,18 @@
             "index": {
                 "genericRuleRange": [
                     0,
-                    205
+                    206
                 ],
                 "frameRuleRange": [
-                    203,
-                    231
+                    204,
+                    232
                 ],
                 "specificRuleRange": [
-                    205,
-                    807
+                    206,
+                    809
                 ],
-                "genericStringEnd": 823,
-                "frameStringEnd": 864
+                "genericStringEnd": 826,
+                "frameStringEnd": 867
             }
         }
     }


### PR DESCRIPTION
Asana Task/Github Issue: https://app.asana.com/1/137249556945/project/1201844467387842/task/1217888821609653

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Data-only updates to cookie-consent automation rules; no runtime code paths change, though incorrect selectors could mis-handle banners on affected sites.
> 
> **Overview**
> Bumps the embedded **autoconsent** rule set in `features/autoconsent.json` to **v16.30.0**, refreshing selectors, site rules, and internal rule indices.
> 
> **Cookie-banner coverage:** Adds generic hide/detect entries for **R42 CookieBar** (`#r42CookieBar`, deny controls) and a dedicated **`r42-cookiebar`** rule. Replaces the long `dialog#r42CookieBar` click path with **`#cookie_modal_placeholder dialog.bm-modal--cookie`** (used by the new **`bankmillennium.pl`** rule with an XPath click on “Odrzuć”). Adds **`bibliotheek-nl`** for Dutch library sites plus related modal/consent cookie markers (`Analytics_consent=2`, `Marketing_consent=2`, `.modalwindow-container.bar`, etc.), and relocates some generic selectors (e.g. `.cookie-wrapper > .cookie-notice`, `#consent-modal`, `#privacy-settings-content`) within the hide list.
> 
> **Rule churn:** Removes the auto rule **`auto_NL_averoachmea.nl_fxj_+1`**. Many existing auto/site rules only change numeric string/rule index references after the new rules are inserted; **`ecosia`** and **`transip-nl`** pick up updated element indices. Index metadata (`genericRuleRange`, `frameRuleRange`, `specificRuleRange`, `genericStringEnd`, `frameStringEnd`) is adjusted accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 798a1eff84a08d4776e64dbb9612d96b4a270d24. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->