### PR TITLE
Rollout serializeTokenRefresh to 10% on Android

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -4212,6 +4212,9 @@
                         "steps": [
                             {
                                 "percent": 5
+                            },
+                            {
+                                "percent": 10
                             }
                         ]
                     }


### PR DESCRIPTION
## Summary
- Increases the `serializeTokenRefresh` rollout step for Android from 5% to 10%.

## Test plan
- [x] `npm run build` succeeds
- [x] `npm run lint` passes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches auth-related token refresh behavior for more Android users, but exposure only increases from 5% to 10% via a standard rollout step append.
> 
> **Overview**
> Advances the Android **Privacy Pro** `serializeTokenRefresh` feature rollout by **appending** a new `rollout.steps` entry at **10%**, keeping the existing **5%** step unchanged (per discrete rollout-step semantics).
> 
> This widens the audience that gets serialized token refresh behavior on Android; no other flags or settings change in this PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd749187f28ffc2a6b4c65ab29794480f9b721eb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->