### PR TITLE
In context SAD FF

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -5238,6 +5238,16 @@
                 "toastNotifications": {
                     "state": "enabled",
                     "minSupportedVersion": "0.129.0"
+                },
+                "inContextInstructions": {
+                    "state": "disabled"
+                },
+                "inContextInstructionsExperiment": {
+                    "state": "disabled",
+                    "cohorts": [
+                        { "name": "control", "weight": 1 },
+                        { "name": "instructions", "weight": 1 }
+                    ]
                 }
             }
         },

--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -5240,10 +5240,10 @@
                     "minSupportedVersion": "0.129.0"
                 },
                 "inContextInstructions": {
-                    "state": "disabled"
+                    "state": "enabled"
                 },
                 "inContextInstructionsExperiment": {
-                    "state": "disabled",
+                    "state": "enabled",
                     "cohorts": [
                         { "name": "control", "weight": 1 },
                         { "name": "instructions", "weight": 1 }


### PR DESCRIPTION
**Asana Task/Github Issue:**https://app.asana.com/1/137249556945/project/1212592783523117/task/1218055639490013?focus=true

## Description
<!-- 
  Please delete either or both process sections below.
-->

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Privacy-configuration override only; enables UI experiment flags without changing application code in this repo.
> 
> **Overview**
> **Windows** `setAsDefaultAndAddToDock` now turns on two new sub-features in `windows-override.json`: `inContextInstructions` and an `inContextInstructionsExperiment` with equal-weight **control** and **instructions** cohorts.
> 
> This is config-only rollout for in-context guidance in the set-as-default / dock prompt flow; no other platforms or files are changed in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b961354d818f2ab5d0f0a5aa2d4876f091618fe1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->