### PR TITLE
[Autofill] Fix various sites

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -961,6 +961,36 @@
                             },
                             {
                                 "condition": [
+                                    { "domain": "login.app.carta.com" }
+                                ],
+                                "patchSettings": [
+                                    {
+                                        "path": "/formTypeSettings/-",
+                                        "op": "add",
+                                        "value": {
+                                            "selector": "form",
+                                            "type": "login"
+                                        }
+                                    }
+                                ]
+                            },
+                            {
+                                "condition": [
+                                    { "domain": "www.kathykuohome.com" }
+                                ],
+                                "patchSettings": [
+                                    {
+                                        "path": "/inputTypeSettings/-",
+                                        "op": "add",
+                                        "value": {
+                                            "selector": "input[autocomplete=\"new-password\"]",
+                                            "type": "unknown"
+                                        }
+                                    }
+                                ]
+                            },
+                            {
+                                "condition": [
                                     { "domain": "fedex.com" }
                                 ],
                                 "patchSettings": [

--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -946,6 +946,21 @@
                         "conditionalChanges": [
                             {
                                 "condition": [
+                                    { "domain": "www.aestheticcity.academy" }
+                                ],
+                                "patchSettings": [
+                                    {
+                                        "path": "/inputTypeSettings/-",
+                                        "op": "add",
+                                        "value": {
+                                            "selector": "input[name=\"confirm-email\"]",
+                                            "type": "unknown"
+                                        }
+                                    }
+                                ]
+                            },
+                            {
+                                "condition": [
                                     { "domain": "fedex.com" }
                                 ],
                                 "patchSettings": [

--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -1150,6 +1150,30 @@
                                             "selector": "profile-lookup[app-name='account-login'] input[type='text']",
                                             "type": "credentials.username"
                                         }
+                                    },
+                                    {
+                                        "path": "/inputTypeSettings/-",
+                                        "op": "add",
+                                        "value": {
+                                            "selector": "#ps_month",
+                                            "type": "identities.birthdayMonth"
+                                        }
+                                    },
+                                    {
+                                        "path": "/inputTypeSettings/-",
+                                        "op": "add",
+                                        "value": {
+                                            "selector": "#ps_day",
+                                            "type": "identities.birthdayDay"
+                                        }
+                                    },
+                                    {
+                                        "path": "/inputTypeSettings/-",
+                                        "op": "add",
+                                        "value": {
+                                            "selector": "#ps_year",
+                                            "type": "identities.birthdayYear"
+                                        }
                                     }
                                 ]
                             },

--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -961,7 +961,7 @@
                             },
                             {
                                 "condition": [
-                                    { "domain": "login.app.carta.com" }
+                                    { "urlPattern": "https://login.app.carta.com/registration*" }
                                 ],
                                 "patchSettings": [
                                     {

--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -976,21 +976,6 @@
                             },
                             {
                                 "condition": [
-                                    { "domain": "www.kathykuohome.com" }
-                                ],
-                                "patchSettings": [
-                                    {
-                                        "path": "/inputTypeSettings/-",
-                                        "op": "add",
-                                        "value": {
-                                            "selector": "input[autocomplete=\"new-password\"]",
-                                            "type": "unknown"
-                                        }
-                                    }
-                                ]
-                            },
-                            {
-                                "condition": [
                                     { "domain": "www.theinformation.com" }
                                 ],
                                 "patchSettings": [
@@ -1000,21 +985,6 @@
                                         "value": {
                                             "selector": "#login-email",
                                             "type": "credentials.username"
-                                        }
-                                    }
-                                ]
-                            },
-                            {
-                                "condition": [
-                                    { "domain": "payments.municipay.com" }
-                                ],
-                                "patchSettings": [
-                                    {
-                                        "path": "/inputTypeSettings/-",
-                                        "op": "add",
-                                        "value": {
-                                            "selector": "#ind_user_password2_confirmation",
-                                            "type": "unknown"
                                         }
                                     }
                                 ]

--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -991,6 +991,36 @@
                             },
                             {
                                 "condition": [
+                                    { "domain": "www.theinformation.com" }
+                                ],
+                                "patchSettings": [
+                                    {
+                                        "path": "/inputTypeSettings/-",
+                                        "op": "add",
+                                        "value": {
+                                            "selector": "#login-email",
+                                            "type": "credentials.username"
+                                        }
+                                    }
+                                ]
+                            },
+                            {
+                                "condition": [
+                                    { "domain": "payments.municipay.com" }
+                                ],
+                                "patchSettings": [
+                                    {
+                                        "path": "/inputTypeSettings/-",
+                                        "op": "add",
+                                        "value": {
+                                            "selector": "#ind_user_password2_confirmation",
+                                            "type": "unknown"
+                                        }
+                                    }
+                                ]
+                            },
+                            {
+                                "condition": [
                                     { "domain": "fedex.com" }
                                 ],
                                 "patchSettings": [

--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -1194,7 +1194,7 @@
                             },
                             {
                                 "condition": [
-                                    { "domain": "login.app.carta.com" }
+                                    { "urlPattern": "https://login.app.carta.com/registration*" }
                                 ],
                                 "patchSettings": [
                                     {

--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -1194,6 +1194,36 @@
                             },
                             {
                                 "condition": [
+                                    { "domain": "login.app.carta.com" }
+                                ],
+                                "patchSettings": [
+                                    {
+                                        "path": "/formTypeSettings/-",
+                                        "op": "add",
+                                        "value": {
+                                            "selector": "form",
+                                            "type": "login"
+                                        }
+                                    }
+                                ]
+                            },
+                            {
+                                "condition": [
+                                    { "domain": "www.kathykuohome.com" }
+                                ],
+                                "patchSettings": [
+                                    {
+                                        "path": "/inputTypeSettings/-",
+                                        "op": "add",
+                                        "value": {
+                                            "selector": "input[autocomplete=\"new-password\"]",
+                                            "type": "unknown"
+                                        }
+                                    }
+                                ]
+                            },
+                            {
+                                "condition": [
                                     { "domain": "fedex.com" }
                                 ],
                                 "patchSettings": [

--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -1179,6 +1179,21 @@
                         "conditionalChanges": [
                             {
                                 "condition": [
+                                    { "domain": "www.aestheticcity.academy" }
+                                ],
+                                "patchSettings": [
+                                    {
+                                        "path": "/inputTypeSettings/-",
+                                        "op": "add",
+                                        "value": {
+                                            "selector": "input[name=\"confirm-email\"]",
+                                            "type": "unknown"
+                                        }
+                                    }
+                                ]
+                            },
+                            {
+                                "condition": [
                                     { "domain": "fedex.com" }
                                 ],
                                 "patchSettings": [

--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -1224,6 +1224,36 @@
                             },
                             {
                                 "condition": [
+                                    { "domain": "www.theinformation.com" }
+                                ],
+                                "patchSettings": [
+                                    {
+                                        "path": "/inputTypeSettings/-",
+                                        "op": "add",
+                                        "value": {
+                                            "selector": "#login-email",
+                                            "type": "credentials.username"
+                                        }
+                                    }
+                                ]
+                            },
+                            {
+                                "condition": [
+                                    { "domain": "payments.municipay.com" }
+                                ],
+                                "patchSettings": [
+                                    {
+                                        "path": "/inputTypeSettings/-",
+                                        "op": "add",
+                                        "value": {
+                                            "selector": "#ind_user_password2_confirmation",
+                                            "type": "unknown"
+                                        }
+                                    }
+                                ]
+                            },
+                            {
+                                "condition": [
                                     { "domain": "fedex.com" }
                                 ],
                                 "patchSettings": [

--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -1363,6 +1363,30 @@
                                             "selector": "profile-lookup[app-name='account-login'] input[type='text']",
                                             "type": "credentials.username"
                                         }
+                                    },
+                                    {
+                                        "path": "/inputTypeSettings/-",
+                                        "op": "add",
+                                        "value": {
+                                            "selector": "#ps_month",
+                                            "type": "identities.birthdayMonth"
+                                        }
+                                    },
+                                    {
+                                        "path": "/inputTypeSettings/-",
+                                        "op": "add",
+                                        "value": {
+                                            "selector": "#ps_day",
+                                            "type": "identities.birthdayDay"
+                                        }
+                                    },
+                                    {
+                                        "path": "/inputTypeSettings/-",
+                                        "op": "add",
+                                        "value": {
+                                            "selector": "#ps_year",
+                                            "type": "identities.birthdayYear"
+                                        }
                                     }
                                 ]
                             },

--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -1209,21 +1209,6 @@
                             },
                             {
                                 "condition": [
-                                    { "domain": "www.kathykuohome.com" }
-                                ],
-                                "patchSettings": [
-                                    {
-                                        "path": "/inputTypeSettings/-",
-                                        "op": "add",
-                                        "value": {
-                                            "selector": "input[autocomplete=\"new-password\"]",
-                                            "type": "unknown"
-                                        }
-                                    }
-                                ]
-                            },
-                            {
-                                "condition": [
                                     { "domain": "www.theinformation.com" }
                                 ],
                                 "patchSettings": [
@@ -1233,21 +1218,6 @@
                                         "value": {
                                             "selector": "#login-email",
                                             "type": "credentials.username"
-                                        }
-                                    }
-                                ]
-                            },
-                            {
-                                "condition": [
-                                    { "domain": "payments.municipay.com" }
-                                ],
-                                "patchSettings": [
-                                    {
-                                        "path": "/inputTypeSettings/-",
-                                        "op": "add",
-                                        "value": {
-                                            "selector": "#ind_user_password2_confirmation",
-                                            "type": "unknown"
                                         }
                                     }
                                 ]

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -1049,21 +1049,6 @@
                             },
                             {
                                 "condition": [
-                                    { "domain": "www.kathykuohome.com" }
-                                ],
-                                "patchSettings": [
-                                    {
-                                        "path": "/inputTypeSettings/-",
-                                        "op": "add",
-                                        "value": {
-                                            "selector": "input[autocomplete=\"new-password\"]",
-                                            "type": "unknown"
-                                        }
-                                    }
-                                ]
-                            },
-                            {
-                                "condition": [
                                     { "domain": "www.theinformation.com" }
                                 ],
                                 "patchSettings": [
@@ -1073,21 +1058,6 @@
                                         "value": {
                                             "selector": "#login-email",
                                             "type": "credentials.username"
-                                        }
-                                    }
-                                ]
-                            },
-                            {
-                                "condition": [
-                                    { "domain": "payments.municipay.com" }
-                                ],
-                                "patchSettings": [
-                                    {
-                                        "path": "/inputTypeSettings/-",
-                                        "op": "add",
-                                        "value": {
-                                            "selector": "#ind_user_password2_confirmation",
-                                            "type": "unknown"
                                         }
                                     }
                                 ]

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -1064,6 +1064,36 @@
                             },
                             {
                                 "condition": [
+                                    { "domain": "www.theinformation.com" }
+                                ],
+                                "patchSettings": [
+                                    {
+                                        "path": "/inputTypeSettings/-",
+                                        "op": "add",
+                                        "value": {
+                                            "selector": "#login-email",
+                                            "type": "credentials.username"
+                                        }
+                                    }
+                                ]
+                            },
+                            {
+                                "condition": [
+                                    { "domain": "payments.municipay.com" }
+                                ],
+                                "patchSettings": [
+                                    {
+                                        "path": "/inputTypeSettings/-",
+                                        "op": "add",
+                                        "value": {
+                                            "selector": "#ind_user_password2_confirmation",
+                                            "type": "unknown"
+                                        }
+                                    }
+                                ]
+                            },
+                            {
+                                "condition": [
                                     { "domain": "fedex.com" }
                                 ],
                                 "patchSettings": [

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -1034,7 +1034,7 @@
                             },
                             {
                                 "condition": [
-                                    { "domain": "login.app.carta.com" }
+                                    { "urlPattern": "https://login.app.carta.com/registration*" }
                                 ],
                                 "patchSettings": [
                                     {

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -1034,6 +1034,36 @@
                             },
                             {
                                 "condition": [
+                                    { "domain": "login.app.carta.com" }
+                                ],
+                                "patchSettings": [
+                                    {
+                                        "path": "/formTypeSettings/-",
+                                        "op": "add",
+                                        "value": {
+                                            "selector": "form",
+                                            "type": "login"
+                                        }
+                                    }
+                                ]
+                            },
+                            {
+                                "condition": [
+                                    { "domain": "www.kathykuohome.com" }
+                                ],
+                                "patchSettings": [
+                                    {
+                                        "path": "/inputTypeSettings/-",
+                                        "op": "add",
+                                        "value": {
+                                            "selector": "input[autocomplete=\"new-password\"]",
+                                            "type": "unknown"
+                                        }
+                                    }
+                                ]
+                            },
+                            {
+                                "condition": [
                                     { "domain": "fedex.com" }
                                 ],
                                 "patchSettings": [

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -1019,6 +1019,21 @@
                         "conditionalChanges": [
                             {
                                 "condition": [
+                                    { "domain": "www.aestheticcity.academy" }
+                                ],
+                                "patchSettings": [
+                                    {
+                                        "path": "/inputTypeSettings/-",
+                                        "op": "add",
+                                        "value": {
+                                            "selector": "input[name=\"confirm-email\"]",
+                                            "type": "unknown"
+                                        }
+                                    }
+                                ]
+                            },
+                            {
+                                "condition": [
                                     { "domain": "fedex.com" }
                                 ],
                                 "patchSettings": [

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -1203,6 +1203,30 @@
                                             "selector": "profile-lookup[app-name='account-login'] input[type='text']",
                                             "type": "credentials.username"
                                         }
+                                    },
+                                    {
+                                        "path": "/inputTypeSettings/-",
+                                        "op": "add",
+                                        "value": {
+                                            "selector": "#ps_month",
+                                            "type": "identities.birthdayMonth"
+                                        }
+                                    },
+                                    {
+                                        "path": "/inputTypeSettings/-",
+                                        "op": "add",
+                                        "value": {
+                                            "selector": "#ps_day",
+                                            "type": "identities.birthdayDay"
+                                        }
+                                    },
+                                    {
+                                        "path": "/inputTypeSettings/-",
+                                        "op": "add",
+                                        "value": {
+                                            "selector": "#ps_year",
+                                            "type": "identities.birthdayYear"
+                                        }
                                     }
                                 ]
                             },

--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -1690,21 +1690,6 @@
                             },
                             {
                                 "condition": [
-                                    { "domain": "www.kathykuohome.com" }
-                                ],
-                                "patchSettings": [
-                                    {
-                                        "path": "/inputTypeSettings/-",
-                                        "op": "add",
-                                        "value": {
-                                            "selector": "input[autocomplete=\"new-password\"]",
-                                            "type": "unknown"
-                                        }
-                                    }
-                                ]
-                            },
-                            {
-                                "condition": [
                                     { "domain": "www.theinformation.com" }
                                 ],
                                 "patchSettings": [
@@ -1714,21 +1699,6 @@
                                         "value": {
                                             "selector": "#login-email",
                                             "type": "credentials.username"
-                                        }
-                                    }
-                                ]
-                            },
-                            {
-                                "condition": [
-                                    { "domain": "payments.municipay.com" }
-                                ],
-                                "patchSettings": [
-                                    {
-                                        "path": "/inputTypeSettings/-",
-                                        "op": "add",
-                                        "value": {
-                                            "selector": "#ind_user_password2_confirmation",
-                                            "type": "unknown"
                                         }
                                     }
                                 ]

--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -1866,6 +1866,30 @@
                                             "selector": "profile-lookup[app-name='account-login'] input[type='text']",
                                             "type": "credentials.username"
                                         }
+                                    },
+                                    {
+                                        "path": "/inputTypeSettings/-",
+                                        "op": "add",
+                                        "value": {
+                                            "selector": "#ps_month",
+                                            "type": "identities.birthdayMonth"
+                                        }
+                                    },
+                                    {
+                                        "path": "/inputTypeSettings/-",
+                                        "op": "add",
+                                        "value": {
+                                            "selector": "#ps_day",
+                                            "type": "identities.birthdayDay"
+                                        }
+                                    },
+                                    {
+                                        "path": "/inputTypeSettings/-",
+                                        "op": "add",
+                                        "value": {
+                                            "selector": "#ps_year",
+                                            "type": "identities.birthdayYear"
+                                        }
                                     }
                                 ]
                             },

--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -1675,7 +1675,7 @@
                             },
                             {
                                 "condition": [
-                                    { "domain": "login.app.carta.com" }
+                                    { "urlPattern": "https://login.app.carta.com/registration*" }
                                 ],
                                 "patchSettings": [
                                     {

--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -1705,6 +1705,36 @@
                             },
                             {
                                 "condition": [
+                                    { "domain": "www.theinformation.com" }
+                                ],
+                                "patchSettings": [
+                                    {
+                                        "path": "/inputTypeSettings/-",
+                                        "op": "add",
+                                        "value": {
+                                            "selector": "#login-email",
+                                            "type": "credentials.username"
+                                        }
+                                    }
+                                ]
+                            },
+                            {
+                                "condition": [
+                                    { "domain": "payments.municipay.com" }
+                                ],
+                                "patchSettings": [
+                                    {
+                                        "path": "/inputTypeSettings/-",
+                                        "op": "add",
+                                        "value": {
+                                            "selector": "#ind_user_password2_confirmation",
+                                            "type": "unknown"
+                                        }
+                                    }
+                                ]
+                            },
+                            {
+                                "condition": [
                                     { "domain": "fedex.com" }
                                 ],
                                 "patchSettings": [

--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -1675,6 +1675,36 @@
                             },
                             {
                                 "condition": [
+                                    { "domain": "login.app.carta.com" }
+                                ],
+                                "patchSettings": [
+                                    {
+                                        "path": "/formTypeSettings/-",
+                                        "op": "add",
+                                        "value": {
+                                            "selector": "form",
+                                            "type": "login"
+                                        }
+                                    }
+                                ]
+                            },
+                            {
+                                "condition": [
+                                    { "domain": "www.kathykuohome.com" }
+                                ],
+                                "patchSettings": [
+                                    {
+                                        "path": "/inputTypeSettings/-",
+                                        "op": "add",
+                                        "value": {
+                                            "selector": "input[autocomplete=\"new-password\"]",
+                                            "type": "unknown"
+                                        }
+                                    }
+                                ]
+                            },
+                            {
+                                "condition": [
                                     { "domain": "fedex.com" }
                                 ],
                                 "patchSettings": [

--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -1660,6 +1660,21 @@
                         "conditionalChanges": [
                             {
                                 "condition": [
+                                    { "domain": "www.aestheticcity.academy" }
+                                ],
+                                "patchSettings": [
+                                    {
+                                        "path": "/inputTypeSettings/-",
+                                        "op": "add",
+                                        "value": {
+                                            "selector": "input[name=\"confirm-email\"]",
+                                            "type": "unknown"
+                                        }
+                                    }
+                                ]
+                            },
+                            {
+                                "condition": [
                                     { "domain": "fedex.com" }
                                 ],
                                 "patchSettings": [


### PR DESCRIPTION
**Asana Task/Github Issue:**
- https://app.asana.com/1/137249556945/project/1200930669568058/task/1214119314244884
- https://app.asana.com/1/137249556945/project/1200930669568058/task/1212905853578241
- https://app.asana.com/1/137249556945/project/1200930669568058/task/1211065562517472
- https://app.asana.com/1/137249556945/project/1200930669568058/task/1209295499038956
## Description
Four site-specific autofill fixes from a bug bash, added to `siteSpecificFixes.settings.conditionalChanges` in all four platform overrides (macos, ios, android, windows).
| Asana | Site | Rule |
|---|---|---|
| [1214119314244884](https://app.asana.com/1/137249556945/project/1200930669568058/task/1214119314244884) | `www.aestheticcity.academy` | `input[name="confirm-email"]` → `unknown` |
| [1212905853578241](https://app.asana.com/1/137249556945/project/1200930669568058/task/1212905853578241) | `cvs.com` | `#ps_month` / `#ps_day` / `#ps_year` → birthday month/day/year |
| [1211065562517472](https://app.asana.com/1/137249556945/project/1200930669568058/task/1211065562517472) | `login.app.carta.com` | `form` → `login` form type |
| [1209295499038956](https://app.asana.com/1/137249556945/project/1200930669568058/task/1209295499038956) | `www.theinformation.com` | `#login-email` → `credentials.username` |
Companion autofill algorithm fixes are in duckduckgo/duckduckgo-autofill#944.
### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
  - https://www.aestheticcity.academy/courses/take/foundations_course/lessons/72459064-1-on-making-places-cities
  - https://www.cvs.com/account-auth/dob
  - https://login.app.carta.com
  - https://www.theinformation.com/sessions/new
- Problems experienced:
  - Aesthetic City: autofill filled the site's `confirm-email` honeypot, so the site's own validation silently rejected the login submit — the "Sign in" button appeared to do nothing.
  - CVS: date-of-birth fields were classified as password fields (`#ps_month` as `credentials.password.current`, `#ps_day`/`#ps_year` as `credentials.password.new`), showing password icons and blocking the numeric keyboard on iOS.
  - Carta: the page title and URL both contain "registration", so the sign-in form scored as a signup and offered password generation.
  - The Information: `#login-email` was not treated as a username, so autofill never triggered.
- Platforms affected:
  - [x] iOS
  - [x] Android
  - [x] Windows
  - [x] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked: none
- Feature being disabled/modified: `siteSpecificFixes` (autofill input and form type overrides only)
- [ ] This change is a speculative mitigation to fix reported breakage.
Not speculative — each rule targets a selector confirmed on the live page. Two further rules (Kathy Kuo Home, Municipay) were written and then removed in the final commit because the evidence did not support them; Kathy Kuo's site has since been rebuilt and the reported URL now 404s.
Tests: `npm test` — 3,188 passing, lint/prettier/tsc clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only autofill selector overrides on named domains; no auth or core infrastructure changes.
> 
> **Overview**
> Adds **four new `conditionalChanges` entries** under `siteSpecificFixes` in **android, ios, macos, and windows** overrides so autofill behaves correctly on specific broken sites.
> 
> **www.aestheticcity.academy** — marks `input[name="confirm-email"]` as `unknown` so autofill does not fill a honeypot that blocked sign-in.
> 
> **login.app.carta.com** (registration URL pattern) — treats `form` as **login** form type so the sign-in flow is not misclassified as signup/password generation.
> 
> **www.theinformation.com** — maps `#login-email` to `credentials.username` so autofill can offer credentials.
> 
> **cvs.com** — extends the existing CVS block with `#ps_month`, `#ps_day`, and `#ps_year` as birthday month/day/year instead of password fields (fixes wrong icons and iOS keyboard).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 85c7532f0ad3a65554715b75558e93c6d0d3c5c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->