### PR TITLE
Add domains to conditionalChanges in windows-override.json for media …

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -65,6 +65,12 @@
                     {
                         "condition": [
                             {
+                                "domain": "onedrive.live.com"
+                            },
+                            {
+                                "domain": "sharepoint.com"
+                            },
+                            {
                                 "domain": "youtube.com"
                             },
                             {


### PR DESCRIPTION
…devices disable

**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1200277586140538/task/1217877709998978?focus=true

## Description
<!-- 
  Please delete either or both process sections below.
-->

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only domain list expansion for an existing Windows site-specific API patch; no new behavior beyond applying the same mitigation on two additional Microsoft domains.
> 
> **Overview**
> On **Windows**, the `apiManipulation` override already applies extra **MediaDevices** patches (noop `addEventListener` / `removeEventListener`, `ondevicechange` undefined) only on a fixed set of domains via `conditionalChanges`.
> 
> This PR **adds** `onedrive.live.com` and `sharepoint.com` to that domain list so Microsoft cloud document sites get the same conditional mitigation as sites like YouTube and LinkedIn—aligning with the PR’s media-devices disable / breakage mitigation intent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f04346bcd6410af05c060351ac245b0f608027b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->