### PR TITLE
Rollout EF to Dapper for 50% users

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -6373,6 +6373,9 @@
                     "rollout": {
                         "steps": [
                             {
+                                "percent": 20.0
+                            },
+                            {
                                 "percent": 50.0
                             }
                         ]
@@ -6382,6 +6385,9 @@
                     "state": "enabled",
                     "rollout": {
                         "steps": [
+                            {
+                                "percent": 20.0
+                            },
                             {
                                 "percent": 50.0
                             }
@@ -6393,6 +6399,9 @@
                     "rollout": {
                         "steps": [
                             {
+                                "percent": 20.0
+                            },
+                            {
                                 "percent": 50.0
                             }
                         ]
@@ -6403,6 +6412,9 @@
                     "rollout": {
                         "steps": [
                             {
+                                "percent": 20.0
+                            },
+                            {
                                 "percent": 50.0
                             }
                         ]
@@ -6412,6 +6424,9 @@
                     "state": "enabled",
                     "rollout": {
                         "steps": [
+                            {
+                                "percent": 20.0
+                            },
                             {
                                 "percent": 50.0
                             }


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/72649045549333/task/1215838942577432?focus=true

## Description
Rollout EF to Dapper for 50% users

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only staged feature-flag rollout on Windows; no auth or data-path code changes in this diff.
> 
> **Overview**
> **Windows** `secureStorageDapper` rollout is now staged: each enabled sub-feature (`bookmarks`, `brokenSites`, `promoHistory`, `remoteMessages`, `vault`) gets a new **20%** rollout step before the existing **50%** step.
> 
> This only changes `overrides/windows-override.json` rollout percentages for the EF→Dapper secure-storage path—no application code.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4644ea8c0285511028d47a52c7bcdfa65c3a0b1a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->