### PR TITLE
Add usage warning feature flag on iOS

### DIFF
--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -431,6 +431,11 @@
                     "description": "Contextual Unified Toggle Input (UTI) for Duck.ai",
                     "minSupportedVersion": "7.230.0"
                 },
+                "usageWarnings": {
+                    "state": "enabled",
+                    "description": "Warn users as they approach their daily/weekly Duck.ai limits",
+                    "minSupportedVersion": "7.235.0"
+                },
                 "aiChatAtb": {
                     "state": "enabled",
                     "description": "Add ATB to Duck.ai",

--- a/overrides/ios-override.json
+++ b/overrides/ios-override.json
@@ -434,7 +434,7 @@
                 "usageWarnings": {
                     "state": "enabled",
                     "description": "Warn users as they approach their daily/weekly Duck.ai limits",
-                    "minSupportedVersion": "7.235.0"
+                    "minSupportedVersion": "7.238.0"
                 },
                 "aiChatAtb": {
                     "state": "enabled",


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/1201011656765697/task/1218122847911023?focus=true

## Description
Add usage warning feature flag on iOS

### Feature change process:

- [ ] I have added a [schema](https://github.com/duckduckgo/privacy-configuration/tree/main/schema) to validate this feature change.
- [ ] I have tested this change locally in all supported browsers.
- [ ] This code for the config change is ready to merge.
- [ ] This feature was covered by a tech design.

### Site breakage mitigation process:
#### Brief explanation
- Reported URL:
- Problems experienced:
- Platforms affected:
  - [ ] iOS
  - [ ] Android
  - [ ] Windows
  - [ ] MacOS
  - [ ] Extensions
- Tracker(s) being unblocked:
- Feature being disabled/modified:
- [ ] This change is a speculative mitigation to fix reported breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only iOS remote feature toggle with a version gate; no logic or shared defaults changed in this repo.
> 
> **Overview**
> Adds an iOS-only **`usageWarnings`** sub-feature under **`aiChat`** in `overrides/ios-override.json`, **enabled** from app version **7.238.0**, so clients can show warnings as users near daily/weekly Duck.ai usage limits.
> 
> No rollout cohorts or extra settings—same pattern as neighboring Duck.ai feature toggles.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 416d06f1747d45612a93057eefb73973b98ade3b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->