### PR TITLE
Add internalFeedback message-bridge sub-feature (internal feedback form)

### DIFF
--- a/features/message-bridge.json
+++ b/features/message-bridge.json
@@ -8,6 +8,7 @@
         "subscriptions": "disabled",
         "serpSettings": "disabled",
         "serp": "disabled",
+        "internalFeedback": "disabled",
         "domains": []
     }
 }

--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -2781,7 +2781,18 @@
                 "serpSettings": "disabled",
                 "serp": "disabled",
                 "duckAiNativeStorage": "disabled",
+                "internalFeedback": "disabled",
                 "domains": [
+                    {
+                        "domain": "internalapps.duckduckgo.com",
+                        "patchSettings": [
+                            {
+                                "op": "replace",
+                                "path": "/internalFeedback",
+                                "value": "enabled"
+                            }
+                        ]
+                    },
                     {
                         "domain": [
                             "duckduckgo.com",

--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -153,7 +153,18 @@
                 "serpSettings": "disabled",
                 "serp": "disabled",
                 "duckAiNativeStorage": "disabled",
+                "internalFeedback": "disabled",
                 "domains": [
+                    {
+                        "domain": "internalapps.duckduckgo.com",
+                        "patchSettings": [
+                            {
+                                "op": "replace",
+                                "path": "/internalFeedback",
+                                "value": "enabled"
+                            }
+                        ]
+                    },
                     {
                         "domain": [
                             "duckduckgo.com",

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -312,7 +312,18 @@
                 "serpSettings": "disabled",
                 "serp": "disabled",
                 "duckAiNativeStorage": "disabled",
+                "internalFeedback": "disabled",
                 "domains": [
+                    {
+                        "domain": "internalapps.duckduckgo.com",
+                        "patchSettings": [
+                            {
+                                "op": "replace",
+                                "path": "/internalFeedback",
+                                "value": "enabled"
+                            }
+                        ]
+                    },
                     {
                         "domain": [
                             "duckduckgo.com",

--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -2443,7 +2443,18 @@
                 "serpSettings": "disabled",
                 "serp": "disabled",
                 "duckAiNativeStorage": "disabled",
+                "internalFeedback": "disabled",
                 "domains": [
+                    {
+                        "domain": "internalapps.duckduckgo.com",
+                        "patchSettings": [
+                            {
+                                "op": "replace",
+                                "path": "/internalFeedback",
+                                "value": "enabled"
+                            }
+                        ]
+                    },
                     {
                         "domain": [
                             "duckduckgo.com",

--- a/schema/features/message-bridge.ts
+++ b/schema/features/message-bridge.ts
@@ -7,6 +7,7 @@ export type MessageBridgeSettings = CSSInjectFeatureSettings<{
     serpSettings?: FeatureState;
     serp?: FeatureState;
     duckAiNativeStorage?: FeatureState;
+    internalFeedback?: FeatureState;
 }>;
 
 export type MessageBridgeFeature<VersionType> = Feature<MessageBridgeSettings, VersionType>;


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/task/1217365602062371

## Description

### Feature change process:

- [x] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change (one-line addition to `schema/features/message-bridge.ts`).
- [ ] I have tested this change locally in all supported browsers. (Native `internalFeedback` handlers don't exist yet — this change is inert until they ship; the page falls back to UA detection.)
- [x] This code for the config change is ready to merge.
- [x] This feature was covered by a tech design.

### What
- New `messageBridge` sub-feature `internalFeedback`, used by the internal feedback form (https://internalapps.duckduckgo.com/internal-feedback/) to request device info from our browsers
- `"internalFeedback": "disabled"` in the base feature + all four platform overrides; enabled only for `internalapps.duckduckgo.com` via `patchSettings` (same pattern as `aiChat`)
- Additions only — no existing settings touched (46 insertions, 0 deletions)
- Internal-only domain; no effect on real users. Safe ahead of the native handlers: the bridge installs but requests fail and the page falls back

### Reference
- Form-side implementation: duckduckgo/internal-feedback-form#123 (`?bridgeDebug=1` conformance panel for native verification)

Draft until a messageBridge owner sanity-checks the override blocks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only additions scoped to an internal domain with default disabled; no changes to existing bridge settings or user-facing behavior until native code ships.
> 
> **Overview**
> Adds a new **`messageBridge`** sub-setting **`internalFeedback`** so the internal feedback form on `internalapps.duckduckgo.com` can use the bridge to request device info from DuckDuckGo browsers.
> 
> The base `features/message-bridge.json` and Android, iOS, macOS, and Windows overrides all default **`internalFeedback`** to **`disabled`**. Each platform override enables it only for **`internalapps.duckduckgo.com`** via domain **`patchSettings`** (same pattern as **`aiChat`**). The TypeScript schema in `message-bridge.ts` documents the optional setting.
> 
> Until native handlers ship, the change is effectively inert: the page can fall back to UA detection. No public-user domains are affected.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 65837067accf832bacc581a28d9ea02c5441a78a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->