### PR TITLE
Update ad-blocking extension scriptlets for v2026.8.27

### DIFF
--- a/features/ad-blocking-extension.json
+++ b/features/ad-blocking-extension.json
@@ -4,28 +4,28 @@
     },
     "exceptions": [],
     "settings": {
-        "version": "2026.8.20",
+        "version": "2026.8.27",
         "enabledByDefault": false,
         "scriptlets": {
             "scriptlets/isolated/ublock-filters.js": {
-                "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/99ecade91c2ac5bfc11707f75cf9c0d56ae365d87b1b062c57935852372cb473.js",
-                "signature": "MEUCIALEZThRK76E81j3tlY/EZVteGV2dl1eT1HZMXdp/E8sAiEAzQolGCE8XWVR8senQIT/4wBE42FRtdjzkJ4uqsAjoko="
+                "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/5f41c2de023c0378bcf3da0472c9085633c3fe4079af82786928fefcccdfdaa2.js",
+                "signature": "MEUCIQCVHyVU6xBj7zL7be4DnOPby1liz1BPebQeMqdURtlR2AIgAzatFhmwLDJG+UvyzIH0h98yS7EdCxUiSynUsolXyRc="
             },
             "scriptlets/main/ublock-filters.js": {
-                "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/fbf5a76ad0f0febee778c80b0b9bab89bdc7aa29907a15c13f609f5ca531ef3d.js",
-                "signature": "MEUCIQD2SIYoeMI1ojtxxCALD7Fop89pfpq+fx6hJnym2gFmqwIgPBkbgdLrpFbD5am9icKFbFY1pF8Ft+xaY+gnzqxVtXA="
+                "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/a1b5737fc965f6e55847e5eaf3fd04f6d907c19818ca8f8207b806b30e0032c5.js",
+                "signature": "MEQCICZ30nGovspzsH6UQ9nMn8LLES6FtQJKKILu+tkeGPvtAiAYEkhhOH0gKa7Cpb09b/bA34G0ESSKPe1xlNkNRzVEkw=="
             },
             "scriptlets/main/ublock-experimental.js": {
                 "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855.js",
-                "signature": "MEUCID+szntDl56/AjE+gossNixSauM9KOZGMMaexAnzktQtAiEAvBMy4nH1GJlZBS0oQQHvGzS/yhMT7vr1fmZVFe6xmHM="
+                "signature": "MEYCIQDyxCip4v5bIN+eTAZ5EC8jLbMb5PqtxIXpel2uogZ0QwIhAIG9tCGA5zuhc/1ZNOMOa+sM/uSZnqSfwGYR89n0+vaD"
             },
             "scriptlets/isolated/ublock-experimental.js": {
                 "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855.js",
-                "signature": "MEQCIF0h9eonAoJbXxmyfx9O3FUeEmcTZfvsf/Gf83z0P9ECAiBp6l7YuvJVYI4t2+Tm0QczprgL1BntyWC+UsC1VCmVXQ=="
+                "signature": "MEYCIQD/tBJYYZ/+nModlRGIT+NOR3u3Ne/gtpwbu3mZYI5EfAIhAPfhrsWPvdf56FK8HpWyPEqenNroSfXXUoJDV1gWLfzW"
             },
             "rules/youtube.json": {
                 "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/2337db6aa7466667595226f780b6590779db3007ac0a65ef3833f89610c92824.json",
-                "signature": "MEYCIQDVeM9xiCGu7IdvLFf++j11IRr3QHxg5ODb5P0gUwfRKAIhAK/vfWj1u6d1iYIDsCeb2ddiliJz6bItpZsuK6j6e3bB"
+                "signature": "MEYCIQDWUgpe9qIuo2lyRuFOJ+sLyXvrw3Nz6lO6kWhWHXnEKAIhALR16UtNsFAd5wCvCXCMur7VW0XKlxbjc7ohoElBqGMU"
             }
         }
     }


### PR DESCRIPTION
Update ad-blocking extension scriptlets for v2026.8.27.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates signed CDN scriptlet URLs and signatures for the content blocker; incorrect pairing would break verification or blocklist delivery for users who enable the extension.
> 
> **Overview**
> Bumps the macOS/iOS **ad-blocking extension** feature config from **2026.8.20** to **2026.8.27**.
> 
> **`ublock-filters`** scriptlets (isolated and main) get new CDN URLs and updated signatures. **Experimental** scriptlet entries keep the same URLs but refresh signatures. **`rules/youtube.json`** keeps its URL and only updates its signature.
> 
> No changes to exceptions, `enabledByDefault`, or other settings structure.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5be819b6ad28e724a7d8c9c419cde67492572295. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->