### PR TITLE
Enable the BAD_URL error page wide event

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -5719,6 +5719,11 @@
                     "minSupportedVersion": 52930000
                 }
             }
+        },
+        "badUrlErrorPageWideEvent": {
+            "state": "enabled",
+            "minSupportedVersion": 52950000,
+            "exceptions": []
         }
     },
     "unprotectedTemporary": [],


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1216807998862658/task/1218170363449836?focus=true

## Description
<!-- 
  Please delete either or both process sections below.
-->

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [x] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [x] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single Android privacy-config flag for optional telemetry on a specific error page; no auth, blocking, or user-facing behavior changes beyond event emission on supported builds.
> 
> **Overview**
> Turns on the **`badUrlErrorPageWideEvent`** remote feature for Android in `android-override.json`, so clients on **app version ≥ 52950000** can emit the wide event when users hit the **BAD_URL** error page.
> 
> The flag is **enabled** with an empty **`exceptions`** list, matching other standalone wide-event toggles (e.g. `returnSessionWideEvent`). No rollout percentages or nested sub-features are added.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2bac092e5741c806c19385bb5e1247a82270f9f2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->