### PR TITLE
Update autoconsent to v16.38.0

### DIFF
--- a/features/autoconsent.json
+++ b/features/autoconsent.json
@@ -1869,6 +1869,63 @@
                 ".mst-gdpr__cookie-settings--success-btn",
                 "[x-on\\:click=save]",
                 "gdpr_cookie_consent=",
+                "._flo-consent-root",
+                "._flo-consent-root ._flo-consent-modal-contextual ._flo-consent-button--accept-selected",
+                "._flo-consent-root ._flo-consent-modal:not(._flo-consent-modal-contextual)",
+                "._flo-consent-modal:not(._flo-consent-modal-contextual) ._flo-consent-button--reject",
+                "._flo-consent-button--settings",
+                "._flo-consent-modal-contextual ._flo-consent-button--accept-selected",
+                "._flo-consent-modal-contextual ._flo-consent-checkbox:checked:not(._flo-consent-checkbox--necessary)",
+                "._flo-consent-root._flo-consent-hide",
+                "#cbPopupWrap.cb-popup--open",
+                "#cbPopupWrap #cbRefuseTrigger",
+                "cbDataAccepted=1",
+                ".cky-consent-container [data-cky-tag=donotsell-button]",
+                ".cky-modal [data-cky-tag=optout-option-toggle]",
+                ".cky-modal [data-cky-tag=optout-option-toggle]:not(:checked)",
+                ".cky-modal [data-cky-tag=optout-confirm-button]",
+                ".cky-modal [data-cky-tag=optout-success]",
+                ".cky-modal [data-cky-tag=optout-close]",
+                "#rgpd-popup",
+                "#rgpd-custom-popup",
+                "#rgpd-popup #rgpd-continue-without-accepting",
+                "#rgpd-continue-without-accepting",
+                "consentLevel=none",
+                "#cookie-advice.fv-cookie-advice",
+                "#cookie-advice .fv-cookie-advice__message a:not([href]), #cookie-advice .fv-cookie-advice__message button",
+                ".fv-cookies-management",
+                ":is(fv-cookies-management-sheet, .modal-content):has(.fv-cookies-management) button[class*=\"--primary\"]",
+                "fever_cookies_configuration",
+                "body > #idxrcookies",
+                "body > #idxrcookies #idxrcookiesKO",
+                "module-rgpd-component",
+                "cookieConsent=consent_1",
+                ".mco-consent-pop-up",
+                ".mco-consent-slide-up",
+                ".mco-consent-slide-up__backdrop",
+                ".mco-overlay:has(.mco-consent)",
+                "#mco-consent",
+                "[class*=\"mco-consent-\"][class*=\"__button-decline\"]",
+                "\"acceptedAll\":false",
+                "#__consent .md-consent__inner",
+                "#__consent .md-consent__overlay",
+                "#__consent form[name='consent'] .md-consent__settings input[type='checkbox']",
+                "#__consent:not([hidden]) .md-consent__inner",
+                "#__consent .md-consent__settings input[type='checkbox']:checked",
+                "#__consent .md-consent__controls button.md-button--primary",
+                ".stpd_cmp_wrapper",
+                ".stpd_cmp_wrapper .stpd_cmp_form",
+                ".stpd_cmp_wrapper .stpd_flexed_btns button[type=\"submit\"]",
+                ".stpd_cmp_wrapper .stpd_flexed_btns button[type=\"button\"]:not(.withdraw_consent)",
+                ".stpd_cmp_wrapper .stpd_purposes_list",
+                ".stpd_cmp_wrapper input[type=\"checkbox\"]:checked",
+                "euconsent-v2=",
+                "#cookie_modal",
+                "#cookie_modal #id_cookies_necessary",
+                "#cookie_modal #id_cookies_all",
+                "[data-automation-id=\"legalNotice\"]",
+                "[data-automation-id=\"legalNoticeDeclineButton\"]",
+                "enablePrivacyTracking=false",
                 "body > div#root > div#ccpa-iframe-theme-provider[data-testid=\"ccpa-iframe-theme-provider\"] > div#ccpa-iframe[data-testid=\"ccpa-iframe\"] > div#ccpa_consent_banner[data-testid=\"ccpa_consent_banner\"] > div:not([id]) > div:nth-child(3):not([id]) > span:not([id]) > span:not([id]) > div:nth-child(2):not([id]) > span:nth-child(1):not([id]) > button#decline_cookies_button[data-testid=\"decline_cookies_button\"]",
                 "body:not([id]) > div#banner-0 > div:nth-child(1)#grouped-pageload-Banner > div:not([id]) > div:not([id]) > div:not([id]) > div:nth-child(3):not([id]) > button:nth-child(2):not([id])",
                 "body > div#iubenda-cs-banner > div:not([id]) > div:not([id]) > div:not([id]) > div:nth-child(5):not([id]) > div:nth-child(2):not([id]) > button:nth-child(1):not([id])",
@@ -1910,63 +1967,6 @@
                 "span[role=checkbox][aria-checked=true]",
                 "#save-all-pur",
                 "#reminder",
-                "body > div:not([id]) > div#cookie-banner > div:nth-child(2):not([id]) > button:nth-child(2)#cookie-banner-reject",
-                ".show-cookies-modal .cookies-modal #cookies-reject",
-                ".fixed [data-testid=closeCookieBanner]",
-                "[data-testid=consent-banner]",
-                "[data-testid=manage-preferences]",
-                "[data-testid=consent-mgr-dialog] [data-ga-button=save-preferences]",
-                "#CookieConsent",
-                "#CookieConsentDeclined",
-                "[data-testid=consent-banner] [data-testid=reject-button]",
-                "xpath///div[contains(., \"Vill du tillåta användningen av cookies från Instagram i den här webbläsaren?\") or contains(., \"Allow the use of cookies from Instagram on this browser?\") or contains(., \"Povolit v prohlížeči použití souborů cookie z Instagramu?\") or contains(., \"Dopustiti upotrebu kolačića s Instagrama na ovom pregledniku?\") or contains(., \"Разрешить использование файлов cookie от Instagram в этом браузере?\") or contains(., \"Vuoi consentire l'uso dei cookie di Instagram su questo browser?\") or contains(., \"Povoliť používanie cookies zo služby Instagram v tomto prehliadači?\") or contains(., \"Die Verwendung von Cookies durch Instagram in diesem Browser erlauben?\") or contains(., \"Sallitaanko Instagramin evästeiden käyttö tällä selaimella?\") or contains(., \"Engedélyezed az Instagram cookie-jainak használatát ebben a böngészőben?\") or contains(., \"Het gebruik van cookies van Instagram toestaan in deze browser?\") or contains(., \"Bu tarayıcıda Instagram'dan çerez kullanımına izin verilsin mi?\") or contains(., \"Permitir o uso de cookies do Instagram neste navegador?\") or contains(., \"Permiţi folosirea modulelor cookie de la Instagram în acest browser?\") or contains(., \"Autoriser l’utilisation des cookies d’Instagram sur ce navigateur ?\") or contains(., \"¿Permitir el uso de cookies de Instagram en este navegador?\") or contains(., \"Zezwolić na użycie plików cookie z Instagramu w tej przeglądarce?\") or contains(., \"Να επιτρέπεται η χρήση cookies από τo Instagram σε αυτό το πρόγραμμα περιήγησης;\") or contains(., \"Разрешавате ли използването на бисквитки от Instagram на този браузър?\") or contains(., \"Vil du tillade brugen af cookies fra Instagram i denne browser?\") or contains(., \"Vil du tillate bruk av informasjonskapsler fra Instagram i denne nettleseren?\")]",
-                "xpath///button[contains(., 'Отклонить необязательные файлы cookie') or contains(., 'Decline optional cookies') or contains(., 'Refuser les cookies optionnels') or contains(., 'Hylkää valinnaiset evästeet') or contains(., 'Afvis valgfrie cookies') or contains(., 'Odmietnuť nepovinné cookies') or contains(., 'Απόρριψη προαιρετικών cookies') or contains(., 'Neka valfria cookies') or contains(., 'Optionale Cookies ablehnen') or contains(., 'Rifiuta cookie facoltativi') or contains(., 'Odbij neobavezne kolačiće') or contains(., 'Avvis valgfrie informasjonskapsler') or contains(., 'İsteğe bağlı çerezleri reddet') or contains(., 'Recusar cookies opcionais') or contains(., 'Optionele cookies afwijzen') or contains(., 'Rechazar cookies opcionales') or contains(., 'Odrzuć opcjonalne pliki cookie') or contains(., 'Отхвърляне на бисквитките по избор') or contains(., 'Odmítnout volitelné soubory cookie') or contains(., 'Refuză modulele cookie opţionale') or contains(., 'A nem kötelező cookie-k elutasítása')]",
-                ".pop-cookie",
-                "body > aside:not([id]) > div:nth-child(2)#cookie-consent-modal > div:not([id]) > div:not([id]) > div:not([id]) > div:not([id]) > div:not([id]) > div:not([id]) > div:nth-child(2):not([id]) > button:nth-child(2):not([id])",
-                "#cookieBanner.cbShort .cbCloseButton",
-                "#cookieBanner #cookieBannerContent, #globalCookieBanner",
-                "[data-role=\"cookies-modal\"] [class*=container]",
-                "#gdpr-banner-container",
-                "body > div:not([id])[data-popup=\"\"][data-popup-cookies=\"\"][data-terms-cookies-popup-common=\"\"][data-popup-need-overlay=\"true\"] > div:not([id])[data-terms-cookies-popup=\"\"][data-terms-cookies-popup-common=\"\"] > div:not([id]) > div:nth-child(2):not([id]) > button:nth-child(2):not([id])[data-cookies=\"disallow_all_cookies\"]",
-                "#gdpr-banner-container #gdpr-banner [data-testid=gdpr-banner-decline-button]",
-                "div:has(> div > a[href*='/privacy-policy'])",
-                "div:has(> div > div > div[role=alert] > a[href^=\"https://policy.medium.com/medium-privacy-policy-\"])",
-                "#cookie-container",
-                "div[aria-label=\"Cookie Policy Banner\"]",
-                "#onetrust-banner-sdk",
-                ".ucb",
-                ".ucb-banner",
-                ".ucb-banner .ucb-btn-save",
-                ".dip-consent,.dip-consent-container",
-                ".dip-consent-container",
-                ".dip-consent-content",
-                ".dip-consent-btn[tabindex=\"2\"]",
-                "div#cookieWarning",
-                "a#btnCookiesDenyAll",
-                "[class*=ConsentManager]",
-                "[class*=ConsentManager_cookieBar]",
-                "xpath///button[contains(@class, \"ConsentManager_cookieBarButton\") and contains(., \"weigeren\")]",
-                "[data-testid=cookie-dialog-root]",
-                "input[type=radio][id$=-declineLabel]",
-                "[data-testid=confirm-choice-button]",
-                "ccm-notification",
-                "gdpr-banner",
-                ".cookies-agreement-notification,.modal-new:has([data-module=SetupCookies])",
-                ".cookies-agreement-notification",
-                ".cookies-agreement-notification .cb_setup",
-                "[data-module=SetupCookies]",
-                "body > div#cookieconsent > div#cookieconsent-bar > div:nth-child(3):not([id]) > a:nth-child(2)#decline",
-                "body > header#header > div:nth-child(1)#CookiesConsent > div:not([id]) > div:nth-child(2):not([id]) > form:nth-child(2):not([id]) > div:nth-child(5):not([id]) > button:not([id])[data-testid=\"AcceptRequiredCookies\"]",
-                "[data-module=SetupCookies] input[type=checkbox]:checked:not(:disabled)",
-                "[class^=cookie_wrapper]",
-                "[name=button_save_choice]",
-                "div.b-cookies-informer",
-                "div.b-cookies-informer__nav > button:nth-child(1)",
-                "body > div#cookieChoiceInfo > div:nth-child(2)#cookieButtonBar > a:nth-child(2)#cookieChoiceRefuse",
-                "div[role=\"dialog\"][aria-label^=\"Privacy Disclosure\"]",
-                "div.b-cookies-informer__switchers",
-                "div.b-cookies-informer__switchers input:not([disabled])",
-                "div.b-cookies-informer__nav > button",
                 "[aria-labelledby=cookieConsentTitle]",
                 "xpath///button[contains(., 'Reject non-essential')]",
                 "consent=rejected",
@@ -2723,7 +2723,64 @@
                 "dialog[aria-labelledby=\"consent-title\"] button.border-xe-primary-500, div.animate-slideFromLeft button.border-xe-primary-500",
                 "[data-testid=\"performance-toggle\"]",
                 "dialog[aria-labelledby=\"consent-title\"] button.bg-xe-primary-500, div.animate-slideFromLeft button.bg-xe-primary-500",
-                "xeConsentState={%22performance%22:false%2C%22marketing%22:false"
+                "xeConsentState={%22performance%22:false%2C%22marketing%22:false",
+                "body > aside:not([id]) > div:nth-child(2)#cookie-consent-modal > div:not([id]) > div:not([id]) > div:not([id]) > div:not([id]) > div:not([id]) > div:not([id]) > div:nth-child(2):not([id]) > button:nth-child(2):not([id])",
+                "body > div:not([id]) > div#cookie-banner > div:nth-child(2):not([id]) > button:nth-child(2)#cookie-banner-reject",
+                "body > div:not([id])[data-popup=\"\"][data-popup-cookies=\"\"][data-terms-cookies-popup-common=\"\"][data-popup-need-overlay=\"true\"] > div:not([id])[data-terms-cookies-popup=\"\"][data-terms-cookies-popup-common=\"\"] > div:not([id]) > div:nth-child(2):not([id]) > button:nth-child(2):not([id])[data-cookies=\"disallow_all_cookies\"]",
+                "body > div#cookieconsent > div#cookieconsent-bar > div:nth-child(3):not([id]) > a:nth-child(2)#decline",
+                "body > header#header > div:nth-child(1)#CookiesConsent > div:not([id]) > div:nth-child(2):not([id]) > form:nth-child(2):not([id]) > div:nth-child(5):not([id]) > button:not([id])[data-testid=\"AcceptRequiredCookies\"]",
+                "body > div#cookieChoiceInfo > div:nth-child(2)#cookieButtonBar > a:nth-child(2)#cookieChoiceRefuse",
+                ".show-cookies-modal .cookies-modal #cookies-reject",
+                ".fixed [data-testid=closeCookieBanner]",
+                "[data-testid=consent-banner]",
+                "[data-testid=manage-preferences]",
+                "[data-testid=consent-mgr-dialog] [data-ga-button=save-preferences]",
+                "div[role=\"dialog\"][aria-label^=\"Privacy Disclosure\"]",
+                "#CookieConsent",
+                "#CookieConsentDeclined",
+                "[data-testid=consent-banner] [data-testid=reject-button]",
+                "xpath///div[contains(., \"Vill du tillåta användningen av cookies från Instagram i den här webbläsaren?\") or contains(., \"Allow the use of cookies from Instagram on this browser?\") or contains(., \"Povolit v prohlížeči použití souborů cookie z Instagramu?\") or contains(., \"Dopustiti upotrebu kolačića s Instagrama na ovom pregledniku?\") or contains(., \"Разрешить использование файлов cookie от Instagram в этом браузере?\") or contains(., \"Vuoi consentire l'uso dei cookie di Instagram su questo browser?\") or contains(., \"Povoliť používanie cookies zo služby Instagram v tomto prehliadači?\") or contains(., \"Die Verwendung von Cookies durch Instagram in diesem Browser erlauben?\") or contains(., \"Sallitaanko Instagramin evästeiden käyttö tällä selaimella?\") or contains(., \"Engedélyezed az Instagram cookie-jainak használatát ebben a böngészőben?\") or contains(., \"Het gebruik van cookies van Instagram toestaan in deze browser?\") or contains(., \"Bu tarayıcıda Instagram'dan çerez kullanımına izin verilsin mi?\") or contains(., \"Permitir o uso de cookies do Instagram neste navegador?\") or contains(., \"Permiţi folosirea modulelor cookie de la Instagram în acest browser?\") or contains(., \"Autoriser l’utilisation des cookies d’Instagram sur ce navigateur ?\") or contains(., \"¿Permitir el uso de cookies de Instagram en este navegador?\") or contains(., \"Zezwolić na użycie plików cookie z Instagramu w tej przeglądarce?\") or contains(., \"Να επιτρέπεται η χρήση cookies από τo Instagram σε αυτό το πρόγραμμα περιήγησης;\") or contains(., \"Разрешавате ли използването на бисквитки от Instagram на този браузър?\") or contains(., \"Vil du tillade brugen af cookies fra Instagram i denne browser?\") or contains(., \"Vil du tillate bruk av informasjonskapsler fra Instagram i denne nettleseren?\")]",
+                "xpath///button[contains(., 'Отклонить необязательные файлы cookie') or contains(., 'Decline optional cookies') or contains(., 'Refuser les cookies optionnels') or contains(., 'Hylkää valinnaiset evästeet') or contains(., 'Afvis valgfrie cookies') or contains(., 'Odmietnuť nepovinné cookies') or contains(., 'Απόρριψη προαιρετικών cookies') or contains(., 'Neka valfria cookies') or contains(., 'Optionale Cookies ablehnen') or contains(., 'Rifiuta cookie facoltativi') or contains(., 'Odbij neobavezne kolačiće') or contains(., 'Avvis valgfrie informasjonskapsler') or contains(., 'İsteğe bağlı çerezleri reddet') or contains(., 'Recusar cookies opcionais') or contains(., 'Optionele cookies afwijzen') or contains(., 'Rechazar cookies opcionales') or contains(., 'Odrzuć opcjonalne pliki cookie') or contains(., 'Отхвърляне на бисквитките по избор') or contains(., 'Odmítnout volitelné soubory cookie') or contains(., 'Refuză modulele cookie opţionale') or contains(., 'A nem kötelező cookie-k elutasítása')]",
+                ".pop-cookie",
+                "#gdpr-banner-container",
+                "#gdpr-banner-container #gdpr-banner [data-testid=gdpr-banner-decline-button]",
+                "div:has(> div > a[href*='/privacy-policy'])",
+                "div:has(> div > div > div[role=alert] > a[href^=\"https://policy.medium.com/medium-privacy-policy-\"])",
+                "#cookie-container",
+                "div[aria-label=\"Cookie Policy Banner\"]",
+                "#onetrust-banner-sdk",
+                "div#cookieWarning",
+                "a#btnCookiesDenyAll",
+                "[class*=ConsentManager]",
+                "[class*=ConsentManager_cookieBar]",
+                "xpath///button[contains(@class, \"ConsentManager_cookieBarButton\") and contains(., \"weigeren\")]",
+                "[data-testid=cookie-dialog-root]",
+                "input[type=radio][id$=-declineLabel]",
+                "[data-testid=confirm-choice-button]",
+                "ccm-notification",
+                "gdpr-banner",
+                ".cookies-agreement-notification,.modal-new:has([data-module=SetupCookies])",
+                ".cookies-agreement-notification",
+                ".cookies-agreement-notification .cb_setup",
+                "[data-module=SetupCookies]",
+                "[data-module=SetupCookies] input[type=checkbox]:checked:not(:disabled)",
+                "[name=button_save_choice]",
+                "div.b-cookies-informer",
+                "div.b-cookies-informer__nav > button:nth-child(1)",
+                "div.b-cookies-informer__switchers",
+                "div.b-cookies-informer__switchers input:not([disabled])",
+                "div.b-cookies-informer__nav > button",
+                "#cookieBanner.cbShort .cbCloseButton",
+                "#cookieBanner #cookieBannerContent, #globalCookieBanner",
+                ".ucb",
+                ".ucb-banner",
+                ".ucb-banner .ucb-btn-save",
+                ".dip-consent,.dip-consent-container",
+                ".dip-consent-container",
+                ".dip-consent-content",
+                ".dip-consent-btn[tabindex=\"2\"]",
+                "[class^=cookie_wrapper]",
+                "[data-role=\"cookies-modal\"] [class*=container]"
             ],
             "r": [
                 [
@@ -4624,6 +4681,60 @@
                 ],
                 [
                     1,
+                    "consent-flo",
+                    2,
+                    "",
+                    22,
+                    [
+                        858
+                    ],
+                    [
+                        {
+                            "e": 859
+                        }
+                    ],
+                    [
+                        {
+                            "v": 860
+                        }
+                    ],
+                    [
+                        {
+                            "if": {
+                                "e": 861
+                            },
+                            "then": [
+                                {
+                                    "c": 861
+                                }
+                            ],
+                            "else": [
+                                {
+                                    "c": 862
+                                },
+                                {
+                                    "wv": 863
+                                },
+                                {
+                                    "all": true,
+                                    "optional": true,
+                                    "k": 864
+                                },
+                                {
+                                    "c": 863
+                                }
+                            ]
+                        }
+                    ],
+                    [
+                        {
+                            "e": 865
+                        }
+                    ],
+                    {}
+                ],
+                [
+                    1,
                     "consentmanager-ncmp",
                     2,
                     "",
@@ -4998,6 +5109,37 @@
                         }
                     ],
                     [],
+                    {}
+                ],
+                [
+                    1,
+                    "cookiebot.be",
+                    2,
+                    "",
+                    22,
+                    [
+                        866
+                    ],
+                    [
+                        {
+                            "e": 867
+                        }
+                    ],
+                    [
+                        {
+                            "v": 866
+                        }
+                    ],
+                    [
+                        {
+                            "c": 867
+                        }
+                    ],
+                    [
+                        {
+                            "cc": 868
+                        }
+                    ],
                     {}
                 ],
                 [
@@ -5412,27 +5554,58 @@
                             "else": [
                                 {
                                     "if": {
-                                        "e": 277
+                                        "e": 869
                                     },
                                     "then": [
                                         {
-                                            "k": 277
+                                            "c": 869
                                         },
                                         {
-                                            "w": 278
+                                            "w": 870
                                         },
                                         {
                                             "all": true,
                                             "optional": true,
-                                            "k": 279
+                                            "k": 871
                                         },
                                         {
-                                            "c": 280
+                                            "c": 872
+                                        },
+                                        {
+                                            "optional": true,
+                                            "wv": 873
+                                        },
+                                        {
+                                            "optional": true,
+                                            "c": 874
                                         }
                                     ],
                                     "else": [
                                         {
-                                            "h": 281
+                                            "if": {
+                                                "e": 277
+                                            },
+                                            "then": [
+                                                {
+                                                    "k": 277
+                                                },
+                                                {
+                                                    "w": 278
+                                                },
+                                                {
+                                                    "all": true,
+                                                    "optional": true,
+                                                    "k": 279
+                                                },
+                                                {
+                                                    "c": 280
+                                                }
+                                            ],
+                                            "else": [
+                                                {
+                                                    "h": 281
+                                                }
+                                            ]
                                         }
                                     ]
                                 }
@@ -5991,6 +6164,38 @@
                 ],
                 [
                     1,
+                    "drouot-rgpd",
+                    2,
+                    "",
+                    22,
+                    [
+                        875,
+                        876
+                    ],
+                    [
+                        {
+                            "e": 877
+                        }
+                    ],
+                    [
+                        {
+                            "v": 875
+                        }
+                    ],
+                    [
+                        {
+                            "c": 878
+                        }
+                    ],
+                    [
+                        {
+                            "cc": 879
+                        }
+                    ],
+                    {}
+                ],
+                [
+                    1,
                     "Drupal",
                     2,
                     "",
@@ -6533,6 +6738,46 @@
                     [
                         {
                             "cc": 793
+                        }
+                    ],
+                    {}
+                ],
+                [
+                    1,
+                    "fever-cookie-advice",
+                    2,
+                    "",
+                    22,
+                    [
+                        880
+                    ],
+                    [
+                        {
+                            "e": 880
+                        }
+                    ],
+                    [
+                        {
+                            "v": 880
+                        }
+                    ],
+                    [
+                        {
+                            "c": 881
+                        },
+                        {
+                            "wv": 882
+                        },
+                        {
+                            "c": 883
+                        }
+                    ],
+                    [
+                        {
+                            "wait": 500
+                        },
+                        {
+                            "cc": 884
                         }
                     ],
                     {}
@@ -7201,6 +7446,71 @@
                         }
                     ],
                     [],
+                    {}
+                ],
+                [
+                    1,
+                    "idxrcookies",
+                    2,
+                    "",
+                    22,
+                    [
+                        885
+                    ],
+                    [
+                        {
+                            "e": 886
+                        }
+                    ],
+                    [
+                        {
+                            "v": 886
+                        }
+                    ],
+                    [
+                        {
+                            "c": 886
+                        }
+                    ],
+                    [],
+                    {}
+                ],
+                [
+                    1,
+                    "infomaniak-rgpd",
+                    2,
+                    "",
+                    22,
+                    [
+                        887
+                    ],
+                    [
+                        {
+                            "e": 887
+                        }
+                    ],
+                    [
+                        {
+                            "visible": [
+                                "module-rgpd-component",
+                                ".modal"
+                            ]
+                        }
+                    ],
+                    [
+                        {
+                            "waitForThenClick": [
+                                "module-rgpd-component",
+                                ".buttons > button:nth-of-type(2)"
+                            ],
+                            "retry": 3
+                        }
+                    ],
+                    [
+                        {
+                            "cc": 888
+                        }
+                    ],
                     {}
                 ],
                 [
@@ -7884,6 +8194,40 @@
                 ],
                 [
                     1,
+                    "mco-consent",
+                    2,
+                    "",
+                    22,
+                    [
+                        889,
+                        890,
+                        891,
+                        892
+                    ],
+                    [
+                        {
+                            "e": 893
+                        }
+                    ],
+                    [
+                        {
+                            "v": 894
+                        }
+                    ],
+                    [
+                        {
+                            "c": 894
+                        }
+                    ],
+                    [
+                        {
+                            "cc": 895
+                        }
+                    ],
+                    {}
+                ],
+                [
+                    1,
                     "mediamarkt.de",
                     2,
                     "",
@@ -8097,6 +8441,39 @@
                             "v": 846
                         }
                     ],
+                    {}
+                ],
+                [
+                    1,
+                    "mkdocs-material",
+                    2,
+                    "",
+                    22,
+                    [
+                        896,
+                        897
+                    ],
+                    [
+                        {
+                            "e": 898
+                        }
+                    ],
+                    [
+                        {
+                            "v": 899
+                        }
+                    ],
+                    [
+                        {
+                            "all": true,
+                            "optional": true,
+                            "k": 900
+                        },
+                        {
+                            "c": 901
+                        }
+                    ],
+                    [],
                     {}
                 ],
                 [
@@ -9135,6 +9512,64 @@
                 ],
                 [
                     1,
+                    "setupad",
+                    2,
+                    "",
+                    22,
+                    [
+                        902
+                    ],
+                    [
+                        {
+                            "e": 903
+                        }
+                    ],
+                    [
+                        {
+                            "v": 903
+                        }
+                    ],
+                    [
+                        {
+                            "if": {
+                                "e": 904
+                            },
+                            "then": [
+                                {
+                                    "c": 904
+                                }
+                            ],
+                            "else": [
+                                {
+                                    "c": 905
+                                },
+                                {
+                                    "wv": 906
+                                },
+                                {
+                                    "all": true,
+                                    "optional": true,
+                                    "k": 907
+                                },
+                                {
+                                    "c": 904
+                                }
+                            ]
+                        },
+                        {
+                            "check": "none",
+                            "wv": 902
+                        }
+                    ],
+                    [
+                        {
+                            "cc": 908
+                        }
+                    ],
+                    {}
+                ],
+                [
+                    1,
                     "shopify",
                     0,
                     "",
@@ -9290,6 +9725,36 @@
                             "cc": 136
                         }
                     ],
+                    {}
+                ],
+                [
+                    1,
+                    "socialfunders",
+                    2,
+                    "",
+                    22,
+                    [
+                        909
+                    ],
+                    [
+                        {
+                            "e": 910
+                        },
+                        {
+                            "e": 911
+                        }
+                    ],
+                    [
+                        {
+                            "v": 909
+                        }
+                    ],
+                    [
+                        {
+                            "c": 910
+                        }
+                    ],
+                    [],
                     {}
                 ],
                 [
@@ -10949,6 +11414,37 @@
                 ],
                 [
                     1,
+                    "workday",
+                    2,
+                    "",
+                    22,
+                    [
+                        912
+                    ],
+                    [
+                        {
+                            "e": 913
+                        }
+                    ],
+                    [
+                        {
+                            "v": 912
+                        }
+                    ],
+                    [
+                        {
+                            "c": 913
+                        }
+                    ],
+                    [
+                        {
+                            "cc": 914
+                        }
+                    ],
+                    {}
+                ],
+                [
+                    1,
                     "WP Cookie Notice for GDPR",
                     2,
                     "",
@@ -11371,12 +11867,12 @@
                     [],
                     [
                         {
-                            "e": 858
+                            "e": 915
                         }
                     ],
                     [
                         {
-                            "v": 858
+                            "v": 915
                         }
                     ],
                     [
@@ -11384,14 +11880,14 @@
                             "wait": 500
                         },
                         {
-                            "c": 858
+                            "c": 915
                         }
                     ],
                     [
                         {
                             "timeout": 1000,
                             "check": "none",
-                            "wv": 858
+                            "wv": 915
                         }
                     ],
                     {}
@@ -11405,17 +11901,17 @@
                     [],
                     [
                         {
-                            "e": 859
+                            "e": 916
                         }
                     ],
                     [
                         {
-                            "v": 859
+                            "v": 916
                         }
                     ],
                     [
                         {
-                            "c": 859
+                            "c": 916
                         }
                     ],
                     [],
@@ -11430,12 +11926,12 @@
                     [],
                     [
                         {
-                            "e": 860
+                            "e": 917
                         }
                     ],
                     [
                         {
-                            "v": 860
+                            "v": 917
                         }
                     ],
                     [
@@ -11443,14 +11939,14 @@
                             "wait": 500
                         },
                         {
-                            "c": 860
+                            "c": 917
                         }
                     ],
                     [
                         {
                             "timeout": 1000,
                             "check": "none",
-                            "wv": 860
+                            "wv": 917
                         }
                     ],
                     {}
@@ -11464,12 +11960,12 @@
                     [],
                     [
                         {
-                            "e": 861
+                            "e": 918
                         }
                     ],
                     [
                         {
-                            "v": 861
+                            "v": 918
                         }
                     ],
                     [
@@ -11477,14 +11973,14 @@
                             "wait": 500
                         },
                         {
-                            "c": 861
+                            "c": 918
                         }
                     ],
                     [
                         {
                             "timeout": 1000,
                             "check": "none",
-                            "wv": 861
+                            "wv": 918
                         }
                     ],
                     {}
@@ -11498,12 +11994,12 @@
                     [],
                     [
                         {
-                            "e": 862
+                            "e": 919
                         }
                     ],
                     [
                         {
-                            "v": 862
+                            "v": 919
                         }
                     ],
                     [
@@ -11511,14 +12007,14 @@
                             "wait": 500
                         },
                         {
-                            "c": 862
+                            "c": 919
                         }
                     ],
                     [
                         {
                             "timeout": 1000,
                             "check": "none",
-                            "wv": 862
+                            "wv": 919
                         }
                     ],
                     {}
@@ -11532,12 +12028,12 @@
                     [],
                     [
                         {
-                            "e": 863
+                            "e": 920
                         }
                     ],
                     [
                         {
-                            "v": 863
+                            "v": 920
                         }
                     ],
                     [
@@ -11545,14 +12041,14 @@
                             "wait": 500
                         },
                         {
-                            "c": 863
+                            "c": 920
                         }
                     ],
                     [
                         {
                             "timeout": 1000,
                             "check": "none",
-                            "wv": 863
+                            "wv": 920
                         }
                     ],
                     {}
@@ -11566,12 +12062,12 @@
                     [],
                     [
                         {
-                            "e": 864
+                            "e": 921
                         }
                     ],
                     [
                         {
-                            "v": 864
+                            "v": 921
                         }
                     ],
                     [
@@ -11579,14 +12075,14 @@
                             "wait": 500
                         },
                         {
-                            "c": 864
+                            "c": 921
                         }
                     ],
                     [
                         {
                             "timeout": 1000,
                             "check": "none",
-                            "wv": 864
+                            "wv": 921
                         }
                     ],
                     {}
@@ -11600,12 +12096,12 @@
                     [],
                     [
                         {
-                            "e": 865
+                            "e": 922
                         }
                     ],
                     [
                         {
-                            "v": 865
+                            "v": 922
                         }
                     ],
                     [
@@ -11613,14 +12109,14 @@
                             "wait": 500
                         },
                         {
-                            "c": 865
+                            "c": 922
                         }
                     ],
                     [
                         {
                             "timeout": 1000,
                             "check": "none",
-                            "wv": 865
+                            "wv": 922
                         }
                     ],
                     {}
@@ -11634,12 +12130,12 @@
                     [],
                     [
                         {
-                            "e": 866
+                            "e": 923
                         }
                     ],
                     [
                         {
-                            "v": 866
+                            "v": 923
                         }
                     ],
                     [
@@ -11647,14 +12143,14 @@
                             "wait": 500
                         },
                         {
-                            "c": 866
+                            "c": 923
                         }
                     ],
                     [
                         {
                             "timeout": 1000,
                             "check": "none",
-                            "wv": 866
+                            "wv": 923
                         }
                     ],
                     {}
@@ -11668,12 +12164,12 @@
                     [],
                     [
                         {
-                            "e": 867
+                            "e": 924
                         }
                     ],
                     [
                         {
-                            "v": 867
+                            "v": 924
                         }
                     ],
                     [
@@ -11681,14 +12177,14 @@
                             "wait": 500
                         },
                         {
-                            "c": 867
+                            "c": 924
                         }
                     ],
                     [
                         {
                             "timeout": 1000,
                             "check": "none",
-                            "wv": 867
+                            "wv": 924
                         }
                     ],
                     {}
@@ -11702,12 +12198,12 @@
                     [],
                     [
                         {
-                            "e": 868
+                            "e": 925
                         }
                     ],
                     [
                         {
-                            "v": 868
+                            "v": 925
                         }
                     ],
                     [
@@ -11715,14 +12211,14 @@
                             "wait": 500
                         },
                         {
-                            "c": 868
+                            "c": 925
                         }
                     ],
                     [
                         {
                             "timeout": 1000,
                             "check": "none",
-                            "wv": 868
+                            "wv": 925
                         }
                     ],
                     {}
@@ -11736,12 +12232,12 @@
                     [],
                     [
                         {
-                            "e": 869
+                            "e": 926
                         }
                     ],
                     [
                         {
-                            "v": 869
+                            "v": 926
                         }
                     ],
                     [
@@ -11749,14 +12245,14 @@
                             "wait": 500
                         },
                         {
-                            "c": 869
+                            "c": 926
                         }
                     ],
                     [
                         {
                             "timeout": 1000,
                             "check": "none",
-                            "wv": 869
+                            "wv": 926
                         }
                     ],
                     {}
@@ -11770,12 +12266,12 @@
                     [],
                     [
                         {
-                            "e": 870
+                            "e": 927
                         }
                     ],
                     [
                         {
-                            "v": 870
+                            "v": 927
                         }
                     ],
                     [
@@ -11783,14 +12279,14 @@
                             "wait": 500
                         },
                         {
-                            "c": 870
+                            "c": 927
                         }
                     ],
                     [
                         {
                             "timeout": 1000,
                             "check": "none",
-                            "wv": 870
+                            "wv": 927
                         }
                     ],
                     {}
@@ -11804,12 +12300,12 @@
                     [],
                     [
                         {
-                            "e": 871
+                            "e": 928
                         }
                     ],
                     [
                         {
-                            "v": 871
+                            "v": 928
                         }
                     ],
                     [
@@ -11817,14 +12313,14 @@
                             "wait": 500
                         },
                         {
-                            "c": 871
+                            "c": 928
                         }
                     ],
                     [
                         {
                             "timeout": 1000,
                             "check": "none",
-                            "wv": 871
+                            "wv": 928
                         }
                     ],
                     {}
@@ -11838,12 +12334,12 @@
                     [],
                     [
                         {
-                            "e": 871
+                            "e": 928
                         }
                     ],
                     [
                         {
-                            "v": 871
+                            "v": 928
                         }
                     ],
                     [
@@ -11851,14 +12347,14 @@
                             "wait": 500
                         },
                         {
-                            "c": 871
+                            "c": 928
                         }
                     ],
                     [
                         {
                             "timeout": 1000,
                             "check": "none",
-                            "wv": 871
+                            "wv": 928
                         }
                     ],
                     {}
@@ -11872,17 +12368,17 @@
                     [],
                     [
                         {
-                            "e": 872
+                            "e": 929
                         }
                     ],
                     [
                         {
-                            "v": 872
+                            "v": 929
                         }
                     ],
                     [
                         {
-                            "c": 872
+                            "c": 929
                         }
                     ],
                     [],
@@ -11897,17 +12393,17 @@
                     [],
                     [
                         {
-                            "e": 873
+                            "e": 930
                         }
                     ],
                     [
                         {
-                            "v": 873
+                            "v": 930
                         }
                     ],
                     [
                         {
-                            "c": 873
+                            "c": 930
                         }
                     ],
                     [],
@@ -11922,12 +12418,12 @@
                     [],
                     [
                         {
-                            "e": 874
+                            "e": 931
                         }
                     ],
                     [
                         {
-                            "v": 874
+                            "v": 931
                         }
                     ],
                     [
@@ -11935,14 +12431,14 @@
                             "wait": 500
                         },
                         {
-                            "c": 874
+                            "c": 931
                         }
                     ],
                     [
                         {
                             "timeout": 1000,
                             "check": "none",
-                            "wv": 874
+                            "wv": 931
                         }
                     ],
                     {}
@@ -11956,12 +12452,12 @@
                     [],
                     [
                         {
-                            "e": 871
+                            "e": 928
                         }
                     ],
                     [
                         {
-                            "v": 871
+                            "v": 928
                         }
                     ],
                     [
@@ -11969,14 +12465,14 @@
                             "wait": 500
                         },
                         {
-                            "c": 871
+                            "c": 928
                         }
                     ],
                     [
                         {
                             "timeout": 1000,
                             "check": "none",
-                            "wv": 871
+                            "wv": 928
                         }
                     ],
                     {}
@@ -11990,12 +12486,12 @@
                     [],
                     [
                         {
-                            "e": 875
+                            "e": 932
                         }
                     ],
                     [
                         {
-                            "v": 875
+                            "v": 932
                         }
                     ],
                     [
@@ -12003,14 +12499,14 @@
                             "wait": 500
                         },
                         {
-                            "c": 875
+                            "c": 932
                         }
                     ],
                     [
                         {
                             "timeout": 1000,
                             "check": "none",
-                            "wv": 875
+                            "wv": 932
                         }
                     ],
                     {}
@@ -12024,12 +12520,12 @@
                     [],
                     [
                         {
-                            "e": 876
+                            "e": 933
                         }
                     ],
                     [
                         {
-                            "v": 876
+                            "v": 933
                         }
                     ],
                     [
@@ -12037,14 +12533,14 @@
                             "wait": 500
                         },
                         {
-                            "c": 876
+                            "c": 933
                         }
                     ],
                     [
                         {
                             "timeout": 1000,
                             "check": "none",
-                            "wv": 876
+                            "wv": 933
                         }
                     ],
                     {}
@@ -12058,18 +12554,18 @@
                     [],
                     [
                         {
-                            "e": 877
+                            "e": 934
                         }
                     ],
                     [
                         {
-                            "v": 877
+                            "v": 934
                         }
                     ],
                     [
                         {
                             "text": "Decline",
-                            "c": 877
+                            "c": 934
                         }
                     ],
                     [],
@@ -12084,25 +12580,25 @@
                     [],
                     [
                         {
-                            "e": 878
+                            "e": 935
                         }
                     ],
                     [
                         {
-                            "v": 878
+                            "v": 935
                         }
                     ],
                     [
                         {
-                            "k": 879
+                            "k": 936
                         },
                         {
                             "all": true,
                             "optional": true,
-                            "k": 880
+                            "k": 937
                         },
                         {
-                            "k": 881
+                            "k": 938
                         }
                     ],
                     [
@@ -12121,47 +12617,47 @@
                     "^https://plus\\.gmx\\.com/lt(?:[?#]|$)",
                     1,
                     [
-                        882
+                        939
                     ],
                     [
                         {
-                            "e": 882
+                            "e": 939
                         }
                     ],
                     [
                         {
-                            "v": 883
+                            "v": 940
                         }
                     ],
                     [
                         {
                             "if": {
-                                "e": 884
+                                "e": 941
                             },
                             "then": [
                                 {
-                                    "c": 884
+                                    "c": 941
                                 }
                             ],
                             "else": [
                                 {
                                     "if": {
-                                        "e": 885
+                                        "e": 942
                                     },
                                     "then": [
                                         {
-                                            "c": 885
+                                            "c": 942
                                         },
                                         {
-                                            "wv": 886
+                                            "wv": 943
                                         },
                                         {
-                                            "c": 886
+                                            "c": 943
                                         }
                                     ],
                                     "else": [
                                         {
-                                            "c": 886
+                                            "c": 943
                                         }
                                     ]
                                 }
@@ -12170,7 +12666,7 @@
                     ],
                     [
                         {
-                            "cc": 887
+                            "cc": 944
                         }
                     ],
                     {}
@@ -12182,49 +12678,49 @@
                     "^https://cmp-consent-tool\\.privacymanager\\.io/",
                     1,
                     [
-                        888,
-                        889
+                        945,
+                        946
                     ],
                     [
                         {
-                            "e": 890
+                            "e": 947
                         }
                     ],
                     [
                         {
-                            "v": 890
+                            "v": 947
                         }
                     ],
                     [
                         {
                             "if": {
-                                "e": 891
+                                "e": 948
                             },
                             "then": [
                                 {
-                                    "k": 891
+                                    "k": 948
                                 },
                                 {
-                                    "c": 892
+                                    "c": 949
                                 }
                             ],
                             "else": [
                                 {
-                                    "c": 893
+                                    "c": 950
                                 },
                                 {
-                                    "w": 894
+                                    "w": 951
                                 },
                                 {
-                                    "w": 895
+                                    "w": 952
                                 },
                                 {
                                     "all": true,
                                     "optional": true,
-                                    "k": 896
+                                    "k": 953
                                 },
                                 {
-                                    "k": 895
+                                    "k": 952
                                 }
                             ]
                         }
@@ -12241,20 +12737,20 @@
                     [],
                     [
                         {
-                            "e": 897
+                            "e": 954
                         },
                         {
-                            "e": 898
+                            "e": 955
                         }
                     ],
                     [
                         {
-                            "v": 898
+                            "v": 955
                         }
                     ],
                     [
                         {
-                            "c": 898
+                            "c": 955
                         }
                     ],
                     [],
@@ -14025,12 +14521,12 @@
                     [],
                     [
                         {
-                            "e": 911
+                            "e": 1713
                         }
                     ],
                     [
                         {
-                            "v": 911
+                            "v": 1713
                         }
                     ],
                     [
@@ -14038,14 +14534,14 @@
                             "wait": 500
                         },
                         {
-                            "c": 911
+                            "c": 1713
                         }
                     ],
                     [
                         {
                             "timeout": 1000,
                             "check": "none",
-                            "wv": 911
+                            "wv": 1713
                         }
                     ],
                     {}
@@ -15197,12 +15693,12 @@
                     [],
                     [
                         {
-                            "e": 899
+                            "e": 1714
                         }
                     ],
                     [
                         {
-                            "v": 899
+                            "v": 1714
                         }
                     ],
                     [
@@ -15210,14 +15706,14 @@
                             "wait": 500
                         },
                         {
-                            "c": 899
+                            "c": 1714
                         }
                     ],
                     [
                         {
                             "timeout": 1000,
                             "check": "none",
-                            "wv": 899
+                            "wv": 1714
                         }
                     ],
                     {}
@@ -15231,12 +15727,12 @@
                     [],
                     [
                         {
-                            "e": 916
+                            "e": 1715
                         }
                     ],
                     [
                         {
-                            "v": 916
+                            "v": 1715
                         }
                     ],
                     [
@@ -15244,14 +15740,14 @@
                             "wait": 500
                         },
                         {
-                            "c": 916
+                            "c": 1715
                         }
                     ],
                     [
                         {
                             "timeout": 1000,
                             "check": "none",
-                            "wv": 916
+                            "wv": 1715
                         }
                     ],
                     {}
@@ -15367,12 +15863,12 @@
                     [],
                     [
                         {
-                            "e": 944
+                            "e": 1716
                         }
                     ],
                     [
                         {
-                            "v": 944
+                            "v": 1716
                         }
                     ],
                     [
@@ -15380,14 +15876,14 @@
                             "wait": 500
                         },
                         {
-                            "c": 944
+                            "c": 1716
                         }
                     ],
                     [
                         {
                             "timeout": 1000,
                             "check": "none",
-                            "wv": 944
+                            "wv": 1716
                         }
                     ],
                     {}
@@ -15401,12 +15897,12 @@
                     [],
                     [
                         {
-                            "e": 945
+                            "e": 1717
                         }
                     ],
                     [
                         {
-                            "v": 945
+                            "v": 1717
                         }
                     ],
                     [
@@ -15414,14 +15910,14 @@
                             "wait": 500
                         },
                         {
-                            "c": 945
+                            "c": 1717
                         }
                     ],
                     [
                         {
                             "timeout": 1000,
                             "check": "none",
-                            "wv": 945
+                            "wv": 1717
                         }
                     ],
                     {}
@@ -15469,12 +15965,12 @@
                     [],
                     [
                         {
-                            "e": 951
+                            "e": 1718
                         }
                     ],
                     [
                         {
-                            "v": 951
+                            "v": 1718
                         }
                     ],
                     [
@@ -15482,14 +15978,14 @@
                             "wait": 500
                         },
                         {
-                            "c": 951
+                            "c": 1718
                         }
                     ],
                     [
                         {
                             "timeout": 1000,
                             "check": "none",
-                            "wv": 951
+                            "wv": 1718
                         }
                     ],
                     {}
@@ -20194,12 +20690,12 @@
                     [],
                     [
                         {
-                            "e": 951
+                            "e": 1718
                         }
                     ],
                     [
                         {
-                            "v": 951
+                            "v": 1718
                         }
                     ],
                     [
@@ -20207,14 +20703,14 @@
                             "wait": 500
                         },
                         {
-                            "c": 951
+                            "c": 1718
                         }
                     ],
                     [
                         {
                             "timeout": 1000,
                             "check": "none",
-                            "wv": 951
+                            "wv": 1718
                         }
                     ],
                     {}
@@ -28413,7 +28909,7 @@
                     ],
                     [
                         {
-                            "c": 900
+                            "c": 1719
                         }
                     ],
                     [],
@@ -28428,12 +28924,12 @@
                     [],
                     [
                         {
-                            "e": 901
+                            "e": 1720
                         }
                     ],
                     [
                         {
-                            "v": 901
+                            "v": 1720
                         }
                     ],
                     [
@@ -28474,24 +28970,24 @@
                     "^https://[a-z]*\\.hashicorp\\.com/",
                     22,
                     [
-                        902
+                        1721
                     ],
                     [
                         {
-                            "e": 902
+                            "e": 1721
                         }
                     ],
                     [
                         {
-                            "v": 902
+                            "v": 1721
                         }
                     ],
                     [
                         {
-                            "c": 903
+                            "c": 1722
                         },
                         {
-                            "c": 904
+                            "c": 1723
                         }
                     ],
                     [],
@@ -28504,28 +29000,28 @@
                     "^https://(www\\.)?(menshealth|womenshealthmag|cosmopolitan|esquire|elle|elledecor|harpersbazaar|goodhousekeeping|popularmechanics|caranddriver|delish|veranda|roadandtrack|bestproducts|countryliving|housebeautiful|bicycling|biography|pitchfork|prevention|runnersworld|thepioneerwoman|townandcountrymag)\\.com/",
                     10,
                     [
-                        952
+                        1724
                     ],
                     [
                         {
-                            "e": 952
+                            "e": 1724
                         }
                     ],
                     [
                         {
                             "check": "any",
-                            "v": 952
+                            "v": 1724
                         }
                     ],
                     [
                         {
-                            "h": 952
+                            "h": 1724
                         }
                     ],
                     [
                         {
                             "check": "none",
-                            "v": 952
+                            "v": 1724
                         }
                     ],
                     {}
@@ -28537,21 +29033,21 @@
                     "^https://www\\.hetzner\\.com/",
                     22,
                     [
-                        905
+                        1725
                     ],
                     [
                         {
-                            "e": 905
+                            "e": 1725
                         }
                     ],
                     [
                         {
-                            "v": 905
+                            "v": 1725
                         }
                     ],
                     [
                         {
-                            "k": 906
+                            "k": 1726
                         }
                     ],
                     [],
@@ -28595,21 +29091,21 @@
                     "^https://(www\\.)?(m\\.)?imdb.com/",
                     22,
                     [
-                        902
+                        1721
                     ],
                     [
                         {
-                            "e": 902
+                            "e": 1721
                         }
                     ],
                     [
                         {
-                            "v": 902
+                            "v": 1721
                         }
                     ],
                     [
                         {
-                            "c": 907
+                            "c": 1727
                         }
                     ],
                     [],
@@ -28624,17 +29120,17 @@
                     [],
                     [
                         {
-                            "e": 908
+                            "e": 1728
                         }
                     ],
                     [
                         {
-                            "v": 908
+                            "v": 1728
                         }
                     ],
                     [
                         {
-                            "c": 909
+                            "c": 1729
                         },
                         {
                             "wait": 2000
@@ -28688,17 +29184,17 @@
                     [],
                     [
                         {
-                            "e": 910
+                            "e": 1730
                         }
                     ],
                     [
                         {
-                            "e": 910
+                            "e": 1730
                         }
                     ],
                     [
                         {
-                            "h": 910
+                            "h": 1730
                         }
                     ],
                     [],
@@ -28841,21 +29337,21 @@
                     "^https?://(www\\.)?kleinanzeigen\\.de",
                     22,
                     [
-                        915
+                        1731
                     ],
                     [
                         {
-                            "e": 917
+                            "e": 1732
                         }
                     ],
                     [
                         {
-                            "v": 917
+                            "v": 1732
                         }
                     ],
                     [
                         {
-                            "k": 917
+                            "k": 1732
                         }
                     ],
                     [],
@@ -28870,17 +29366,17 @@
                     [],
                     [
                         {
-                            "e": 918
+                            "e": 1733
                         }
                     ],
                     [
                         {
-                            "v": 918
+                            "v": 1733
                         }
                     ],
                     [
                         {
-                            "h": 918
+                            "h": 1733
                         }
                     ],
                     [],
@@ -28927,17 +29423,17 @@
                     [],
                     [
                         {
-                            "e": 919
+                            "e": 1734
                         }
                     ],
                     [
                         {
-                            "v": 919
+                            "v": 1734
                         }
                     ],
                     [
                         {
-                            "h": 919
+                            "h": 1734
                         }
                     ],
                     [],
@@ -28950,7 +29446,7 @@
                     "^https://www\\.midwayusa\\.com/",
                     22,
                     [
-                        920
+                        1735
                     ],
                     [
                         {
@@ -28961,12 +29457,12 @@
                     ],
                     [
                         {
-                            "v": 920
+                            "v": 1735
                         }
                     ],
                     [
                         {
-                            "h": 921
+                            "h": 1736
                         }
                     ],
                     [],
@@ -29077,21 +29573,21 @@
                     "^https://(www\\.)?nba\\.com/",
                     22,
                     [
-                        922
+                        1737
                     ],
                     [
                         {
-                            "e": 922
+                            "e": 1737
                         }
                     ],
                     [
                         {
-                            "v": 922
+                            "v": 1737
                         }
                     ],
                     [
                         {
-                            "h": 922
+                            "h": 1737
                         }
                     ],
                     [],
@@ -29104,21 +29600,21 @@
                     "^https://(www\\.)?netbeat\\.de/",
                     22,
                     [
-                        930
+                        1738
                     ],
                     [
                         {
-                            "e": 930
+                            "e": 1738
                         }
                     ],
                     [
                         {
-                            "v": 930
+                            "v": 1738
                         }
                     ],
                     [
                         {
-                            "c": 931
+                            "c": 1739
                         }
                     ],
                     [],
@@ -29131,22 +29627,22 @@
                     "^https://(www\\.)?nhnieuws\\.nl/",
                     22,
                     [
-                        932
+                        1740
                     ],
                     [
                         {
-                            "e": 933
+                            "e": 1741
                         }
                     ],
                     [
                         {
                             "check": "any",
-                            "v": 933
+                            "v": 1741
                         }
                     ],
                     [
                         {
-                            "c": 934
+                            "c": 1742
                         }
                     ],
                     [
@@ -29165,21 +29661,21 @@
                     [],
                     [
                         {
-                            "e": 935
+                            "e": 1743
                         }
                     ],
                     [
                         {
-                            "v": 935
+                            "v": 1743
                         }
                     ],
                     [
                         {
                             "all": true,
-                            "c": 936
+                            "c": 1744
                         },
                         {
-                            "c": 937
+                            "c": 1745
                         }
                     ],
                     [],
@@ -29192,11 +29688,11 @@
                     "^https://nos\\.nl/",
                     22,
                     [
-                        938
+                        1746
                     ],
                     [
                         {
-                            "e": 938
+                            "e": 1746
                         }
                     ],
                     [
@@ -29208,7 +29704,7 @@
                     ],
                     [
                         {
-                            "h": 938
+                            "h": 1746
                         }
                     ],
                     [],
@@ -29221,16 +29717,16 @@
                     "^https://(www\\.)?nutritionix\\.com/",
                     22,
                     [
-                        939
+                        1747
                     ],
                     [
                         {
-                            "e": 939
+                            "e": 1747
                         }
                     ],
                     [
                         {
-                            "v": 939
+                            "v": 1747
                         }
                     ],
                     [
@@ -29251,30 +29747,30 @@
                     "^https://ok\\.ru/",
                     22,
                     [
-                        940
+                        1748
                     ],
                     [
                         {
-                            "e": 941
+                            "e": 1749
                         }
                     ],
                     [
                         {
-                            "v": 941
+                            "v": 1749
                         }
                     ],
                     [
                         {
-                            "w": 942
+                            "w": 1750
                         },
                         {
                             "wait": 1000
                         },
                         {
-                            "k": 942
+                            "k": 1750
                         },
                         {
-                            "wv": 943
+                            "wv": 1751
                         },
                         {
                             "wait": 500
@@ -29282,14 +29778,14 @@
                         {
                             "all": true,
                             "optional": true,
-                            "k": 946
+                            "k": 1752
                         },
                         {
-                            "c": 948
+                            "c": 1753
                         },
                         {
                             "check": "none",
-                            "wv": 943
+                            "wv": 1751
                         }
                     ],
                     [],
@@ -29302,33 +29798,33 @@
                     "^https://onlyfans\\.com/",
                     22,
                     [
-                        949
+                        1754
                     ],
                     [
                         {
-                            "e": 949
+                            "e": 1754
                         }
                     ],
                     [
                         {
-                            "e": 949
+                            "e": 1754
                         }
                     ],
                     [
                         {
-                            "k": 950
+                            "k": 1755
                         },
                         {
                             "if": {
-                                "e": 953
+                                "e": 1756
                             },
                             "then": [
                                 {
                                     "all": true,
-                                    "k": 954
+                                    "k": 1757
                                 },
                                 {
-                                    "k": 955
+                                    "k": 1758
                                 }
                             ]
                         }
@@ -29582,17 +30078,17 @@
                     ],
                     [
                         {
-                            "e": 912
+                            "e": 1759
                         }
                     ],
                     [
                         {
-                            "v": 912
+                            "v": 1759
                         }
                     ],
                     [
                         {
-                            "k": 912
+                            "k": 1759
                         }
                     ],
                     [],
@@ -29609,12 +30105,12 @@
                     ],
                     [
                         {
-                            "e": 913
+                            "e": 1760
                         }
                     ],
                     [
                         {
-                            "v": 913
+                            "v": 1760
                         }
                     ],
                     [
@@ -31103,21 +31599,21 @@
                     "^https://(www\\.)?uswitch\\.com/",
                     10,
                     [
-                        923
+                        1761
                     ],
                     [
                         {
-                            "e": 924
+                            "e": 1762
                         }
                     ],
                     [
                         {
-                            "v": 924
+                            "v": 1762
                         }
                     ],
                     [
                         {
-                            "c": 925
+                            "c": 1763
                         }
                     ],
                     [],
@@ -31163,21 +31659,21 @@
                     "^https://www\\.vodafone\\.de/",
                     22,
                     [
-                        926
+                        1764
                     ],
                     [
                         {
-                            "e": 927
+                            "e": 1765
                         }
                     ],
                     [
                         {
-                            "v": 928
+                            "v": 1766
                         }
                     ],
                     [
                         {
-                            "k": 929
+                            "k": 1767
                         }
                     ],
                     [],
@@ -31277,21 +31773,21 @@
                     "^https://(www\\.)?wikiwand\\.com/",
                     22,
                     [
-                        947
+                        1768
                     ],
                     [
                         {
-                            "e": 947
+                            "e": 1768
                         }
                     ],
                     [
                         {
-                            "v": 947
+                            "v": 1768
                         }
                     ],
                     [
                         {
-                            "h": 947
+                            "h": 1768
                         }
                     ],
                     [],
@@ -31368,7 +31864,7 @@
                         },
                         {
                             "optional": true,
-                            "h": 914
+                            "h": 1769
                         }
                     ],
                     [],
@@ -31549,18 +32045,18 @@
             "index": {
                 "genericRuleRange": [
                     0,
-                    212
+                    223
                 ],
                 "frameRuleRange": [
-                    210,
-                    238
+                    221,
+                    249
                 ],
                 "specificRuleRange": [
-                    212,
-                    819
+                    223,
+                    830
                 ],
-                "genericStringEnd": 858,
-                "frameStringEnd": 899
+                "genericStringEnd": 915,
+                "frameStringEnd": 956
             }
         }
     }


### PR DESCRIPTION
Asana Task/Github Issue: https://app.asana.com/1/137249556945/project/1201844467387842/task/1218206563098821

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Data-only rule sync; main risk is mis-clicks or missed banners on affected sites if upstream selectors are wrong, not application code changes.
> 
> **Overview**
> Bumps the bundled **autoconsent** rule set in `features/autoconsent.json` to **v16.38.0**, expanding cookie-banner detection and auto-reject flows.
> 
> The update adds many new shared selectors and **generic/frame rules** for additional CMPs (e.g. Flo consent, Cookiebot.be, Drouot RGPD, Fever cookie advice, idxrcookies, Infomaniak RGPD, MCO consent, MkDocs Material, Setupad, Socialfunders, Workday) and extends an existing **cookieconsent2** branch with extra click/wait steps. A large block of previously mid-table selectors (Instagram/xpath declines, OneTrust, GDPR banners, etc.) is **moved** to sit with the xe.com consent selectors, and rule index ranges / string-pool offsets are increased so site-specific and auto-generated rules reference the new string indices.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 166014a87df2c7a2af05b68bef480c873c794948. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->