### PR TITLE
Enable sendDuckAiSessionWideEvent flag on Android

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -986,6 +986,10 @@
                 "contextualSheetRedesign": {
                     "state": "enabled",
                     "minSupportedVersion": 52950000
+                },
+                "sendDuckAiSessionWideEvent": {
+                    "state": "enabled",
+                    "minSupportedVersion": 52950000
                 }
             }
         },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1212810093780571/task/1218364439640177?focus=true

## Description
Enabling sendDuckAiSessionWideEvent which controls the wide event that measures duck.ai sessions.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [x] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single Android remote-config flag enabling Duck.ai session telemetry; no logic or security-path changes in this diff.
> 
> **Overview**
> Turns on the **`sendDuckAiSessionWideEvent`** sub-feature under **`aiChat`** in the Android privacy config override so eligible app builds (≥ `52950000`) emit the Duck.ai session **wide event** used for session measurement.
> 
> This is config-only: no application code changes in this PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce1f126f1276d0c33351c517eac2f08744531693. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->