### PR TITLE
Update ad-blocking extension scriptlets for v2026.9.2

### DIFF
--- a/features/ad-blocking-extension.json
+++ b/features/ad-blocking-extension.json
@@ -4,28 +4,28 @@
     },
     "exceptions": [],
     "settings": {
-        "version": "2026.8.27",
+        "version": "2026.9.2",
         "enabledByDefault": false,
         "scriptlets": {
             "scriptlets/isolated/ublock-filters.js": {
                 "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/5f41c2de023c0378bcf3da0472c9085633c3fe4079af82786928fefcccdfdaa2.js",
-                "signature": "MEUCIQCVHyVU6xBj7zL7be4DnOPby1liz1BPebQeMqdURtlR2AIgAzatFhmwLDJG+UvyzIH0h98yS7EdCxUiSynUsolXyRc="
+                "signature": "MEQCICtEilob0O42L74Emjyi2P8n1arM3eCJyn2qMg/oT/p6AiBEpjfDZBPB6oor1Bes82UlXkkyYeYQaoYgf6mEkhXCAA=="
             },
             "scriptlets/main/ublock-filters.js": {
-                "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/a1b5737fc965f6e55847e5eaf3fd04f6d907c19818ca8f8207b806b30e0032c5.js",
-                "signature": "MEQCICZ30nGovspzsH6UQ9nMn8LLES6FtQJKKILu+tkeGPvtAiAYEkhhOH0gKa7Cpb09b/bA34G0ESSKPe1xlNkNRzVEkw=="
+                "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/75f8fbc1cd768f02885fa66daf8a7343e70df1df0386a83db99ec7c3cdbf5ce6.js",
+                "signature": "MEQCICLHLfkmf1MjqzIIucodD3VYPANHb8jhYlBtOmnn9hArAiBFiTWtru2YY7GoiL46w7jvXPBcz3cIsylID9Hi/hUjhA=="
             },
             "scriptlets/main/ublock-experimental.js": {
                 "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855.js",
-                "signature": "MEYCIQDyxCip4v5bIN+eTAZ5EC8jLbMb5PqtxIXpel2uogZ0QwIhAIG9tCGA5zuhc/1ZNOMOa+sM/uSZnqSfwGYR89n0+vaD"
+                "signature": "MEUCIQDy9VcN+Z/sFMN59xWrIwlS4zhVCdQNgaA8QtAeDqwSuwIgRvBW5CX25tZpEmlmHV1+GBRAlICJnxe/ymQSI0aQI9Q="
             },
             "scriptlets/isolated/ublock-experimental.js": {
                 "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855.js",
-                "signature": "MEYCIQD/tBJYYZ/+nModlRGIT+NOR3u3Ne/gtpwbu3mZYI5EfAIhAPfhrsWPvdf56FK8HpWyPEqenNroSfXXUoJDV1gWLfzW"
+                "signature": "MEQCIBythw2VTjYFKp/I2921OQnXxTI7RtqJ4OVvNPsnfzBMAiAFYJToOsMmgmgTXviCDZ1KETuZDCQsPI+x64AMcXtJUQ=="
             },
             "rules/youtube.json": {
                 "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/2337db6aa7466667595226f780b6590779db3007ac0a65ef3833f89610c92824.json",
-                "signature": "MEYCIQDWUgpe9qIuo2lyRuFOJ+sLyXvrw3Nz6lO6kWhWHXnEKAIhALR16UtNsFAd5wCvCXCMur7VW0XKlxbjc7ohoElBqGMU"
+                "signature": "MEYCIQD2O+dKjX5aZ9Bx3uKrthrqJlhcJvc/K4UXI0JBUgxEdQIhAOs7VEwLp59VSpzkyXK0QYAGWV8CNQoyc/TrZVHWoeQi"
             }
         }
     }


### PR DESCRIPTION
Update ad-blocking extension scriptlets for v2026.9.2.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes signed scriptlet payloads used by the content blocker; bad URLs or signatures could break extension updates or ad-blocking behavior on macOS/iOS clients.
> 
> **Overview**
> Bumps the macOS/iOS ad-blocking extension feature config from **2026.8.27** to **2026.9.2**.
> 
> Updates signed CDN references for content-blocker scriptlets: refreshed **signatures** for isolated/main uBlock filters, uBlock experimental scriptlets, and `rules/youtube.json`. The **main `ublock-filters.js`** scriptlet also points to a new static CDN asset (`75f8fbc1…`); other scriptlet URLs are unchanged (including the empty experimental bundle hash).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 84f603792d351e8eb8b6506423131e53b0d81e33. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->