### PR TITLE
Enables dataDirectoryAccess on macOS

### DIFF
--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -2961,6 +2961,10 @@
                 "newDataImportExperience": {
                     "state": "enabled",
                     "minSupportedVersion": "1.169.0"
+                },
+                "dataDirectoryAccess": {
+                    "state": "enabled",
+                    "minSupportedVersion": "1.206.0"
                 }
             }
         },


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/1208671677432066/task/1217685130715318?focus=true

## Description
This Feature Flag enables the new Data Import flow on macOS +27.
Project: https://app.asana.com/1/137249556945/project/1208671677432066/task/1216653246808027?focus=true

Thanks in advance!

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single JSON override enabling a version-gated feature flag with no rollout or logic changes in this repo.
> 
> **Overview**
> Turns on the **`dataDirectoryAccess`** sub-feature under **`dataImport`** in the macOS privacy configuration override, gated to app versions **1.206.0** and newer.
> 
> This sits next to the already-enabled **`newDataImportExperience`** flag (1.169.0+) and is intended to unlock the newer data import flow that can access browser data directories on macOS.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fbc2faebdbf9e31259637d743094ce2dad32580f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->