### PR TITLE
Enable session restore experiment for 170.7+

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -6303,6 +6303,27 @@
         "sessionRestoreNavigationHistory": {
             "state": "internal",
             "exceptions": []
+        },
+        "sessionRestorePrompt": {
+            "state": "enabled",
+            "minSupportedVersion": "0.170.7",
+            "exceptions": [],
+            "features": {
+                "sessionRestorePromptExperiment": {
+                    "state": "enabled",
+                    "minSupportedVersion": "0.170.7",
+                    "cohorts": [
+                        {
+                            "name": "control",
+                            "weight": 1
+                        },
+                        {
+                            "name": "promptAfterRestore",
+                            "weight": 1
+                        }
+                    ]
+                }
+            }
         }
     },
     "unprotectedTemporary": []


### PR DESCRIPTION
**Asana Task/Github Issue:** 

## Description
Add the configuration for the session restore prompt experiment and enable it for versions 170.7 and above.

The experiment will have two equally weighted cohorts: `control` and `promptAfterRestore`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only change to Windows feature overrides; no runtime logic or security-sensitive code paths.
> 
> **Overview**
> Turns on the **session restore prompt** feature flag on Windows for builds **0.170.7+**, alongside existing internal session-restore flags.
> 
> The flag includes **sessionRestorePromptExperiment**, a 50/50 split between **`control`** and **`promptAfterRestore`** cohorts so the team can test showing a prompt after session restore versus no change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 82e3328feb4481c0bbd0c4039284a21e256b7886. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->