### PR TITLE
Enable onboarding subscription experiment on Windows

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -6407,6 +6407,27 @@
                     ]
                 }
             }
+        },
+        "onboardingSubscriptionUpsell": {
+            "state": "enabled",
+            "minSupportedVersion": "0.171.2",
+            "exceptions": [],
+            "features": {
+                "onboardingSubscriptionUpsellExperiment": {
+                    "state": "enabled",
+                    "minSupportedVersion": "0.171.2",
+                    "cohorts": [
+                        {
+                            "name": "control",
+                            "weight": 1
+                        },
+                        {
+                            "name": "treatment",
+                            "weight": 1
+                        }
+                    ]
+                }
+            }
         }
     },
     "unprotectedTemporary": []


### PR DESCRIPTION
**Asana Task/Github Issue:**

## Description

Enable the onboarding subscription upsell experiment for Windows on versions 0.171.2 and above.

The experiment will have two equally weighted cohorts: control and treatment.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Configuration-only change to feature-flag overrides with no application logic or security impact.
> 
> **Overview**
> Adds a Windows override for **`onboardingSubscriptionUpsell`** (enabled from **0.171.2+**) with nested **`onboardingSubscriptionUpsellExperiment`**, split evenly between **control** and **treatment** cohorts.
> 
> This turns on the onboarding subscription upsell A/B test for Windows clients that meet the minimum version.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 74879d03e38a7aaa629fd78e53a846250382f427. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->