### PR TITLE
Enable serializeTokenRefresh feature flag on Android at 5%

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -4068,6 +4068,16 @@
                 "useQueryPurchases": {
                     "state": "enabled",
                     "minSupportedVersion": 52840000
+                },
+                "serializeTokenRefresh": {
+                    "state": "enabled",
+                    "rollout": {
+                        "steps": [
+                            {
+                                "percent": 5
+                            }
+                        ]
+                    }
                 }
             }
         },


### PR DESCRIPTION
## Summary
- Enables the `serializeTokenRefresh` kill switch (introduced in duckduckgo/Android#9471) for the `privacyPro` feature on Android
- Rolls out to 5% of users

## Test plan
- [ ] Config builds and validates via CI
- [ ] Verify via test link that Android clients on the rollout receive the flag enabled

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches subscription auth token refresh behavior for Privacy Pro at 5% rollout; incorrect serialization could affect login or subscription state for enrolled users.
> 
> **Overview**
> Adds the **`serializeTokenRefresh`** sub-feature under **`privacyPro`** in the Android override, turning on the kill switch that was introduced in the Android app and limiting exposure with a **5%** incremental rollout step.
> 
> Android clients in that cohort should serialize Privacy Pro token refresh instead of the prior behavior; everyone else keeps the flag off until rollout expands.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 28aaa4052145106939cc70d7e0475fb88c8149ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->