### PR TITLE
Stop enrolling users in the dock only variant for the widget prompt/ add to dock onboarding experiment

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -5340,7 +5340,7 @@
                         },
                         {
                             "name": "treatmentDockOnly",
-                            "weight": 1
+                            "weight": 0
                         },
                         {
                             "name": "treatmentWidgetOnly",


### PR DESCRIPTION
**Asana Task/Github Issue:**https://app.asana.com/1/137249556945/project/72649045549333/task/1218044639614463?focus=true

## Description
Set the weight of the dockonly variant of the add to dock/ widget prompt onboarding experiment to 0 to stop enrolling new users in the experiment.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [x] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single cohort weight change in Android remote config; no app code or security/data-path changes.
> 
> **Overview**
> Updates the Android privacy config for **`onboardingPrompts.addToDockAndWidgetExperimentJul25`**: the **`treatmentDockOnly`** cohort weight goes from **1** to **0**, so new users are no longer assigned to the dock-only onboarding variant.
> 
> The experiment stays **enabled**; **control**, **widget-only**, and **dock-and-widget** cohorts still have weight **1**. Only enrollment into the dock-only arm is turned off.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6515b4ece725dee9bce4279a187bbcf5dec87829. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->