### PR TITLE
iOS: Remove subscriptionPromoForExistingUsers override

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -3200,10 +3200,6 @@
                 "allowProTierPurchase": {
                     "state": "enabled",
                     "minSupportedVersion": "7.210.0"
-                },
-                "subscriptionPromoForExistingUsers": {
-                    "state": "disabled",
-                    "minSupportedVersion": "7.235.0"
                 }
             }
         },

--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -3202,7 +3202,7 @@
                     "minSupportedVersion": "7.210.0"
                 },
                 "subscriptionPromoForExistingUsers": {
-                    "state": "enabled",
+                    "state": "disabled",
                     "minSupportedVersion": "7.235.0"
                 }
             }


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/task/1218135697815900?focus=true

## Description

Removes the `subscriptionPromoForExistingUsers` subfeature from the iOS `privacyPro` override so each app version uses its bundled default.

Earlier iOS builds keep their existing disabled default. The current iOS release enables the feature by default in code together with a required App Store product-availability check.

Change in `overrides/ios-override.json`, under `privacyPro`:

- Removed the `subscriptionPromoForExistingUsers` override.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single remote-config override removal affecting subscription promo UI exposure, not purchase or auth logic.
> 
> **Overview**
> Removes the **`subscriptionPromoForExistingUsers`** subfeature from **`privacyPro`** in `overrides/ios-override.json`. That override had turned the flag **on** for app versions **7.235.0+**; deleting it rolls back the **subscription promo half-sheet for existing users** on iOS.
> 
> No other `privacyPro` flags change in this diff (e.g. **`allowProTierPurchase`** stays enabled).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dbe05e1a7f28cb9ad6bef72f41daa0b6e5b7aa42. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->