### PR TITLE
Start CPM prompt rollout at 5%

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -1098,6 +1098,17 @@
                             }
                         ]
                     }
+                },
+                "cookiePopUpOptInPrompt": {
+                    "state": "enabled",
+                    "minSupportedVersion": 52950000,
+                    "rollout": {
+                        "steps": [
+                            {
+                                "percent": 5
+                            }
+                        ]
+                    }
                 }
             }
         },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1202552961248957/task/1218258810937562?focus=true

## Description
Start CPM prompt rollout at 5%

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [x] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [x] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Limited Android exposure (5%) but changes cookie/consent UX on real sites, where breakage or compliance impact is possible.
> 
> **Overview**
> Starts a **5% Android rollout** for the autoconsent **`cookiePopUpOptInPrompt`** feature (CPM opt-in prompt) in `android-override.json`.
> 
> The new flag is **enabled** for app builds **≥ 52950000**, with a single rollout step at **5%**—sibling to the existing `cookiePopUpPreferenceSetting` rollout under `autoconsent.features`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 55f47a07f1d8ea0b5a19786fc6cba4c02793e99a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->