### PR TITLE
Added eventHub data for video detector

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -5564,7 +5564,7 @@
                                     "21-39": { "gte": 21, "lt": 40 },
                                     "40+": { "gte": 40 }
                                 }
-                            },
+                            }
                         }
                     },
                     "webTelemetry_video_unavailable_week": {

--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -5518,6 +5518,78 @@
                                 }
                             }
                         }
+                    },
+                    "webTelemetry_video_blocked": {
+                        "state": "enabled",
+                        "trigger": {
+                            "type": "immediate",
+                            "source": "video_blocked"
+                        },
+                        "parameters": {}
+                    },
+                    "webTelemetry_video_error": {
+                        "state": "enabled",
+                        "trigger": {
+                            "type": "immediate",
+                            "source": "video_error"
+                        },
+                        "parameters": {}
+                    },
+                    "webTelemetry_video_placeholder": {
+                        "state": "enabled",
+                        "trigger": {
+                            "type": "immediate",
+                            "source": "video_placeholder"
+                        },
+                        "parameters": {}
+                    },
+                    "webTelemetry_video_unavailable_day": {
+                        "state": "enabled",
+                        "trigger": {
+                            "period": {
+                                "days": 1
+                            }
+                        },
+                        "parameters": {
+                            "count": {
+                                "template": "counter",
+                                "source": "video_unavailable",
+                                "buckets": {
+                                    "0": { "gte": 0, "lt": 1 },
+                                    "1": { "gte": 1, "lt": 2 },
+                                    "2-3": { "gte": 2, "lt": 4 },
+                                    "4-7": { "gte": 4, "lt": 8 },
+                                    "8-14": { "gte": 8, "lt": 15 },
+                                    "15-20": { "gte": 15, "lt": 21 },
+                                    "21-39": { "gte": 21, "lt": 40 },
+                                    "40+": { "gte": 40 }
+                                }
+                            },
+                        }
+                    },
+                    "webTelemetry_video_unavailable_week": {
+                        "state": "enabled",
+                        "trigger": {
+                            "period": {
+                                "days": 7
+                            }
+                        },
+                        "parameters": {
+                            "count": {
+                                "template": "counter",
+                                "source": "video_unavailable",
+                                "buckets": {
+                                    "0": { "gte": 0, "lt": 1 },
+                                    "1": { "gte": 1, "lt": 2 },
+                                    "2-3": { "gte": 2, "lt": 4 },
+                                    "4-7": { "gte": 4, "lt": 8 },
+                                    "8-14": { "gte": 8, "lt": 15 },
+                                    "15-20": { "gte": 15, "lt": 21 },
+                                    "21-39": { "gte": 21, "lt": 40 },
+                                    "40+": { "gte": 40 }
+                                }
+                            }
+                        }
                     }
                 }
             }

--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -5519,30 +5519,6 @@
                             }
                         }
                     },
-                    "webTelemetry_video_blocked": {
-                        "state": "enabled",
-                        "trigger": {
-                            "type": "immediate",
-                            "source": "video_blocked"
-                        },
-                        "parameters": {}
-                    },
-                    "webTelemetry_video_error": {
-                        "state": "enabled",
-                        "trigger": {
-                            "type": "immediate",
-                            "source": "video_error"
-                        },
-                        "parameters": {}
-                    },
-                    "webTelemetry_video_placeholder": {
-                        "state": "enabled",
-                        "trigger": {
-                            "type": "immediate",
-                            "source": "video_placeholder"
-                        },
-                        "parameters": {}
-                    },
                     "webTelemetry_video_unavailable_day": {
                         "state": "enabled",
                         "trigger": {

--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -6139,6 +6139,78 @@
                             "source": "captcha_other"
                         },
                         "parameters": {}
+                    },
+                    "webTelemetry_video_blocked": {
+                        "state": "enabled",
+                        "trigger": {
+                            "type": "immediate",
+                            "source": "video_blocked"
+                        },
+                        "parameters": {}
+                    },
+                    "webTelemetry_video_error": {
+                        "state": "enabled",
+                        "trigger": {
+                            "type": "immediate",
+                            "source": "video_error"
+                        },
+                        "parameters": {}
+                    },
+                    "webTelemetry_video_placeholder": {
+                        "state": "enabled",
+                        "trigger": {
+                            "type": "immediate",
+                            "source": "video_placeholder"
+                        },
+                        "parameters": {}
+                    },
+                    "webTelemetry_video_unavailable_day": {
+                        "state": "enabled",
+                        "trigger": {
+                            "period": {
+                                "days": 1
+                            }
+                        },
+                        "parameters": {
+                            "count": {
+                                "template": "counter",
+                                "source": "video_unavailable",
+                                "buckets": {
+                                    "0": { "gte": 0, "lt": 1 },
+                                    "1": { "gte": 1, "lt": 2 },
+                                    "2-3": { "gte": 2, "lt": 4 },
+                                    "4-7": { "gte": 4, "lt": 8 },
+                                    "8-14": { "gte": 8, "lt": 15 },
+                                    "15-20": { "gte": 15, "lt": 21 },
+                                    "21-39": { "gte": 21, "lt": 40 },
+                                    "40+": { "gte": 40 }
+                                }
+                            },
+                        }
+                    },
+                    "webTelemetry_video_unavailable_week": {
+                        "state": "enabled",
+                        "trigger": {
+                            "period": {
+                                "days": 7
+                            }
+                        },
+                        "parameters": {
+                            "count": {
+                                "template": "counter",
+                                "source": "video_unavailable",
+                                "buckets": {
+                                    "0": { "gte": 0, "lt": 1 },
+                                    "1": { "gte": 1, "lt": 2 },
+                                    "2-3": { "gte": 2, "lt": 4 },
+                                    "4-7": { "gte": 4, "lt": 8 },
+                                    "8-14": { "gte": 8, "lt": 15 },
+                                    "15-20": { "gte": 15, "lt": 21 },
+                                    "21-39": { "gte": 21, "lt": 40 },
+                                    "40+": { "gte": 40 }
+                                }
+                            }
+                        }
                     }
                 }
             }

--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -6185,7 +6185,7 @@
                                     "21-39": { "gte": 21, "lt": 40 },
                                     "40+": { "gte": 40 }
                                 }
-                            },
+                            }
                         }
                     },
                     "webTelemetry_video_unavailable_week": {


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/72649045549333/task/1217886097730457?focus=true

## Description

This is to implement pixels for the video breakage detector configured in #5906.
`immediate` pixels are in Windows only, pending Android support.

### Feature change process:

- [x] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change. Should use this schema: https://github.com/duckduckgo/privacy-configuration/blob/main/schema/features/web-detection.ts
- [x] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [x] This feature was covered by a tech design. See: https://app.asana.com/1/137249556945/project/72649045549333/task/1217886097730455?focus=true

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Privacy-configuration telemetry wiring only; no application logic or security-sensitive behavior changes.
> 
> **Overview**
> Adds **eventHub** `webTelemetry_*` entries so clients can emit pixels for the video breakage detector (paired with prior `webDetection` work).
> 
> On **Android**, this enables **daily and weekly** bucketed counters for `video_unavailable` (`webTelemetry_video_unavailable_day` / `_week`), using the same counter template and bucket ranges as in the Windows config.
> 
> On **Windows**, it adds **immediate** telemetry for `video_blocked`, `video_error`, and `video_placeholder`, plus the same **day/week** `video_unavailable` counters. All new entries are `state: "enabled"`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eaa56a4481283c61c467b647e58f338dca1b62fa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->