### PR TITLE
Fix Picrew images blocked by Fuse Platform

### DIFF
--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -2655,6 +2655,17 @@
                     }
                 ]
             },
+            "fuseplatform.net": {
+                "rules": [
+                    {
+                        "rule": "cdn.fuseplatform.net",
+                        "domains": [
+                            "picrew.me"
+                        ],
+                        "reason": "Images fail to load when this request is blocked"
+                    }
+                ]
+            },
             "fwmrm.net": {
                 "rules": [
                     {

--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -2662,7 +2662,7 @@
                         "domains": [
                             "picrew.me"
                         ],
-                        "reason": "Images fail to load when this request is blocked"
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5882"
                     }
                 ]
             },


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/11472677167855/task/1217899940552554

## Description
<!-- 
  Please delete either or both process sections below.
-->
Images fail to load when this request is blocked

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-domain tracker allowlist exception for image CDN on one site; no changes to auth, data handling, or broad `<all>` unblocks.
> 
> **Overview**
> **Fixes Picrew images** that fail when `cdn.fuseplatform.net` is blocked as a tracker.
> 
> Adds a **site-scoped allowlist** in `tracker-allowlist.json`: under `fuseplatform.net`, requests matching `cdn.fuseplatform.net` are permitted only on `picrew.me` (not globally).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c2c740f5926a939fa2f67b680fe9f5a1d9aee11. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->