### PR TITLE
Bump preview links to v5

### DIFF
--- a/.github/workflows/publish-test-url.yml
+++ b/.github/workflows/publish-test-url.yml
@@ -61,9 +61,9 @@ jobs:
               id: generate_preview_links
               run: |
                   PR_NUMBER=${{ github.event.pull_request.number || 'unknown' }}
-                  PREVIEW_LINKS=$(find generated/v4 -type f | while read -r file; do
-                    RELATIVE_PATH=${file#generated/v4/}
-                    echo "- [${RELATIVE_PATH}](https://${{ github.repository_owner }}.github.io/$(basename "${{ github.repository }}")/pr-${PR_NUMBER}/v4/${RELATIVE_PATH})"
+                  PREVIEW_LINKS=$(find generated/v5 -type f | while read -r file; do
+                    RELATIVE_PATH=${file#generated/v5/}
+                    echo "- [${RELATIVE_PATH}](https://${{ github.repository_owner }}.github.io/$(basename "${{ github.repository }}")/pr-${PR_NUMBER}/v5/${RELATIVE_PATH})"
                   done)
                   LAST_UPDATED=$(date -u +"%Y-%m-%d %H:%M:%S UTC")
                   echo "preview_links<<EOF" >> $GITHUB_OUTPUT


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1200890834746050/task/1218288552823885?focus=true

## Description
Bump preview links to v5

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only path change for preview URLs; no application or security impact.
> 
> **Overview**
> Updates the **Publish Test URL** workflow so PR preview comment links are built from **`generated/v5`** instead of **`generated/v4`**.
> 
> The `find` path, relative-path strip, and GitHub Pages URLs in the **Generate preview links** step now use the **`v5`** segment so posted links match the current generated config layout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d9167bf3a50642179199812d51045c3baa1960e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->