### PR TITLE
Set updatedCreateImage to internal, 7.237.0

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -422,6 +422,10 @@
                     "state": "enabled",
                     "minSupportedVersion": "7.235.0"
                 },
+                "updatedCreateImage": {
+                    "state": "internal",
+                    "minSupportedVersion": "7.237.0"
+                },
                 "contextualUnifiedToggleInput": {
                     "state": "enabled",
                     "description": "Contextual Unified Toggle Input (UTI) for Duck.ai",


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1208671677432066/task/1217865341581115?focus=true

## Description
<!-- 
  Please delete either or both process sections below.
-->
Enables updatedCreateImage to internal users

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [x] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single iOS remote-config flag limited to internal users; no app logic or broad rollout in this PR.
> 
> **Overview**
> Adds the **`updatedCreateImage`** sub-feature under **`aiChat`** in `overrides/ios-override.json`, turning on the refreshed Duck.ai image-creation experience for **internal** iOS builds on app version **7.237.0** and newer.
> 
> This sits next to **`updatedModelPicker`** and follows the same remote-config pattern: no rollout percentages, only `state` and `minSupportedVersion`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fdd95ba64efaffac512df14945bcff9bff623056. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->