### PR TITLE
Disable optimizeContentScopeMessaging flag on Android

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -3511,7 +3511,7 @@
                 },
                 "optimizeContentScopeMessaging": {
                     "minSupportedVersion": 52920000,
-                    "state": "enabled"
+                    "state": "disabled"
                 },
                 "cacheContentScopeExperiments": {
                     "minSupportedVersion": 52920000,


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/488551667048375/task/1217999943331464?focus=true

## Description
Disables `optimizeContentScopeMessaging` Android flag to help investigate a problem in a new release. 
- See linked task for details.
- This is a temporary change

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit badd0e57b7b50f5e67b31622efdecd016c324dec. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->