### PR TITLE
Enable the non-blocking onboarding experiment on macOS

### DIFF
--- a/overrides/macos-override.json
+++ b/overrides/macos-override.json
@@ -2946,6 +2946,20 @@
                         ]
                     }
                 },
+                "onboardingNonBlocking": {
+                    "state": "enabled",
+                    "minSupportedVersion": "1.207.0",
+                    "cohorts": [
+                        {
+                            "name": "control",
+                            "weight": 1
+                        },
+                        {
+                            "name": "treatment",
+                            "weight": 1
+                        }
+                    ]
+                },
                 "onboardingChromeExtension": {
                     "state": "enabled",
                     "minSupportedVersion": "1.202.0",


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/task/1218387527866076?focus=true

## Description

Enables the `onboardingNonBlocking` experiment under `macOSBrowserConfig` for macOS 1.207.0 and later, with control and treatment cohorts weighted equally.

The experiment measures whether letting new users browse before finishing onboarding improves retention and the actions taken during onboarding. The app-side implementation is duckduckgo/apple-browsers#6785, which resolves this subfeature's cohort and reads the treatment cohort as non-blocking onboarding.

### Feature change process:

- [x] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change. The existing `MacOSBrowserConfig` schema accepts subfeatures without settings, so no schema change is needed.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes first-run onboarding behavior for a subset of new macOS users via remote config, which can affect retention metrics but is limited to an A/B cohort with a version gate.
> 
> **Overview**
> Turns on the **`onboardingNonBlocking`** remote-config experiment under **`macOSBrowserConfig`** for DuckDuckGo macOS **1.207.0+**, alongside existing onboarding flags like `onboardingChromeExtension`.
> 
> Eligible clients get a **50/50** split between **control** and **treatment** cohorts so the app can compare blocking vs **non-blocking** first-run onboarding (browse before finishing setup). This is config-only; behavior lives in the macOS browser build that reads the cohort.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 72c928e3d6302997b2bcf3ad29c8eb2c190ab7f2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->