### PR TITLE
Add pdfPageContext to windows-override.json

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -1321,6 +1321,9 @@
                     "minSupportedVersion": "0.136.4",
                     "state": "enabled"
                 },
+                "pdfPageContext": {
+                    "state": "disabled"
+                },
                 "multiplePageContexts": {
                     "state": "enabled",
                     "minSupportedVersion": "0.152.0"


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1209292120581622/task/1216436016021961?focus=true

## Description
Added pdfPageContext with disabled state to windows override.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only change that disables a feature flag on Windows; no runtime logic or security-sensitive paths are modified.
> 
> **Overview**
> Adds a **Windows override** entry for `pdfPageContext` with **`state: disabled`**, placed alongside the existing enabled `pageContext` flag so Windows clients explicitly do not roll out PDF-specific page context until it is turned on here.
> 
> No application code changes—only `overrides/windows-override.json`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae14d9aeb1a225ce05075c1bc3fe1617d57cd642. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->