### PR TITLE
Removes dataDirectoryAccess from macOS

### DIFF
--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -2961,6 +2961,10 @@
                 "newDataImportExperience": {
                     "state": "enabled",
                     "minSupportedVersion": "1.169.0"
+                },
+                "dataDirectoryAccess": {
+                    "state": "enabled",
+                    "minSupportedVersion": "1.206.0"
                 }
             }
         },

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -2985,10 +2985,6 @@
                 "newDataImportExperience": {
                     "state": "enabled",
                     "minSupportedVersion": "1.169.0"
-                },
-                "dataDirectoryAccess": {
-                    "state": "enabled",
-                    "minSupportedVersion": "1.206.0"
                 }
             }
         },


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/1208671677432066/task/1217685130715318?focus=true

## Description
The `dataDirectoryAccess` Flag has been enabled, by default, in code.
I'm reverting PR #5852 as it's no longer needed.

Ref.
https://github.com/duckduckgo/apple-browsers/pull/6600

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single JSON override deletion with no logic changes; behavior should match the new app default rather than disabling the feature.
> 
> **Overview**
> Removes the **`dataDirectoryAccess`** sub-feature from the macOS **`dataImport`** block in `macos-override.json`, leaving **`newDataImportExperience`** as the only enabled child feature there.
> 
> This rolls back the earlier override that turned on directory access via remote config, because the DuckDuckGo macOS app now enables that capability by default in code (see apple-browsers PR #6600). **`dataImport`** itself stays enabled on macOS; only the redundant remote flag is dropped.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 91254b8f8270f967fc431d6a9be3e76f2a9f5e13. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->