### PR TITLE
Enable promoPresentationCoordination for all iOS users

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -3467,7 +3467,7 @@
                     ]
                 },
                 "promoPresentationCoordination": {
-                    "state": "internal",
+                    "state": "enabled",
                     "minSupportedVersion": "7.235.0"
                 }
             }


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1209527836175384/task/1217960578355799?focus=true

## Description

Enables `promoPresentationCoordination` for all iOS users running version 7.235.0 or later.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [x] This feature was covered by a tech design.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Widens promo coordination behavior to all supported iOS users, which can affect when and how subscription or promotional UI is shown.
> 
> **Overview**
> Turns on **`promoPresentationCoordination`** for the iOS browser by changing its state from `internal` to `enabled` in `overrides/ios-override.json`, under `iOSBrowserConfig`.
> 
> Eligible clients remain those on **7.235.0+** (`minSupportedVersion` unchanged). This is a remote-config rollout only—no app code changes in this PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8bf85c17be418e4c95e81aa86f9eeef9ee0f9b85. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->