### PR TITLE
Add windows webView.blockExtensionsOnInternalOrigins sub-feature

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -4898,6 +4898,9 @@
                 "chromiumUserAgentBrand": {
                     "state": "internal"
                 },
+                "blockExtensionsOnInternalOrigins": {
+                    "state": "internal"
+                },
                 "allowRetriesForServiceWorkerTimeouts": {
                     "state": "enabled",
                     "rollout": {


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1208671677432066/task/1218148901511594?focus=true

## Description

Adds `webView.blockExtensionsOnInternalOrigins` (`state: internal`) to the Windows override.

Gates a Chromium change that stops extensions injecting into, reading cookies from, or filtering requests to our internal surfaces (New Tab Page, Privacy Dashboard, Autofill, AI Chat tools harness). Those display as `duck://` but commit to real https origins under `ddg.local`, so `<all_urls>` matches them like any other site.

Inert without the matching browser build:
- ddg-cef-build-automation#1969 (Chromium)
- duckduckgo/windows-browser#8967 (flag plumbing)

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [x] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

No schema added — `webView` sub-features are plain state toggles with no settings payload, matching the existing entries (`chromiumUserAgentBrand`, `chromeWebStore`). Verified `npm run build` succeeds and the flag lands in `generated/v3|v4|v5/windows-config.json`.

Windows-only, and Windows is the only platform reading `webView`, so no other generated config changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Windows-only config toggle at internal state with no schema or rollout; no runtime logic in this repo.
> 
> **Overview**
> Adds **`webView.blockExtensionsOnInternalOrigins`** with **`state: internal`** to the Windows privacy-config override, alongside the other plain `webView` toggles.
> 
> This flag gates Chromium behavior that blocks extensions from injecting into, reading cookies from, or filtering requests on internal browser surfaces (e.g. New Tab, Privacy Dashboard, Autofill, AI Chat harness) that appear as `duck://` but load real `ddg.local` HTTPS origins. It only affects generated Windows config; it is inert until the matching Windows browser and CEF builds ship the plumbing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f847c33baf2e5f52ab800d9d26f0ba27c7853787. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->