### PR TITLE
Update content-blocker extension to 2026.9.9

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -5146,7 +5146,7 @@
             "minSupportedVersion": "0.148.0",
             "exceptions": [],
             "settings": {
-                "extensionUrl": "https://staticcdn.duckduckgo.com/extensions/content-blocker/content-blocker-extension-2026.9.2.crx"
+                "extensionUrl": "https://staticcdn.duckduckgo.com/extensions/content-blocker/content-blocker-extension-2026.9.9.crx"
             },
             "features": {
                 "onboardingEnabled": {


### PR DESCRIPTION
Update content-blocker extension to 2026.9.9.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single CDN URL bump in Windows override config; no auth or app logic changes.
> 
> **Overview**
> Bumps the Windows remote-config **`adBlockV2Extension`** CDN package from **2026.9.2** to **2026.9.9** by updating `settings.extensionUrl` in `windows-override.json`. No other feature flags or `minSupportedVersion` values change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe15464b745a970e0f7e414c6d01cd05896ab7f3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->