### PR TITLE
Feature flag for iPad duck.ai button

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -449,7 +449,7 @@
                     "minSupportedVersion": "7.229.0"
                 },
                 "iPadChromeMenuButton": {
-                    "state": "internal",
+                    "state": "enabled",
                     "description": "Single Duck.ai menu button in the iPad tabs bar",
                     "minSupportedVersion": "7.238.0"
                 },

--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -448,6 +448,11 @@
                     "state": "enabled",
                     "minSupportedVersion": "7.229.0"
                 },
+                "iPadChromeMenuButton": {
+                    "state": "internal",
+                    "description": "Single Duck.ai menu button in the iPad tabs bar",
+                    "minSupportedVersion": "7.238.0"
+                },
                 "supportsSyncChatsDeletion": {
                     "state": "enabled",
                     "minSupportedVersion": "7.208.2"


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/1201011656765697/task/1218326687494667?focus=true

## Description
Feature flag for iPad duck.ai button

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> iOS privacy-configuration override only; enables a UI feature flag with a version floor and no auth or data-handling changes.
> 
> **Overview**
> Adds an iOS remote-config feature flag **`iPadChromeMenuButton`** under **`aiChat.features`** in `overrides/ios-override.json`. The flag is **enabled** with **`minSupportedVersion` `7.238.0`** and documents a **single Duck.ai menu button in the iPad tabs bar**, alongside existing iPad Duck.ai controls like `iPadDuckAIBarControls`.
> 
> This is config-only: it lets the iOS app gate the new chrome menu entry remotely without changing runtime logic in this repo.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bb898922b4e46fddcdf601852dc3f30f9804d6f2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->