### PR TITLE
Android: Add AppTP exception for Garmin Explore

### DIFF
--- a/features/app-tracker-protection.json
+++ b/features/app-tracker-protection.json
@@ -419,6 +419,10 @@
                     "reason": "App loads websites"
                 },
                 {
+                    "packageName": "com.garmin.android.apps.explore",
+                    "reason": "Users report app issues with AppTP enabled"
+                },
+                {
                     "packageName": "com.ghostery.android.ghostery",
                     "reason": "App loads websites"
                 },


### PR DESCRIPTION
Asana: https://app.asana.com/1/137249556945/project/1202279501986195/task/1218244026581731

AppTP blocks map downloads in the Garmin Explore app. Viewing maps is the primary purpose of the app, so this effectively breaks it. Disabling AppTP for the app restores functionality.

Adds `com.garmin.android.apps.explore` to the `unprotectedApps` exception list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)