### PR TITLE
Re-enable optimizeContentScopeMessaging flag on Android

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -3641,7 +3641,7 @@
                 },
                 "optimizeContentScopeMessaging": {
                     "minSupportedVersion": 52920000,
-                    "state": "disabled"
+                    "state": "enabled"
                 },
                 "cacheContentScopeExperiments": {
                     "minSupportedVersion": 52920000,


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/608920331025315/task/1218007361371428?focus=true

## Description
Re-enable `optimizeContentScopeMessaging` on Android

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Re-enables a client behavior change in content-scope/native messaging for eligible Android versions; incorrect behavior could affect page injection or breakage, though scope is limited to the version gate.
> 
> **Overview**
> Turns the Android remote-config flag **`optimizeContentScopeMessaging`** back on under **`clientContentFeatures`**, changing its state from `disabled` to `enabled`. The existing **`minSupportedVersion`** of `52920000` is unchanged, so only supported Android builds receive the optimized content-scope messaging path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 11c411cefd70d6d7b2922d208eb8e40d30b486a5. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->