### PR TITLE
Enable aiChat usageLimits internally on Windows.

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -1483,6 +1483,9 @@
                 "promptBar": {
                     "state": "enabled",
                     "minSupportedVersion": "0.171.0"
+                },
+                "usageLimits": {
+                    "state": "internal"
                 }
             },
             "minSupportedVersion": "0.100.0",


### PR DESCRIPTION
## Summary
- Enable `aiChat.usageLimits` on Windows with `state: "internal"`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Windows preview config only, internal gating with no rollout or enabled-state change for production users.
> 
> **Overview**
> Adds the **`usageLimits`** subfeature under **`aiChat.features`** in the Windows override with **`state: "internal`**, so usage-limits UI and behavior are available on internal Windows builds only and remain off for general users.
> 
> This is the first platform override in the repo to define **`usageLimits`**; gating matches other internal-only aiChat subfeatures (state only, no rollout steps).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f4fc6000f07c95bfd533ca99377c74e5ed9e5eec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->