### PR TITLE
Fix Visible sign-in blank page with GPC

### DIFF
--- a/features/gpc.json
+++ b/features/gpc.json
@@ -243,6 +243,10 @@
         {
             "domain": "nytimes.com",
             "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5884"
+        },
+        {
+            "domain": "visible.com",
+            "reason": "Sign-in page is blank on first load when GPC is enabled"
         }
     ],
     "settings": {

--- a/features/gpc.json
+++ b/features/gpc.json
@@ -246,7 +246,7 @@
         },
         {
             "domain": "visible.com",
-            "reason": "Sign-in page is blank on first load when GPC is enabled"
+            "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5888"
         }
     ],
     "settings": {


### PR DESCRIPTION
**Asana Task/Github Issue:**
app.asana.com/1/137249556945/project/11472677167855/task/1217967351386497

## Description
<!-- 
  Please delete either or both process sections below.
-->
Sign-in page is blank on first load when GPC is enabled

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-domain config exception with no code or auth changes; only reduces GPC signaling on visible.com.
> 
> **Overview**
> Adds **visible.com** to the GPC feature `exceptions` list so Global Privacy Control is not applied on that site, addressing a **blank sign-in page on first load** when GPC is enabled.
> 
> This follows the same site-breakage pattern as other domain exceptions in `features/gpc.json`, with a link to privacy-configuration PR 5888 as the reason.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fdcc7a3c8fb21e1669f62a1bb1a01796074b7e15. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->