### PR TITLE
Remove autoconsent exception for dillards.com

### DIFF
--- a/features/autoconsent.json
+++ b/features/autoconsent.json
@@ -768,10 +768,6 @@
             "reason": "https://github.com/duckduckgo/privacy-configuration/pull/4503"
         },
         {
-            "domain": "dillards.com",
-            "reason": "https://github.com/duckduckgo/privacy-configuration/pull/4606"
-        },
-        {
             "domain": "depop.com",
             "reason": "https://github.com/duckduckgo/privacy-configuration/pull/4653"
         },

--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -2333,10 +2333,6 @@
                     "reason": "https://github.com/duckduckgo/privacy-configuration/pull/3908"
                 },
                 {
-                    "domain": "dillards.com",
-                    "reason": "https://github.com/duckduckgo/privacy-configuration/pull/4277"
-                },
-                {
                     "domain": "ynab.com",
                     "reason": "https://github.com/duckduckgo/privacy-configuration/pull/4196"
                 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1203268166580279/task/1217973147173861?focus=true

## Description

Removes the autoconsent (cookie popup management) exception for `dillards.com`, re-enabling CPM on the site.

Two entries covered the same site and were both removed:
- `features/autoconsent.json` — global exception added in #4606
- `overrides/windows-override.json` — Windows-only exception added in #4277

No config outside the `autoconsent` scope was changed. `npm run build`, `npm run unit-tests`, and `npm run lint` all pass.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL: https://www.dillards.com/p/section-x-mens-santiago-crossband-sandals/514432727
- Problems experienced: none — the previously reported cookie popup breakage no longer applies, so the exception is no longer needed.
- Platforms affected:
  - [x] iOS
  - [x] Android
  - [x] Windows
  - [x] MacOS
  - [x] Extensions
- Tracker(s) being unblocked: n/a
- Feature being disabled/modified: `autoconsent` (exception removed)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dce236cd-26a2-4893-91dd-bb16652d2c76?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dce236cd-26a2-4893-91dd-bb16652d2c76&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

