### PR TITLE
Fix Music & Arts breakage caused by GPC

### DIFF
--- a/features/gpc.json
+++ b/features/gpc.json
@@ -69,6 +69,10 @@
             "reason": "https://github.com/duckduckgo/privacy-configuration/pull/4725"
         },
         {
+            "domain": "musicarts.com",
+            "reason": "Page goes blank after loading when GPC is enabled"
+        },
+        {
             "domain": "scheels.com",
             "reason": "https://github.com/duckduckgo/privacy-configuration/pull/4800"
         },

--- a/features/gpc.json
+++ b/features/gpc.json
@@ -70,7 +70,7 @@
         },
         {
             "domain": "musicarts.com",
-            "reason": "Page goes blank after loading when GPC is enabled"
+            "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5881"
         },
         {
             "domain": "scheels.com",


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/11472677167855/task/1212822117776122

## Description
<!-- 
  Please delete either or both process sections below.
-->
Page goes blank after loading when GPC is enabled

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-domain GPC exception for site breakage mitigation; same pattern as other retailer exceptions with no auth or data-handling changes.
> 
> **Overview**
> Adds **`musicarts.com`** to the Global Privacy Control **exceptions** list in `features/gpc.json`, alongside the existing **`guitarcenter.com`** entry.
> 
> With GPC enabled globally, Music & Arts was reported to load a blank page; exempting the domain stops sending the GPC signal there so the site can render normally. The change is a single config entry referencing privacy-configuration PR **5881**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c0cbe456c9ce295d084bd91ba83ccc32423630f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->