### PR TITLE
Update ad-blocking extension scriptlets for v2026.9.9

### DIFF
--- a/features/ad-blocking-extension.json
+++ b/features/ad-blocking-extension.json
@@ -4,28 +4,28 @@
     },
     "exceptions": [],
     "settings": {
-        "version": "2026.9.2",
+        "version": "2026.9.9",
         "enabledByDefault": false,
         "scriptlets": {
             "scriptlets/isolated/ublock-filters.js": {
-                "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/5f41c2de023c0378bcf3da0472c9085633c3fe4079af82786928fefcccdfdaa2.js",
-                "signature": "MEQCICtEilob0O42L74Emjyi2P8n1arM3eCJyn2qMg/oT/p6AiBEpjfDZBPB6oor1Bes82UlXkkyYeYQaoYgf6mEkhXCAA=="
+                "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/d2e960fb51ed72d44be3067dac16efde16510551329c85f17924ed55fdbabef1.js",
+                "signature": "MEUCIDi8sAms78kAabES6iuRuAxfA70ccO/YsKwuhwOl21kcAiEAhXL+Zq2IBoB6Z7fkCpNbEvvlTNfql6YxBsgh+03I2YQ="
             },
             "scriptlets/main/ublock-filters.js": {
-                "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/75f8fbc1cd768f02885fa66daf8a7343e70df1df0386a83db99ec7c3cdbf5ce6.js",
-                "signature": "MEQCICLHLfkmf1MjqzIIucodD3VYPANHb8jhYlBtOmnn9hArAiBFiTWtru2YY7GoiL46w7jvXPBcz3cIsylID9Hi/hUjhA=="
+                "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/983880c072de4138c757feb7bf604c69e755b28216619a4d665c0ce948ac0c23.js",
+                "signature": "MEQCIDQyGisEjDJxrUIqkehGJhTwJJU6pRCubN2UyZVHzVSOAiB8FnQOdIjGjD3a0hcPCADSr48nec79LlwRuh+ylGEg9A=="
             },
             "scriptlets/main/ublock-experimental.js": {
                 "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855.js",
-                "signature": "MEUCIQDy9VcN+Z/sFMN59xWrIwlS4zhVCdQNgaA8QtAeDqwSuwIgRvBW5CX25tZpEmlmHV1+GBRAlICJnxe/ymQSI0aQI9Q="
+                "signature": "MEUCIQC0TVXKdaP0EOs1XQeZBE6vqvWoLwyc43alZVRlNapspAIgBpnKnaFBBUIt2evExyqn0zWJzKw68lYYCRVx4oAtZX4="
             },
             "scriptlets/isolated/ublock-experimental.js": {
                 "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855.js",
-                "signature": "MEQCIBythw2VTjYFKp/I2921OQnXxTI7RtqJ4OVvNPsnfzBMAiAFYJToOsMmgmgTXviCDZ1KETuZDCQsPI+x64AMcXtJUQ=="
+                "signature": "MEQCIGT3s2QvfYv2bjIlXL40aZOOgev7JMJyWc/UeYW7MqWdAiBYbNaGwkY1Lrs+wrYCxPIx7UWmFNNA3ppC4G4gI2nw+A=="
             },
             "rules/youtube.json": {
                 "url": "https://staticcdn.duckduckgo.com/extensions/content-blocker/scriptlets/2337db6aa7466667595226f780b6590779db3007ac0a65ef3833f89610c92824.json",
-                "signature": "MEYCIQD2O+dKjX5aZ9Bx3uKrthrqJlhcJvc/K4UXI0JBUgxEdQIhAOs7VEwLp59VSpzkyXK0QYAGWV8CNQoyc/TrZVHWoeQi"
+                "signature": "MEUCIQCMiLTx0ILFi5b3KnCTpjw8+NSyu/23S0qRPtx9F/AnagIgWkm8Zc3J6tM47lZu5bBRUK3ZWagv4SgvN9bDpblw5Kw="
             }
         }
     }


### PR DESCRIPTION
Update ad-blocking extension scriptlets for v2026.9.9.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Clients load and verify signed scriptlet assets from CDN; bad URLs or signatures could break the extension or change ad-blocking behavior on macOS/iOS.
> 
> **Overview**
> Bumps the macOS/iOS ad-blocking extension config from **2026.9.2** to **2026.9.9** in `features/ad-blocking-extension.json`.
> 
> **uBlock filter scriptlets** (`scriptlets/isolated/ublock-filters.js` and `scriptlets/main/ublock-filters.js`) now point at new CDN hashes and carry updated integrity signatures. **Experimental uBlock scriptlets** keep the same URLs but get new signatures. **`rules/youtube.json`** keeps the same URL with an updated signature.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 92b0d8d41872579ed46a10b98b556c00c74a5525. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->