### PR TITLE
Re-stage TDS A/B experiment

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -351,7 +351,7 @@
                     ]
                 },
                 "tdsNextExperiment015": {
-                    "state": "enabled",
+                    "state": "disabled",
                     "minSupportedVersion": 52361000,
                     "rollout": {
                         "steps": [
@@ -363,6 +363,31 @@
                     "settings": {
                         "controlUrl": "v5/experiments/202609v1-android-tds-control.json",
                         "treatmentUrl": "v5/experiments/202609v1-android-tds-treatment.json"
+                    },
+                    "cohorts": [
+                        {
+                            "name": "control",
+                            "weight": 1
+                        },
+                        {
+                            "name": "treatment",
+                            "weight": 1
+                        }
+                    ]
+                },
+                "tdsNextExperiment016": {
+                    "state": "enabled",
+                    "minSupportedVersion": 52361000,
+                    "rollout": {
+                        "steps": [
+                            {
+                                "percent": 25
+                            }
+                        ]
+                    },
+                    "settings": {
+                        "controlUrl": "v5/experiments/202609v2-android-tds-control.json",
+                        "treatmentUrl": "v5/experiments/202609v2-android-tds-treatment.json"
                     },
                     "cohorts": [
                         {

--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -820,7 +820,7 @@
                     ]
                 },
                 "tdsNextExperiment015": {
-                    "state": "enabled",
+                    "state": "disabled",
                     "rollout": {
                         "steps": [
                             {
@@ -831,6 +831,30 @@
                     "settings": {
                         "controlUrl": "v5/experiments/202609v1-ios-tds-control.json",
                         "treatmentUrl": "v5/experiments/202609v1-ios-tds-treatment.json"
+                    },
+                    "cohorts": [
+                        {
+                            "name": "control",
+                            "weight": 1
+                        },
+                        {
+                            "name": "treatment",
+                            "weight": 1
+                        }
+                    ]
+                },
+                "tdsNextExperiment016": {
+                    "state": "enabled",
+                    "rollout": {
+                        "steps": [
+                            {
+                                "percent": 25
+                            }
+                        ]
+                    },
+                    "settings": {
+                        "controlUrl": "v5/experiments/202609v2-ios-tds-control.json",
+                        "treatmentUrl": "v5/experiments/202609v2-ios-tds-treatment.json"
                     },
                     "cohorts": [
                         {

--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -807,7 +807,7 @@
                     ]
                 },
                 "tdsNextExperiment015": {
-                    "state": "enabled",
+                    "state": "disabled",
                     "rollout": {
                         "steps": [
                             {
@@ -818,6 +818,30 @@
                     "settings": {
                         "controlUrl": "v6/experiments/202609v1-macos-tds-control.json",
                         "treatmentUrl": "v6/experiments/202609v1-macos-tds-treatment.json"
+                    },
+                    "cohorts": [
+                        {
+                            "name": "control",
+                            "weight": 1
+                        },
+                        {
+                            "name": "treatment",
+                            "weight": 1
+                        }
+                    ]
+                },
+                "tdsNextExperiment016": {
+                    "state": "enabled",
+                    "rollout": {
+                        "steps": [
+                            {
+                                "percent": 25
+                            }
+                        ]
+                    },
+                    "settings": {
+                        "controlUrl": "v6/experiments/202609v2-macos-tds-control.json",
+                        "treatmentUrl": "v6/experiments/202609v2-macos-tds-treatment.json"
                     },
                     "cohorts": [
                         {


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1200342317600122/task/1216912112094811?focus=true

## Description
<!-- 
  Please delete either or both process sections below.
-->

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Enabling a new TDS block-list experiment changes which tracker data subset a portion of users receive, which can affect site breakage and blocking behavior until the experiment is evaluated.
> 
> **Overview**
> Rotates the **TDS Next** block-list A/B test on **Android**, **iOS**, and **macOS** by turning off `tdsNextExperiment015` and enabling **`tdsNextExperiment016`**.
> 
> `tdsNextExperiment015` (`202609v1` control/treatment URLs) is set to **`disabled`**. The new **`tdsNextExperiment016`** subfeature is **`enabled`** with the same **25%** rollout step and balanced control/treatment cohorts, but points at **`202609v2`** experiment JSON (Android/iOS under `v5/experiments/`, macOS under `v6/experiments/`).
> 
> No Windows override changes in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d3fb0c8746748ffe02d8e78720b2b59e51d20eff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->