### PR TITLE
Change AiChat | pdfPageContext state from 'disabled' to 'internal'

### DIFF
--- a/overrides/windows-override.json
+++ b/overrides/windows-override.json
@@ -1322,7 +1322,7 @@
                     "state": "enabled"
                 },
                 "pdfPageContext": {
-                    "state": "disabled"
+                    "state": "internal"
                 },
                 "multiplePageContexts": {
                     "state": "enabled",


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1208671677432066/task/1216436095972490?focus=true

## Description
Enabling attaching PDF pages to AiChat internally.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single feature-flag state change in Windows privacy/remote config with no application code changes.
> 
> **Overview**
> **Windows remote config** updates the AiChat subfeature `pdfPageContext` from `disabled` to `internal`, so attaching PDF pages to AiChat can be exercised for internal builds/users on Windows without a public rollout.
> 
> This is limited to `overrides/windows-override.json`; other platforms (e.g. macOS) still have `pdfPageContext` disabled in their overrides.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1cacdc3f6d2ded2c6cfc2c69964b5ba0eb455f85. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->