### PR TITLE
Rollout EF2Dapper feature to 20%

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -6359,19 +6359,54 @@
             "exceptions": [],
             "features": {
                 "bookmarks": {
-                    "state": "preview"
+                    "state": "enabled",
+                    "rollout": {
+                        "steps": [
+                            {
+                                "percent": 20.0
+                            }
+                        ]
+                    }
                 },
                 "brokenSites": {
-                    "state": "preview"
+                    "state": "enabled",
+                    "rollout": {
+                        "steps": [
+                            {
+                                "percent": 20.0
+                            }
+                        ]
+                    }
                 },
                 "promoHistory": {
-                    "state": "preview"
+                    "state": "enabled",
+                    "rollout": {
+                        "steps": [
+                            {
+                                "percent": 20.0
+                            }
+                        ]
+                    }
                 },
                 "remoteMessages": {
-                    "state": "preview"
+                    "state": "enabled",
+                    "rollout": {
+                        "steps": [
+                            {
+                                "percent": 20.0
+                            }
+                        ]
+                    }
                 },
                 "vault": {
-                    "state": "preview"
+                    "state": "enabled",
+                    "rollout": {
+                        "steps": [
+                            {
+                                "percent": 20.0
+                            }
+                        ]
+                    }
                 }
             }
         },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/72649045549333/task/1215838942577432?focus=true

## Description
Enables EF to Dapper migration for 20% of stable users.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Configuration-only change to Windows feature rollout percentages; no application code or security logic is modified in this diff.
> 
> **Overview**
> **Windows remote config** advances the **EF → Dapper** secure-storage migration (`secureStorageDapper`) from **preview** to **enabled** with a **20%** incremental rollout for five sub-features: `bookmarks`, `brokenSites`, `promoHistory`, `remoteMessages`, and `vault`.
> 
> The parent flag remains enabled with `minSupportedVersion` **0.170.0**; only these nested feature states and rollout steps change in `windows-override.json`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c0e9cee5d274653de211fa68b8c0907a26a2b7a0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->