### PR TITLE
Fix luna.amazon.com not loading on macOS

### DIFF
--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -965,6 +965,40 @@
                 ]
             }
         },
+        "apiManipulation": {
+            "state": "enabled",
+            "exceptions": [],
+            "settings": {
+                "apiChanges": {},
+                "domains": [
+                    {
+                        // Luna's bootstrap only calls tempo.initialize() when the native-wrapper
+                        // signals are absent or contradictory: `isMac = window.webkit && !isIOS`,
+                        // `isWindows = typeof CefSharp !== 'undefined'`, run only if
+                        // `!(isMac ? !isWindows : isWindows)`. Every WKWebView browser looks like
+                        // Luna's own macOS app, so the page never boots. Defining CefSharp takes the
+                        // contradictory branch. It is referenced nowhere else on the site, and
+                        // lunaState.isMac/isWindows come from the injected platform ("web"), not
+                        // from this, so no native code paths are enabled by it.
+                        "domain": "luna.amazon.com",
+                        "patchSettings": [
+                            {
+                                "op": "add",
+                                "path": "/apiChanges/CefSharp",
+                                "value": {
+                                    "type": "descriptor",
+                                    "value": {
+                                        "type": "object",
+                                        "value": {}
+                                    },
+                                    "define": true
+                                }
+                            }
+                        ]
+                    }
+                ]
+            }
+        },
         "autoconsent": {
             "state": "enabled",
             "exceptions": [

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -972,14 +972,7 @@
                 "apiChanges": {},
                 "domains": [
                     {
-                        // Luna's bootstrap only calls tempo.initialize() when the native-wrapper
-                        // signals are absent or contradictory: `isMac = window.webkit && !isIOS`,
-                        // `isWindows = typeof CefSharp !== 'undefined'`, run only if
-                        // `!(isMac ? !isWindows : isWindows)`. Every WKWebView browser looks like
-                        // Luna's own macOS app, so the page never boots. Defining CefSharp takes the
-                        // contradictory branch. It is referenced nowhere else on the site, and
-                        // lunaState.isMac/isWindows come from the injected platform ("web"), not
-                        // from this, so no native code paths are enabled by it.
+                        // https://github.com/duckduckgo/privacy-configuration/pull/5863
                         "domain": "luna.amazon.com",
                         "patchSettings": [
                             {


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1206777341262243/task/1217749921473788

## Description

`luna.amazon.com` renders a blank page in the macOS browser. The inline bootstrap in `root.html` only calls `tempo.initialize()` when the native-wrapper signals are absent or contradictory:

```js
const isMac     = window.webkit && !isIOS;
const isWindows = typeof CefSharp !== 'undefined';
if (!(isMac ? !isWindows : isWindows)) { window.tempo.initialize(configuration); }
```

Luna's own macOS app is a WKWebView and its Windows app is CEF — in those, the native shell initializes the page itself. Any WKWebView-based browser therefore looks like Luna's macOS app: `initialize()` is never called, so there is no error and no failed request, just a permanently empty `#root`.

With `isMac` true the guard reduces to `!(!isWindows)`, so defining `CefSharp` takes the contradictory branch and the app boots. It is referenced nowhere else on the site (checked across all 53 bundles), and `lunaState.isMac`/`isWindows` are derived from the injected `platform` value (`"web"`), not from this property, so no native code paths are enabled by it.

Verified in a local debug build: `#root` 2160 bytes and blank before, 96107 bytes with full navigation and content after. Single-variable control with `apiManipulation` disabled reproduces the breakage.

Note that `apiManipulation` moves to `state: "enabled"` for macOS so the domain-scoped entry can apply. Base `apiChanges` is empty, so it is a no-op everywhere else.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL: https://luna.amazon.com/
- Problems experienced: blank page — the app never initializes, with no console error or failed request
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [x] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked: none
- Feature being disabled/modified: `apiManipulation`, scoped to `luna.amazon.com`
- [ ] This change is a speculative mitigation to fix reported breakage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015gms7yB4VzgE2Y7C7HVWdZ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Site-scoped API shim on a single domain for web compatibility; no broad macOS apiManipulation changes beyond enabling the feature with empty defaults.
> 
> **Overview**
> **macOS** gains an **`apiManipulation`** override (enabled with empty global **`apiChanges`**) so domain-specific patches can run. For **`luna.amazon.com`**, the change **defines** a global **`CefSharp`** object via **`apiChanges`**.
> 
> That addresses a **blank page** in the macOS browser: Luna’s bootstrap only calls **`tempo.initialize()`** when native-wrapper signals look contradictory (Mac WKWebView without **`CefSharp`** matches Luna’s own Mac app path, so the app never boots). Injecting **`CefSharp`** satisfies the guard and restores normal load. Scope is limited to **`luna.amazon.com`**; other sites keep the empty base **`apiChanges`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d852de6418859b7139e48f369593509a79deb067. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->