### PR TITLE
Remove autoconsent exception for theguardian.com

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -1143,10 +1143,6 @@
                     "reason": "https://github.com/duckduckgo/privacy-configuration/pull/4648"
                 },
                 {
-                    "domain": "theguardian.com",
-                    "reason": "https://github.com/duckduckgo/privacy-configuration/pull/4985"
-                },
-                {
                     "domain": "mumsnet.com",
                     "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5119"
                 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1203268166580279/task/1217450724898837?focus=true

## Description

Removes the `theguardian.com` autoconsent exception from `overrides/ios-override.json`, re-enabling automatic cookie pop-up handling on the site for iOS. No config outside the `autoconsent` scope was touched, and the existing autoconsent CMP rule for the site in `features/autoconsent.json` is left as-is.

Validation: `npm run build`, `npm run unit-tests` (3188 passing) and a Prettier format check on the changed file all pass.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL: http://theguardian.com/
- Problems experienced: N/A — removing a previously added exception (originally https://github.com/duckduckgo/privacy-configuration/pull/4985)
- Platforms affected:
  - [x] iOS
- Tracker(s) being unblocked: none
- Feature being disabled/modified: `autoconsent` (exception removed)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-525f9482-fe7f-40dc-b877-75152972793a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-525f9482-fe7f-40dc-b877-75152972793a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

