### PR TITLE
Enable captcha detector

### DIFF
--- a/features/event-hub.json
+++ b/features/event-hub.json
@@ -328,6 +328,294 @@
                     }
                 }
             },
+            "webTelemetry_captcha_datadome_day": {
+                "state": "enabled",
+                "trigger": {
+                    "period": {
+                        "days": 1
+                    }
+                },
+                "parameters": {
+                    "count": {
+                        "template": "counter",
+                        "source": "captcha_datadome",
+                        "buckets": {
+                            "0": { "gte": 0, "lt": 1 },
+                            "1": { "gte": 1, "lt": 2 },
+                            "2-3": { "gte": 2, "lt": 4 },
+                            "4-7": { "gte": 4, "lt": 8 },
+                            "8-14": { "gte": 8, "lt": 15 },
+                            "15-20": { "gte": 15, "lt": 21 },
+                            "21-39": { "gte": 21, "lt": 40 },
+                            "40+": { "gte": 40 }
+                        }
+                    }
+                }
+            },
+            "webTelemetry_captcha_datadome_week": {
+                "state": "enabled",
+                "trigger": {
+                    "period": {
+                        "days": 7
+                    }
+                },
+                "parameters": {
+                    "count": {
+                        "template": "counter",
+                        "source": "captcha_datadome",
+                        "buckets": {
+                            "0": { "gte": 0, "lt": 1 },
+                            "1": { "gte": 1, "lt": 2 },
+                            "2-3": { "gte": 2, "lt": 4 },
+                            "4-7": { "gte": 4, "lt": 8 },
+                            "8-14": { "gte": 8, "lt": 15 },
+                            "15-20": { "gte": 15, "lt": 21 },
+                            "21-39": { "gte": 21, "lt": 40 },
+                            "40+": { "gte": 40 }
+                        }
+                    }
+                }
+            },
+            "webTelemetry_captcha_imperva_day": {
+                "state": "enabled",
+                "trigger": {
+                    "period": {
+                        "days": 1
+                    }
+                },
+                "parameters": {
+                    "count": {
+                        "template": "counter",
+                        "source": "captcha_imperva",
+                        "buckets": {
+                            "0": { "gte": 0, "lt": 1 },
+                            "1": { "gte": 1, "lt": 2 },
+                            "2-3": { "gte": 2, "lt": 4 },
+                            "4-7": { "gte": 4, "lt": 8 },
+                            "8-14": { "gte": 8, "lt": 15 },
+                            "15-20": { "gte": 15, "lt": 21 },
+                            "21-39": { "gte": 21, "lt": 40 },
+                            "40+": { "gte": 40 }
+                        }
+                    }
+                }
+            },
+            "webTelemetry_captcha_imperva_week": {
+                "state": "enabled",
+                "trigger": {
+                    "period": {
+                        "days": 7
+                    }
+                },
+                "parameters": {
+                    "count": {
+                        "template": "counter",
+                        "source": "captcha_imperva",
+                        "buckets": {
+                            "0": { "gte": 0, "lt": 1 },
+                            "1": { "gte": 1, "lt": 2 },
+                            "2-3": { "gte": 2, "lt": 4 },
+                            "4-7": { "gte": 4, "lt": 8 },
+                            "8-14": { "gte": 8, "lt": 15 },
+                            "15-20": { "gte": 15, "lt": 21 },
+                            "21-39": { "gte": 21, "lt": 40 },
+                            "40+": { "gte": 40 }
+                        }
+                    }
+                }
+            },
+            "webTelemetry_captcha_arkose_day": {
+                "state": "enabled",
+                "trigger": {
+                    "period": {
+                        "days": 1
+                    }
+                },
+                "parameters": {
+                    "count": {
+                        "template": "counter",
+                        "source": "captcha_arkose",
+                        "buckets": {
+                            "0": { "gte": 0, "lt": 1 },
+                            "1": { "gte": 1, "lt": 2 },
+                            "2-3": { "gte": 2, "lt": 4 },
+                            "4-7": { "gte": 4, "lt": 8 },
+                            "8-14": { "gte": 8, "lt": 15 },
+                            "15-20": { "gte": 15, "lt": 21 },
+                            "21-39": { "gte": 21, "lt": 40 },
+                            "40+": { "gte": 40 }
+                        }
+                    }
+                }
+            },
+            "webTelemetry_captcha_arkose_week": {
+                "state": "enabled",
+                "trigger": {
+                    "period": {
+                        "days": 7
+                    }
+                },
+                "parameters": {
+                    "count": {
+                        "template": "counter",
+                        "source": "captcha_arkose",
+                        "buckets": {
+                            "0": { "gte": 0, "lt": 1 },
+                            "1": { "gte": 1, "lt": 2 },
+                            "2-3": { "gte": 2, "lt": 4 },
+                            "4-7": { "gte": 4, "lt": 8 },
+                            "8-14": { "gte": 8, "lt": 15 },
+                            "15-20": { "gte": 15, "lt": 21 },
+                            "21-39": { "gte": 21, "lt": 40 },
+                            "40+": { "gte": 40 }
+                        }
+                    }
+                }
+            },
+            "webTelemetry_captcha_geetest_day": {
+                "state": "enabled",
+                "trigger": {
+                    "period": {
+                        "days": 1
+                    }
+                },
+                "parameters": {
+                    "count": {
+                        "template": "counter",
+                        "source": "captcha_geetest",
+                        "buckets": {
+                            "0": { "gte": 0, "lt": 1 },
+                            "1": { "gte": 1, "lt": 2 },
+                            "2-3": { "gte": 2, "lt": 4 },
+                            "4-7": { "gte": 4, "lt": 8 },
+                            "8-14": { "gte": 8, "lt": 15 },
+                            "15-20": { "gte": 15, "lt": 21 },
+                            "21-39": { "gte": 21, "lt": 40 },
+                            "40+": { "gte": 40 }
+                        }
+                    }
+                }
+            },
+            "webTelemetry_captcha_geetest_week": {
+                "state": "enabled",
+                "trigger": {
+                    "period": {
+                        "days": 7
+                    }
+                },
+                "parameters": {
+                    "count": {
+                        "template": "counter",
+                        "source": "captcha_geetest",
+                        "buckets": {
+                            "0": { "gte": 0, "lt": 1 },
+                            "1": { "gte": 1, "lt": 2 },
+                            "2-3": { "gte": 2, "lt": 4 },
+                            "4-7": { "gte": 4, "lt": 8 },
+                            "8-14": { "gte": 8, "lt": 15 },
+                            "15-20": { "gte": 15, "lt": 21 },
+                            "21-39": { "gte": 21, "lt": 40 },
+                            "40+": { "gte": 40 }
+                        }
+                    }
+                }
+            },
+            "webTelemetry_captcha_awswaf_day": {
+                "state": "enabled",
+                "trigger": {
+                    "period": {
+                        "days": 1
+                    }
+                },
+                "parameters": {
+                    "count": {
+                        "template": "counter",
+                        "source": "captcha_awswaf",
+                        "buckets": {
+                            "0": { "gte": 0, "lt": 1 },
+                            "1": { "gte": 1, "lt": 2 },
+                            "2-3": { "gte": 2, "lt": 4 },
+                            "4-7": { "gte": 4, "lt": 8 },
+                            "8-14": { "gte": 8, "lt": 15 },
+                            "15-20": { "gte": 15, "lt": 21 },
+                            "21-39": { "gte": 21, "lt": 40 },
+                            "40+": { "gte": 40 }
+                        }
+                    }
+                }
+            },
+            "webTelemetry_captcha_awswaf_week": {
+                "state": "enabled",
+                "trigger": {
+                    "period": {
+                        "days": 7
+                    }
+                },
+                "parameters": {
+                    "count": {
+                        "template": "counter",
+                        "source": "captcha_awswaf",
+                        "buckets": {
+                            "0": { "gte": 0, "lt": 1 },
+                            "1": { "gte": 1, "lt": 2 },
+                            "2-3": { "gte": 2, "lt": 4 },
+                            "4-7": { "gte": 4, "lt": 8 },
+                            "8-14": { "gte": 8, "lt": 15 },
+                            "15-20": { "gte": 15, "lt": 21 },
+                            "21-39": { "gte": 21, "lt": 40 },
+                            "40+": { "gte": 40 }
+                        }
+                    }
+                }
+            },
+            "webTelemetry_captcha_perimeterx_day": {
+                "state": "enabled",
+                "trigger": {
+                    "period": {
+                        "days": 1
+                    }
+                },
+                "parameters": {
+                    "count": {
+                        "template": "counter",
+                        "source": "captcha_perimeterx",
+                        "buckets": {
+                            "0": { "gte": 0, "lt": 1 },
+                            "1": { "gte": 1, "lt": 2 },
+                            "2-3": { "gte": 2, "lt": 4 },
+                            "4-7": { "gte": 4, "lt": 8 },
+                            "8-14": { "gte": 8, "lt": 15 },
+                            "15-20": { "gte": 15, "lt": 21 },
+                            "21-39": { "gte": 21, "lt": 40 },
+                            "40+": { "gte": 40 }
+                        }
+                    }
+                }
+            },
+            "webTelemetry_captcha_perimeterx_week": {
+                "state": "enabled",
+                "trigger": {
+                    "period": {
+                        "days": 7
+                    }
+                },
+                "parameters": {
+                    "count": {
+                        "template": "counter",
+                        "source": "captcha_perimeterx",
+                        "buckets": {
+                            "0": { "gte": 0, "lt": 1 },
+                            "1": { "gte": 1, "lt": 2 },
+                            "2-3": { "gte": 2, "lt": 4 },
+                            "4-7": { "gte": 4, "lt": 8 },
+                            "8-14": { "gte": 8, "lt": 15 },
+                            "15-20": { "gte": 15, "lt": 21 },
+                            "21-39": { "gte": 21, "lt": 40 },
+                            "40+": { "gte": 40 }
+                        }
+                    }
+                }
+            },
             "webTelemetry_captcha_other_day": {
                 "state": "enabled",
                 "trigger": {

--- a/features/web-detection.json
+++ b/features/web-detection.json
@@ -98,7 +98,6 @@
             },
             "captcha": {
                 "recaptcha": {
-                    "state": "disabled",
                     "match": {
                         "element": {
                             "selector": [
@@ -106,12 +105,29 @@
                                 "iframe[src*='rec\\61 ptcha']",
                                 "iframe[title*='rec\\61 ptcha' i]"
                             ],
-                            "visibility": "content"
+                            "visibility": "visible"
+                        }
+                    },
+                    "triggers": {
+                        "auto": {
+                            "state": "enabled",
+                            "when": {
+                                "intervalMs": [
+                                    10000,
+                                    15000,
+                                    20000
+                                ]
+                            }
+                        }
+                    },
+                    "actions": {
+                        "fireEvent": {
+                            "state": "enabled",
+                            "type": "captcha_recaptcha"
                         }
                     }
                 },
                 "hcaptcha": {
-                    "state": "disabled",
                     "match": {
                         "element": {
                             "selector": [
@@ -119,12 +135,29 @@
                                 "iframe[src*='hc\\61 ptcha.com']",
                                 "iframe[title*='hc\\61 ptcha' i]"
                             ],
-                            "visibility": "content"
+                            "visibility": "visible"
+                        }
+                    },
+                    "triggers": {
+                        "auto": {
+                            "state": "enabled",
+                            "when": {
+                                "intervalMs": [
+                                    10000,
+                                    15000,
+                                    20000
+                                ]
+                            }
+                        }
+                    },
+                    "actions": {
+                        "fireEvent": {
+                            "state": "enabled",
+                            "type": "captcha_hcaptcha"
                         }
                     }
                 },
                 "turnstile": {
-                    "state": "disabled",
                     "match": {
                         "element": {
                             "selector": [
@@ -132,12 +165,29 @@
                                 ".cf-t\\75 rnstile:not(#t\\75 rnstile-wrapper) iframe",
                                 "iframe[src*='challenges.clo\\75 dfl\\61 re.com/t\\75 rnstile']"
                             ],
-                            "visibility": "content"
+                            "visibility": "visible"
+                        }
+                    },
+                    "triggers": {
+                        "auto": {
+                            "state": "enabled",
+                            "when": {
+                                "intervalMs": [
+                                    10000,
+                                    15000,
+                                    20000
+                                ]
+                            }
+                        }
+                    },
+                    "actions": {
+                        "fireEvent": {
+                            "state": "enabled",
+                            "type": "captcha_turnstile"
                         }
                     }
                 },
                 "cloudflare": {
-                    "state": "disabled",
                     "match": {
                         "element": {
                             "selector": [
@@ -148,24 +198,58 @@
                                 "#cf-ch\\61 llenge-running",
                                 "#ch\\61 llenge-stage"
                             ],
-                            "visibility": "content"
+                            "visibility": "visible"
+                        }
+                    },
+                    "triggers": {
+                        "auto": {
+                            "state": "enabled",
+                            "when": {
+                                "intervalMs": [
+                                    10000,
+                                    15000,
+                                    20000
+                                ]
+                            }
+                        }
+                    },
+                    "actions": {
+                        "fireEvent": {
+                            "state": "enabled",
+                            "type": "captcha_cloudflare"
                         }
                     }
                 },
                 "datadome": {
-                    "state": "disabled",
                     "match": {
                         "element": {
                             "selector": [
                                 "iframe[src*='c\\61 ptcha-delivery.com']",
                                 "iframe[title*='d\\61 tadome' i]"
                             ],
-                            "visibility": "content"
+                            "visibility": "visible"
+                        }
+                    },
+                    "triggers": {
+                        "auto": {
+                            "state": "enabled",
+                            "when": {
+                                "intervalMs": [
+                                    10000,
+                                    15000,
+                                    20000
+                                ]
+                            }
+                        }
+                    },
+                    "actions": {
+                        "fireEvent": {
+                            "state": "enabled",
+                            "type": "captcha_other"
                         }
                     }
                 },
                 "imperva": {
-                    "state": "disabled",
                     "match": {
                         "any": [
                             {
@@ -186,14 +270,31 @@
                                     "selector": [
                                         "iframe[src*='_Inc\\61 psul\\61 _Resource']"
                                     ],
-                                    "visibility": "content"
+                                    "visibility": "visible"
                                 }
                             }
                         ]
+                    },
+                    "triggers": {
+                        "auto": {
+                            "state": "enabled",
+                            "when": {
+                                "intervalMs": [
+                                    10000,
+                                    15000,
+                                    20000
+                                ]
+                            }
+                        }
+                    },
+                    "actions": {
+                        "fireEvent": {
+                            "state": "enabled",
+                            "type": "captcha_other"
+                        }
                     }
                 },
                 "arkose": {
-                    "state": "disabled",
                     "match": {
                         "element": {
                             "selector": [
@@ -202,12 +303,29 @@
                                 "#FunC\\61 ptcha-Token",
                                 "[d\\61 ta-pkey]"
                             ],
-                            "visibility": "content"
+                            "visibility": "visible"
+                        }
+                    },
+                    "triggers": {
+                        "auto": {
+                            "state": "enabled",
+                            "when": {
+                                "intervalMs": [
+                                    10000,
+                                    15000,
+                                    20000
+                                ]
+                            }
+                        }
+                    },
+                    "actions": {
+                        "fireEvent": {
+                            "state": "enabled",
+                            "type": "captcha_other"
                         }
                     }
                 },
                 "geetest": {
-                    "state": "disabled",
                     "match": {
                         "element": {
                             "selector": [
@@ -216,24 +334,58 @@
                                 ".geet\\65 st_c\\61 ptcha",
                                 "[class*='geet\\65 st_']"
                             ],
-                            "visibility": "content"
+                            "visibility": "visible"
+                        }
+                    },
+                    "triggers": {
+                        "auto": {
+                            "state": "enabled",
+                            "when": {
+                                "intervalMs": [
+                                    10000,
+                                    15000,
+                                    20000
+                                ]
+                            }
+                        }
+                    },
+                    "actions": {
+                        "fireEvent": {
+                            "state": "enabled",
+                            "type": "captcha_other"
                         }
                     }
                 },
                 "awswaf": {
-                    "state": "disabled",
                     "match": {
                         "element": {
                             "selector": [
                                 "iframe[src*='c\\61 ptcha.awsw\\61 f.com']",
                                 "iframe[src*='token.awsw\\61 f.com']"
                             ],
-                            "visibility": "content"
+                            "visibility": "visible"
+                        }
+                    },
+                    "triggers": {
+                        "auto": {
+                            "state": "enabled",
+                            "when": {
+                                "intervalMs": [
+                                    10000,
+                                    15000,
+                                    20000
+                                ]
+                            }
+                        }
+                    },
+                    "actions": {
+                        "fireEvent": {
+                            "state": "enabled",
+                            "type": "captcha_other"
                         }
                     }
                 },
                 "perimeterx": {
-                    "state": "disabled",
                     "match": {
                         "any": [
                             {
@@ -243,7 +395,7 @@
                                         "iframe[src*='px-c\\64 n.net']",
                                         "iframe[src*='px-clo\\75 d.net']"
                                     ],
-                                    "visibility": "content"
+                                    "visibility": "visible"
                                 }
                             },
                             {
@@ -259,6 +411,24 @@
                                 }
                             }
                         ]
+                    },
+                    "triggers": {
+                        "auto": {
+                            "state": "enabled",
+                            "when": {
+                                "intervalMs": [
+                                    10000,
+                                    15000,
+                                    20000
+                                ]
+                            }
+                        }
+                    },
+                    "actions": {
+                        "fireEvent": {
+                            "state": "enabled",
+                            "type": "captcha_other"
+                        }
                     }
                 },
                 "other": {
@@ -269,6 +439,24 @@
                                 "slide( right)? to (verify|complete)",
                                 "complete the security check to (access|continue)"
                             ]
+                        }
+                    },
+                    "triggers": {
+                        "auto": {
+                            "state": "enabled",
+                            "when": {
+                                "intervalMs": [
+                                    10000,
+                                    15000,
+                                    20000
+                                ]
+                            }
+                        }
+                    },
+                    "actions": {
+                        "fireEvent": {
+                            "state": "enabled",
+                            "type": "captcha_other"
                         }
                     }
                 }

--- a/features/web-detection.json
+++ b/features/web-detection.json
@@ -245,7 +245,7 @@
                     "actions": {
                         "fireEvent": {
                             "state": "enabled",
-                            "type": "captcha_other"
+                            "type": "captcha_datadome"
                         }
                     }
                 },
@@ -290,7 +290,7 @@
                     "actions": {
                         "fireEvent": {
                             "state": "enabled",
-                            "type": "captcha_other"
+                            "type": "captcha_imperva"
                         }
                     }
                 },
@@ -321,7 +321,7 @@
                     "actions": {
                         "fireEvent": {
                             "state": "enabled",
-                            "type": "captcha_other"
+                            "type": "captcha_arkose"
                         }
                     }
                 },
@@ -352,7 +352,7 @@
                     "actions": {
                         "fireEvent": {
                             "state": "enabled",
-                            "type": "captcha_other"
+                            "type": "captcha_geetest"
                         }
                     }
                 },
@@ -381,7 +381,7 @@
                     "actions": {
                         "fireEvent": {
                             "state": "enabled",
-                            "type": "captcha_other"
+                            "type": "captcha_awswaf"
                         }
                     }
                 },
@@ -427,7 +427,7 @@
                     "actions": {
                         "fireEvent": {
                             "state": "enabled",
-                            "type": "captcha_other"
+                            "type": "captcha_perimeterx"
                         }
                     }
                 },

--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -4226,6 +4226,54 @@
                         },
                         "parameters": {}
                     },
+                    "webTelemetry_captcha_datadome": {
+                        "state": "enabled",
+                        "trigger": {
+                            "type": "immediate",
+                            "source": "captcha_datadome"
+                        },
+                        "parameters": {}
+                    },
+                    "webTelemetry_captcha_imperva": {
+                        "state": "enabled",
+                        "trigger": {
+                            "type": "immediate",
+                            "source": "captcha_imperva"
+                        },
+                        "parameters": {}
+                    },
+                    "webTelemetry_captcha_arkose": {
+                        "state": "enabled",
+                        "trigger": {
+                            "type": "immediate",
+                            "source": "captcha_arkose"
+                        },
+                        "parameters": {}
+                    },
+                    "webTelemetry_captcha_geetest": {
+                        "state": "enabled",
+                        "trigger": {
+                            "type": "immediate",
+                            "source": "captcha_geetest"
+                        },
+                        "parameters": {}
+                    },
+                    "webTelemetry_captcha_awswaf": {
+                        "state": "enabled",
+                        "trigger": {
+                            "type": "immediate",
+                            "source": "captcha_awswaf"
+                        },
+                        "parameters": {}
+                    },
+                    "webTelemetry_captcha_perimeterx": {
+                        "state": "enabled",
+                        "trigger": {
+                            "type": "immediate",
+                            "source": "captcha_perimeterx"
+                        },
+                        "parameters": {}
+                    },
                     "webTelemetry_captcha_other": {
                         "state": "enabled",
                         "trigger": {

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -3506,6 +3506,54 @@
                         },
                         "parameters": {}
                     },
+                    "webTelemetry_captcha_datadome": {
+                        "state": "enabled",
+                        "trigger": {
+                            "type": "immediate",
+                            "source": "captcha_datadome"
+                        },
+                        "parameters": {}
+                    },
+                    "webTelemetry_captcha_imperva": {
+                        "state": "enabled",
+                        "trigger": {
+                            "type": "immediate",
+                            "source": "captcha_imperva"
+                        },
+                        "parameters": {}
+                    },
+                    "webTelemetry_captcha_arkose": {
+                        "state": "enabled",
+                        "trigger": {
+                            "type": "immediate",
+                            "source": "captcha_arkose"
+                        },
+                        "parameters": {}
+                    },
+                    "webTelemetry_captcha_geetest": {
+                        "state": "enabled",
+                        "trigger": {
+                            "type": "immediate",
+                            "source": "captcha_geetest"
+                        },
+                        "parameters": {}
+                    },
+                    "webTelemetry_captcha_awswaf": {
+                        "state": "enabled",
+                        "trigger": {
+                            "type": "immediate",
+                            "source": "captcha_awswaf"
+                        },
+                        "parameters": {}
+                    },
+                    "webTelemetry_captcha_perimeterx": {
+                        "state": "enabled",
+                        "trigger": {
+                            "type": "immediate",
+                            "source": "captcha_perimeterx"
+                        },
+                        "parameters": {}
+                    },
                     "webTelemetry_captcha_other": {
                         "state": "enabled",
                         "trigger": {

--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -6083,6 +6083,54 @@
                         },
                         "parameters": {}
                     },
+                    "webTelemetry_captcha_datadome": {
+                        "state": "enabled",
+                        "trigger": {
+                            "type": "immediate",
+                            "source": "captcha_datadome"
+                        },
+                        "parameters": {}
+                    },
+                    "webTelemetry_captcha_imperva": {
+                        "state": "enabled",
+                        "trigger": {
+                            "type": "immediate",
+                            "source": "captcha_imperva"
+                        },
+                        "parameters": {}
+                    },
+                    "webTelemetry_captcha_arkose": {
+                        "state": "enabled",
+                        "trigger": {
+                            "type": "immediate",
+                            "source": "captcha_arkose"
+                        },
+                        "parameters": {}
+                    },
+                    "webTelemetry_captcha_geetest": {
+                        "state": "enabled",
+                        "trigger": {
+                            "type": "immediate",
+                            "source": "captcha_geetest"
+                        },
+                        "parameters": {}
+                    },
+                    "webTelemetry_captcha_awswaf": {
+                        "state": "enabled",
+                        "trigger": {
+                            "type": "immediate",
+                            "source": "captcha_awswaf"
+                        },
+                        "parameters": {}
+                    },
+                    "webTelemetry_captcha_perimeterx": {
+                        "state": "enabled",
+                        "trigger": {
+                            "type": "immediate",
+                            "source": "captcha_perimeterx"
+                        },
+                        "parameters": {}
+                    },
                     "webTelemetry_captcha_other": {
                         "state": "enabled",
                         "trigger": {


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1200811069326255/task/1218116544194301?focus=true

## Description

Enables the captcha detector in production.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Ships active DOM scanning and new telemetry pixels across desktop/mobile clients; mis-detection or polling load could affect browsing experience even though the change is config-only.
> 
> **Overview**
> Turns on **captcha detection** in `web-detection.json` by wiring each provider detector (reCAPTCHA, hCaptcha, Turnstile, Cloudflare, DataDome, Imperva, Arkose, GeeTest, AWS WAF, PerimeterX, and generic “other”) with **auto polling** (10–20s intervals), **`fireEvent`** actions typed as `captcha_*`, and **`visible`** element matching instead of `content` (per-detector `state: disabled` is removed).
> 
> **Event hub** gains day/week **bucketed counters** for the previously untracked providers: DataDome, Imperva, Arkose, GeeTest, AWS WAF, and PerimeterX. **iOS, macOS, and Windows overrides** add matching **immediate** `webTelemetry_captcha_*` triggers so those events can be recorded on those clients alongside the existing captcha telemetry entries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7a7afae3b906c8db4891ba3c0b365339f1a3feb8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->