### PR TITLE
Rollout custom error pages away transition fix to 10%

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -5742,6 +5742,24 @@
                     }
                 }
             }
+        },
+        "customErrorPages": {
+            "state": "enabled",
+            "minSupportedVersion": 52950000,
+            "exceptions": [],
+            "features": {
+                "keepErrorPageUntilNextPageStartsLoading": {
+                    "state": "enabled",
+                    "minSupportedVersion": 52950000,
+                    "rollout": {
+                        "steps": [
+                            {
+                                "percent": 10
+                            }
+                        ]
+                    }
+                }
+            }
         }
     },
     "unprotectedTemporary": [],


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1216807998862658/task/1218170466406489?focus=true

## Description
<!-- 
  Please delete either or both process sections below.
-->

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [x] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [x] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only Android feature flag with a 10% rollout; affects error-page UX timing, not auth or data handling.
> 
> **Overview**
> Adds Android remote config for **custom error pages** (`customErrorPages`), gated to app version **52950000+**.
> 
> Enables sub-feature **`keepErrorPageUntilNextPageStartsLoading`** at a **10%** rollout so a slice of users keeps the custom error UI visible until the next navigation actually starts loading (addressing the “away” transition flicker).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f7a18fd5b6be7d77d023bc7e2588f47311f4f68d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->