### PR TITLE
Fix NYTimes Google authentication with GPC

### DIFF
--- a/features/gpc.json
+++ b/features/gpc.json
@@ -239,6 +239,10 @@
         {
             "domain": "walesonline.co.uk",
             "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5748"
+        },
+        {
+            "domain": "nytimes.com",
+            "reason": "Google authentication completes in the popup instead of the main browser window when GPC is enabled"
         }
     ],
     "settings": {

--- a/features/gpc.json
+++ b/features/gpc.json
@@ -242,7 +242,7 @@
         },
         {
             "domain": "nytimes.com",
-            "reason": "Google authentication completes in the popup instead of the main browser window when GPC is enabled"
+            "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5884"
         }
     ],
     "settings": {


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/11472677167855/task/1218117832433612

## Description
<!-- 
  Please delete either or both process sections below.
-->
Google authentication completes in the popup instead of the main browser window when GPC is enabled

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only allowlist change that reduces GPC on one domain; no application code or auth logic is modified.
> 
> **Overview**
> Adds **`nytimes.com`** to the GPC **`exceptions`** list so Global Privacy Control is not applied on that site, addressing breakage where **Google authentication finishes in the popup** instead of the main window when GPC is on.
> 
> This is a **site-breakage mitigation** only; **`gpc.json`** is the sole change, with the exception linked to privacy-configuration PR **5884**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa515d84f7f319497638d7ccb870af94766054fb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->