### PR TITLE
Enable nativeInputAttachmentChanges and contextualSheetRedesign on 5.295.0

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -975,6 +975,14 @@
                 "contextualSuggestedPrompts": {
                     "state": "enabled",
                     "minSupportedVersion": 52920000
+                },
+                "nativeInputAttachmentChanges": {
+                    "state": "enabled",
+                    "minSupportedVersion": 52950000
+                },
+                "contextualSheetRedesign": {
+                    "state": "enabled",
+                    "minSupportedVersion": 52950000
                 }
             }
         },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/45878998844068/task/1218086367583614?focus=true

## Description
Enable contextual redesign and also attachment changes in native input on 5.295.0 and up.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Remote-config-only change with version gating; no server logic or security-sensitive paths are modified.
> 
> **Overview**
> Turns on two new **Android** `aiChat` feature flags in `android-override.json`, both gated to app version **5.295.0** (`minSupportedVersion`: `52950000`).
> 
> **`nativeInputAttachmentChanges`** enables the updated native Duck AI input behavior for attachments. **`contextualSheetRedesign`** enables the redesigned contextual AI sheet UI. Neither flag uses a rollout percentage—they are fully **enabled** for clients at or above that version.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3e2141cdcb1152a1326822602b7f562a24452026. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->