### PR TITLE
Rollout custom error pages away transition fix to 20%

### DIFF
--- a/overrides/android-override.json
+++ b/overrides/android-override.json
@@ -5853,6 +5853,9 @@
                         "steps": [
                             {
                                 "percent": 10
+                            },
+                            {
+                                "percent": 20
                             }
                         ]
                     }


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1216807998862658/task/1218170466406491?focus=true

## Description
<!-- 
  Please delete either or both process sections below.
-->

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [x] I have tested this change locally in all supported browsers.
- [x] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [x] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Remote config rollout bump only; expands exposure of custom error page transition behavior without changing app code or security-sensitive logic.
> 
> **Overview**
> Advances the Android rollout for **`keepErrorPageUntilNextPageStartsLoading`** (under `customErrorPages`) by adding a **20%** rollout step after the existing **10%** step. More users on app version ≥ 52950000 will get the behavior that keeps the custom error page visible until the next navigation actually starts loading.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 39120890d9fcbde3df3ff377631db6884af9ecf0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->