### PR TITLE
Remove autoconsent exception for dillards.com

### DIFF
--- a/features/autoconsent.json
+++ b/features/autoconsent.json
@@ -768,10 +768,6 @@
             "reason": "https://github.com/duckduckgo/privacy-configuration/pull/4503"
         },
         {
-            "domain": "dillards.com",
-            "reason": "https://github.com/duckduckgo/privacy-configuration/pull/4606"
-        },
-        {
             "domain": "depop.com",
             "reason": "https://github.com/duckduckgo/privacy-configuration/pull/4653"
         },

--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -2336,10 +2336,6 @@
                     "reason": "https://github.com/duckduckgo/privacy-configuration/pull/3908"
                 },
                 {
-                    "domain": "dillards.com",
-                    "reason": "https://github.com/duckduckgo/privacy-configuration/pull/4277"
-                },
-                {
                     "domain": "ynab.com",
                     "reason": "https://github.com/duckduckgo/privacy-configuration/pull/4196"
                 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Removes the autoconsent exception for `dillards.com`, so cookie popup handling applies again on the site (e.g. https://www.dillards.com/p/section-x-mens-santiago-crossband-sandals/514432727).

Two entries matched and both were removed, since override exceptions are additive to the global list:
- `features/autoconsent.json` (added in #4606)
- `overrides/windows-override.json`, `autoconsent` exceptions (added in #4277)

No config outside the `autoconsent` scope was changed. `npm run build`, `npm run unit-tests`, and `npm run lint` all pass.

Task: https://app.asana.com/1/137249556945/project/1203268166580279/task/1217973147173861?focus=true

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-94cb2bd2-71b9-44f8-9ccb-e742a108b34a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-94cb2bd2-71b9-44f8-9ccb-e742a108b34a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

