### PR TITLE
Add partnershipsHub sub-feature

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -3944,6 +3944,17 @@
         "privacyPro": {
             "state": "enabled",
             "features": {
+                "partnershipsHub": {
+                    "state": "disabled",
+                    "settings": {
+                        "url": "https://duckduckgo.com/partner-benefits"
+                    },
+                    "targets": [
+                        {
+                            "localeCountry": "us"
+                        }
+                    ]
+                },
                 "refreshSubscriptionPlanFeatures": {
                     "state": "enabled",
                     "minSupportedVersion": 52440000


### PR DESCRIPTION
 **Asana Task/Github Issue:** https://app.asana.com/1/137249556945/task/1217906511578744?focus=true

## Description
Add the `partnershipsHub` sub-feature for the Partner Benefits entry point. Disabled and targeted to US, so internal builds can enable it from dev settings and read the hub URL from config.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge. 
- [x] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [x] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Android-only remote config with the feature disabled and no rollout; no production behavior change until the client enables it.
> 
> **Overview**
> Adds a new **`partnershipsHub`** sub-feature under **`privacyPro`** in the Android override for the Partner Benefits entry point.
> 
> It is **disabled** by default, **US-only** via `localeCountry: us`, and supplies the hub URL **`https://duckduckgo.com/partner-benefits`** in settings so the app can read it from remote config when internal builds turn the flag on from dev settings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b65f2e38012876c4ace663c048c20659a3263116. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1217906511578744