### PR TITLE
Enable FF for next steps card new logic

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -4989,7 +4989,7 @@
                     "minSupportedVersion": "0.150.0"
                 },
                 "nextStepsListNewLogicWidget": {
-                    "state": "disabled"
+                    "state": "enabled"
                 },
                 "omnibar": {
                     "state": "enabled",

--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -4989,7 +4989,8 @@
                     "minSupportedVersion": "0.150.0"
                 },
                 "nextStepsListNewLogicWidget": {
-                    "state": "enabled"
+                    "state": "enabled",
+                    "minSupportedVersion": "0.171.0"
                 },
                 "omnibar": {
                     "state": "enabled",


### PR DESCRIPTION
**Asana Task/Github Issue:**https://app.asana.com/1/137249556945/project/1212592783523117/task/1216920471261685?focus=true

## Description

Enabling FF for next steps cards new logic: new order and new rotation logic.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [x] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Windows-only remote config toggle for new-tab next-steps UI, version-gated; no auth or data-path changes.
> 
> **Overview**
> **Enables** the Windows privacy-config flag `nextStepsListNewLogicWidget` under `htmlNewTabPage`, turning on the updated next-steps card behavior (new ordering and rotation) for clients on **0.171.0+**.
> 
> Previously this sub-feature was **disabled**; it now matches the other next-steps widgets as **enabled**, with a minimum supported version so older builds keep the old logic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f22ccc86153e59623bbc89b0f1aa97cf89de75ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->