### PR TITLE
Update autoconsent to v16.37.0

### DIFF
--- a/features/autoconsent.json
+++ b/features/autoconsent.json
@@ -1848,6 +1848,27 @@
                 "#divConfigCookies #btnAcceptNoCookies",
                 "#mensajeCookies .cajaCookies",
                 "#mensajeCookies #btnConfigCookies",
+                "dialog[data-testid=\"cookie-message-modal\"]",
+                "[data-testid=\"cookie-message-bottom-sheet\"]",
+                "[data-testid=\"cookie-message-bottom-sheet-overlay\"]",
+                "dialog[data-testid=\"cookie-message-modal\"] button[data-testid=\"decline-all-cookies\"], [data-testid=\"cookie-message-bottom-sheet\"] button[data-testid=\"decline-all-cookies\"]",
+                "dialog[data-testid=\"cookie-message-modal\"], [data-testid=\"cookie-message-bottom-sheet\"]",
+                "#gdprCookieBar",
+                "#gdprCookieBarOverlay",
+                ".mst-gdpr__cookie-bar-wrapper",
+                ".mst-gdpr__cookie-bar-overlay",
+                ".mst-gdpr__cookie-bar .mst-gdpr__buttons",
+                ".mst-gdpr__buttons [data-trigger-settings=decline],.mst-gdpr__buttons button[\\@click=handleDecline]",
+                ".mst-gdpr__buttons [data-trigger-settings=decline]",
+                ".mst-gdpr__buttons button[\\@click=handleDecline]",
+                ".mst-gdpr__buttons [data-trigger-settings=trigger]",
+                ".mst-gdpr__buttons button[\\@click=openSettings]",
+                "[data-mst-gdpr-settings-apply],.mst-gdpr__cookie-settings--success-btn,[x-on\\:click=save]",
+                "input.checkbox[data-group-id]:not([disabled]):checked",
+                "[data-mst-gdpr-settings-apply]",
+                ".mst-gdpr__cookie-settings--success-btn",
+                "[x-on\\:click=save]",
+                "gdpr_cookie_consent=",
                 "body > div#root > div#ccpa-iframe-theme-provider[data-testid=\"ccpa-iframe-theme-provider\"] > div#ccpa-iframe[data-testid=\"ccpa-iframe\"] > div#ccpa_consent_banner[data-testid=\"ccpa_consent_banner\"] > div:not([id]) > div:nth-child(3):not([id]) > span:not([id]) > span:not([id]) > div:nth-child(2):not([id]) > span:nth-child(1):not([id]) > button#decline_cookies_button[data-testid=\"decline_cookies_button\"]",
                 "body:not([id]) > div#banner-0 > div:nth-child(1)#grouped-pageload-Banner > div:not([id]) > div:not([id]) > div:not([id]) > div:nth-child(3):not([id]) > button:nth-child(2):not([id])",
                 "body > div#iubenda-cs-banner > div:not([id]) > div:not([id]) > div:not([id]) > div:nth-child(5):not([id]) > div:nth-child(2):not([id]) > button:nth-child(1):not([id])",
@@ -1889,27 +1910,6 @@
                 "span[role=checkbox][aria-checked=true]",
                 "#save-all-pur",
                 "#reminder",
-                "body > div:not([id]) > div:not([id]) > div:nth-child(3):not([id]) > button:nth-child(2)#cookieadmin_reject_button",
-                "body > aside:not([id]) > div:nth-child(1):not([id]) > div:nth-child(2):not([id]) > div:nth-child(2):not([id]) > button:nth-child(2):not([id])",
-                ".cck-container",
-                ".cck-actions-button[href=\"#refuse\"]",
-                "C4_CC=eyJ2ZXJzaW9uIjoxLCJjb25zZW50ZWQiOnRydWUs",
-                "#gdrp",
-                ".cookie-consent",
-                ".cookies-modal",
-                ".show-cookies-modal .cookies-modal #cookies-accept",
-                "body > div:not([id]) > div:nth-child(2):not([id]) > div:nth-child(2):not([id]) > div:nth-child(2):not([id]) > div:not([id]) > button:not([id])",
-                "body > div:not([id]) > div:not([id]) > div#ch2-dialog > div:nth-child(2):not([id]) > button:nth-child(1):not([id])",
-                "[data-testid=cookieBanner] button",
-                "[data-testid=cookieBanner__manageCookiesButton]",
-                "[data-testid=cookieModal] input[type=radio][value=false]:not(:checked):not(:disabled)",
-                "button[data-a-target=\"consent-banner-manage-preferences\"]",
-                "#cookiePrefsModal #formContent, .privacy-sheet-content #formContent",
-                "[data-testid=cookieModal__acceptButton]",
-                "[data-a-target=consent-modal-save]",
-                ".ReactModalPortal:has([data-a-target=consent-modal-save])",
-                "[data-testid=\"BottomBar\"]",
-                "body > section#cookie-consent > div:not([id]) > form:nth-child(3):not([id]) > div:nth-child(5):not([id]) > button:nth-child(1):not([id])",
                 "body > div:not([id]) > div#cookie-banner > div:nth-child(2):not([id]) > button:nth-child(2)#cookie-banner-reject",
                 ".show-cookies-modal .cookies-modal #cookies-reject",
                 ".fixed [data-testid=closeCookieBanner]",
@@ -1972,10 +1972,10 @@
                 "consent=rejected",
                 "#cookie-consent",
                 "#cookie-consent .cookie-all__btn",
-                "[class*=ConsentBanner]",
-                "[class*=ConsentBanner] .frDWEu",
-                "[class*=ConsentBanner] .hXIpFU",
-                "xeConsentState={%22performance%22:false%2C%22marketing%22:false%2C%22compliance%22:false}",
+                "body > div:not([id]) > div:not([id]) > div:nth-child(3):not([id]) > button:nth-child(2)#cookieadmin_reject_button",
+                "body > div:not([id]) > div:nth-child(2):not([id]) > div:nth-child(2):not([id]) > div:nth-child(2):not([id]) > div:not([id]) > button:not([id])",
+                "body > section#cookie-consent > div:not([id]) > form:nth-child(3):not([id]) > div:nth-child(5):not([id]) > button:nth-child(1):not([id])",
+                "body > aside:not([id]) > div:nth-child(1):not([id]) > div:nth-child(2):not([id]) > div:nth-child(2):not([id]) > button:nth-child(2):not([id])",
                 "#cookie-consent[style*=\"max-height\"] #cookie-status-reject",
                 "#cookie-consent .cookie-selection__btn",
                 "body > div#message-banner > div:not([id]) > div:nth-child(2):not([id]) > button:not([id])",
@@ -2680,7 +2680,50 @@
                 ".cdk-overlay-container app-esaa-cookie-component",
                 ".btn-cookie-refuser",
                 ".fixed.bottom-0:has([data-test=cookieBannerButton])",
-                ".fixed.bottom-0 [data-test=cookieBannerButton]"
+                ".fixed.bottom-0 [data-test=cookieBannerButton]",
+                "body > div:not([id]) > div:not([id]) > div#ch2-dialog > div:nth-child(2):not([id]) > button:nth-child(1):not([id])",
+                "#bbccookies-prompt",
+                "#bbccookies-reject-button",
+                "#note .cpref",
+                "#note .cpref #cPrefToggle",
+                "#cPrefToggle",
+                "#cPrefModal label[for=\"tab-4r\"]",
+                "#cPrefSave",
+                "C4_CC=eyJ2ZXJzaW9uIjoxLCJjb25zZW50ZWQiOnRydWUs",
+                "[data-testid=cookieBanner] button",
+                "[data-testid=cookieBanner__manageCookiesButton]",
+                "[data-testid=cookieModal] input[type=radio][value=false]:not(:checked):not(:disabled)",
+                "[data-testid=cookieModal__acceptButton]",
+                ".cck-container",
+                ".cck-actions-button[href=\"#refuse\"]",
+                "#gdrp",
+                ".cookie-consent",
+                ".cookies-modal",
+                ".show-cookies-modal .cookies-modal #cookies-accept",
+                ".cookie-modal.open",
+                ".cookie-modal.open .cookie-box",
+                ".cookie-modal.open .btn-box .simple-btn.cancel",
+                "#cookiePrefsModal #formContent, .privacy-sheet-content #formContent",
+                "#cookie-consent #cookie-consent-btn-customise",
+                "#cookie-consent #cookie-consent-btn-accept-some",
+                "#cookie-consent-btn-customise",
+                "#consent-marketing:checked",
+                "#consent-marketing",
+                "#consent-analytics:checked",
+                "#consent-analytics",
+                "#cookie-consent-btn-accept-some",
+                "%22analytics%22%3Afalse%2C%22marketing%22%3Afalse",
+                "button[data-a-target=\"consent-banner-manage-preferences\"]",
+                "[data-a-target=consent-modal-save]",
+                ".ReactModalPortal:has([data-a-target=consent-modal-save])",
+                "[data-testid=\"BottomBar\"]",
+                "dialog[aria-labelledby=\"consent-title\"]",
+                "div.animate-slideFromLeft.fixed.bottom-0.z-50",
+                "dialog[aria-labelledby=\"consent-title\"], div.animate-slideFromLeft.fixed.bottom-0.z-50",
+                "dialog[aria-labelledby=\"consent-title\"] button.border-xe-primary-500, div.animate-slideFromLeft button.border-xe-primary-500",
+                "[data-testid=\"performance-toggle\"]",
+                "dialog[aria-labelledby=\"consent-title\"] button.bg-xe-primary-500, div.animate-slideFromLeft button.bg-xe-primary-500",
+                "xeConsentState={%22performance%22:false%2C%22marketing%22:false"
             ],
             "r": [
                 [
@@ -3033,12 +3076,12 @@
                     ],
                     [
                         {
-                            "e": 53
+                            "v": 53
                         }
                     ],
                     [
                         {
-                            "e": 53
+                            "v": 53
                         }
                     ],
                     [
@@ -3091,6 +3134,45 @@
                     [
                         {
                             "cc": 58
+                        }
+                    ],
+                    {}
+                ],
+                [
+                    1,
+                    "as-adventure",
+                    2,
+                    "",
+                    22,
+                    [
+                        837,
+                        838,
+                        839
+                    ],
+                    [
+                        {
+                            "e": 840
+                        }
+                    ],
+                    [
+                        {
+                            "check": "any",
+                            "v": 841
+                        }
+                    ],
+                    [
+                        {
+                            "all": true,
+                            "retry": 10,
+                            "retryInterval": 500,
+                            "c": 840
+                        }
+                    ],
+                    [
+                        {
+                            "timeout": 2000,
+                            "check": "none",
+                            "wv": 841
                         }
                     ],
                     {}
@@ -7924,6 +8006,101 @@
                 ],
                 [
                     1,
+                    "mirasvit-gdpr",
+                    2,
+                    "",
+                    22,
+                    [
+                        842,
+                        843,
+                        844,
+                        845
+                    ],
+                    [
+                        {
+                            "e": 846
+                        }
+                    ],
+                    [
+                        {
+                            "check": "any",
+                            "v": 846
+                        }
+                    ],
+                    [
+                        {
+                            "if": {
+                                "check": "any",
+                                "v": 847
+                            },
+                            "then": [
+                                {
+                                    "any": [
+                                        {
+                                            "k": 848
+                                        },
+                                        {
+                                            "k": 849
+                                        }
+                                    ]
+                                }
+                            ],
+                            "else": [
+                                {
+                                    "any": [
+                                        {
+                                            "k": 850
+                                        },
+                                        {
+                                            "k": 851
+                                        }
+                                    ]
+                                },
+                                {
+                                    "check": "any",
+                                    "timeout": 5000,
+                                    "wv": 852
+                                },
+                                {
+                                    "all": true,
+                                    "timeout": 2000,
+                                    "optional": true,
+                                    "c": 853
+                                },
+                                {
+                                    "any": [
+                                        {
+                                            "k": 854
+                                        },
+                                        {
+                                            "k": 855
+                                        },
+                                        {
+                                            "k": 856
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "check": "none",
+                            "timeout": 10000,
+                            "wv": 846
+                        }
+                    ],
+                    [
+                        {
+                            "cc": 857
+                        },
+                        {
+                            "check": "none",
+                            "v": 846
+                        }
+                    ],
+                    {}
+                ],
+                [
+                    1,
                     "moneysavingexpert.com",
                     2,
                     "",
@@ -11194,12 +11371,12 @@
                     [],
                     [
                         {
-                            "e": 837
+                            "e": 858
                         }
                     ],
                     [
                         {
-                            "v": 837
+                            "v": 858
                         }
                     ],
                     [
@@ -11207,14 +11384,14 @@
                             "wait": 500
                         },
                         {
-                            "c": 837
+                            "c": 858
                         }
                     ],
                     [
                         {
                             "timeout": 1000,
                             "check": "none",
-                            "wv": 837
+                            "wv": 858
                         }
                     ],
                     {}
@@ -11228,17 +11405,17 @@
                     [],
                     [
                         {
-                            "e": 838
+                            "e": 859
                         }
                     ],
                     [
                         {
-                            "v": 838
+                            "v": 859
                         }
                     ],
                     [
                         {
-                            "c": 838
+                            "c": 859
                         }
                     ],
                     [],
@@ -11253,12 +11430,12 @@
                     [],
                     [
                         {
-                            "e": 839
+                            "e": 860
                         }
                     ],
                     [
                         {
-                            "v": 839
+                            "v": 860
                         }
                     ],
                     [
@@ -11266,14 +11443,14 @@
                             "wait": 500
                         },
                         {
-                            "c": 839
+                            "c": 860
                         }
                     ],
                     [
                         {
                             "timeout": 1000,
                             "check": "none",
-                            "wv": 839
+                            "wv": 860
                         }
                     ],
                     {}
@@ -11287,12 +11464,12 @@
                     [],
                     [
                         {
-                            "e": 840
+                            "e": 861
                         }
                     ],
                     [
                         {
-                            "v": 840
+                            "v": 861
                         }
                     ],
                     [
@@ -11300,14 +11477,14 @@
                             "wait": 500
                         },
                         {
-                            "c": 840
+                            "c": 861
                         }
                     ],
                     [
                         {
                             "timeout": 1000,
                             "check": "none",
-                            "wv": 840
+                            "wv": 861
                         }
                     ],
                     {}
@@ -11321,12 +11498,12 @@
                     [],
                     [
                         {
-                            "e": 841
+                            "e": 862
                         }
                     ],
                     [
                         {
-                            "v": 841
+                            "v": 862
                         }
                     ],
                     [
@@ -11334,14 +11511,14 @@
                             "wait": 500
                         },
                         {
-                            "c": 841
+                            "c": 862
                         }
                     ],
                     [
                         {
                             "timeout": 1000,
                             "check": "none",
-                            "wv": 841
+                            "wv": 862
                         }
                     ],
                     {}
@@ -11355,12 +11532,12 @@
                     [],
                     [
                         {
-                            "e": 842
+                            "e": 863
                         }
                     ],
                     [
                         {
-                            "v": 842
+                            "v": 863
                         }
                     ],
                     [
@@ -11368,14 +11545,14 @@
                             "wait": 500
                         },
                         {
-                            "c": 842
+                            "c": 863
                         }
                     ],
                     [
                         {
                             "timeout": 1000,
                             "check": "none",
-                            "wv": 842
+                            "wv": 863
                         }
                     ],
                     {}
@@ -11389,12 +11566,12 @@
                     [],
                     [
                         {
-                            "e": 843
+                            "e": 864
                         }
                     ],
                     [
                         {
-                            "v": 843
+                            "v": 864
                         }
                     ],
                     [
@@ -11402,14 +11579,14 @@
                             "wait": 500
                         },
                         {
-                            "c": 843
+                            "c": 864
                         }
                     ],
                     [
                         {
                             "timeout": 1000,
                             "check": "none",
-                            "wv": 843
+                            "wv": 864
                         }
                     ],
                     {}
@@ -11423,12 +11600,12 @@
                     [],
                     [
                         {
-                            "e": 844
+                            "e": 865
                         }
                     ],
                     [
                         {
-                            "v": 844
+                            "v": 865
                         }
                     ],
                     [
@@ -11436,14 +11613,14 @@
                             "wait": 500
                         },
                         {
-                            "c": 844
+                            "c": 865
                         }
                     ],
                     [
                         {
                             "timeout": 1000,
                             "check": "none",
-                            "wv": 844
+                            "wv": 865
                         }
                     ],
                     {}
@@ -11457,12 +11634,12 @@
                     [],
                     [
                         {
-                            "e": 845
+                            "e": 866
                         }
                     ],
                     [
                         {
-                            "v": 845
+                            "v": 866
                         }
                     ],
                     [
@@ -11470,14 +11647,14 @@
                             "wait": 500
                         },
                         {
-                            "c": 845
+                            "c": 866
                         }
                     ],
                     [
                         {
                             "timeout": 1000,
                             "check": "none",
-                            "wv": 845
+                            "wv": 866
                         }
                     ],
                     {}
@@ -11491,12 +11668,12 @@
                     [],
                     [
                         {
-                            "e": 846
+                            "e": 867
                         }
                     ],
                     [
                         {
-                            "v": 846
+                            "v": 867
                         }
                     ],
                     [
@@ -11504,14 +11681,14 @@
                             "wait": 500
                         },
                         {
-                            "c": 846
+                            "c": 867
                         }
                     ],
                     [
                         {
                             "timeout": 1000,
                             "check": "none",
-                            "wv": 846
+                            "wv": 867
                         }
                     ],
                     {}
@@ -11525,12 +11702,12 @@
                     [],
                     [
                         {
-                            "e": 847
+                            "e": 868
                         }
                     ],
                     [
                         {
-                            "v": 847
+                            "v": 868
                         }
                     ],
                     [
@@ -11538,14 +11715,14 @@
                             "wait": 500
                         },
                         {
-                            "c": 847
+                            "c": 868
                         }
                     ],
                     [
                         {
                             "timeout": 1000,
                             "check": "none",
-                            "wv": 847
+                            "wv": 868
                         }
                     ],
                     {}
@@ -11559,12 +11736,12 @@
                     [],
                     [
                         {
-                            "e": 848
+                            "e": 869
                         }
                     ],
                     [
                         {
-                            "v": 848
+                            "v": 869
                         }
                     ],
                     [
@@ -11572,14 +11749,14 @@
                             "wait": 500
                         },
                         {
-                            "c": 848
+                            "c": 869
                         }
                     ],
                     [
                         {
                             "timeout": 1000,
                             "check": "none",
-                            "wv": 848
+                            "wv": 869
                         }
                     ],
                     {}
@@ -11593,12 +11770,12 @@
                     [],
                     [
                         {
-                            "e": 849
+                            "e": 870
                         }
                     ],
                     [
                         {
-                            "v": 849
+                            "v": 870
                         }
                     ],
                     [
@@ -11606,14 +11783,14 @@
                             "wait": 500
                         },
                         {
-                            "c": 849
+                            "c": 870
                         }
                     ],
                     [
                         {
                             "timeout": 1000,
                             "check": "none",
-                            "wv": 849
+                            "wv": 870
                         }
                     ],
                     {}
@@ -11627,12 +11804,12 @@
                     [],
                     [
                         {
-                            "e": 850
+                            "e": 871
                         }
                     ],
                     [
                         {
-                            "v": 850
+                            "v": 871
                         }
                     ],
                     [
@@ -11640,14 +11817,14 @@
                             "wait": 500
                         },
                         {
-                            "c": 850
+                            "c": 871
                         }
                     ],
                     [
                         {
                             "timeout": 1000,
                             "check": "none",
-                            "wv": 850
+                            "wv": 871
                         }
                     ],
                     {}
@@ -11661,12 +11838,12 @@
                     [],
                     [
                         {
-                            "e": 850
+                            "e": 871
                         }
                     ],
                     [
                         {
-                            "v": 850
+                            "v": 871
                         }
                     ],
                     [
@@ -11674,14 +11851,14 @@
                             "wait": 500
                         },
                         {
-                            "c": 850
+                            "c": 871
                         }
                     ],
                     [
                         {
                             "timeout": 1000,
                             "check": "none",
-                            "wv": 850
+                            "wv": 871
                         }
                     ],
                     {}
@@ -11695,17 +11872,17 @@
                     [],
                     [
                         {
-                            "e": 851
+                            "e": 872
                         }
                     ],
                     [
                         {
-                            "v": 851
+                            "v": 872
                         }
                     ],
                     [
                         {
-                            "c": 851
+                            "c": 872
                         }
                     ],
                     [],
@@ -11720,17 +11897,17 @@
                     [],
                     [
                         {
-                            "e": 852
+                            "e": 873
                         }
                     ],
                     [
                         {
-                            "v": 852
+                            "v": 873
                         }
                     ],
                     [
                         {
-                            "c": 852
+                            "c": 873
                         }
                     ],
                     [],
@@ -11745,12 +11922,12 @@
                     [],
                     [
                         {
-                            "e": 853
+                            "e": 874
                         }
                     ],
                     [
                         {
-                            "v": 853
+                            "v": 874
                         }
                     ],
                     [
@@ -11758,14 +11935,14 @@
                             "wait": 500
                         },
                         {
-                            "c": 853
+                            "c": 874
                         }
                     ],
                     [
                         {
                             "timeout": 1000,
                             "check": "none",
-                            "wv": 853
+                            "wv": 874
                         }
                     ],
                     {}
@@ -11779,12 +11956,12 @@
                     [],
                     [
                         {
-                            "e": 850
+                            "e": 871
                         }
                     ],
                     [
                         {
-                            "v": 850
+                            "v": 871
                         }
                     ],
                     [
@@ -11792,14 +11969,14 @@
                             "wait": 500
                         },
                         {
-                            "c": 850
+                            "c": 871
                         }
                     ],
                     [
                         {
                             "timeout": 1000,
                             "check": "none",
-                            "wv": 850
+                            "wv": 871
                         }
                     ],
                     {}
@@ -11813,12 +11990,12 @@
                     [],
                     [
                         {
-                            "e": 854
+                            "e": 875
                         }
                     ],
                     [
                         {
-                            "v": 854
+                            "v": 875
                         }
                     ],
                     [
@@ -11826,14 +12003,14 @@
                             "wait": 500
                         },
                         {
-                            "c": 854
+                            "c": 875
                         }
                     ],
                     [
                         {
                             "timeout": 1000,
                             "check": "none",
-                            "wv": 854
+                            "wv": 875
                         }
                     ],
                     {}
@@ -11847,12 +12024,12 @@
                     [],
                     [
                         {
-                            "e": 855
+                            "e": 876
                         }
                     ],
                     [
                         {
-                            "v": 855
+                            "v": 876
                         }
                     ],
                     [
@@ -11860,14 +12037,14 @@
                             "wait": 500
                         },
                         {
-                            "c": 855
+                            "c": 876
                         }
                     ],
                     [
                         {
                             "timeout": 1000,
                             "check": "none",
-                            "wv": 855
+                            "wv": 876
                         }
                     ],
                     {}
@@ -11881,18 +12058,18 @@
                     [],
                     [
                         {
-                            "e": 856
+                            "e": 877
                         }
                     ],
                     [
                         {
-                            "v": 856
+                            "v": 877
                         }
                     ],
                     [
                         {
                             "text": "Decline",
-                            "c": 856
+                            "c": 877
                         }
                     ],
                     [],
@@ -11907,25 +12084,25 @@
                     [],
                     [
                         {
-                            "e": 857
+                            "e": 878
                         }
                     ],
                     [
                         {
-                            "v": 857
+                            "v": 878
                         }
                     ],
                     [
                         {
-                            "k": 858
+                            "k": 879
                         },
                         {
                             "all": true,
                             "optional": true,
-                            "k": 859
+                            "k": 880
                         },
                         {
-                            "k": 860
+                            "k": 881
                         }
                     ],
                     [
@@ -11944,47 +12121,47 @@
                     "^https://plus\\.gmx\\.com/lt(?:[?#]|$)",
                     1,
                     [
-                        861
+                        882
                     ],
                     [
                         {
-                            "e": 861
+                            "e": 882
                         }
                     ],
                     [
                         {
-                            "v": 862
+                            "v": 883
                         }
                     ],
                     [
                         {
                             "if": {
-                                "e": 863
+                                "e": 884
                             },
                             "then": [
                                 {
-                                    "c": 863
+                                    "c": 884
                                 }
                             ],
                             "else": [
                                 {
                                     "if": {
-                                        "e": 864
+                                        "e": 885
                                     },
                                     "then": [
                                         {
-                                            "c": 864
+                                            "c": 885
                                         },
                                         {
-                                            "wv": 865
+                                            "wv": 886
                                         },
                                         {
-                                            "c": 865
+                                            "c": 886
                                         }
                                     ],
                                     "else": [
                                         {
-                                            "c": 865
+                                            "c": 886
                                         }
                                     ]
                                 }
@@ -11993,7 +12170,7 @@
                     ],
                     [
                         {
-                            "cc": 866
+                            "cc": 887
                         }
                     ],
                     {}
@@ -12005,49 +12182,49 @@
                     "^https://cmp-consent-tool\\.privacymanager\\.io/",
                     1,
                     [
-                        867,
-                        868
+                        888,
+                        889
                     ],
                     [
                         {
-                            "e": 869
+                            "e": 890
                         }
                     ],
                     [
                         {
-                            "v": 869
+                            "v": 890
                         }
                     ],
                     [
                         {
                             "if": {
-                                "e": 870
+                                "e": 891
                             },
                             "then": [
                                 {
-                                    "k": 870
+                                    "k": 891
                                 },
                                 {
-                                    "c": 871
+                                    "c": 892
                                 }
                             ],
                             "else": [
                                 {
-                                    "c": 872
+                                    "c": 893
                                 },
                                 {
-                                    "w": 873
+                                    "w": 894
                                 },
                                 {
-                                    "w": 874
+                                    "w": 895
                                 },
                                 {
                                     "all": true,
                                     "optional": true,
-                                    "k": 875
+                                    "k": 896
                                 },
                                 {
-                                    "k": 874
+                                    "k": 895
                                 }
                             ]
                         }
@@ -12064,20 +12241,20 @@
                     [],
                     [
                         {
-                            "e": 876
+                            "e": 897
                         },
                         {
-                            "e": 877
+                            "e": 898
                         }
                     ],
                     [
                         {
-                            "v": 877
+                            "v": 898
                         }
                     ],
                     [
                         {
-                            "c": 877
+                            "c": 898
                         }
                     ],
                     [],
@@ -14544,12 +14721,12 @@
                     [],
                     [
                         {
-                            "e": 878
+                            "e": 961
                         }
                     ],
                     [
                         {
-                            "v": 878
+                            "v": 961
                         }
                     ],
                     [
@@ -14557,14 +14734,14 @@
                             "wait": 500
                         },
                         {
-                            "c": 878
+                            "c": 961
                         }
                     ],
                     [
                         {
                             "timeout": 1000,
                             "check": "none",
-                            "wv": 878
+                            "wv": 961
                         }
                     ],
                     {}
@@ -14578,12 +14755,12 @@
                     [],
                     [
                         {
-                            "e": 887
+                            "e": 962
                         }
                     ],
                     [
                         {
-                            "v": 887
+                            "v": 962
                         }
                     ],
                     [
@@ -14591,14 +14768,14 @@
                             "wait": 500
                         },
                         {
-                            "c": 887
+                            "c": 962
                         }
                     ],
                     [
                         {
                             "timeout": 1000,
                             "check": "none",
-                            "wv": 887
+                            "wv": 962
                         }
                     ],
                     {}
@@ -14986,12 +15163,12 @@
                     [],
                     [
                         {
-                            "e": 898
+                            "e": 963
                         }
                     ],
                     [
                         {
-                            "v": 898
+                            "v": 963
                         }
                     ],
                     [
@@ -14999,14 +15176,14 @@
                             "wait": 500
                         },
                         {
-                            "c": 898
+                            "c": 963
                         }
                     ],
                     [
                         {
                             "timeout": 1000,
                             "check": "none",
-                            "wv": 898
+                            "wv": 963
                         }
                     ],
                     {}
@@ -26958,12 +27135,12 @@
                     [],
                     [
                         {
-                            "e": 879
+                            "e": 964
                         }
                     ],
                     [
                         {
-                            "v": 879
+                            "v": 964
                         }
                     ],
                     [
@@ -26971,14 +27148,14 @@
                             "wait": 500
                         },
                         {
-                            "c": 879
+                            "c": 964
                         }
                     ],
                     [
                         {
                             "timeout": 1000,
                             "check": "none",
-                            "wv": 879
+                            "wv": 964
                         }
                     ],
                     {}
@@ -26992,12 +27169,12 @@
                     [],
                     [
                         {
-                            "e": 888
+                            "e": 1670
                         }
                     ],
                     [
                         {
-                            "v": 888
+                            "v": 1670
                         }
                     ],
                     [
@@ -27005,14 +27182,14 @@
                             "wait": 500
                         },
                         {
-                            "c": 888
+                            "c": 1670
                         }
                     ],
                     [
                         {
                             "timeout": 1000,
                             "check": "none",
-                            "wv": 888
+                            "wv": 1670
                         }
                     ],
                     {}
@@ -27231,24 +27408,51 @@
                     1,
                     "bbc.com",
                     2,
-                    "^https://(www\\.)?bbc\\.(com|co\\.uk)",
+                    "^https://(www\\.)?bbc\\.(com|co\\.uk)/",
                     22,
                     [
-                        1542
+                        1542,
+                        1671
                     ],
                     [
                         {
-                            "e": 1543
+                            "any": [
+                                {
+                                    "e": 1543
+                                },
+                                {
+                                    "e": 1671
+                                }
+                            ]
                         }
                     ],
                     [
                         {
-                            "v": 1543
+                            "any": [
+                                {
+                                    "v": 1543
+                                },
+                                {
+                                    "v": 1671
+                                }
+                            ]
                         }
                     ],
                     [
                         {
-                            "c": 1544
+                            "if": {
+                                "e": 1671
+                            },
+                            "then": [
+                                {
+                                    "c": 1672
+                                }
+                            ],
+                            "else": [
+                                {
+                                    "c": 1544
+                                }
+                            ]
                         }
                     ],
                     [
@@ -27256,6 +27460,39 @@
                             "cc": 1545
                         }
                     ],
+                    {}
+                ],
+                [
+                    1,
+                    "bcferries.com",
+                    2,
+                    "^https?://(\\w+\\.)?bcferries\\.com/",
+                    22,
+                    [
+                        1673
+                    ],
+                    [
+                        {
+                            "e": 1674
+                        }
+                    ],
+                    [
+                        {
+                            "v": 1673
+                        }
+                    ],
+                    [
+                        {
+                            "c": 1675
+                        },
+                        {
+                            "c": 1676
+                        },
+                        {
+                            "c": 1677
+                        }
+                    ],
+                    [],
                     {}
                 ],
                 [
@@ -27423,7 +27660,7 @@
                     ],
                     [
                         {
-                            "cc": 882
+                            "cc": 1678
                         }
                     ],
                     {}
@@ -27681,25 +27918,25 @@
                     ],
                     [
                         {
-                            "e": 889
+                            "e": 1679
                         }
                     ],
                     [
                         {
-                            "v": 889
+                            "v": 1679
                         }
                     ],
                     [
                         {
-                            "c": 890
+                            "c": 1680
                         },
                         {
                             "all": true,
                             "optional": true,
-                            "k": 891
+                            "k": 1681
                         },
                         {
-                            "c": 894
+                            "c": 1682
                         }
                     ],
                     [
@@ -27997,18 +28234,18 @@
                     ],
                     [
                         {
-                            "e": 880
+                            "e": 1683
                         }
                     ],
                     [
                         {
-                            "v": 880
+                            "v": 1683
                         }
                     ],
                     [
                         {
-                            "c": 881,
-                            "h": 880
+                            "c": 1684,
+                            "h": 1683
                         }
                     ],
                     [],
@@ -28081,21 +28318,21 @@
                     "^https://(www\\.)?financestrategists\\.com/",
                     22,
                     [
-                        883
+                        1685
                     ],
                     [
                         {
-                            "e": 883
+                            "e": 1685
                         }
                     ],
                     [
                         {
-                            "v": 883
+                            "v": 1685
                         }
                     ],
                     [
                         {
-                            "h": 883
+                            "h": 1685
                         }
                     ],
                     [],
@@ -28108,21 +28345,21 @@
                     "^https://www\\.geeksforgeeks\\.org/",
                     22,
                     [
-                        884
+                        1686
                     ],
                     [
                         {
-                            "e": 884
+                            "e": 1686
                         }
                     ],
                     [
                         {
-                            "v": 884
+                            "v": 1686
                         }
                     ],
                     [
                         {
-                            "h": 884
+                            "h": 1686
                         }
                     ],
                     [],
@@ -28162,16 +28399,16 @@
                     "^https://(\\w+\\.)?glastonburyfestivals\\.co\\.uk/",
                     22,
                     [
-                        885
+                        1687
                     ],
                     [
                         {
-                            "e": 886
+                            "e": 1688
                         }
                     ],
                     [
                         {
-                            "v": 886
+                            "v": 1688
                         }
                     ],
                     [
@@ -28771,6 +29008,38 @@
                 ],
                 [
                     1,
+                    "mipro.com.tw",
+                    2,
+                    "^https?://(\\w+\\.)?mipro\\.com\\.tw/",
+                    22,
+                    [
+                        1689
+                    ],
+                    [
+                        {
+                            "e": 1690
+                        }
+                    ],
+                    [
+                        {
+                            "v": 1691
+                        }
+                    ],
+                    [
+                        {
+                            "c": 1691
+                        }
+                    ],
+                    [
+                        {
+                            "negated": true,
+                            "e": 1689
+                        }
+                    ],
+                    {}
+                ],
+                [
+                    1,
                     "msn",
                     0,
                     "^https?://(www\\.)?msn\\.com/",
@@ -29207,12 +29476,12 @@
                     ],
                     [
                         {
-                            "e": 893
+                            "e": 1692
                         }
                     ],
                     [
                         {
-                            "v": 893
+                            "v": 1692
                         }
                     ],
                     [
@@ -30416,6 +30685,63 @@
                 ],
                 [
                     1,
+                    "tlc-direct",
+                    2,
+                    "^https?://(\\w+\\.)?tlc-direct\\.co\\.uk/",
+                    22,
+                    [
+                        959
+                    ],
+                    [
+                        {
+                            "e": 1693
+                        },
+                        {
+                            "e": 1694
+                        }
+                    ],
+                    [
+                        {
+                            "v": 959
+                        }
+                    ],
+                    [
+                        {
+                            "c": 1695
+                        },
+                        {
+                            "if": {
+                                "e": 1696
+                            },
+                            "then": [
+                                {
+                                    "k": 1697
+                                }
+                            ]
+                        },
+                        {
+                            "if": {
+                                "e": 1698
+                            },
+                            "then": [
+                                {
+                                    "k": 1699
+                                }
+                            ]
+                        },
+                        {
+                            "c": 1700
+                        }
+                    ],
+                    [
+                        {
+                            "cc": 1701
+                        }
+                    ],
+                    {}
+                ],
+                [
+                    1,
                     "toho-one.com",
                     2,
                     "^https?://www\\.toho-one\\.com/",
@@ -30654,7 +30980,7 @@
                             ],
                             "else": [
                                 {
-                                    "c": 892
+                                    "c": 1702
                                 },
                                 {
                                     "w": 1662
@@ -30665,11 +30991,11 @@
                                     "k": 1623
                                 },
                                 {
-                                    "c": 895
+                                    "c": 1703
                                 },
                                 {
                                     "check": "none",
-                                    "wv": 896
+                                    "wv": 1704
                                 }
                             ]
                         }
@@ -30684,7 +31010,7 @@
                     "^https://([a-z0-9-]+\\.)?(twitter|x)\\.com/",
                     22,
                     [
-                        897
+                        1705
                     ],
                     [
                         {
@@ -30975,35 +31301,38 @@
                     1,
                     "xe.com",
                     2,
-                    "^https://www\\.xe\\.com/",
+                    "^https?://(www\\.)?xe\\.com/",
                     22,
                     [
-                        961
+                        1706,
+                        1707
                     ],
                     [
                         {
-                            "e": 961
+                            "e": 1708
                         }
                     ],
                     [
                         {
-                            "v": 961
+                            "v": 1708
                         }
                     ],
                     [
                         {
-                            "wait": 1000
+                            "retry": 3,
+                            "retryInterval": 500,
+                            "c": 1709
                         },
                         {
-                            "c": 962
+                            "wv": 1710
                         },
                         {
-                            "c": 963
+                            "c": 1711
                         }
                     ],
                     [
                         {
-                            "cc": 964
+                            "cc": 1712
                         }
                     ],
                     {}
@@ -31220,18 +31549,18 @@
             "index": {
                 "genericRuleRange": [
                     0,
-                    210
+                    212
                 ],
                 "frameRuleRange": [
-                    208,
-                    236
+                    210,
+                    238
                 ],
                 "specificRuleRange": [
-                    210,
-                    814
+                    212,
+                    819
                 ],
-                "genericStringEnd": 837,
-                "frameStringEnd": 878
+                "genericStringEnd": 858,
+                "frameStringEnd": 899
             }
         }
     }


### PR DESCRIPTION
Asana Task/Github Issue: https://app.asana.com/1/137249556945/project/1201844467387842/task/1218199591768510

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Data-only privacy-configuration updates; impact is limited to cookie-banner automation behavior on affected sites, with no auth or data-path changes.
> 
> **Overview**
> Bumps the **autoconsent** rule bundle in `features/autoconsent.json` to **v16.37.0**, expanding how DuckDuckGo auto-dismisses cookie banners.
> 
> The shared selector tables gain coverage for newer CMP patterns (e.g. `cookie-message-modal` / bottom-sheet UIs, **Mirasvit** `.mst-gdpr__*` bars, and related decline/settings controls), with several existing selectors **reordered** between generic and frame lists as indices shift.
> 
> **New site-specific rules** include `as-adventure`, `mirasvit-gdpr`, `bcferries.com`, `mipro.com.tw`, and `tlc-direct`. **Existing rules** are adjusted where needed—e.g. **BBC** handles an alternate banner variant and tightens the URL pattern; **xe.com** broadens host matching and uses retry/click steps for its consent dialog; **aquasana.com** fixes a visibility step (`e` → `v`). Rule index metadata (`genericRuleRange`, `frameRuleRange`, string table bounds) is updated to match the larger string table.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e1981779c9bf31cefef533f3614e9629b803ad6f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->