### PR TITLE
[iOS] Enable NTP instrumentation for all users

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -3541,7 +3541,7 @@
                     ]
                 },
                 "newTabPageSessionInstrumentation": {
-                    "state": "internal",
+                    "state": "enabled",
                     "minSupportedVersion": "7.233.0",
                     "description": "Wide event measuring Starting Experience Success Rate."
                 },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/414235014887631/task/1217456842764055?focus=true

## Description
Enable wide event for New Tab Page session monitoring.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [x] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single remote-config state flip for analytics instrumentation; no app logic or security paths change in this repo.
> 
> **Overview**
> Turns on **New Tab Page session instrumentation** for the general iOS population by changing `newTabPageSessionInstrumentation` from `internal` to `enabled` in `overrides/ios-override.json`.
> 
> That flag sits under `iOSBrowserConfig` (min version **7.233.0**) and gates wide-event telemetry for **Starting Experience Success Rate** on NTP sessions. No rollout steps, cohorts, or settings change—only who receives the feature via remote config.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc867a78ded1b6327d7f14cffc9e6273b31956fd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->