### PR TITLE
Narrowed matching pattern for "video unavailable"

### DIFF
--- a/features/web-detection.json
+++ b/features/web-detection.json
@@ -496,7 +496,7 @@
                     "match": {
                         "text": {
                             "pattern": [
-                                "not available in your (country|region|location|area)",
+                                "(content|video|media) is not available in your (country|region|location|area)",
                                 "due to (rights|licensing) restrictions",
                                 "n.est pas disponible dans (votre pays|le pays)"
                             ]


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/task/1217886097730457?focus=true

## Description

A small update to the pattern-matching text to reduce false positives for video availability detection.

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single regex tweak in remote config for page-text detection; may miss rare wording that lacked a content/video/media prefix but reduces misclassified `video_unavailable` events.
> 
> **Overview**
> Tightens the **video unavailable** text detector in `web-detection.json` by requiring a **content/video/media** subject before the geo-restriction phrase.
> 
> The first pattern changes from matching bare `"not available in your (country|region|…)"` to `"(content|video|media) is not available in your (country|region|…)"`, which should cut false positives while keeping the other unavailable patterns (rights/licensing, French copy) unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e890ce393af26121803d5c7b7b19f7c7b9ba1f56. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->