### PR TITLE
[iOS] Rename search token experiment flag

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -3486,9 +3486,9 @@
                 "webScrollFreezeObservability": {
                     "state": "disabled"
                 },
-                "searchTokenExperimentV2": {
+                "searchTokenExperimentV4": {
                     "state": "enabled",
-                    "minSupportedVersion": "7.233.0",
+                    "minSupportedVersion": "7.236.0",
                     "settings": {
                         "tokenTTLSeconds": 300,
                         "refreshWindowSeconds": 120

--- a/schema/features/ios-browser-config.ts
+++ b/schema/features/ios-browser-config.ts
@@ -12,7 +12,7 @@ type SubFeatures<VersionType> = {
             idleThresholdSeconds: number;
         }
     >;
-    searchTokenExperimentV2?: SubFeature<
+    searchTokenExperimentV4?: SubFeature<
         VersionType,
         {
             // Lifetime of the search token in seconds


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/task/1218018673872219?focus=true

## Description
This PR includes the following changes to the search token experiment config:

- Updates the experiment name to reset the experiment.
- Bumps the minimum app version.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only rename and version gate for an existing experiment; no logic or security surface changes in this repo.
> 
> **Overview**
> Resets the iOS **search token SERP experiment** by renaming the remote-config subfeature from `searchTokenExperimentV2` to `searchTokenExperimentV4` in `ios-override.json` and the `ios-browser-config` schema so clients treat it as a new experiment cohort assignment.
> 
> **Minimum app version** for the flag moves from **7.233.0** to **7.236.0**. Experiment **settings** (`tokenTTLSeconds`, `refreshWindowSeconds`), **description**, and **control/treatment cohorts** are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b2e0e19ce74915db2784fc691e53a4ecdf2064f8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->