### PR TITLE
Enable Bitwarden extension on Windows Preview 0.174

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -4883,19 +4883,24 @@
                     "state": "enabled"
                 },
                 "extensionTabHandling": {
-                    "state": "internal"
+                    "state": "preview",
+                    "minSupportedVersion": "0.174.0"
                 },
                 "chromeWebStore": {
-                    "state": "internal"
+                    "state": "preview",
+                    "minSupportedVersion": "0.174.0"
                 },
                 "allowExtensionsUpdate": {
-                    "state": "internal"
+                    "state": "preview",
+                    "minSupportedVersion": "0.174.0"
                 },
                 "chromiumUserAgentBrand": {
-                    "state": "internal"
+                    "state": "preview",
+                    "minSupportedVersion": "0.174.0"
                 },
                 "blockExtensionsOnInternalOrigins": {
-                    "state": "internal"
+                    "state": "preview",
+                    "minSupportedVersion": "0.174.0"
                 },
                 "allowRetriesForServiceWorkerTimeouts": {
                     "state": "enabled",
@@ -5742,55 +5747,24 @@
             }
         },
         "extensions": {
-            "state": "internal",
+            "state": "preview",
+            "minSupportedVersion": "0.174.0",
             "exceptions": [],
             "features": {
                 "extensionPages": {
-                    "state": "internal"
+                    "state": "preview"
                 },
                 "extensionContextMenus": {
-                    "state": "internal"
+                    "state": "preview"
                 },
                 "extensionActionButtons": {
-                    "state": "internal"
-                }
-            }
-        },
-        "passwordManagerExtensions": {
-            "state": "internal",
-            "exceptions": [],
-            "settings": {
-                "manifestXml": "https://staticcdn.duckduckgo.com/d5c04536-5379-4709-8d19-d13fdd456ff6/extensions-test/manifest.xml"
-            },
-            "features": {
-                "bitwarden": {
-                    "state": "internal",
-                    "settings": {
-                        "id": "nngceckbapebfimnlniiiahkandclblb"
-                    }
-                },
-                "lastpass": {
-                    "state": "internal",
-                    "settings": {
-                        "id": "hdokiejnpimakedhajhdlcegeplioahd"
-                    }
-                },
-                "onepassword": {
-                    "state": "internal",
-                    "settings": {
-                        "id": "aeblfdkhhhdcdjpifhhbdiojplfjncoa"
-                    }
-                },
-                "roboform": {
-                    "state": "internal",
-                    "settings": {
-                        "id": "pnlccmojcmeohlpggmfnbbiapkmbliob"
-                    }
+                    "state": "preview"
                 }
             }
         },
         "extensionManagement": {
-            "state": "internal",
+            "state": "preview",
+            "minSupportedVersion": "0.174.0",
             "exceptions": [],
             "settings": {
                 "hiddenExtensionIds": [
@@ -5816,7 +5790,7 @@
             },
             "features": {
                 "curatedExtensions": {
-                    "state": "internal",
+                    "state": "enabled",
                     "settings": {
                         "catalog": [
                             {
@@ -5827,24 +5801,6 @@
                                 "iconUri": "https://staticcdn.duckduckgo.com/d5c04536-5379-4709-8d19-d13fdd456ff6/extensions-test/bitwarden-128.png",
                                 "cwsUri": "https://chromewebstore.google.com/detail/bitwarden-password-manage/nngceckbapebfimnlniiiahkandclblb",
                                 "categoryId": "password-manager"
-                            },
-                            {
-                                "id": "aeblfdkhhhdcdjpifhhbdiojplfjncoa",
-                                "name": "1Password – Password Manager",
-                                "publisher": "AgileBits Inc",
-                                "publisherUri": "https://1password.com/",
-                                "iconUri": "https://staticcdn.duckduckgo.com/d5c04536-5379-4709-8d19-d13fdd456ff6/extensions-test/onepassword-128.png",
-                                "cwsUri": "https://chromewebstore.google.com/detail/1password-%E2%80%93-password-mana/aeblfdkhhhdcdjpifhhbdiojplfjncoa",
-                                "categoryId": "password-manager"
-                            },
-                            {
-                                "id": "hdokiejnpimakedhajhdlcegeplioahd",
-                                "name": "LastPass: Free Password Manager",
-                                "publisher": "LastPass",
-                                "publisherUri": "https://lastpass.com/",
-                                "iconUri": "https://staticcdn.duckduckgo.com/d5c04536-5379-4709-8d19-d13fdd456ff6/extensions-test/lastpass-128.png",
-                                "cwsUri": "https://chromewebstore.google.com/detail/lastpass-free-password-ma/hdokiejnpimakedhajhdlcegeplioahd",
-                                "categoryId": "password-manager"
                             }
                         ]
                     }
@@ -5852,11 +5808,12 @@
             }
         },
         "chromeWebstorePatching": {
-            "state": "internal",
+            "state": "preview",
+            "minSupportedVersion": "0.174.0",
             "exceptions": [],
             "settings": {
                 "patchWebstore": {
-                    "state": "disabled"
+                    "state": "enabled"
                 },
                 "installButtonSelectors": [
                     {

--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -5763,7 +5763,7 @@
             }
         },
         "extensionManagement": {
-            "state": "preview",
+            "state": "enabled",
             "minSupportedVersion": "0.174.0",
             "exceptions": [],
             "settings": {

--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -5813,7 +5813,7 @@
             "exceptions": [],
             "settings": {
                 "patchWebstore": {
-                    "state": "enabled"
+                    "state": "disabled"
                 },
                 "installButtonSelectors": [
                     {


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/72649045549333/task/1216307850019527?focus=true

## Description
Enable Bitwarden extension on Windows Preview 0.174

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> User-facing extension and password-manager rollout on Windows with a version gate; catalog and feature-flag changes could affect which extensions install or appear for preview users.
> 
> **Overview**
> **Promotes Windows extension support to Preview for browser `0.174.0`**, moving the top-level `extensions` stack and related Chromium flags (`extensionTabHandling`, `chromeWebStore`, `allowExtensionsUpdate`, etc.) from `internal` to `preview` with `minSupportedVersion: "0.174.0"`.
> 
> **Turns on extension management for that cohort**: `extensionManagement` and `curatedExtensions` go from `internal` to `enabled` (also gated on `0.174.0`), and `chromeWebstorePatching` moves to `preview`.
> 
> **Consolidates third-party password managers around the curated catalog**: removes the separate `passwordManagerExtensions` block (manifest URL and per-vendor internal entries) and **narrows `curatedExtensions` to Bitwarden only**, dropping 1Password and LastPass from the catalog while keeping their IDs in `specialBehavior` / hidden lists where already configured.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0cd2c1f8308d1b1001edb35ab447458a16858111. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->