### PR TITLE
Add contentScopeExperiment7: adwall rendered-text xpath A/B

### DIFF
--- a/features/web-detection.json
+++ b/features/web-detection.json
@@ -411,6 +411,46 @@
             },
             {
                 "condition": {
+                    "experiment": {
+                        "experimentName": "contentScopeExperiment7",
+                        "cohort": "treatment"
+                    }
+                },
+                "patchSettings": [
+                    {
+                        "op": "add",
+                        "path": "/detectors/adwalls/generic_en/match/text/0/xpath",
+                        "value": "//body//text()[not(ancestor::script) and not(ancestor::style) and not(ancestor::template) and not(ancestor::noscript)]"
+                    },
+                    {
+                        "op": "add",
+                        "path": "/detectors/adwalls/generic_de/match/text/xpath",
+                        "value": "//body//text()[not(ancestor::script) and not(ancestor::style) and not(ancestor::template) and not(ancestor::noscript)]"
+                    },
+                    {
+                        "op": "add",
+                        "path": "/detectors/adwalls/generic_es/match/text/xpath",
+                        "value": "//body//text()[not(ancestor::script) and not(ancestor::style) and not(ancestor::template) and not(ancestor::noscript)]"
+                    },
+                    {
+                        "op": "add",
+                        "path": "/detectors/adwalls/generic_it/match/text/xpath",
+                        "value": "//body//text()[not(ancestor::script) and not(ancestor::style) and not(ancestor::template) and not(ancestor::noscript)]"
+                    },
+                    {
+                        "op": "add",
+                        "path": "/detectors/adwalls/generic_nl/match/text/xpath",
+                        "value": "//body//text()[not(ancestor::script) and not(ancestor::style) and not(ancestor::template) and not(ancestor::noscript)]"
+                    },
+                    {
+                        "op": "add",
+                        "path": "/detectors/adwalls/generic_se/match/text/xpath",
+                        "value": "//body//text()[not(ancestor::script) and not(ancestor::style) and not(ancestor::template) and not(ancestor::noscript)]"
+                    }
+                ]
+            },
+            {
+                "condition": {
                     "domain": "homedepot.com"
                 },
                 "patchSettings": [

--- a/features/web-detection.json
+++ b/features/web-detection.json
@@ -410,6 +410,122 @@
                 ]
             },
             {
+                "condition": [
+                    {
+                        "experiment": {
+                            "experimentName": "contentScopeExperiment7",
+                            "cohort": "control"
+                        }
+                    },
+                    {
+                        "experiment": {
+                            "experimentName": "contentScopeExperiment7",
+                            "cohort": "treatment"
+                        }
+                    }
+                ],
+                "patchSettings": [
+                    {
+                        "op": "add",
+                        "path": "/detectors/adwalls/generic_en/triggers",
+                        "value": { "auto": { "state": "enabled", "when": { "intervalMs": [
+                                        500,
+                                        1000,
+                                        5000
+                                    ] } } }
+                    },
+                    {
+                        "op": "add",
+                        "path": "/detectors/adwalls/generic_en/actions",
+                        "value": { "fireEvent": { "state": "enabled", "type": "adwall" } }
+                    },
+                    {
+                        "op": "add",
+                        "path": "/detectors/adwalls/generic_de/triggers",
+                        "value": { "auto": { "state": "enabled", "when": { "intervalMs": [
+                                        500,
+                                        1000,
+                                        5000
+                                    ] } } }
+                    },
+                    {
+                        "op": "add",
+                        "path": "/detectors/adwalls/generic_de/actions",
+                        "value": { "fireEvent": { "state": "enabled", "type": "adwall" } }
+                    },
+                    {
+                        "op": "add",
+                        "path": "/detectors/adwalls/generic_es/triggers",
+                        "value": { "auto": { "state": "enabled", "when": { "intervalMs": [
+                                        500,
+                                        1000,
+                                        5000
+                                    ] } } }
+                    },
+                    {
+                        "op": "add",
+                        "path": "/detectors/adwalls/generic_es/actions",
+                        "value": { "fireEvent": { "state": "enabled", "type": "adwall" } }
+                    },
+                    {
+                        "op": "add",
+                        "path": "/detectors/adwalls/generic_it/triggers",
+                        "value": { "auto": { "state": "enabled", "when": { "intervalMs": [
+                                        500,
+                                        1000,
+                                        5000
+                                    ] } } }
+                    },
+                    {
+                        "op": "add",
+                        "path": "/detectors/adwalls/generic_it/actions",
+                        "value": { "fireEvent": { "state": "enabled", "type": "adwall" } }
+                    },
+                    {
+                        "op": "add",
+                        "path": "/detectors/adwalls/generic_nl/triggers",
+                        "value": { "auto": { "state": "enabled", "when": { "intervalMs": [
+                                        500,
+                                        1000,
+                                        5000
+                                    ] } } }
+                    },
+                    {
+                        "op": "add",
+                        "path": "/detectors/adwalls/generic_nl/actions",
+                        "value": { "fireEvent": { "state": "enabled", "type": "adwall" } }
+                    },
+                    {
+                        "op": "add",
+                        "path": "/detectors/adwalls/generic_se/triggers",
+                        "value": { "auto": { "state": "enabled", "when": { "intervalMs": [
+                                        500,
+                                        1000,
+                                        5000
+                                    ] } } }
+                    },
+                    {
+                        "op": "add",
+                        "path": "/detectors/adwalls/generic_se/actions",
+                        "value": { "fireEvent": { "state": "enabled", "type": "adwall" } }
+                    },
+                    {
+                        "op": "add",
+                        "path": "/detectors/adwalls/admiral/triggers",
+                        "value": { "auto": { "state": "enabled", "when": { "intervalMs": [
+                                        500,
+                                        1000,
+                                        5000
+                                    ] } } }
+                    },
+                    {
+                        "op": "add",
+                        "path": "/detectors/adwalls/admiral/actions",
+                        "value": { "fireEvent": { "state": "enabled", "type": "admiralAdwall" } }
+                    }
+                ]
+            },
+            {
                 "condition": {
                     "experiment": {
                         "experimentName": "contentScopeExperiment7",

--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -4866,6 +4866,28 @@
                             "weight": 1
                         }
                     ]
+                },
+                "contentScopeExperiment7": {
+                    "state": "enabled",
+                    "minSupportedVersion": 52920000,
+                    "description": "Adwall detection: rendered-text xpath matching for the generic adwall detectors",
+                    "rollout": {
+                        "steps": [
+                            {
+                                "percent": 25
+                            }
+                        ]
+                    },
+                    "cohorts": [
+                        {
+                            "name": "control",
+                            "weight": 1
+                        },
+                        {
+                            "name": "treatment",
+                            "weight": 1
+                        }
+                    ]
                 }
             }
         },

--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -1071,6 +1071,28 @@
                             "weight": 1
                         }
                     ]
+                },
+                "contentScopeExperiment7": {
+                    "state": "enabled",
+                    "minSupportedVersion": "7.234.0",
+                    "description": "Adwall detection: rendered-text xpath matching for the generic adwall detectors",
+                    "rollout": {
+                        "steps": [
+                            {
+                                "percent": 25
+                            }
+                        ]
+                    },
+                    "cohorts": [
+                        {
+                            "name": "control",
+                            "weight": 1
+                        },
+                        {
+                            "name": "treatment",
+                            "weight": 1
+                        }
+                    ]
                 }
             }
         },

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -219,6 +219,28 @@
                             "weight": 1
                         }
                     ]
+                },
+                "contentScopeExperiment7": {
+                    "state": "enabled",
+                    "minSupportedVersion": "1.203.0",
+                    "description": "Adwall detection: rendered-text xpath matching for the generic adwall detectors",
+                    "rollout": {
+                        "steps": [
+                            {
+                                "percent": 25
+                            }
+                        ]
+                    },
+                    "cohorts": [
+                        {
+                            "name": "control",
+                            "weight": 1
+                        },
+                        {
+                            "name": "treatment",
+                            "weight": 1
+                        }
+                    ]
                 }
             }
         },

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -222,7 +222,7 @@
                 },
                 "contentScopeExperiment7": {
                     "state": "enabled",
-                    "minSupportedVersion": "1.203.0",
+                    "minSupportedVersion": "1.204.0",
                     "description": "Adwall detection: rendered-text xpath matching for the generic adwall detectors",
                     "rollout": {
                         "steps": [


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1212311623899110/task/1217050663226751?focus=true

## Description

Treatment adds a rendered-text xpath to the six adwall detectors that currently match against body textContent, so text present only inside script, style, template or noscript no longer counts as a detection.

Control keeps textContent matching. admiral and the generic_en "allow ads" condition are already selector-scoped and are left unchanged.

Enabled on Android, iOS and macOS at 25%, gated to the first release of each that bundles content-scope-scripts 16.5.0.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes live adwall detection logic for a quarter of users on three platforms; false negatives on real adwalls or false positives on sites are possible until the experiment is evaluated.
> 
> **Overview**
> Introduces **`contentScopeExperiment7`**, a 25% rollout on Android, iOS, and macOS (version-gated for builds with content-scope-scripts 16.5.0) comparing control vs treatment for generic adwall text matching.
> 
> For users in the experiment, **web-detection** now applies the same adwall auto-triggers and `fireEvent` actions to the generic locale detectors and `admiral` when either cohort is active—parallel to the existing Android/Windows injection path.
> 
> **Treatment** adds a shared rendered-text **xpath** on the six generic adwall detectors (`generic_en`’s first text rule only; the button-scoped “allow ads” rule and `admiral` are unchanged). Matching skips text under `script`, `style`, `template`, and `noscript` to reduce false positives from non-rendered content. **Control** keeps prior textContent-style matching without that xpath.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 129bafcf8033675cd45bfbbb27145afc02c625ab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->