### PR TITLE
Set updatedModelPicker to enabled, 7.235.0

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -408,8 +408,8 @@
                     }
                 },
                 "updatedModelPicker": {
-                    "state": "internal",
-                    "minSupportedVersion": "7.234.0"
+                    "state": "enabled",
+                    "minSupportedVersion": "7.235.0"
                 },
                 "contextualUnifiedToggleInput": {
                     "state": "enabled",


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1210947754188321/task/1217159579063408?focus=true

## Description
<!-- 
  Please delete either or both process sections below.
-->
Enabled updatedModelPicker feature

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [x] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single iOS feature-flag change with a version bump; no secrets, rollout steps, or experiment metrics touched.
> 
> **Overview**
> Updates the iOS privacy override so **`updatedModelPicker`** under **`aiChat`** is **`enabled`** instead of **`internal`**, exposing the updated Duck.ai model picker to eligible app builds rather than internal-only gating.
> 
> **`minSupportedVersion`** is raised from **`7.234.0`** to **`7.235.0`** alongside the state change so clients pick up the transition.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d8a0b80243f0ea1378e83023069db400777ce02d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->