### PR TITLE
Override UA string for spotify.com on macOS

### DIFF
--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -2003,6 +2003,10 @@
                     {
                         "domain": "chatgpt.com",
                         "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5808"
+                    },
+                    {
+                        "domain": "spotify.com",
+                        "reason": "https://github.com/duckduckgo/privacy-configuration/pull/5910"
                     }
                 ],
                 "webViewDefault": [


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/1200277586140538/task/1218139717342198?focus=true

## Description
### Site breakage mitigation process:
#### Brief explanation
- Reported URL: https://open.spotify.com/album/3x8qThM7qP41LYoEhVerfm?go=1&sp_cid=9ec1d394-1376-4ac5-af1e-0376ade4af36&sp_cid=9ec1d394-1376-4ac5-af1e-0376ade4af36&sp_cid=9ec1d394-1376-4ac5-af1e-0376ade4af36&fallback=getapp
- Problems experienced: Clicking the play button just spawns a new identical tab. Using a default UA string shows the same (working) UI as Safari.
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [x] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked: N/A
- Feature being disabled/modified: UA string
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-domain web-compat config change with no auth or data-handling impact; scope is limited to UA policy on Spotify for macOS clients.
> 
> **Overview**
> Adds **`spotify.com`** to the macOS **`customUserAgent`** `defaultSites` list in `overrides/macos-override.json`, so DuckDuckGo for Mac serves a default user agent on Spotify (same pattern as sites like `hulu.com` and `deezer.com`).
> 
> This targets reported breakage on `open.spotify.com` where the play control opens a duplicate tab instead of starting playback; using a default UA aligns behavior with Safari. The change is **macOS-only** (Android already lists `spotify.com` elsewhere).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit abddaec468dda4e07beb2d4ca456d0f59cdeb4a0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->