### PR TITLE
Update content-blocker extension to 2026.8.27

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -5051,7 +5051,7 @@
             "minSupportedVersion": "0.148.0",
             "exceptions": [],
             "settings": {
-                "extensionUrl": "https://staticcdn.duckduckgo.com/extensions/content-blocker/content-blocker-extension-2026.8.25.crx"
+                "extensionUrl": "https://staticcdn.duckduckgo.com/extensions/content-blocker/content-blocker-extension-2026.8.27.crx"
             },
             "features": {
                 "onboardingEnabled": {


### PR DESCRIPTION
Update content-blocker extension to 2026.8.27.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single remote-config URL update for the ad-block extension; no application logic changes.
> 
> **Overview**
> Updates the **Windows** remote config for `adBlockV2Extension` so the bundled content-blocker CRX points to **`content-blocker-extension-2026.8.27.crx`** instead of **2026.8.25**.
> 
> No other settings in that feature block change—only the `extensionUrl` version bump.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a80b2c2cc8c0515d09f7f361de2a31a143f5997. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->