### PR TITLE
Roll out optimizeCnameDetection.cacheCnamesInMemory to 100% on Android

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -5311,6 +5311,17 @@
                     }
                 }
             }
+        },
+        "optimizeCnameDetection": {
+            "state": "enabled",
+            "minSupportedVersion": 52930000,
+            "exceptions": [],
+            "features": {
+                "cacheCnamesInMemory": {
+                    "state": "enabled",
+                    "minSupportedVersion": 52930000
+                }
+            }
         }
     },
     "unprotectedTemporary": [],


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1212608036467427/task/1217541925377931?focus=true

## Description
Enables the optimizeCnameDetection feature and its cacheCnamesInMemory sub-feature at a 100% rollout, gated to 5.293.0 (52930000) — the first release containing duckduckgo/Android#9512, which added the flag.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Config-only change, but it flips tracker-related CNAME detection behavior for all users on 5.293.0+, so incorrect caching could affect blocking accuracy or performance.
> 
> **Overview**
> Turns on the Android remote-config flag for **CNAME detection optimization**, including the **cache CNAMEs in memory** behavior, for app builds **5.293.0+** (`minSupportedVersion` **52930000**).
> 
> The override adds a new `optimizeCnameDetection` feature block with `cacheCnamesInMemory` enabled and no staged `rollout` steps, so eligible clients get the optimization immediately once they meet the version gate (matching the client support added in duckduckgo/Android#9512).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c823c1f65bae246a73d09c95b234a849054c1797. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->