### PR TITLE
remove gpc cpm michaels-com mitigations

### DIFF
--- a/features/autoconsent.json
+++ b/features/autoconsent.json
@@ -860,10 +860,6 @@
             "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5487"
         },
         {
-            "domain": "michaels.com",
-            "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5542"
-        },
-        {
             "domain": "doublelist.com",
             "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5685"
         },

--- a/features/gpc.json
+++ b/features/gpc.json
@@ -109,10 +109,6 @@
             "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5506"
         },
         {
-            "domain": "michaels.com",
-            "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5542"
-        },
-        {
             "domain": "blueair.com",
             "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5650"
         },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1206670747178362/task/1216419596350751?focus=true

## Description

### Site breakage mitigation process:
#### Brief explanation
- Reported URL: michaels.com
- Problems experienced: remove mitigation as issue got fixed
- Platforms affected:
  - [x ] iOS
  - [x ] Android
  - [ x] Windows
  - [x ] MacOS
  - [x ] Extensions
- Tracker(s) being unblocked: NA
- Feature being disabled/modified: gpc, autoconsent added back
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only rollback of a single-domain mitigation; limited scope with possible minor regression if breakage returns on michaels.com.
> 
> **Overview**
> Removes the **michaels.com** site-breakage exceptions so privacy features apply there again after the underlying site issue was resolved.
> 
> The `michaels.com` entry is deleted from the exception lists in **`features/gpc.json`** and **`features/autoconsent.json`** (both previously tied to privacy-configuration PR #5542). **GPC** and **automatic cookie consent** handling will run on michaels.com instead of being skipped.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 03bf30715d06da52b746dea8440cd05d9dfab610. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->