### PR TITLE
Enable native input url clearing (Android)

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -4189,7 +4189,8 @@
         },
         "nativeInputUrlClearingFeature": {
             "state": "enabled",
-            "minSupportedVersion": 52940000
+            "minSupportedVersion": 52940000,
+            "exceptions": []
         },
         "swipingTabs": {
             "state": "enabled",

--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -4187,6 +4187,10 @@
                 }
             }
         },
+        "nativeInputUrlClearingFeature": {
+            "state": "enabled",
+            "minSupportedVersion": 52940000
+        },
         "swipingTabs": {
             "state": "enabled",
             "minSupportedVersion": 52390000,


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1200204095367872/task/1218029177631555?focus=true

## Description

- Enables `nativeInputUrlClearingFeature` on 5.294.0+

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [x] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single Android feature-flag enablement with a version floor and no rollout or exceptions; low blast radius beyond native input UX.
> 
> **Overview**
> Turns on the **`nativeInputUrlClearingFeature`** remote-config flag for Android at app version **5.294.0+** (`minSupportedVersion`: `52940000`), with no domain exceptions.
> 
> This is a privacy-configuration-only change in `android-override.json`; clients that read the flag will enable native URL-clearing behavior in the native input flow once they meet the version gate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 88eb76de7d42e31ca96f4f482255b039e1439495. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->