### PR TITLE
Disable aiChat pdfPageContext sub-feature on macOS

### DIFF
--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -419,6 +419,9 @@
                     "state": "enabled",
                     "minSupportedVersion": "1.183.0"
                 },
+                "pdfPageContext": {
+                    "state": "disabled"
+                },
                 "applicationMenuShortcut": {
                     "state": "enabled"
                 },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/414235014887631/task/1218240222336499

## Description

Adds `aiChat.pdfPageContext` to the macOS override as `disabled`.

The sub-feature has had no entry in remote config since it shipped. The macOS client declares it with `defaultValue: .enabled`, which applies only when the key is missing from config — so it was on for all macOS users with no remote off switch. This turns it off and puts it under remote control.

Generated output verified locally: v4 and v5 macOS configs both emit `pdfPageContext.state: "disabled"`. Windows already had it disabled; iOS has no entry and stays internal-only client-side.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single macOS privacy-config override that disables an AI Chat sub-feature; no auth or data-path code changes.
> 
> **Overview**
> Adds **`aiChat.pdfPageContext`** to `overrides/macos-override.json` with **`state: "disabled"`**, matching Windows.
> 
> Without this key, macOS was falling back to the client default (enabled), so PDF page context for Duck AI Chat stayed on with no remote kill switch. The override turns the sub-feature off for macOS and lets remote config control it going forward.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b1ca37347480590dd5f471f653557c3a94eae1e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->