### PR TITLE
Fix video playing on DiamondCentric network

### DIFF
--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -1092,15 +1092,6 @@
                 ]
             },
             {
-                "domain": "brewerfanatic.com",
-                "rules": [
-                    {
-                        "selector": ".adthrive-ad",
-                        "type": "hide"
-                    }
-                ]
-            },
-            {
                 "domain": "business-standard.com",
                 "rules": [
                     {

--- a/features/element-hiding.json
+++ b/features/element-hiding.json
@@ -1092,6 +1092,15 @@
                 ]
             },
             {
+                "domain": "brewerfanatic.com",
+                "rules": [
+                    {
+                        "selector": ".adthrive-ad",
+                        "type": "hide"
+                    }
+                ]
+            },
+            {
                 "domain": "business-standard.com",
                 "rules": [
                     {

--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -1905,7 +1905,17 @@
                             "natashaskitchen.com",
                             "theperfectloaf.com",
                             "thewoksoflife.com",
-                            "spendwithpennies.com"
+                            "spendwithpennies.com",
+                            "brewerfanatic.com",
+                            "fishonfirst.com",
+                            "northsidebaseball.com",
+                            "twinsdaily.com",
+                            "talksox.com",
+                            "jayscentre.com",
+                            "padresmission.com",
+                            "royalskeep.com",
+                            "grandcentralmets.com",
+                            "diamondcentric.net"
                         ],
                         "reason": [
                             "applesfera.com - https://github.com/duckduckgo/privacy-configuration/issues/1723",
@@ -1921,7 +1931,8 @@
                             "nytimes.com - https://github.com/duckduckgo/privacy-configuration/pull/4549",
                             "vidbox.dev - domain propagation from doubleclick.net catch-all",
                             "nypost.com - Anti-adblock wall blocks the article and prevents page interaction. https://github.com/duckduckgo/privacy-configuration/pull/5575",
-                            "https://github.com/duckduckgo/privacy-configuration/pull/5582"
+                            "https://github.com/duckduckgo/privacy-configuration/pull/5582",
+                            "brewerfanatic.com - https://github.com/duckduckgo/privacy-configuration/pull/5918"
                         ]
                     },
                     {

--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -368,14 +368,15 @@
                             "natashaskitchen.com",
                             "theperfectloaf.com",
                             "thewoksoflife.com",
-                            "spendwithpennies.com"
+                            "spendwithpennies.com",
+                            "brewerfanatic.com"
                         ],
                         "reason": [
                             "gardeningknowhow.com, adamtheautomator.com, packhacker.com - https://github.com/duckduckgo/privacy-configuration/issues/1122",
                             "cookingclassy.com - https://github.com/duckduckgo/privacy-configuration/pull/3325",
                             "modernhoney.com - https://github.com/duckduckgo/privacy-configuration/pull/4111",
-                            "https://github.com/duckduckgo/privacy-configuration/pull/5582"
-                        ]
+                            "https://github.com/duckduckgo/privacy-configuration/pull/5582",
+                            "brewerfanatic.com - https://github.com/duckduckgo/privacy-configuration/pull/5918"
                     }
                 ]
             },
@@ -1927,14 +1928,16 @@
                             "natashaskitchen.com",
                             "theperfectloaf.com",
                             "thewoksoflife.com",
-                            "spendwithpennies.com"
+                            "spendwithpennies.com",
+                            "brewerfanatic.com"
                         ],
                         "reason": [
                             "nypost.com - Anti-adblock wall blocks the article and prevents page interaction. Requires full securepubads.g.doubleclick.net (GPT ad requests + viewability beacons) for the wall render check to pass. https://github.com/duckduckgo/privacy-configuration/pull/5575",
                             "rocketnews24.com - domain propagation from doubleclick.net catch-all",
                             "wunderground.com - domain propagation from doubleclick.net catch-all",
                             "vidbox.dev - domain propagation from doubleclick.net catch-all",
-                            "https://github.com/duckduckgo/privacy-configuration/pull/5582"
+                            "https://github.com/duckduckgo/privacy-configuration/pull/5582",
+                            "brewerfanatic.com - https://github.com/duckduckgo/privacy-configuration/pull/5918"
                         ]
                     },
                     {

--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -386,6 +386,7 @@
                             "modernhoney.com - https://github.com/duckduckgo/privacy-configuration/pull/4111",
                             "https://github.com/duckduckgo/privacy-configuration/pull/5582",
                             "brewerfanatic.com - https://github.com/duckduckgo/privacy-configuration/pull/5918"
+                        ]
                     }
                 ]
             },

--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -369,7 +369,16 @@
                             "theperfectloaf.com",
                             "thewoksoflife.com",
                             "spendwithpennies.com",
-                            "brewerfanatic.com"
+                            "brewerfanatic.com",
+                            "fishonfirst.com",
+                            "northsidebaseball.com",
+                            "twinsdaily.com",
+                            "talksox.com",
+                            "jayscentre.com",
+                            "padresmission.com",
+                            "royalskeep.com",
+                            "grandcentralmets.com",
+                            "diamondcentric.net"
                         ],
                         "reason": [
                             "gardeningknowhow.com, adamtheautomator.com, packhacker.com - https://github.com/duckduckgo/privacy-configuration/issues/1122",
@@ -1929,7 +1938,16 @@
                             "theperfectloaf.com",
                             "thewoksoflife.com",
                             "spendwithpennies.com",
-                            "brewerfanatic.com"
+                            "brewerfanatic.com",
+                            "fishonfirst.com",
+                            "northsidebaseball.com",
+                            "twinsdaily.com",
+                            "talksox.com",
+                            "jayscentre.com",
+                            "padresmission.com",
+                            "royalskeep.com",
+                            "grandcentralmets.com",
+                            "diamondcentric.net"
                         ],
                         "reason": [
                             "nypost.com - Anti-adblock wall blocks the article and prevents page interaction. Requires full securepubads.g.doubleclick.net (GPT ad requests + viewability beacons) for the wall render check to pass. https://github.com/duckduckgo/privacy-configuration/pull/5575",

--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -335,12 +335,23 @@
                             "natashaskitchen.com",
                             "theperfectloaf.com",
                             "thewoksoflife.com",
-                            "spendwithpennies.com"
+                            "spendwithpennies.com",
+                            "brewerfanatic.com",
+                            "fishonfirst.com",
+                            "northsidebaseball.com",
+                            "twinsdaily.com",
+                            "talksox.com",
+                            "jayscentre.com",
+                            "padresmission.com",
+                            "royalskeep.com",
+                            "grandcentralmets.com",
+                            "diamondcentric.net"
                         ],
                         "reason": [
                             "biancazapatka.com - https://github.com/duckduckgo/privacy-configuration/pull/4995",
                             "gardeningknowhow.com, adamtheautomator.com, packhacker.com, cookingclassy.com, modernhoney.com - domain propagation from adthrive.com rule",
-                            "https://github.com/duckduckgo/privacy-configuration/pull/5582"
+                            "https://github.com/duckduckgo/privacy-configuration/pull/5582",
+                            "brewerfanatic.com - https://github.com/duckduckgo/privacy-configuration/pull/5918"
                         ]
                     },
                     {

--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -1367,7 +1367,17 @@
                             "natashaskitchen.com",
                             "theperfectloaf.com",
                             "thewoksoflife.com",
-                            "spendwithpennies.com"
+                            "spendwithpennies.com",
+                            "brewerfanatic.com",
+                            "fishonfirst.com",
+                            "northsidebaseball.com",
+                            "twinsdaily.com",
+                            "talksox.com",
+                            "jayscentre.com",
+                            "padresmission.com",
+                            "royalskeep.com",
+                            "grandcentralmets.com",
+                            "diamondcentric.net"
                         ],
                         "reason": [
                             "ah.nl - 'Bonus offer' elements do not render and are not clickable.",
@@ -1378,7 +1388,8 @@
                             "modernhoney.com - https://github.com/duckduckgo/privacy-configuration/pull/4111",
                             "vidbox.dev - domain propagation from doubleclick.net catch-all",
                             "nypost.com - Anti-adblock wall blocks the article and prevents page interaction. https://github.com/duckduckgo/privacy-configuration/pull/5575",
-                            "https://github.com/duckduckgo/privacy-configuration/pull/5582"
+                            "https://github.com/duckduckgo/privacy-configuration/pull/5582",
+                            "brewerfanatic.com - https://github.com/duckduckgo/privacy-configuration/pull/5918"
                         ]
                     },
                     {

--- a/features/tracker-allowlist.json
+++ b/features/tracker-allowlist.json
@@ -1722,7 +1722,17 @@
                             "natashaskitchen.com",
                             "theperfectloaf.com",
                             "thewoksoflife.com",
-                            "spendwithpennies.com"
+                            "spendwithpennies.com",
+                            "brewerfanatic.com",
+                            "fishonfirst.com",
+                            "northsidebaseball.com",
+                            "twinsdaily.com",
+                            "talksox.com",
+                            "jayscentre.com",
+                            "padresmission.com",
+                            "royalskeep.com",
+                            "grandcentralmets.com",
+                            "diamondcentric.net"
                         ],
                         "reason": [
                             "ah.nl - 'Bonus offer' elements do not render and are not clickable.",
@@ -1754,7 +1764,8 @@
                             "olx.ba - https://github.com/duckduckgo/privacy-configuration/pull/5185",
                             "ign.com - https://github.com/duckduckgo/privacy-configuration/pull/5330",
                             "nypost.com - Anti-adblock wall blocks the article and prevents page interaction. https://github.com/duckduckgo/privacy-configuration/pull/5575",
-                            "https://github.com/duckduckgo/privacy-configuration/pull/5582"
+                            "https://github.com/duckduckgo/privacy-configuration/pull/5582",
+                            "brewerfanatic.com - https://github.com/duckduckgo/privacy-configuration/pull/5918"
                         ]
                     },
                     {
@@ -1784,7 +1795,17 @@
                             "natashaskitchen.com",
                             "theperfectloaf.com",
                             "thewoksoflife.com",
-                            "spendwithpennies.com"
+                            "spendwithpennies.com",
+                            "brewerfanatic.com",
+                            "fishonfirst.com",
+                            "northsidebaseball.com",
+                            "twinsdaily.com",
+                            "talksox.com",
+                            "jayscentre.com",
+                            "padresmission.com",
+                            "royalskeep.com",
+                            "grandcentralmets.com",
+                            "diamondcentric.net"
                         ],
                         "reason": [
                             "ah.nl - 'Bonus offer' elements do not render and are not clickable.",
@@ -1793,7 +1814,8 @@
                             "vidbox.dev - domain propagation from doubleclick.net catch-all",
                             "ign.com - https://github.com/duckduckgo/privacy-configuration/pull/5330",
                             "nypost.com - Anti-adblock wall blocks the article and prevents page interaction. https://github.com/duckduckgo/privacy-configuration/pull/5575",
-                            "https://github.com/duckduckgo/privacy-configuration/pull/5582"
+                            "https://github.com/duckduckgo/privacy-configuration/pull/5582",
+                            "brewerfanatic.com - https://github.com/duckduckgo/privacy-configuration/pull/5918"
                         ]
                     },
                     {
@@ -1823,7 +1845,17 @@
                             "natashaskitchen.com",
                             "theperfectloaf.com",
                             "thewoksoflife.com",
-                            "spendwithpennies.com"
+                            "spendwithpennies.com",
+                            "brewerfanatic.com",
+                            "fishonfirst.com",
+                            "northsidebaseball.com",
+                            "twinsdaily.com",
+                            "talksox.com",
+                            "jayscentre.com",
+                            "padresmission.com",
+                            "royalskeep.com",
+                            "grandcentralmets.com",
+                            "diamondcentric.net"
                         ],
                         "reason": [
                             "https://github.com/duckduckgo/privacy-configuration/issues/415",
@@ -1832,7 +1864,8 @@
                             "repretel.com - broken videos",
                             "vidbox.dev - domain propagation from doubleclick.net catch-all",
                             "nypost.com - Anti-adblock wall blocks the article and prevents page interaction. https://github.com/duckduckgo/privacy-configuration/pull/5575",
-                            "https://github.com/duckduckgo/privacy-configuration/pull/5582"
+                            "https://github.com/duckduckgo/privacy-configuration/pull/5582",
+                            "brewerfanatic.com - https://github.com/duckduckgo/privacy-configuration/pull/5918"
                         ]
                     },
                     {
@@ -1861,7 +1894,17 @@
                             "natashaskitchen.com",
                             "theperfectloaf.com",
                             "thewoksoflife.com",
-                            "spendwithpennies.com"
+                            "spendwithpennies.com",
+                            "brewerfanatic.com",
+                            "fishonfirst.com",
+                            "northsidebaseball.com",
+                            "twinsdaily.com",
+                            "talksox.com",
+                            "jayscentre.com",
+                            "padresmission.com",
+                            "royalskeep.com",
+                            "grandcentralmets.com",
+                            "diamondcentric.net"
                         ],
                         "reason": [
                             "sbs.com.au - https://github.com/duckduckgo/privacy-configuration/pull/2436",
@@ -1869,7 +1912,8 @@
                             "wunderground.com - https://github.com/duckduckgo/privacy-configuration/pull/3096",
                             "vidbox.dev - domain propagation from doubleclick.net catch-all",
                             "nypost.com - Anti-adblock wall blocks the article and prevents page interaction. https://github.com/duckduckgo/privacy-configuration/pull/5575",
-                            "https://github.com/duckduckgo/privacy-configuration/pull/5582"
+                            "https://github.com/duckduckgo/privacy-configuration/pull/5582",
+                            "brewerfanatic.com - https://github.com/duckduckgo/privacy-configuration/pull/5918"
                         ]
                     },
                     {


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/1204912272578138/task/1217313926439192?focus=true

## Description
### Site breakage mitigation process:
#### Brief explanation
- Reported URL: https://brewerfanatic.com/videos/milwaukee-brewers/is-the-brewers-rotation-better-than-the-dodgers-r451/
- Problems experienced: Video not playing due to Adthrive and securepubads being blocked.
- Platforms affected:
  - [x] iOS
  - [x] Android
  - [x] Windows
  - [x] MacOS
  - [x] Extensions
- Tracker(s) being unblocked: Adthrive and securepubads
- Feature being disabled/modified: N/A
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only tracker allowlist expansion on named third-party sites; no app logic changes, but it deliberately permits more ad-related requests on those domains.
> 
> **Overview**
> Adds **ten Diamond Centric baseball fan sites** (including `brewerfanatic.com` and `diamondcentric.net`) to the tracker allowlist so **Adthrive** and **Google Publisher / `securepubads.g.doubleclick.net`** resources are not blocked on those domains.
> 
> The same domain list is appended in parallel across multiple existing rules—`ads.adthrive.com/abd/abd.js`, the `adthrive.com` catch-all, and several DoubleClick GPT/pubads rules—following the same propagation pattern used for recipe publishers in PR #5582. Reason metadata cites brewerfanatic breakage fix PR #5918.
> 
> **Intent:** restore video playback where blocking those ad stack scripts broke the player (reported on Brewer Fanatic).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cec7110d670fc43d3b36e3ba2c8c17572024bff3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->