### PR TITLE
Update content-blocker extension to 2026.9.2

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -5138,7 +5138,7 @@
             "minSupportedVersion": "0.148.0",
             "exceptions": [],
             "settings": {
-                "extensionUrl": "https://staticcdn.duckduckgo.com/extensions/content-blocker/content-blocker-extension-2026.8.27.crx"
+                "extensionUrl": "https://staticcdn.duckduckgo.com/extensions/content-blocker/content-blocker-extension-2026.9.2.crx"
             },
             "features": {
                 "onboardingEnabled": {


### PR DESCRIPTION
Update content-blocker extension to 2026.9.2.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single CDN URL version bump in a Windows override; no application logic or security-sensitive code changes.
> 
> **Overview**
> Bumps the **Windows** `adBlockV2Extension` override so clients load the newer content-blocker CRX from DuckDuckGo’s static CDN.
> 
> The only change is `extensionUrl`: `content-blocker-extension-2026.8.27.crx` → `content-blocker-extension-2026.9.2.crx`. Feature flags (`state`, `minSupportedVersion`, onboarding/migration/watchdog) are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c5e13c189887f5850d03e6f36f547d6e045ef42d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->